### PR TITLE
TRUNK-4038: Location tree widget truncates location names with an apostrophe

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/tags/locationTree.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/locationTree.tag
@@ -64,7 +64,7 @@ $j(document).ready(function() {
 			},
 			callback: {
 				onselect: function(NODE, TREE_OBJ) {
-					$j('#${id}_display').html($j(NODE).attr('name'));
+					$j('#${id}_display').html($j(NODE).children(":first").text());
 					$j('#${id}_hidden_input').val($j(NODE).attr('id'));
 					locationTreeTag_hideTree('${id}');
 				}


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-4038
