### PR TITLE
TRUNK-3197: An option is added for each sort Obs to be in asc or desc order

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
@@ -180,7 +180,7 @@ public class HibernateObsDAO implements ObsDAO {
 	 * @param answers
 	 * @param personTypes
 	 * @param locations
-	 * @param sortList
+	 * @param sortList If a field needs to be in <i>asc</i> order, <code>" asc"</code> has to be appended to the field name. For example: <code>fieldname asc</code>
 	 * @param mostRecentN
 	 * @param obsGroupId
 	 * @param fromDate
@@ -218,11 +218,20 @@ public class HibernateObsDAO implements ObsDAO {
 			criteria.add(Restrictions.in("location", locations));
 		}
 		
-		// TODO add an option for each sort item to be asc/desc
 		if (CollectionUtils.isNotEmpty(sortList)) {
 			for (String sort : sortList) {
 				if (sort != null && !"".equals(sort)) {
-					criteria.addOrder(Order.desc(sort));
+					// Split the sort, the field name shouldn't contain space char, so it's safe
+					String[] split = sort.split(" ", 2);
+					String fieldName = split[0];
+					
+					if (split.length == 2 && "asc".equals(split[1])) {
+						/* If asc is specified */
+						criteria.addOrder(Order.asc(fieldName));
+					} else {
+						/* If the field hasn't got ordering or desc is specified */
+						criteria.addOrder(Order.desc(fieldName));
+					}
 				}
 			}
 		}

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateObsDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateObsDAOTest.java
@@ -1,0 +1,92 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.api.db.hibernate;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
+import org.hibernate.criterion.Order;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Obs;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.test.Verifies;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Tests for {@link org.openmrs.api.db.hibernate.HibernateObsDAO}
+ */
+public class HibernateObsDAOTest extends BaseContextSensitiveTest {
+	
+	private HibernateObsDAO dao = null;
+	
+	private SessionFactory sessionFactory = null;
+	
+	@Before
+	public void setUp() throws Exception {
+		if (dao == null)
+			// fetch the dao from the spring application context
+			dao = (HibernateObsDAO) applicationContext.getBean("obsDAO");
+		
+		sessionFactory = (SessionFactory) applicationContext.getBean("sessionFactory");
+	}
+	
+	/**
+	 * @verifies the order of the fetched Obs is proper according to the specified sort options
+	 * @see org.openmrs.api.db.hibernate.HibernateObsDAO#getObservations(java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, Integer, Integer, java.util.Date, java.util.Date, boolean)
+	 */
+	@Test
+	@Verifies(value = "the order of the fetched Obs is proper according to the specified sort options", method = "getObservations(java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, java.util.List, Integer, Integer, java.util.Date, java.util.Date, boolean)")
+	public void getObservations_shouldBeOrderedCorrectly() throws Exception {
+		Session session = sessionFactory.getCurrentSession();
+		
+		List<Obs> obsListActual;
+		List<Obs> obsListExpected;
+		
+		//Order by id desc
+		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.desc("id")).list();
+		
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id"), null, null, null, null,
+		    false);
+		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
+		
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id desc"), null, null, null,
+		    null, false);
+		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
+		
+		//Order by id asc
+		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.asc("id")).list();
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id asc"), null, null, null,
+		    null, false);
+		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
+		
+		//Order by person_id asc and id desc
+		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.asc("person.id")).addOrder(
+		    Order.desc("id")).list();
+		
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("person.id asc", "id"), null,
+		    null, null, null, false);
+		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
+		
+		//Order by person_id asc and id asc
+		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.asc("person.id"))
+		        .addOrder(Order.asc("id")).list();
+		
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("person.id asc", "id asc"),
+		    null, null, null, null, false);
+		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
+	}
+}


### PR DESCRIPTION
**Description:**

> TODO: add an option for each sort item to be asc/desc
> File: /openmrs/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
> Line: 213

**@dkayiwa Daniel Kayiwa's advice:**

> My advice is that when iterating over the sortList parameter, for each non empty sort, check if it has a sort order and use it. Else revert to the default as the existing code.
> To give an example of the contents of the sortList: "field1 asc", "field2", "field3 desc".
> From the above, you would sort field1 in ascending order, you would sort field2 using the existing default, and you would sort field3 in descending order, and more.

From these sources, I've implemented the advice, please review.
