### PR TITLE
TRUNK-3683 - Concept Map Types in the standard test dataset have the wrong uuids 

### DIFF
--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -90,9 +90,9 @@
   <concept_reference_term concept_reference_term_id="9" concept_source_id="1" code="127cd4689" name="cd4died term2" description="died" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-127689_3"/>
   <concept_reference_term concept_reference_term_id="10" concept_source_id="1" code="454545" name="no term name3" description="" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-454545"/>
   <concept_reference_term concept_reference_term_id="11" concept_source_id="1" code="retired code" name="retired name" description="test duplicate term that is retired" retired="1" retired_by="1" retire_reason="test reason" date_retired="2004-08-12 12:00:00" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-retired code"/>
-  <concept_map_type concept_map_type_id="1" name="is-a" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="8a8baebc-49d5-11e0-8fed-18a905e044dc"/>
-  <concept_map_type concept_map_type_id="2" name="same-as" description="Indicates similarity" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="f40555f0-49d5-11e0-8fed-18a905e044dc"/>
-  <concept_map_type concept_map_type_id="3" name="broader-than" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="fa864d62-49d5-11e0-8fed-18a905e044dc"/>
+  <concept_map_type concept_map_type_id="1" name="is-a" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="1ce7a784-7d8f-11e1-909d-c80aa9edcf4e"/>
+  <concept_map_type concept_map_type_id="2" name="same-as" description="Indicates similarity" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="35543629-7d8c-11e1-909d-c80aa9edcf4e"/>
+  <concept_map_type concept_map_type_id="3" name="broader-than" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="4b9d9421-7d8c-11e1-909d-c80aa9edcf4e"/>
   <concept_map_type concept_map_type_id="4" name="is-parent-to" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="0e7a8536-49d6-11e0-8fed-18a905e044dc"/>
   <concept_map_type concept_map_type_id="5" name="related-to" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="1ccba764-49d6-11e0-8fed-18a905e044dc"/>
   <concept_map_type concept_map_type_id="6" name="testing" is_hidden="0" retired="1" retired_by="1" date_retired="2004-08-12 12:00:00" retire_reason="test reason" creator="1" date_created="2004-08-12 00:00:00.0" uuid="8ef30800-4db4-11e0-b7af-18a905e044dc"/>


### PR DESCRIPTION
I have updated some Concept Map Types that had wrong uuids. Notice that I didn't change the uuid of concepts that I didn't find the correspondence in the liquibase-update-to-latest.xml

See the ticket: https://tickets.openmrs.org/browse/TRUNK-3683

Thanks
