### PR TITLE
TRUNK-3407: ConceptDescription equals method fails with 2 different instances of ConceptDescription in 1.8 and earlier

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptDescription.java
+++ b/api/src/main/java/org/openmrs/ConceptDescription.java
@@ -83,7 +83,7 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 		}
 		ConceptDescription rhs = (ConceptDescription) object;
 		if (conceptDescriptionId != null && rhs.conceptDescriptionId != null)
-			return this.conceptDescriptionId == rhs.conceptDescriptionId;
+			return this.conceptDescriptionId.equals(rhs.conceptDescriptionId);
 		else
 			return this == object;
 	}

--- a/api/src/test/java/org/openmrs/ConceptDescriptionTest.java
+++ b/api/src/test/java/org/openmrs/ConceptDescriptionTest.java
@@ -28,8 +28,8 @@ public class ConceptDescriptionTest {
 	@Test
 	@Verifies(value = "should compare on id if its non null", method = "equals(Object)")
 	public void equals_shouldCompareOnIdIfItsNonNull() throws Exception {
-		ConceptDescription firstDesc = new ConceptDescription(1);
-		ConceptDescription secondDesc = new ConceptDescription(1);
+		ConceptDescription firstDesc = new ConceptDescription(1989);
+		ConceptDescription secondDesc = new ConceptDescription(1989);
 		Assert.assertTrue(firstDesc.equals(secondDesc));
 	}
 	


### PR DESCRIPTION
Change == to equals() for comparing Integers
https://tickets.openmrs.org/browse/TRUNK-3407
