### PR TITLE
seperate drop foreign key contraint and drop column into two change sets TRUNK 4198

### DIFF
--- a/api/src/main/java/org/openmrs/util/databasechange/CreateDiscontinueOrders.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/CreateDiscontinueOrders.java
@@ -61,7 +61,7 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 			insertStatement = connection
 			        .prepareStatement("Insert into orders(previous_order_id, concept_id, patient_id, encounter_id, "
 			                + "creator, date_created, date_stopped, discontinued_by, discontinued_reason, discontinued_reason_non_coded, "
-			                + "uuid, order_action, order_type_id, orderer, order_number) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+			                + "uuid, order_action, orderer, order_number) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 			for (DiscontinuedOrder discontinuedOrder : discontinuedOrders) {
 				insertStatement.setInt(1, discontinuedOrder.previousOrderId);
 				insertStatement.setInt(2, discontinuedOrder.conceptId);
@@ -75,9 +75,8 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 				insertStatement.setString(10, discontinuedOrder.discontinuedReasonNonCoded);
 				insertStatement.setString(11, UUID.randomUUID().toString());
 				insertStatement.setString(12, Order.Action.DISCONTINUE.name());
-				insertStatement.setInt(13, discontinuedOrder.orderTypeId);
-				setIntOrNull(insertStatement, 14, discontinuedOrder.orderer);
-				insertStatement.setString(15, discontinuedOrder.orderNumber);
+				setIntOrNull(insertStatement, 13, discontinuedOrder.orderer);
+				insertStatement.setString(14, discontinuedOrder.orderNumber);
 				insertStatement.addBatch();
 				
 				if (index % batchSize == 0) {
@@ -123,14 +122,13 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 		PreparedStatement statement = null;
 		try {
 			statement = connection
-			        .prepareStatement("select order_id, concept_id, patient_id, encounter_id, date_stopped, discontinued_by, discontinued_reason, discontinued_reason_non_coded, order_type_id, orderer from orders where discontinued = ?");
+			        .prepareStatement("select order_id, concept_id, patient_id, encounter_id, date_stopped, discontinued_by, discontinued_reason, discontinued_reason_non_coded, orderer from orders where discontinued = ?");
 			statement.setBoolean(1, true);
 			ResultSet rs = statement.executeQuery();
 			while (rs.next()) {
 				dc.add(new DiscontinuedOrder(rs.getInt("order_id"), rs.getInt("concept_id"), rs.getInt("patient_id"), rs
 				        .getInt("encounter_id"), rs.getInt("discontinued_by"), rs.getInt("discontinued_reason"), rs
-				        .getString("discontinued_reason_non_coded"), rs.getDate("date_stopped"), rs.getInt("order_type_id"),
-				        rs.getInt("orderer")));
+				        .getString("discontinued_reason_non_coded"), rs.getDate("date_stopped"), rs.getInt("orderer")));
 			}
 		}
 		catch (SQLException e) {
@@ -189,14 +187,12 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 		
 		public int previousOrderId;
 		
-		public int orderTypeId;
-		
 		public int orderer;
 		
 		public String orderNumber;
 		
 		private DiscontinuedOrder(int orderId, int conceptId, int patientId, int encounterId, int discontinuedById,
-		    int discontinuedReasonId, String discontinuedReasonNonCoded, Date dateStopped, int orderTypeId, int orderer) {
+		    int discontinuedReasonId, String discontinuedReasonNonCoded, Date dateStopped, int orderer) {
 			this.orderId = orderId;
 			this.previousOrderId = orderId;
 			this.conceptId = conceptId;
@@ -208,7 +204,6 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 			this.dateStopped = dateStopped;
 			this.creator = discontinuedById;
 			this.dateCreated = dateStopped;
-			this.orderTypeId = orderTypeId;
 			this.orderer = orderer;
 			this.orderNumber = String.valueOf(orderId).concat("-DC");
 		}

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -6755,6 +6755,22 @@
         <renameColumn tableName="orders" oldColumnName="discontinued_date" newColumnName="date_stopped" columnDataType="datetime"/>
     </changeSet>
 
+    <changeSet id="201403011303-TRUNK-4198_1" author="harsha">
+        <preConditions onFail="MARK_RAN">
+            <foreignKeyConstraintExists foreignKeyName="type_of_order"/>
+        </preConditions>
+        <comment>Dropping foreign key constraint on orders.order_type_id</comment>
+        <dropForeignKeyConstraint baseTableName="orders" constraintName="type_of_order"/>
+    </changeSet>
+
+    <changeSet id="201403011303-TRUNK-4198_2" author="harsha">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="orders" columnName="order_type_id"/>
+        </preConditions>
+        <comment>Remove the order_type_id column from orders table</comment>
+        <dropColumn tableName="orders" columnName="order_type_id"/>
+    </changeSet>
+
 	<changeSet id="201312201523-TRUNK-4138" author="banka">
         <preConditions onFail="HALT" onFailMessage="Please make sure all discontinued orders have the date_stopped field set">
             <sqlCheck expectedResult="0">select count(*) from orders where discontinued = true and date_stopped is null</sqlCheck>


### PR DESCRIPTION
I have made a new pull request as wyclif mention that I needs to separate drop foreign key constrain and drop column into two different changesets. 
