### PR TITLE
TRUNK-4292: Insert order types for drug and test orders

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -7129,7 +7129,7 @@
                                  referencedColumnNames="user_id"/>
     </changeSet>
     
-    <changeSet id="201403070131" author="andras-szell">
+    <changeSet id="201403070131-TRUNK-4286" author="andras-szell">
         <preConditions>
             <not><sqlCheck expectedResult="0">select count(*) from order_type where java_class like "org.openmrs.DrugOrder" or java_class like "org.openmrs.TestOrder"</sqlCheck></not>
         </preConditions>
@@ -7141,7 +7141,16 @@
             <column name="creator">1</column>
             <column name="date_created">CURRENT_TIMESTAMP</column>
             <column name="retired">false</column>
-            <column name="uuid"></column>
+            <column name="uuid">2ca568f3-a64a-11e3-9aeb-50e549534c5e</column>
+        </insert>
+        <insert tableName="order_type">
+            <column name="name">Test order</column>
+            <column name="description">Test order</column>
+            <column name="java_class_name">org.openmrs.TestOrder</column>
+            <column name="creator">1</column>
+            <column name="date_created">CURRENT_TIMESTAMP</column>
+            <column name="retired">false</column>
+            <column name="uuid">52a447d3-a64a-11e3-9aeb-50e549534c5e</column>
         </insert>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Insert order types for test and drug orders, these should be inserted conditionally, i.e must check that there are no entries in the order_type table with their java_class column set to org.openmrs.DrugOrder or org.openmrs.TestOrder

**NOT READY TO MERGE, ONLY FOR CODE REVIEW**
