### PR TITLE
Responding to review comments for: Liquibase fails to change column with foreign key in MySQL 5.6 - TRUNK-3909

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -7015,6 +7015,7 @@
 	</changeSet>
 	
 	<changeSet id="3-increase-privilege-col-size-person_attribute_type" author="dkayiwa">
+		<validCheckSum>3:f8e6499f5839e64223d9fb7cbe8cdbc6</validCheckSum><!-- TRUNK-3909 -->
 		<preConditions onFail="MARK_RAN">
 			<columnExists tableName="person_attribute_type" columnName="edit_privilege"/>
 		</preConditions>
@@ -7376,6 +7377,7 @@
     </changeSet>
     
     <changeSet id="20121016-1504" author="wyclif">
+    	<validCheckSum>3:ca4bde46e2fe247d1d4d227a539ff465</validCheckSum><!-- TRUNK-3909 -->
 		<preConditions onFail="MARK_RAN">
 			<columnExists tableName="test_order" columnName="order_id"/>
 		</preConditions>


### PR DESCRIPTION
Responding to review comments for: Liquibase fails to change column with foreign key in MySQL 5.6 - TRUNK-3909
