### PR TITLE
TRUNK-3407: ConceptDescription equals method fails with 2 different instances of ConceptDescription in 1.8 and earlier

### DIFF
--- a/src/api/org/openmrs/ConceptDescription.java
+++ b/src/api/org/openmrs/ConceptDescription.java
@@ -83,7 +83,7 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 		}
 		ConceptDescription rhs = (ConceptDescription) object;
 		if (conceptDescriptionId != null && rhs.conceptDescriptionId != null)
-			return this.conceptDescriptionId == rhs.conceptDescriptionId;
+			return this.conceptDescriptionId.equals(rhs.conceptDescriptionId);
 		else
 			return this == object;
 	}


### PR DESCRIPTION
Change == to equals() for comparing Integers (for 1.7.x)
https://tickets.openmrs.org/browse/TRUNK-3407
