### PR TITLE
TRUNK-3868 - Combine PatientDAOTest and HibernatePatientDAOTest 

### DIFF
--- a/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
@@ -272,4 +272,28 @@ public class PatientDAOTest extends BaseContextSensitiveTest {
 		Assert.assertEquals("12345K", patientIdentifiers.get(0).getIdentifier());
 	}
 	
+	
+	/**
+	 * @see PatientDAO#getAllPatientIdentifierTypes(boolean)
+	 * @verifies return ordered
+	 */
+	@Test
+	public void getAllPatientIdentifierTypes_shouldReturnOrdered() throws Exception {
+		//given
+		PatientIdentifierType patientIdentifierType1 = dao.getPatientIdentifierType(1); //non retired, non required
+		
+		PatientIdentifierType patientIdentifierType2 = dao.getPatientIdentifierType(2); //non retired, required
+		patientIdentifierType2.setRequired(true);
+		dao.savePatientIdentifierType(patientIdentifierType2);
+		
+		PatientIdentifierType patientIdentifierType4 = dao.getPatientIdentifierType(4); //retired
+		
+		//when
+		List<PatientIdentifierType> all = dao.getAllPatientIdentifierTypes(true);
+		
+		//then
+		Assert.assertArrayEquals(new Object[] { patientIdentifierType2, patientIdentifierType1, patientIdentifierType4 },
+		    all.toArray());
+	}
+	
 }


### PR DESCRIPTION
Merged the differences between PatientDAOTest and HibernatePatientDAOTest into PatientDAOTest. There was only one test in  HibernatePatientDAOTest that was no present in PatientDAOTest.

If wanted, I can delete the HibernatePatientDAOTest in a new commit.

See the ticket: https://tickets.openmrs.org/browse/TRUNK-3868

Thanks.
