### PR TITLE
NonUniqueObjectException: a different object with the same identifier value was already associated with the session: [org.openmrs.Patient#] - TRUNK-3728

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -177,6 +177,13 @@ public class HibernatePatientDAO implements PatientDAO {
 					}
 				}
 			}
+			
+			//Without evicting person, you will get this error when promoting person to patient
+			//org.hibernate.NonUniqueObjectException: a different object with the same identifier
+			//value was already associated with the session: [org.openmrs.Patient#]
+			//see TRUNK-3728
+			Person person = (Person) sessionFactory.getCurrentSession().get(Person.class, patient.getPersonId());
+			sessionFactory.getCurrentSession().evict(person);
 		}
 		
 		// commenting this out to get the save patient as a user option to work correctly

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -3202,4 +3202,22 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Collections.sort(sortedList, new PatientIdentifierTypeDefaultComparator());
 		Assert.assertEquals(sortedList, list);
 	}
+	
+	/**
+	 * https://tickets.openmrs.org/browse/TRUNK-3728
+	 * 
+	 * @see {@link PatientService#savePatient(Patient)}
+	 */
+	@Test
+	@Verifies(value = "should not throw NonUniqueObjectException when called with person promoted to patient", method = "savePatient(Patient)")
+	public void savePatient_shouldNotThrowNonUniqueObjectExceptionWhenCalledWithPersonPromotedToPatient() throws Exception {
+		Person person = personService.getPerson(1);
+		Patient patient = patientService.getPatientOrPromotePerson(person.getPersonId());
+		PatientIdentifier patientIdentifier = new PatientIdentifier("some identifier", new PatientIdentifierType(2),
+		        new Location(1));
+		patientIdentifier.setPreferred(true);
+		patient.addIdentifier(patientIdentifier);
+		
+		patientService.savePatient(patient);
+	}
 }


### PR DESCRIPTION
NonUniqueObjectException: a different object with the same identifier value was already associated with the session: [org.openmrs.Patient#] - TRUNK-3728
