### PR TITLE
TRUNK-3768: drugOrder.drug should not be a mandatory field for drug order

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
@@ -90,7 +90,7 @@
 			<property name="complex" type="boolean" column="complex" length="1" not-null="true"/>
 			<property name="quantity" type="int" column="quantity" length="11"/>
 			<!-- bi-directional many-to-one association to Drug -->
-			<many-to-one name="drug" class="org.openmrs.Drug" not-null="true">
+			<many-to-one name="drug" class="org.openmrs.Drug" not-null="false">
 				<column name="drug_inventory_id" />
 			</many-to-one>
 	


### PR DESCRIPTION
This was merged into master previously, now backporting for 1.9.3
