### PR TITLE
TRUNK-3098: Add unit-test getConceptsByAnswer_shouldFindAnswersForConcep...

### DIFF
--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -2065,7 +2065,19 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		for (ConceptReferenceTerm conceptReferenceTerm : matches)
 			Assert.assertTrue(uniqueTerms.add(conceptReferenceTerm));
 	}
-	
+
+        /**
+	 * @see ConceptService#getConceptsByAnswer(ConceptClass)
+	 */
+	@Test
+	public void getConceptsByAnswer_shouldFindAnswersForConcept() throws Exception {
+            Concept concept = conceptService.getConcept(7);
+            Assert.assertNotNull(concept);
+            List<Concept> concepts = conceptService.getConceptsByAnswer(concept);
+            Assert.assertEquals(1, concepts.size());
+            Assert.assertEquals(21, concepts.get(0).getId().intValue());
+	}
+           
 	/**
 	 * @see ConceptService#getConceptsByClass(ConceptClass)
 	 * @verifies not fail due to no name in search


### PR DESCRIPTION
I added a unit-test for the TRUNK-3098 issue [1].  The unit-test passed and I believe the issue can be closed, based on the issue's comments.

Please let me know if anything more needs to be done or if I missed something.

[1] https://tickets.openmrs.org/browse/TRUNK-3098
