### PR TITLE
TRUNK-4254 : Allow configurable number of days after which visit can be auto closed

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
@@ -36,21 +36,24 @@ import org.openmrs.util.SystemClock;
 public class AutoCloseVisitsTask extends AbstractTask {
 	
 	private static final Log log = LogFactory.getLog(AutoCloseVisitsTask.class);
-    private AdministrationService administrationService;
-    private VisitService visitService;
-    private Clock clock;
-
-    public AutoCloseVisitsTask(AdministrationService administrationService, VisitService visitService, Clock clock) {
-        this.administrationService = administrationService;
-        this.visitService = visitService;
-        this.clock = clock;
-    }
-
-    public AutoCloseVisitsTask() {
-        this(Context.getAdministrationService(), Context.getVisitService(), new SystemClock());
-    }
-
-    /**
+	
+	private AdministrationService administrationService;
+	
+	private VisitService visitService;
+	
+	private Clock clock;
+	
+	public AutoCloseVisitsTask(AdministrationService administrationService, VisitService visitService, Clock clock) {
+		this.administrationService = administrationService;
+		this.visitService = visitService;
+		this.clock = clock;
+	}
+	
+	public AutoCloseVisitsTask() {
+		this(Context.getAdministrationService(), Context.getVisitService(), new SystemClock());
+	}
+	
+	/**
 	 * @see org.openmrs.scheduler.tasks.AbstractTask#execute()
 	 */
 	@Override
@@ -61,9 +64,11 @@ public class AutoCloseVisitsTask extends AbstractTask {
 			
 			startExecuting();
 			try {
-                String minimumNumberOfDaysProperty = administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS);
-                Integer minimumNumberOfDays = NumberUtils.toInt(minimumNumberOfDaysProperty, OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS_DEFAULT_VALUE);
-                visitService.stopVisits(DateUtils.addDays(clock.getCurrentTime(), -1 * minimumNumberOfDays));
+				String minimumNumberOfDaysProperty = administrationService
+				        .getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS);
+				Integer minimumNumberOfDays = NumberUtils.toInt(minimumNumberOfDaysProperty,
+				    OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS_DEFAULT_VALUE);
+				visitService.stopVisits(DateUtils.addDays(clock.getCurrentTime(), -1 * minimumNumberOfDays));
 			}
 			catch (Exception e) {
 				log.error("Error while auto closing visits:", e);

--- a/api/src/main/java/org/openmrs/util/Clock.java
+++ b/api/src/main/java/org/openmrs/util/Clock.java
@@ -15,6 +15,17 @@ package org.openmrs.util;
 
 import java.util.Date;
 
+/**
+ * Facilitates unit testing the application logic depending on current time.
+ * Default implementation returning <code>new Date()</code> will be used in application code.
+ * FakeClock or stubbed clock instance will be used in unit tests.
+ */
 public interface Clock {
-    Date getCurrentTime();
+	
+	/**
+	 * Get current time.
+	 *
+	 * @return <code>Date</code> representing the current time
+	 */
+	Date getCurrentTime();
 }

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -1013,9 +1013,9 @@ public final class OpenmrsConstants {
 	public static final String GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS = "visits.autoCloseMinimumNumberOfDays";
 	
 	public static final int GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS_DEFAULT_VALUE = 0;
-
+	
 	public static final String GP_CONCEPT_INDEX_UPDATE_TASK_LAST_UPDATED_CONCEPT = "concept.IndexUpdateTask.lastConceptUpdated";
-
+	
 	public static final String GP_CASE_SENSITIVE_NAMES_IN_CONCEPT_NAME_TABLE = "concept.caseSensitiveNamesInConceptNameTable";
 	
 	/**
@@ -1426,7 +1426,7 @@ public final class OpenmrsConstants {
 		props.add(new GlobalProperty(GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS, String
 		        .valueOf(GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS_DEFAULT_VALUE),
 		        "Minimum number of days after which visit should be auto closed"));
-
+		
 		props.add(new GlobalProperty(GP_DEFAULT_CONCEPT_MAP_TYPE, "NARROWER-THAN",
 		        "Default concept map type which is used when no other is set"));
 		

--- a/api/src/main/java/org/openmrs/util/SystemClock.java
+++ b/api/src/main/java/org/openmrs/util/SystemClock.java
@@ -15,9 +15,20 @@ package org.openmrs.util;
 
 import java.util.Date;
 
+/**
+ * Default implementation of Clock which will be used in application code.
+ */
 public class SystemClock implements Clock {
-    @Override
-    public Date getCurrentTime() {
-        return new Date();
-    }
+	
+	/**
+	 * Get current time.
+	 *
+	 * @return <code>Date</code> object representing the current time.
+	 *
+	 * @see java.util.Date#Date()
+	 */
+	@Override
+	public Date getCurrentTime() {
+		return new Date();
+	}
 }

--- a/api/src/test/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTaskTest.java
+++ b/api/src/test/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTaskTest.java
@@ -17,61 +17,74 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AutoCloseVisitsTaskTest {
-    @Mock
-    private AdministrationService administrationService;
-    @Mock
-    private VisitService visitService;
-    @Mock
-    private Clock clock;
-    private AutoCloseVisitsTask autoCloseVisitsTask;
-
-    @Before
-    public void setUp(){
-        initMocks(this);
-        autoCloseVisitsTask = new AutoCloseVisitsTask(administrationService, visitService, clock);
-    }
-
-    @Test
-    public void shouldCloseAllVisitsBeforeConfiguredNumberOfDaysWhenGlobalPropertyIsSet() throws Exception {
-        when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS)).thenReturn("2");
-        when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
-
-        autoCloseVisitsTask.execute();
-
-        verify(visitService).stopVisits(getDate("2014-02-09"));
-    }
-
-    @Test
-    public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsNotSet() throws Exception {
-        when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS)).thenReturn("");
-        when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
-
-        autoCloseVisitsTask.execute();
-
-        verify(visitService).stopVisits(getDate("2014-02-11"));
-    }
-
-    @Test
-    public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsSetToZero() throws Exception {
-        when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS)).thenReturn("0");
-        when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
-
-        autoCloseVisitsTask.execute();
-
-        verify(visitService).stopVisits(getDate("2014-02-11"));
-    }
-
-    @Test
-    public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsSetToNonIntegerValue() throws Exception {
-        when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS)).thenReturn("foo");
-        when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
-
-        autoCloseVisitsTask.execute();
-
-        verify(visitService).stopVisits(getDate("2014-02-11"));
-    }
-
-    private Date getDate(String str) throws ParseException {
-        return DateUtils.parseDate(str, "yyyy-mm-dd");
-    }
+	
+	@Mock
+	private AdministrationService administrationService;
+	
+	@Mock
+	private VisitService visitService;
+	
+	@Mock
+	private Clock clock;
+	
+	private AutoCloseVisitsTask autoCloseVisitsTask;
+	
+	@Before
+	public void setUp() {
+		initMocks(this);
+		autoCloseVisitsTask = new AutoCloseVisitsTask(administrationService, visitService, clock);
+	}
+	
+	@Test
+	public void shouldCloseAllVisitsBeforeConfiguredNumberOfDaysWhenGlobalPropertyIsSet() throws Exception {
+		when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS))
+		        .thenReturn("2");
+		when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
+		
+		autoCloseVisitsTask.execute();
+		
+		verifyStopsVisitsStartedBeforeDate("2014-02-09");
+	}
+	
+	@Test
+	public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsNotSet() throws Exception {
+		when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS))
+		        .thenReturn("");
+		when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
+		
+		autoCloseVisitsTask.execute();
+		
+		verifyStopsVisitsStartedBeforeDate("2014-02-11");
+	}
+	
+	@Test
+	public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsSetToZero() throws Exception {
+		when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS))
+		        .thenReturn("0");
+		when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
+		
+		autoCloseVisitsTask.execute();
+		
+		verifyStopsVisitsStartedBeforeDate("2014-02-11");
+	}
+	
+	@Test
+	public void shouldCloseAllVisitsBeforeCurrentTimeWhenGlobalPropertyIsSetToNonIntegerValue() throws Exception {
+		when(administrationService.getGlobalProperty(OpenmrsConstants.GP_VISIT_AUTO_CLOSE_MINIMUM_NUMBER_OF_DAYS))
+		        .thenReturn("foo");
+		when(clock.getCurrentTime()).thenReturn(getDate("2014-02-11"));
+		
+		autoCloseVisitsTask.execute();
+		
+		verifyStopsVisitsStartedBeforeDate("2014-02-11");
+	}
+	
+	private void verifyStopsVisitsStartedBeforeDate(String dateString) throws ParseException {
+		Date expectedMaximumVisitStartDate = getDate(dateString);
+		verify(visitService).stopVisits(expectedMaximumVisitStartDate);
+	}
+	
+	private Date getDate(String str) throws ParseException {
+		return DateUtils.parseDate(str, "yyyy-mm-dd");
+	}
 }


### PR DESCRIPTION
I have changed AutoCloseVisitsTask to read a global property which indicates minimum number of visit days allowed before auto closing visit. The default value will be 0, so it continues to work the same way it is now.
