### PR TITLE
TRUNK-4005 don't show retired encountertypes on form edit admin page

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/form/FormFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/form/FormFormController.java
@@ -166,7 +166,7 @@ public class FormFormController extends SimpleFormController {
 		
 		if (Context.isAuthenticated()) {
 			fieldTypes = Context.getFormService().getAllFieldTypes();
-			encTypes = Context.getEncounterService().getAllEncounterTypes();
+			encTypes = Context.getEncounterService().getAllEncounterTypes(false);
 		}
 		
 		map.put("fieldTypes", fieldTypes);


### PR DESCRIPTION
I wasn't sure where to write tests for this change. If anyone has suggestions, I'm happy to adjust the pull request.
