### PR TITLE
TRUNK-3321 (1.9.x/master) validate throws wrong error type if object is null 

### DIFF
--- a/api/src/main/java/org/openmrs/api/AdministrationService.java
+++ b/api/src/main/java/org/openmrs/api/AdministrationService.java
@@ -730,6 +730,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @param errors
 	 * @should pass for a valid object
 	 * @should fail for an invalid object
+	 * @should throw throw APIException if the input is null
 	 */
 	@Transactional(readOnly = true)
 	public void validate(Object object, Errors errors) throws APIException;

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -1221,6 +1221,9 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	 */
 	@Override
 	public void validate(Object object, Errors errors) throws APIException {
+		if (object == null)
+			throw new APIException(Context.getMessageSourceService().getMessage("error.null"));
+		
 		dao.validate(object, errors);
 	}
 	

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -35,6 +35,9 @@ import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
 
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
 /**
  * TODO clean up and finish this test class. Should test all methods in the
  * {@link AdministrationService}
@@ -681,5 +684,16 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		Assert.assertTrue("en_GB", searchLocales.contains(new Locale("en", "GB")));
 		Assert.assertTrue("en_US", searchLocales.contains(new Locale("en", "US")));
 		Assert.assertFalse("pl", searchLocales.contains(new Locale("pl")));
+	}
+	
+	/**
+	 * @see AdministrationService#validate(Object,Errors)
+	 * @verifies throws APIException if the input is null
+	 */
+	
+	@Test(expected = APIException.class)
+	public void validate_shouldThrowThrowAPIExceptionIfTheInputIsNull() throws Exception {
+		BindException errors = new BindException(new Object(), "");
+		Context.getAdministrationService().validate(null, errors);
 	}
 }


### PR DESCRIPTION
TRUNK-3321
https://tickets.openmrs.org/browse/TRUNK-3321
validate throws wrong error type if object is null

Changed the AdministrationServiceImpl.validate method to throw an APIException
if the input is null.
