### PR TITLE
Plugging in dependency on javax.validation api JSR-303 definition.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -190,6 +190,10 @@
          <groupId>xml-resolver</groupId>
          <artifactId>xml-resolver</artifactId>
       </dependency>
+       <dependency>
+           <groupId>javax.validation</groupId>
+           <artifactId>validation-api</artifactId>
+       </dependency>
    </dependencies>
    <build>
       <plugins>

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -18,7 +18,9 @@
 			~/.OpenMRS/lucene-index/ 
 		</property>
 
-		<!--  Hibernate Mapping files -->
+        <property name="javax.persistence.validation.mode">none</property>
+
+        <!--  Hibernate Mapping files -->
 		
 		<!-- API -->
 		<mapping resource="org/openmrs/api/db/hibernate/ActiveListItem.hbm.xml" />

--- a/pom.xml
+++ b/pom.xml
@@ -683,7 +683,12 @@
 				<artifactId>ehcache-core</artifactId>
 				<version>2.2.0</version>
 			</dependency>
-		</dependencies>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>1.0.0.GA</version>
+            </dependency>
+        </dependencies>
 	</dependencyManagement>
 
 	<build>


### PR DESCRIPTION
Adding the validation-api dependencies as discussed.
- Includes modifications to the pom.
- Adds a configuration to hibernate to ensure that hibernate doesn't automatically start looking for validators which is the default setting.
