### PR TITLE
Fix for TRUNK-3753

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
@@ -117,7 +117,7 @@
 			<openmrs:extensionPoint pointId="org.openmrs.headerFull.userBar" type="html">
 				<openmrs:hasPrivilege privilege="${extension.requiredPrivilege}">
 					<span>
-						<a href="${extension.url}"><openmrs:message code="${extension.label}"/></a>
+						<a href="<c:url value="${extension.url}" />"><openmrs:message code="${extension.label}"/></a>
 					</span>
 					<c:if test="${extension.portletUrl != null}">
 						<openmrs:portlet url="${extension.portletUrl}" moduleId="${extension.moduleId}" id="${extension.portletUrl}" />


### PR DESCRIPTION
Uses the c:url tag to provide support for external urls, javascript, and local urls (by adding the context path) in the org.openmrs.headerFull.userBar extension point.  This has been manually tested and appears to work fine provided that:
- Javascript starts with "javascript:"
- External links start with "http://" or "https://"

Ticket: https://tickets.openmrs.org/browse/TRUNK-3753
