### PR TITLE
TRUNK-4029: Hibernate config in parent pom.xml is outdated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,89 +264,31 @@
 			<dependency>
 				<groupId>org.openmrs.hibernate</groupId>
 				<artifactId>hibernate-core</artifactId>
-				<version>3.6.5.Final-mod</version>
-				<exclusions>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm-attrs</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>net.sf.ehcache</groupId>
-						<artifactId>ehcache</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>cglib</groupId>
-						<artifactId>cglib</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-search-analyzers</artifactId>
-				<version>3.4.0.Final</version>
+				<version>${hibernateVersion}-mod</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-c3p0</artifactId>
-				<version>3.6.0.Final</version>
+				<version>${hibernateVersion}</version>
 				<exclusions>
                     <exclusion>
                         <groupId>org.hibernate</groupId>
                         <artifactId>hibernate-core</artifactId>
                     </exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm-attrs</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>net.sf.ehcache</groupId>
-						<artifactId>ehcache</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>cglib</groupId>
-						<artifactId>cglib</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-ehcache</artifactId>
-				<version>3.6.0.Final</version>
+				<version>${hibernateVersion}</version>
 				<exclusions>
                     <exclusion>
                         <groupId>org.hibernate</groupId>
                         <artifactId>hibernate-core</artifactId>
                     </exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm-attrs</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>net.sf.ehcache</groupId>
-						<artifactId>ehcache</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>cglib</groupId>
-						<artifactId>cglib</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
+			<!-- Removed until work on TRUNK-425 is complete
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-search</artifactId>
@@ -356,24 +298,14 @@
                         <groupId>org.hibernate</groupId>
                         <artifactId>hibernate-core</artifactId>
                     </exclusion>
-					<exclusion>
-						<groupId>commons-logging</groupId>
-						<artifactId>commons-logging</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>asm</groupId>
-						<artifactId>asm-attrs</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>net.sf.ehcache</groupId>
-						<artifactId>ehcache</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId>cglib</groupId>
-						<artifactId>cglib</artifactId>
-					</exclusion>
 				</exclusions>
 			</dependency>
+			<dependency>
+				<groupId>org.hibernate</groupId>
+				<artifactId>hibernate-search-analyzers</artifactId>
+				<version>3.4.0.Final</version>
+			</dependency>
+			-->
 			<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
@@ -1030,6 +962,7 @@
 		<openmrs.version.shortnumericonly>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${revisionNumber}</openmrs.version.shortnumericonly>
 
 		<springVersion>3.0.5.RELEASE</springVersion>
+		<hibernateVersion>3.6.5.Final</hibernateVersion>
 		<customArgLineForTesting></customArgLineForTesting>
 	</properties>
 </project>


### PR DESCRIPTION
Define hibernate version as a property.
Remove unnecessary exclusions.
Comment out hibernate search (it is commented out in the openmrs-api).

https://tickets.openmrs.org/browse/TRUNK-4029
