### PR TITLE
[#TRUNK-4274] Order.encounter should be required

### DIFF
--- a/api/src/main/java/org/openmrs/api/OrderService.java
+++ b/api/src/main/java/org/openmrs/api/OrderService.java
@@ -361,7 +361,8 @@ public interface OrderService extends OpenmrsService {
 	 * @should fail for a discontinuation order
 	 */
 	@Authorized(PrivilegeConstants.ADD_ORDERS)
-	public Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate) throws Exception;
+	public Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate, Encounter encounter)
+	        throws Exception;
 	
 	/**
 	 * Discontinues an order. Creates a new order that discontinues the orderToDiscontinue.
@@ -379,7 +380,8 @@ public interface OrderService extends OpenmrsService {
 	 * @should fail for a voided order
 	 */
 	@Authorized(PrivilegeConstants.ADD_ORDERS)
-	public Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate) throws Exception;
+	public Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate, Encounter encounter)
+	        throws Exception;
 	
 	/**
 	 * Creates or updates the given order frequency in the database

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -410,25 +410,29 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	
 	/**
 	 * @see org.openmrs.api.OrderService#discontinueOrder(org.openmrs.Order, org.openmrs.Concept,
-	 *      java.util.Date)
+	 *      java.util.Date, org.openmrs.Encounter)
 	 */
 	@Override
-	public Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate) throws Exception {
+	public Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate, Encounter encounter)
+	        throws Exception {
 		stopOrder(orderToDiscontinue, discontinueDate);
 		Order newOrder = orderToDiscontinue.cloneForDiscontinuing();
 		newOrder.setOrderReason(reasonCoded);
+		newOrder.setEncounter(encounter);
 		
 		return saveOrderInternal(newOrder);
 	}
 	
 	/**
-	 * @see org.openmrs.api.OrderService#discontinueOrder(org.openmrs.Order, String, java.util.Date)
+	 * @see org.openmrs.api.OrderService#discontinueOrder(org.openmrs.Order, String, java.util.Date, org.openmrs.Encounter)
 	 */
 	@Override
-	public Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate) throws Exception {
+	public Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate, Encounter encounter)
+	        throws Exception {
 		stopOrder(orderToDiscontinue, discontinueDate);
 		Order newOrder = orderToDiscontinue.cloneForDiscontinuing();
 		newOrder.setOrderReasonNonCoded(reasonNonCoded);
+		newOrder.setEncounter(encounter);
 		
 		return saveOrderInternal(newOrder);
 	}

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -7050,5 +7050,14 @@
         <addForeignKeyConstraint constraintName="fk_orderer_provider" baseTableName="orders" baseColumnNames="orderer"
                                  referencedTableName="provider" referencedColumnNames="provider_id" />
     </changeSet>
+    
+    <changeSet id="201402281648-TRUNK-4274" author="k-joseph">
+		<comment>Making order.encounter required</comment>
+		<ext:modifyColumn tableName="orders">
+			<column name="encounter_id" type="int">
+				<constraints nullable="false" />
+			</column>
+		</ext:modifyColumn>
+	</changeSet>
 
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Order.hbm.xml
@@ -54,7 +54,7 @@
 			<column name="concept_id" />
 		</many-to-one>
 		<!-- bi-directional many-to-one association to Encounter -->
-		<many-to-one name="encounter" class="org.openmrs.Encounter">
+		<many-to-one name="encounter" class="org.openmrs.Encounter" not-null="true">
 			<column name="encounter_id" />
 		</many-to-one>
 

--- a/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
@@ -135,14 +135,16 @@ public class OrderEntryIntegrationTest extends BaseContextSensitiveTest {
 		int ordersCount = orderService.getActiveOrders(patient, null, null, null).size();
 		
 		Concept discontinueReason = Context.getConceptService().getConcept(1);
-		Order discontinuationOrder1 = orderService.discontinueOrder(firstOrderToDiscontinue, discontinueReason, null);
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		Order discontinuationOrder1 = orderService.discontinueOrder(firstOrderToDiscontinue, discontinueReason, null,
+		    encounter);
 		assertEquals(firstOrderToDiscontinue, discontinuationOrder1.getPreviousOrder());
 		
 		//Lets discontinue another order with reason being a string instead of concept
 		Order secondOrderToDiscontinue = orderService.getOrder(5);
 		assertEquals(patient, secondOrderToDiscontinue.getPatient());
 		assertTrue(OrderUtil.isOrderActive(secondOrderToDiscontinue, null));
-		Order discontinuationOrder2 = orderService.discontinueOrder(secondOrderToDiscontinue, "Testing", null);
+		Order discontinuationOrder2 = orderService.discontinueOrder(secondOrderToDiscontinue, "Testing", null, encounter);
 		assertEquals(secondOrderToDiscontinue, discontinuationOrder2.getPreviousOrder());
 		
 		//Lets discontinue another order by saving a DC order

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -41,6 +41,7 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.Drug;
 import org.openmrs.DrugOrder;
+import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Order.Action;
@@ -64,6 +65,8 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	
 	private PatientService patientService;
 	
+	private EncounterService encounterService;
+	
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 	
@@ -78,6 +81,9 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		
 		if (conceptService == null) {
 			conceptService = Context.getConceptService();
+		}
+		if (encounterService == null) {
+			encounterService = Context.getEncounterService();
 		}
 	}
 	
@@ -482,11 +488,12 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "populate correct attributes on the discontinue and discontinued orders", method = "discontinueOrder(Order, String, Date)")
 	public void discontinueOrderWithNonCodedReason_shouldPopulateCorrectAttributesOnBothOrders() throws Exception {
 		Order order = orderService.getOrderByOrderNumber("111");
+		Encounter encounter = encounterService.getEncounter(3);
 		assertTrue(OrderUtil.isOrderActive(order, null));
 		Date discontinueDate = new Date();
 		String discontinueReasonNonCoded = "Test if I can discontinue this";
 		
-		Order discontinueOrder = orderService.discontinueOrder(order, discontinueReasonNonCoded, discontinueDate);
+		Order discontinueOrder = orderService.discontinueOrder(order, discontinueReasonNonCoded, discontinueDate, encounter);
 		
 		Assert.assertEquals(order.getDateStopped(), discontinueDate);
 		Assert.assertNotNull(discontinueOrder);
@@ -505,10 +512,11 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		executeDataSet("org/openmrs/api/include/OrderServiceTest-discontinueReason.xml");
 		
 		Order order = orderService.getOrderByOrderNumber("111");
+		Encounter encounter = encounterService.getEncounter(3);
 		Date discontinueDate = new Date();
 		Concept concept = Context.getConceptService().getConcept(1);
 		
-		Order discontinueOrder = orderService.discontinueOrder(order, concept, discontinueDate);
+		Order discontinueOrder = orderService.discontinueOrder(order, concept, discontinueDate, encounter);
 		
 		Assert.assertEquals(order.getDateStopped(), discontinueDate);
 		Assert.assertNotNull(discontinueOrder);
@@ -526,9 +534,10 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	public void discontinueOrderWithNonCodedReason_shouldFailForADiscontinueOrder() throws Exception {
 		executeDataSet("org/openmrs/api/include/OrderServiceTest-discontinuedOrder.xml");
 		OrderService orderService = Context.getOrderService();
+		Encounter encounter = encounterService.getEncounter(3);
 		Order discontinueOrder = orderService.getOrder(26);
 		
-		orderService.discontinueOrder(discontinueOrder, "Test if I can discontinue this", null);
+		orderService.discontinueOrder(discontinueOrder, "Test if I can discontinue this", null, encounter);
 	}
 	
 	/**
@@ -541,8 +550,9 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		executeDataSet("org/openmrs/api/include/OrderServiceTest-discontinueReason.xml");
 		OrderService orderService = Context.getOrderService();
 		Order discontinueOrder = orderService.getOrder(26);
+		Encounter encounter = encounterService.getEncounter(3);
 		
-		orderService.discontinueOrder(discontinueOrder, (Concept) null, null);
+		orderService.discontinueOrder(discontinueOrder, (Concept) null, null, encounter);
 	}
 	
 	/**
@@ -626,7 +636,8 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		CareSetting careSetting = orderService.getCareSetting(1);
 		Order orderToDiscontinue = orderService.getActiveOrders(patient, Order.class, careSetting, null).get(0);
-		orderService.discontinueOrder(orderToDiscontinue, new Concept(), cal.getTime());
+		Encounter encounter = encounterService.getEncounter(3);
+		orderService.discontinueOrder(orderToDiscontinue, new Concept(), cal.getTime(), encounter);
 	}
 	
 	/**
@@ -639,7 +650,8 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		cal.add(Calendar.HOUR_OF_DAY, 1);
 		Order orderToDiscontinue = orderService.getActiveOrders(Context.getPatientService().getPatient(2), Order.class,
 		    orderService.getCareSetting(1), null).get(0);
-		orderService.discontinueOrder(orderToDiscontinue, "Testing", cal.getTime());
+		Encounter encounter = encounterService.getEncounter(3);
+		orderService.discontinueOrder(orderToDiscontinue, "Testing", cal.getTime(), encounter);
 	}
 	
 	/**
@@ -702,8 +714,9 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	@Test(expected = APIException.class)
 	public void discontinueOrder_shouldFailForAStoppedOrder() throws Exception {
 		Order orderToDiscontinue = orderService.getOrder(1);
+		Encounter encounter = encounterService.getEncounter(3);
 		assertNotNull(orderToDiscontinue.getDateStopped());
-		orderService.discontinueOrder(orderToDiscontinue, Context.getConceptService().getConcept(1), null);
+		orderService.discontinueOrder(orderToDiscontinue, Context.getConceptService().getConcept(1), null, encounter);
 	}
 	
 	/**
@@ -713,8 +726,9 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	@Test(expected = APIException.class)
 	public void discontinueOrder_shouldFailForAVoidedOrder() throws Exception {
 		Order orderToDiscontinue = orderService.getOrder(8);
+		Encounter encounter = encounterService.getEncounter(3);
 		assertTrue(orderToDiscontinue.isVoided());
-		orderService.discontinueOrder(orderToDiscontinue, "testing", null);
+		orderService.discontinueOrder(orderToDiscontinue, "testing", null, encounter);
 	}
 	
 	/**
@@ -724,9 +738,10 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	@Test(expected = APIException.class)
 	public void discontinueOrder_shouldFailForAnExpiredOrder() throws Exception {
 		Order orderToDiscontinue = orderService.getOrder(6);
+		Encounter encounter = encounterService.getEncounter(3);
 		assertNotNull(orderToDiscontinue.getAutoExpireDate());
 		assertTrue(orderToDiscontinue.getAutoExpireDate().before(new Date()));
-		orderService.discontinueOrder(orderToDiscontinue, Context.getConceptService().getConcept(1), null);
+		orderService.discontinueOrder(orderToDiscontinue, Context.getConceptService().getConcept(1), null, encounter);
 	}
 	
 	/**


### PR DESCRIPTION
fix for https://tickets.openmrs.org/browse/TRUNK-4274 | made orders.encounter_id nullable, updated Update OrderService.discontinueOrder() and resolved the failing unit tests
