### PR TITLE
TRUNK-3335: In ProviderFormController the method providerAttributeTypes

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
@@ -111,7 +111,7 @@ public class ProviderFormController {
 	
 	@ModelAttribute("providerAttributeTypes")
 	public List<ProviderAttributeType> getProviderAttributeTypes() throws Exception {
-		return Context.getProviderService().getAllProviderAttributeTypes();
+		return Context.getProviderService().getAllProviderAttributeTypes(false);
 	}
 	
 	@RequestMapping(method = RequestMethod.GET)


### PR DESCRIPTION
TRUNK-3335: In ProviderFormController the method providerAttributeTypes
need to be set to retired. I changed the argument from being empty to
false. This will allow only the providerAddributeTypes which are not
retired to be displayed.
