### PR TITLE
TRUNK-3652

### DIFF
--- a/api/src/main/java/org/openmrs/PatientState.java
+++ b/api/src/main/java/org/openmrs/PatientState.java
@@ -192,12 +192,17 @@ public class PatientState extends BaseOpenmrsData implements java.io.Serializabl
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 * @should return positive if startDates equal and this endDate null
 	 * @should return negative if this startDate null
+	 * @should pass if two states have the same start date, end date and uuid
+	 * @should return positive or negative if two states have the same start date and end date but different uuids
 	 */
 	@Override
 	public int compareTo(PatientState o) {
 		int result = OpenmrsUtil.compareWithNullAsEarliest(getStartDate(), o.getStartDate());
 		if (result == 0) {
 			result = OpenmrsUtil.compareWithNullAsLatest(getEndDate(), o.getEndDate());
+		}
+		if (result == 0) {
+			result = OpenmrsUtil.compareWithNullAsGreatest(getUuid(), o.getUuid());
 		}
 		return result;
 	}

--- a/api/src/test/java/org/openmrs/PatientStateTest.java
+++ b/api/src/test/java/org/openmrs/PatientStateTest.java
@@ -14,10 +14,12 @@
 package org.openmrs;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.test.Verifies;
 
 public class PatientStateTest {
 	
@@ -30,6 +32,10 @@ public class PatientStateTest {
 	private Date rightOutOfRange;
 	
 	private Date leftOutOfRange;
+
+	private String uuid2;
+
+	private String uuid1;
 	
 	@Before
 	public void before() {
@@ -259,4 +265,51 @@ public class PatientStateTest {
 		Assert.assertTrue(result < 0);
 	}
 	
+	/**
+	 * @see PatientState#compareTo(PatientState)
+	 */
+	@Test
+	@Verifies(value = "pass if two states have the same start date, end date and uuid", method = "compareTo(PatientState)")
+	public void compareTo_shouldPassIfTwoStatesHaveTheSameStartDateEndDateAndUuid() throws Exception {
+		
+		PatientState patientState = new PatientState();
+		patientState.setStartDate(leftRange);
+		patientState.setEndDate(rightRange);
+		patientState.setUuid(uuid1);
+		patientState.setVoided(false);
+		
+		PatientState patientState2 = new PatientState();
+		patientState2.setStartDate(leftRange);
+		patientState2.setEndDate(rightRange);
+		patientState2.setUuid(uuid1);
+		patientState2.setVoided(false);
+		
+		Assert.assertTrue(patientState.compareTo(patientState2) == 0);
+	}
+	
+	/**
+	 * @see PatientState#compareTo(PatientState)
+	 */
+	@Test
+	@Verifies(value = "return positive or negative if two states have the same start date and end date but different uuids", method = "compareTo(PatientState)")
+	public void compareTo_shouldReturnPositiveOrNegativeIfTwoStatesHaveTheSameStartDatesEndDatesAndUuids() throws Exception {
+		uuid1 = UUID.randomUUID().toString();
+		uuid2 = UUID.randomUUID().toString();
+		
+		PatientState patientState = new PatientState();
+		patientState.setStartDate(leftRange);
+		patientState.setEndDate(rightRange);
+		patientState.setUuid(uuid1);
+		patientState.setVoided(false);
+		
+		PatientState patientState2 = new PatientState();
+		patientState2.setStartDate(leftRange);
+		patientState2.setEndDate(rightRange);
+		patientState2.setUuid(uuid2);
+		patientState2.setVoided(false);
+		
+		int result = (patientState.compareTo(patientState2));
+		
+		Assert.assertTrue(result <= -1 || result >= 1);
+	}
 }


### PR DESCRIPTION
fix for [TRUNK-3652] Natural ordering of Patient State is not consistent with equals
