### PR TITLE
TRUNK-4134 - ModuleActivator.started()/.contextRefreshed() not called when module is stopped/restarted or newly uploaded

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -24,9 +24,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.Vector;
 import java.util.WeakHashMap;
@@ -75,7 +77,7 @@ public class ModuleFactory {
 	
 	private static final Map<String, DaemonToken> daemonTokens = new WeakHashMap<String, DaemonToken>();
 	
-	private static List<String> actualStartupOrder;
+	private static Set<String> actualStartupOrder;
 	
 	/**
 	 * Add a module (in the form of a jar file) to the list of openmrs modules Returns null if an
@@ -189,7 +191,6 @@ public class ModuleFactory {
 	 * Modules that are already started will be skipped.
 	 */
 	public static void startModules() {
-		List<String> currentStartupOrder = new ArrayList<String>();
 		
 		// loop over and try starting each of the loaded modules
 		if (getLoadedModules().size() > 0) {
@@ -220,7 +221,6 @@ public class ModuleFactory {
 									log.debug("starting module: " + mod.getModuleId());
 								
 								startModule(mod);
-								currentStartupOrder.add(mod.getModuleId());
 							}
 							catch (Exception e) {
 								log.error("Error while starting module: " + mod.getName(), e);
@@ -260,7 +260,6 @@ public class ModuleFactory {
 							// it would only be on the leftover modules list if
 							// it were set to true already
 							startModule(leftoverModule);
-							currentStartupOrder.add(leftoverModule.getModuleId());
 							
 							// set this boolean flag to true so we keep looping over the modules
 							atLeastOneModuleLoaded = true;
@@ -295,7 +294,6 @@ public class ModuleFactory {
 				}
 		}
 		
-		actualStartupOrder = currentStartupOrder;
 	}
 	
 	/**
@@ -648,6 +646,10 @@ public class ModuleFactory {
 				
 				// effectively mark this module as started successfully
 				getStartedModulesMap().put(moduleId, module);
+				if (actualStartupOrder == null) {
+					actualStartupOrder = new LinkedHashSet<String>();
+				}
+				actualStartupOrder.add(moduleId);
 				
 				try {
 					// save the state of this module for future restarts


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-4134
