### PR TITLE
When a module activator's started() method throws an exception, the module should stop - TRUNK-3738

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -811,12 +811,18 @@ public class ModuleUtil {
 					
 					if (module.getModuleActivator() != null) {
 						module.getModuleActivator().contextRefreshed();
-						//if it is system start up, call the started method for all started modules
-						if (isOpenmrsStartup)
-							module.getModuleActivator().started();
-						//if refreshing the context after a user started or uploaded a new module
-						else if (!isOpenmrsStartup && module.equals(startedModule))
-							module.getModuleActivator().started();
+						try {
+							//if it is system start up, call the started method for all started modules
+							if (isOpenmrsStartup)
+								module.getModuleActivator().started();
+							//if refreshing the context after a user started or uploaded a new module
+							else if (!isOpenmrsStartup && module.equals(startedModule))
+								module.getModuleActivator().started();
+						}
+						catch (Exception e) {
+							log.warn("Unable to invoke started() method on the module's activator", e);
+							ModuleFactory.stopModule(module);
+						}
 					}
 					
 				}


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-3738
