### PR TITLE
TRUNK-4129 Modify datatype of drug_order.quantity column and add quantity_units column to drug_order

### DIFF
--- a/api/src/main/java/org/openmrs/DrugOrder.java
+++ b/api/src/main/java/org/openmrs/DrugOrder.java
@@ -42,7 +42,9 @@ public class DrugOrder extends Order implements java.io.Serializable {
 	
 	private Boolean asNeeded = false;
 	
-	private Integer quantity;
+	private Double quantity;
+	
+	private Concept quantityUnits;
 	
 	private Drug drug;
 	
@@ -86,6 +88,7 @@ public class DrugOrder extends Order implements java.io.Serializable {
 		target.asNeeded = getAsNeeded();
 		target.asNeededCondition = getAsNeededCondition();
 		target.quantity = getQuantity();
+		target.quantityUnits = getQuantityUnits();
 		target.drug = getDrug();
 		target.dosingType = getDosingType();
 		target.dosingInstructions = getDosingInstructions();
@@ -201,7 +204,7 @@ public class DrugOrder extends Order implements java.io.Serializable {
 	 * 
 	 * @return quantity
 	 */
-	public Integer getQuantity() {
+	public Double getQuantity() {
 		return this.quantity;
 	}
 	
@@ -210,8 +213,24 @@ public class DrugOrder extends Order implements java.io.Serializable {
 	 * 
 	 * @param quantity
 	 */
-	public void setQuantity(Integer quantity) {
+	public void setQuantity(Double quantity) {
 		this.quantity = quantity;
+	}
+	
+	/**
+	 * @since 1.10
+	 * @return concept
+	 */
+	public Concept getQuantityUnits() {
+		return quantityUnits;
+	}
+	
+	/**
+	 * @since 1.10
+	 * @param quantityUnits
+	 */
+	public void setQuantityUnits(Concept quantityUnits) {
+		this.quantityUnits = quantityUnits;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -140,7 +140,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	 *      java.util.List, java.util.List)
 	 */
 	public <Ord extends Order> List<Ord> getOrders(Class<Ord> orderClassType, List<Patient> patients,
-	                                               List<Concept> concepts, List<User> orderers, List<Encounter> encounters) {
+	        List<Concept> concepts, List<User> orderers, List<Encounter> encounters) {
 		if (orderClassType == null)
 			throw new APIException(
 			        "orderClassType cannot be null.  An order type of Order.class or DrugOrder.class is required");

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -1052,10 +1052,12 @@ public final class OpenmrsConstants {
 	
 	public static final String GLOBAL_PROPERTY_NEXT_ORDER_NUMBER = "orderEntry.nextOrderNumber";
 	
+	public static final String GP_ORDER_ENTRY_UNITS_TO_CONCEPTS_MAPPINGS = "orderEntry.unitsToConceptsMappings";
+	
 	/**
 	 * At OpenMRS startup these global properties/default values/descriptions are inserted into the
 	 * database if they do not exist yet.
-	 * 
+	 *
 	 * @return List<GlobalProperty> of the core global properties
 	 */
 	public static final List<GlobalProperty> CORE_GLOBAL_PROPERTIES() {

--- a/api/src/main/java/org/openmrs/util/databasechange/MigrateDrugOrderQuantityToCodedQuantityUnitsChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MigrateDrugOrderQuantityToCodedQuantityUnitsChangeset.java
@@ -1,0 +1,80 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util.databasechange;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import org.openmrs.util.DatabaseUtil;
+import org.openmrs.util.OpenmrsConstants;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+
+/**
+ * Applies quantity units to drug orders created pre 1.10.x based on a concept specified in a global property.
+ *
+ * @see OpenmrsConstants#GP_ORDER_ENTRY_UNITS_TO_CONCEPTS_MAPPINGS
+ */
+public class MigrateDrugOrderQuantityToCodedQuantityUnitsChangeset implements CustomTaskChange {
+	
+	@Override
+	public void execute(Database database) throws CustomChangeException {
+		JdbcConnection connection = (JdbcConnection) database.getConnection();
+		
+		Integer conceptId = DatabaseUtil.getConceptIdForUnits(connection.getUnderlyingConnection(),
+		    "drug_order_quantity_units");
+		
+		try {
+			PreparedStatement update = connection
+			        .prepareStatement("update drug_order set quantity_units = ? where quantity_units is NULL");
+			if (conceptId == null) {
+				update.setNull(1, Types.INTEGER);
+			} else {
+				update.setInt(1, conceptId);
+			}
+			update.executeUpdate();
+		}
+		catch (DatabaseException e) {
+			throw new CustomChangeException(e);
+		}
+		catch (SQLException e) {
+			throw new CustomChangeException(e);
+		}
+	}
+	
+	@Override
+	public String getConfirmationMessage() {
+		return "Finished migrating drug order quantity to coded quantity units";
+	}
+	
+	@Override
+	public void setUp() throws SetupException {
+	}
+	
+	@Override
+	public void setFileOpener(ResourceAccessor resourceAccessor) {
+	}
+	
+	@Override
+	public ValidationErrors validate(Database database) {
+		return null;
+	}
+}

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -6600,4 +6600,35 @@
         </addColumn>
     </changeSet>
 
+	<changeSet id="201312161618-TRUNK-4129" author="rkorytkowski">
+		<preConditions onFail="MARK_RAN">
+			<not><foreignKeyConstraintExists foreignKeyName="drug_order_quantity_units"/></not>
+		</preConditions>
+		<comment>Adding quantity_units column to drug_order table</comment>
+		<addColumn tableName="drug_order">
+			<column name="quantity_units" type="int" value="NULL"/>
+		</addColumn>
+		<addForeignKeyConstraint baseTableName="drug_order" baseColumnNames="quantity_units"
+								 constraintName="drug_order_quantity_units"
+								 referencedTableName="concept"
+								 referencedColumnNames="concept_id"/>
+	</changeSet>
+
+	<changeSet id="201312161713-TRUNK-4129" author="rkorytkowski">
+		<comment>Changing quantity column of drug_order to double</comment>
+		<modifyDataType tableName="drug_order" columnName="quantity" newDataType="double"/>
+	</changeSet>
+
+	<changeSet id="201312191209-TRUNK-4129" author="rkorytkowski">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<sqlCheck expectedResult="0">
+					select count(*) from drug_order;
+				</sqlCheck>
+			</not>
+		</preConditions>
+		<comment>Migrating drug order quantity to coded quantity units</comment>
+		<customChange class="org.openmrs.util.databasechange.MigrateDrugOrderQuantityToCodedQuantityUnitsChangeset" />
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
@@ -101,7 +101,8 @@
 			<property name="frequency" type="java.lang.String" column="frequency" length="255"/>
 			<property name="asNeeded" type="boolean" column="as_needed" length="1" not-null="true"/>
             <property name="asNeededCondition" type="string" column="as_needed_condition" length="255" />
-			<property name="quantity" type="int" column="quantity" length="11"/>
+			<property name="quantity" type="double" column="quantity" length="22"/>
+			<many-to-one name="quantityUnits" class="org.openmrs.Concept" column="quantity_units" />
 			<!-- bi-directional many-to-one association to Drug -->
 			<many-to-one name="drug" class="org.openmrs.Drug" not-null="false">
 				<column name="drug_inventory_id" />

--- a/api/src/test/java/org/openmrs/util/DatabaseUtilIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUtilIntegrationTest.java
@@ -1,0 +1,58 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util;
+
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.db.DAOException;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class DatabaseUtilIntegrationTest extends BaseContextSensitiveTest {
+	
+	@Autowired
+	AdministrationService adminService;
+	
+	/**
+	 * @verifies return concept_id for drug_order_quantity_units
+	 * @see DatabaseUtil#getConceptIdForUnits(java.sql.Connection, String)
+	 */
+	@Test
+	public void getConceptIdForUnits_shouldReturnConcept_idForDrug_order_quantity_units() throws Exception {
+		adminService.saveGlobalProperty(new GlobalProperty(OpenmrsConstants.GP_ORDER_ENTRY_UNITS_TO_CONCEPTS_MAPPINGS,
+		        "mg:5401,drug_order_quantity_units:5403,ounces:5402"));
+		Context.flushSession();
+		
+		Integer conceptId = DatabaseUtil.getConceptIdForUnits(getConnection(), "drug_order_quantity_units");
+		
+		Assert.assertThat(conceptId, Is.is(5403));
+	}
+	
+	/**
+	 * @verifies fail if units is not specified
+	 * @see DatabaseUtil#getConceptIdForUnits(java.sql.Connection, String)
+	 */
+	@Test(expected = DAOException.class)
+	public void getConceptIdForUnits_shouldFailIfUnitsIsNotSpecified() throws Exception {
+		adminService.saveGlobalProperty(new GlobalProperty(OpenmrsConstants.GP_ORDER_ENTRY_UNITS_TO_CONCEPTS_MAPPINGS,
+		        "mg:5401,ounces:5402"));
+		Context.flushSession();
+		
+		DatabaseUtil.getConceptIdForUnits(getConnection(), "drug_order_quantity_units");
+	}
+}


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-4129

This is ready to be merged. I'm still working on a migration changeset, which will use the drugOrder.unitsToQuantityUnits gp to migrate freetext units to coded quantityUnits.
