### PR TITLE
Adding validation-api dependencies.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -202,6 +202,10 @@
          <groupId>xml-resolver</groupId>
          <artifactId>xml-resolver</artifactId>
       </dependency>
+       <dependency>
+           <groupId>javax.validation</groupId>
+           <artifactId>validation-api</artifactId>
+       </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -18,6 +18,8 @@
 			~/.OpenMRS/lucene-index/ 
 		</property>
 
+        <property name="javax.persistence.validation.mode">none</property>
+
 		<!--  Hibernate Mapping files -->
 		
 		<!-- API -->

--- a/pom.xml
+++ b/pom.xml
@@ -659,7 +659,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-		</dependencies>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>1.0.0.GA</version>
+            </dependency>
+        </dependencies>
 	</dependencyManagement>
 
 	<build>


### PR DESCRIPTION
Adding the validation-api dependencies as discussed.
- Includes modifications to the pom.
- Adds a configuration to hibernate to ensure that hibernate doesn't automatically start looking for validators which is the default setting.
