### PR TITLE
Fix to allow openmrs:require tag attribute value expressions.

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/taglibs/openmrs.tld
+++ b/webapp/src/main/webapp/WEB-INF/taglibs/openmrs.tld
@@ -22,27 +22,27 @@
 	<attribute>
 		<name>privilege</name>
 		<required>false</required>
-		<rtexprvalue>false</rtexprvalue>
+		<rtexprvalue>true</rtexprvalue>
 	</attribute>
 	<attribute>
 		<name>allPrivileges</name>
 		<required>false</required>
-		<rtexprvalue>false</rtexprvalue>
+		<rtexprvalue>true</rtexprvalue>
 	</attribute>
 	<attribute>
 		<name>anyPrivilege</name>
 		<required>false</required>
-		<rtexprvalue>false</rtexprvalue>
+		<rtexprvalue>true</rtexprvalue>
 	</attribute>
 	<attribute>
 		<name>otherwise</name>
 		<required>true</required>
-		<rtexprvalue>false</rtexprvalue>
+		<rtexprvalue>true</rtexprvalue>
 	</attribute>
 	<attribute>
 		<name>redirect</name>
 		<required>false</required>
-		<rtexprvalue>false</rtexprvalue>
+		<rtexprvalue>true</rtexprvalue>
 	</attribute>
 </tag>
 


### PR DESCRIPTION
As per the discussion here: https://groups.google.com/a/openmrs.org/forum/?fromgroups=#!topic/dev/1elGoLRX6ik
