### PR TITLE
Added latest version of jars for JBehave and Selenium for FF compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -649,17 +649,6 @@
 			</dependency>
 
             <dependency>
-                <groupId>org.jbehave.web</groupId>
-                <artifactId>jbehave-web-selenium</artifactId>
-                <version>3.5.3</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-logging</groupId>
-                        <artifactId>commons-logging</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>com.googlecode.lambdaj</groupId>
                 <artifactId>lambdaj</artifactId>
                 <version>2.2</version>

--- a/release-test/pom.xml
+++ b/release-test/pom.xml
@@ -13,10 +13,19 @@
         This infrastructure is reused across all the modules.
     </description>
 	<dependencies>
+
+        <dependency>
+             <groupId>org.seleniumhq.selenium</groupId>
+             <artifactId>selenium-java</artifactId>
+             <version>2.33.0</version>
+         </dependency>
+
 		<dependency>
 			<groupId>org.jbehave.web</groupId>
 			<artifactId>jbehave-web-selenium</artifactId>
+            <version>3.5.5</version>
 		</dependency>
+
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
Added latest version of jars for Jbehave/Selenium. Tested with FF v21 (on Mac). Removed entry from parent pom.xml of JBehave, since it is already mentioned in release-test pom.xml
