### PR TITLE
TRUNK-213: Normalize how locale is used in the OpenMRS data model

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -7378,5 +7378,15 @@
                                  referencedTableName="concept" referencedColumnNames="concept_id" />
     </changeSet>
 	
+	<changeSet id="20121025-TRUNK-213" author="lluismf">
+        <comment>Normalize varchar length of locale columns</comment>
+        <ext:modifyColumn tableName="concept_stop_word">
+			<column name="locale" type="varchar(50)"/>
+		</ext:modifyColumn>
+         <ext:modifyColumn tableName="concept_word">
+			<column name="locale" type="varchar(50)"/>
+		</ext:modifyColumn>
+    </changeSet>
+	
 </databaseChangeLog>
 


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-213
