### PR TITLE
Complex Observations are not handled if it is inside Observation Group

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -106,6 +106,20 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 			}
 		}
 		
+		if (null != obs && obs.hasGroupMembers()) {
+			for (Obs member : obs.getGroupMembers()) {
+				if (null != member && null != member.getConcept() && member.getConcept().isComplex()
+				        && null != member.getComplexData().getData()) {
+					ComplexObsHandler handler = getHandler(member);
+					if (null != handler) {
+						handler.saveObs(member);
+					} else {
+						throw new APIException("Unknown handler for " + member.getConcept());
+					}
+				}
+			}
+		}
+		
 		if (obs.getObsId() == null) {
 			Context.requirePrivilege(PrivilegeConstants.ADD_OBS);
 			return dao.saveObs(obs);


### PR DESCRIPTION
Iterate over Observation group members and use handler to save all complex Observations. Now Complex observations are not saved to file system.
