### PR TITLE
TRUNK-3878: Forgot password form IP-based lockout locks everyone from using it

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/ForgotPasswordFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/ForgotPasswordFormController.java
@@ -77,7 +77,7 @@ public class ForgotPasswordFormController extends SimpleFormController {
 		
 		String username = request.getParameter("uname");
 		
-		String ipAddress = request.getLocalAddr();
+		String ipAddress = request.getRemoteAddr();
 		Integer forgotPasswordAttempts = loginAttemptsByIP.get(ipAddress);
 		if (forgotPasswordAttempts == null)
 			forgotPasswordAttempts = 1;


### PR DESCRIPTION
This is fixed.  And I tested it manually. 
1. OpenMRS running on localhost.   
2. Use browser on localhost, and try the forgot password functionality until you lock yourself out.  It happens on the 6th attempt. 
3. Now try OpenMRS from another computer on the same network - I just used my iPad.   Try the forgot password functionality from this machine.   Earlier, the very first attempt would report a lockout.  Now you get the full 5 chances. 
