### PR TITLE
TRUNK-2224 Show appropriate notification message when void reason is empty when voiding a patient

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
+++ b/web/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
@@ -49,8 +49,8 @@ public class PatientDashboardController {
 	 * render the patient dashboard model and direct to the view
 	 */
 	@RequestMapping("/patientDashboard.form")
-	protected String renderDashboard(@RequestParam(required = true, value = "patientId") Integer patientId, ModelMap map, HttpServletRequest request)
-	        throws Exception {
+	protected String renderDashboard(@RequestParam(required = true, value = "patientId") Integer patientId, ModelMap map,
+	        HttpServletRequest request) throws Exception {
 		
 		// get the patient
 		

--- a/webapp/src/main/webapp/WEB-INF/messages.properties
+++ b/webapp/src/main/webapp/WEB-INF/messages.properties
@@ -1450,6 +1450,7 @@ Patient.saved=Patient saved
 Patient.delete=Delete Patient
 Patient.deleted=Patient deleted
 Patient.cannot.delete=This patient cannot be deleted
+Patient.error.delete.reasonEmpty=Delete reason cannot be empty
 Patient.voided=Patient deleted
 Patient.unvoided=Patient restored
 Patient.other.identifiers=Other Identifiers


### PR DESCRIPTION
Repeating the comment put in the previous pr)
@dkayiwa
yaa true that but the point I am trying to make is.
When one clicks on "Delete" button the block containing the message:
action.equals(msa.getMessage("Patient.delete")) gets triggered and we can find out whether the "delete reason" provided by the user is empty or not,
by using the command, StringUtils.isNotBlank(patient.getVoidReason())
I have thoroughly tested this.
P.S. Talking about the version openmrs 1.11
