### PR TITLE
TRUNK-4051: @SkipBaseSetup annotation is not inherited

### DIFF
--- a/api/src/test/java/org/openmrs/test/SkipBaseSetup.java
+++ b/api/src/test/java/org/openmrs/test/SkipBaseSetup.java
@@ -1,6 +1,7 @@
 package org.openmrs.test;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -15,6 +16,7 @@ import java.lang.annotation.Target;
  * 
  * @see BaseContextSensitiveTest
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target( { ElementType.METHOD, ElementType.TYPE })
 public @interface SkipBaseSetup {


### PR DESCRIPTION
Java annotations are not inherited by default. Adding @Inherited to an annotation definition allows it to be inherited from a superclass. Though, it will not be inherited from the implemented interfaces.

https://tickets.openmrs.org/browse/TRUNK-4051
