### PR TITLE
Substitute deprecated method call in HibernateContextDAO and added unit test

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -13,6 +13,7 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
@@ -387,11 +388,12 @@ public class HibernateContextDAO implements ContextDAO {
 		}
 		
 		// load in the default hibernate properties from hibernate.default.properties
-		InputStream propertyStream = null;
+		////InputStream propertyStream = null;
 		try {
 			Properties props = new Properties();
-			propertyStream = ConfigHelper.getResourceAsStream("/hibernate.default.properties");
-			OpenmrsUtil.loadProperties(props, propertyStream);
+			//propertyStream = ConfigHelper.getResourceAsStream("/hibernate.default.properties");
+			File file = new File(getClass().getClassLoader().getResource("/hibernate.default.properties").getFile());
+			OpenmrsUtil.loadProperties(props, file);
 			
 			// add in all default properties that don't exist in the runtime
 			// properties yet
@@ -401,13 +403,16 @@ public class HibernateContextDAO implements ContextDAO {
 				}
 			}
 		}
-		finally {
+		/*finally {
 			try {
 				propertyStream.close();
 			}
 			catch (Exception e) {
 				// pass
 			}
+		}*/
+		catch (Throwable t) {
+
 		}
 		
 	}

--- a/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
@@ -13,6 +13,8 @@
  */
 package org.openmrs.api.db;
 
+import java.util.Properties;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -349,6 +351,15 @@ public class ContextDAOTest extends BaseContextSensitiveTest {
 		// it would be illegal to save this user (with a whitespace username) but we can get it in the db via xml
 		User u = Context.getUserService().getUser(507);
 		dao.authenticate("  ", "password");
+	}
+	
+	@Verifies(value = "should mergeDefaultRuntimeProperties", method = "mergeDefaultRuntimeProperties(Properties runtimeProperties)")
+	@Test
+	public void mergeDefaultRuntimePropertiesTest() {
+		Properties propertiesForTest = new Properties();
+		propertiesForTest.setProperty("x", "y");   // ading properties for testing
+		dao.mergeDefaultRuntimeProperties(propertiesForTest);
+		Assert.assertNotNull(propertiesForTest.getProperty("hibernate.x")); // check whether "x" has converted to "hibernate.x"
 	}
 	
 }


### PR DESCRIPTION
https://tickets.openmrs.org/browse/TRUNK-4140

Removed deprecated method call.
Added a unit test. But the unit test fails. It throws a java.util.concurrentmodificationexception. Perhaps it could be a problem in HibernateContextDAO.mergeDefaultRuntimeProperties(Properties runtimeProperties) method. can you please check this?
