### PR TITLE
TRUNK-2224 Show appropriate notification message when void reason is empty when voiding a patient

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/messages.properties
+++ b/webapp/src/main/webapp/WEB-INF/messages.properties
@@ -1449,6 +1449,7 @@ Patient.saved=Patient saved
 Patient.delete=Delete Patient
 Patient.deleted=Patient deleted
 Patient.cannot.delete=This patient cannot be deleted
+Patient.error.delete.reasonEmpty=Delete reason cannot be empty
 Patient.voided=Patient deleted
 Patient.unvoided=Patient restored
 Patient.other.identifiers=Other Identifiers


### PR DESCRIPTION
(Repeating the comment put in the previous pr)
@dkayiwa
yaa true that but the point I am trying to make is.
When one clicks on "Delete" button the block containing the message:
action.equals(msa.getMessage("Patient.delete")) gets triggered and we can find out whether the "delete reason" provided by the user is empty or not,
by using the command, StringUtils.isNotBlank(patient.getVoidReason())
I have thoroughly tested this.
P.S. Talking about the version openmrs 1.11
