### PR TITLE
TRUNK-3904 - Added the "this()" reference in the integer constructor of Concept

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -137,6 +137,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param conceptId the concept id to set
 	 */
 	public Concept(Integer conceptId) {
+		this();
 		this.conceptId = conceptId;
 	}
 	


### PR DESCRIPTION
Added the "this()" reference in the integer constructor of Concept.
See the ticket: https://tickets.openmrs.org/browse/TRUNK-3904
Thanks.
