### PR TITLE
TRUNK-3335: In ProviderFormController the method providerAttributeTypes

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -189,8 +189,8 @@ public class HibernatePatientDAO implements PatientDAO {
 	}
 	
 	/**
-     *
-     * @should not search on voided patients
+	 *
+	 * @should not search on voided patients
 	 * @see org.openmrs.api.db.PatientDAO#getPatients(String, String, List, boolean, Integer,
 	 *      Integer, boolean)
 	 */

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -109,7 +109,7 @@ public class PatientSearchCriteria {
 				criteria.add(identifierCriterion);
 			}
 		}
-
+		
 		// make sure the patient object isn't voided
 		criteria.add(Restrictions.eq("voided", false));
 		
@@ -236,7 +236,7 @@ public class PatientSearchCriteria {
 		name = name.replaceAll("  ", " ");
 		name = name.replace(", ", " ");
 		String[] names = name.split(" ");
-
+		
 		if (names.length > 0) {
 			String nameSoFar = names[0];
 			for (int i = 0; i < names.length; i++) {

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-
 public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 	
 	private HibernatePatientDAO dao = null;
@@ -284,13 +283,11 @@ public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 		Assert.assertArrayEquals(new Object[] { openMRSIdNumber, oldIdNumber, socialSecNumber }, patientIdentifierTypes
 		        .toArray());
 	}
-
-
-
-    /**
-     * @see HibernatePatientDAO#getPatients(String, String, java.util.List, boolean, Integer, Integer, boolean)
-     * @verifies return non when searching on voided patients
-     */
+	
+	/**
+	 * @see HibernatePatientDAO#getPatients(String, String, java.util.List, boolean, Integer, Integer, boolean)
+	 * @verifies return non when searching on voided patients
+	 */
 	@Test
 	public void getPatients_shouldNotMatchVoidedPatients() {
 		List<PatientIdentifierType> identifierTypes = Collections.emptyList();
@@ -304,28 +301,27 @@ public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 		patients = dao.getPatients("Hornblower3", null, identifierTypes, false, 0, 11, false);
 		Assert.assertEquals(0, patients.size());
 	}
-
-
-    /**
-     * @see HibernatePatientDAO#getPatients(String, String, java.util.List, boolean, Integer, Integer, boolean)
-     * @verifies return none when searching on voided patient name
-     */
-    @Test
-    public void getPatients_shouldNotMatchVoidedPatientNames() {
-        List<PatientIdentifierType> identifierTypes = Collections.emptyList();
-        List<Patient> patients = dao.getPatients("Oloo", null, identifierTypes, false, 0, 11, false);
-        Assert.assertEquals(1, patients.size());
-
-        Patient patient = patients.get(0);
-
-        Set<PersonName> names = patient.getNames();
-
-        for (PersonName name: names) {
-            name.setVoided(true);
-        }
-
-        dao.savePatient(patient);
-        patients = dao.getPatients("Oloo", null, identifierTypes, false, 0, 11, false);
-        Assert.assertEquals(0, patients.size());
-    }
+	
+	/**
+	 * @see HibernatePatientDAO#getPatients(String, String, java.util.List, boolean, Integer, Integer, boolean)
+	 * @verifies return none when searching on voided patient name
+	 */
+	@Test
+	public void getPatients_shouldNotMatchVoidedPatientNames() {
+		List<PatientIdentifierType> identifierTypes = Collections.emptyList();
+		List<Patient> patients = dao.getPatients("Oloo", null, identifierTypes, false, 0, 11, false);
+		Assert.assertEquals(1, patients.size());
+		
+		Patient patient = patients.get(0);
+		
+		Set<PersonName> names = patient.getNames();
+		
+		for (PersonName name : names) {
+			name.setVoided(true);
+		}
+		
+		dao.savePatient(patient);
+		patients = dao.getPatients("Oloo", null, identifierTypes, false, 0, 11, false);
+		Assert.assertEquals(0, patients.size());
+	}
 }


### PR DESCRIPTION
need to be set to retired. I changed the argument from being empty to
false. This will allow only the providerAddributeTypes which are not
retired to be displayed.  see url https://github.com/crazzykid/openmrs-core/compare/TRUNK-3335?expand=1
