### PR TITLE
Trunk 3195

### DIFF
--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -92,7 +92,7 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 			if (containingAnyFormField.isEmpty()) {
 				Assert.assertEquals(1, formsReturned.size());
 			} else {
-		// put formfield IDs in containingAnyFormField to a Arraylist
+		//  put formfield IDs in containingAnyFormField to a Arraylist
 				Assert.assertEquals(1, formsReturned.size());
 				for (FormField formField : containingAnyFormField) {
 					formFieldIds.add(formField.getId());


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-3195

two test cases:
1) when containingAnyFormField  is empty it should return all the forms
2) when containingAnyFormField  has formfields, it should return all values that have any one or more matching form fields in the containingAnyFormField parameter
