### PR TITLE
TRUNK-3968 Need to have option to void Person when the person is also a patient

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
@@ -138,7 +138,12 @@ public class PersonFormController extends SimpleFormController {
 			Patient patient = (Patient) person;
 			// Redirect if we are not already in the patient form
 			if (!getFormView().contains("patient")) {
-				return new ModelAndView(new RedirectView("../patients/patient.form?patientId=" + patient.getId()));
+				Person person1 = (Person) person;
+				//return new ModelAndView(new RedirectView("../patients/patient.form?patientId=" + patient.getId()));
+				return new ModelAndView(new RedirectView("../person/person.form?personId="
+				        + person1.getPersonId().toString()));
+				//return new ModelAndView(new RedirectView("../person/person.form?personId="+ person1.getPersonId()));
+				//return new ModelAndView(new RedirectView("../person/person.form?personId=" + patient.getId()));
 			}
 		}
 		


### PR DESCRIPTION
This pull request is not for merge. I am unable to figure out the error caused in here.
If I register a patient with some patient-id then it is also registered in the person table with a particular id as seen from mysql database. (say the id in person table for it is patient_id)
If I register a person then it gets registered it gets added in the person table with a particular id as seen from mysql database. (say the id in person table for it is person_id).
Now when I go to the URL:
1. http://localhost:8080/openmrs/admin/person/person.form?personId=<person_id>
(person_id is a place holder for point 2)
It gives the correct output.
2. http://localhost:8080/openmrs/admin/person/person.form?personId=<patient_id>
(patient_id is a place holder for point 1)
It shows bad redirection page.
Screenshot attached in the Ticket.
https://tickets.openmrs.org/browse/TRUNK-3968
Kindly clarify. :)
