### PR TITLE
TRUNK-3778

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -36,9 +36,9 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
-import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
+import org.springframework.orm.hibernate3.annotation.AnnotationSessionFactoryBean;
 
-public class HibernateSessionFactoryBean extends LocalSessionFactoryBean {
+public class HibernateSessionFactoryBean extends AnnotationSessionFactoryBean {
 	
 	private static Log log = LogFactory.getLog(HibernateSessionFactoryBean.class);
 	
@@ -135,6 +135,16 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean {
 		return tmpMappingResources;
 	}
 	
+	public Set<String> getModulePackagesWithMappedClasses() {
+		Set<String> packages = new HashSet<String>();
+		for (Module mod : ModuleFactory.getStartedModules()) {
+			for (String s : mod.getPackagesWithMappedClasses()) {
+				packages.add(s);
+			}
+		}
+		return packages;
+	}
+	
 	/* (non-Javadoc)
 	 * @see org.springframework.orm.hibernate3.AbstractSessionFactoryBean#afterPropertiesSet()
 	 */
@@ -142,8 +152,9 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean {
 	public void afterPropertiesSet() throws Exception {
 		// adding each module's mapping file to the list of mapping resources
 		super.setMappingResources(getModuleMappingResources().toArray(new String[] {}));
-		
 		// just check for testing module's hbm files here?
+		
+		super.setPackagesToScan(getModulePackagesWithMappedClasses().toArray(new String[] {}));
 		
 		super.afterPropertiesSet();
 	}

--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -16,10 +16,12 @@ package org.openmrs.module;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.Vector;
 
 import org.apache.commons.logging.Log;
@@ -82,6 +84,8 @@ public final class Module {
 	private List<GlobalProperty> globalProperties = new Vector<GlobalProperty>();
 	
 	private List<String> mappingFiles = new Vector<String>();
+	
+	private Set<String> packagesWithMappedClasses = new HashSet<String>();
 	
 	private Document config = null;
 	
@@ -628,6 +632,14 @@ public final class Module {
 	
 	public void setMappingFiles(List<String> mappingFiles) {
 		this.mappingFiles = mappingFiles;
+	}
+	
+	public Set<String> getPackagesWithMappedClasses() {
+		return packagesWithMappedClasses;
+	}
+	
+	public void setPackagesWithMappedClasses(Set<String> packagesToScan) {
+		this.packagesWithMappedClasses = packagesToScan;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -23,10 +23,12 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.Vector;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
@@ -277,6 +279,7 @@ public class ModuleFileParser {
 			module.setMessages(getMessages(rootNode, configVersion, jarfile));
 			
 			module.setMappingFiles(getMappingFiles(rootNode, configVersion, jarfile));
+			module.setPackagesWithMappedClasses(getPackagesWithMappedClasses(rootNode, configVersion));
 			
 			module.setConfig(configDoc);
 			
@@ -677,6 +680,17 @@ public class ModuleFileParser {
 				mappings.add(s2);
 		}
 		return mappings;
+	}
+	
+	private Set<String> getPackagesWithMappedClasses(Element rootNode, String configVersion) {
+		String element = getElement(rootNode, configVersion, "packagesWithMappedClasses");
+		Set<String> packages = new HashSet<String>();
+		for (String s : element.split("\\s")) {
+			String s2 = s.trim();
+			if (s2.length() > 0)
+				packages.add(s2);
+		}
+		return packages;
 	}
 	
 	/**


### PR DESCRIPTION
Patch to allow module developers to use JPA annotations.  Big thanks to Rafal Korytkowski and Daniel Kayiwa for clarifying some Maven dependency issues.

Backporting this to 1.9.x would be great as that would mean I can introduce JPA annotations to the team that I'm working with currently developing a module.
