### PR TITLE
TRUNK-3909, backport edit_privilege fix to 1.9.x

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -2340,16 +2340,14 @@
 	</changeSet>
 	
 	<changeSet id="200902142213" author="ewolodzko" dbms="mysql">
-		<validCheckSum>3:ace82a1ecb3a0c3246e39f0bebe38423</validCheckSum> <!-- original checksum -->
-		<validCheckSum>3:288804e42d575fe62c852ed9daa9d59d</validCheckSum> <!-- current checksum with TRUNK-4025 fix-->
 		<comment>
 			Add default sortWeights to all current PersonAttributeTypes
 		</comment>
-		<sql>
-			<![CDATA[
-			UPDATE  person_attribute_type as A JOIN person_attribute_type as B ON A.name = B.name  SET A.sort_weight = (select count(*) from (select * from person_attribute_type) pat where pat.name < A.name) WHERE A.sort_weight is null;
-			]]>
-		</sql>
+		<update tableName="person_attribute_type" >
+			<!-- The weird (select * from person_attribute_type) is needed here instead of just (person_attribute_type) to avoid sql ERROR 1093 -->
+			<column name="sort_weight" valueNumeric="((select count(*) from (select * from person_attribute_type) pat where pat.name &lt; person_attribute_type.name))" />
+			<where>sort_weight is null</where>
+		</update>
 	</changeSet>
 	
 	<changeSet id="200906301606" author="bwolfe" dbms="mysql">


### PR DESCRIPTION
While working on upgrading Malawi database from 1.7 to 1.9.x I ran in the problem that is described in these openmrs core tickets: TRUNK-3386 and TRUNK-3909. I just backported into 1.9.x liquibase-update-to-latest.xml the changes included here.
Once I made this small change the database upgrade completed successfully (still testing to make sure all malawi features still work).
