### PR TITLE
Adding new validation rules for orders and drugOrders.

### DIFF
--- a/api/src/main/java/org/openmrs/Order.java
+++ b/api/src/main/java/org/openmrs/Order.java
@@ -13,11 +13,11 @@
  */
 package org.openmrs;
 
-import java.util.Date;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.order.OrderUtil;
+
+import java.util.Date;
 
 /**
  * Dates should be interpreted as follows: If startDate is null then the order has been going on

--- a/api/src/main/java/org/openmrs/aop/RequiredDataAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/RequiredDataAdvice.java
@@ -166,8 +166,9 @@ public class RequiredDataAdvice implements MethodBeforeAdvice {
 			
 			if (methodName.startsWith("void")) {
 				Voidable voidable = (Voidable) args[0];
+				Date dateVoided = voidable.getDateVoided() == null ? new Date() : voidable.getDateVoided();
 				String voidReason = (String) args[1];
-				recursivelyHandle(VoidHandler.class, voidable, voidReason);
+				recursivelyHandle(VoidHandler.class, voidable, Context.getAuthenticatedUser(), dateVoided, voidReason, null);
 				
 			} else if (methodName.startsWith("unvoid")) {
 				Voidable voidable = (Voidable) args[0];

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
@@ -13,9 +13,6 @@
  */
 package org.openmrs.api.handler;
 
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Order;
@@ -26,6 +23,9 @@ import org.openmrs.aop.RequiredDataAdvice;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  * This class deals with {@link Patient} objects when they are unvoided via the unvoid* method in an

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
@@ -13,19 +13,17 @@
  */
 package org.openmrs.api.handler;
 
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.openmrs.Encounter;
-import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
 import org.openmrs.api.EncounterService;
-import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
+
+import java.util.Date;
+import java.util.List;
 
 /**
  * This class deals with {@link Patient} objects when they are voided via a void* method in an
@@ -61,17 +59,6 @@ public class PatientDataVoidHandler implements VoidHandler<Patient> {
 					//with the patient
 					encounter.setDateVoided(patient.getDateVoided());
 					es.voidEncounter(encounter, voidReason);
-				}
-			}
-		}
-		//void all the orders associated with this patient
-		OrderService os = Context.getOrderService();
-		List<Order> orders = os.getAllOrdersByPatient(patient);
-		if (CollectionUtils.isNotEmpty(orders)) {
-			for (Order order : orders) {
-				if (!order.isVoided()) {
-					order.setDateVoided(patient.getDateVoided());
-					os.voidOrder(order, voidReason);
 				}
 			}
 		}

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -13,14 +13,6 @@
  */
 package org.openmrs.api.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
-
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Cohort;
 import org.openmrs.Encounter;
@@ -52,6 +44,14 @@ import org.openmrs.util.PrivilegeConstants;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
 
 /**
  * Default implementation of the {@link EncounterService}

--- a/api/src/main/java/org/openmrs/validator/OrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/OrderValidator.java
@@ -55,7 +55,11 @@ public class OrderValidator implements Validator {
 	 * @should fail validation if voided is null
 	 * @should fail validation if concept is null
 	 * @should fail validation if patient is null
+	 * @should fail validation if encounter is null
 	 * @should fail validation if orderer is null
+	 * @should fail validation if urgency is null
+	 * @should fail validation if action is null
+	 * @should fail validation if startDate is null
 	 * @should fail validation if startDate after dateStopped
 	 * @should fail validation if startDate after autoExpireDate
 	 * @should pass validation if all fields are correct
@@ -65,31 +69,41 @@ public class OrderValidator implements Validator {
 		if (order == null) {
 			errors.rejectValue("order", "error.general");
 		} else {
-			if (order.getEncounter() != null && order.getPatient() != null) {
-				if (!order.getEncounter().getPatient().equals(order.getPatient()))
-					errors.rejectValue("encounter", "Order.error.encounterPatientMismatch");
-			}
-			
 			// for the following elements Order.hbm.xml says: not-null="true"
 			ValidationUtils.rejectIfEmpty(errors, "voided", "error.null");
 			ValidationUtils.rejectIfEmpty(errors, "concept", "Concept.noConceptSelected");
 			ValidationUtils.rejectIfEmpty(errors, "patient", "error.null");
+			ValidationUtils.rejectIfEmpty(errors, "encounter", "error.null");
 			ValidationUtils.rejectIfEmpty(errors, "orderer", "error.null");
+			ValidationUtils.rejectIfEmpty(errors, "urgency", "error.null");
+			ValidationUtils.rejectIfEmpty(errors, "startDate", "error.null");
+			ValidationUtils.rejectIfEmpty(errors, "action", "error.null");
 			
-			Date startDate = order.getStartDate();
-			if (startDate != null) {
-				Date dateStopped = order.getDateStopped();
-				if (dateStopped != null && startDate.after(dateStopped)) {
-					errors.rejectValue("startDate", "Order.error.startDateAfterDiscontinuedDate");
-					errors.rejectValue("dateStopped", "Order.error.startDateAfterDiscontinuedDate");
-				}
-				
-				Date autoExpireDate = order.getAutoExpireDate();
-				if (autoExpireDate != null && startDate.after(autoExpireDate)) {
-					errors.rejectValue("startDate", "Order.error.startDateAfterAutoExpireDate");
-					errors.rejectValue("autoExpireDate", "Order.error.startDateAfterAutoExpireDate");
-				}
+			validateSamePatientInOrderAndEncounter(order, errors);
+			validateStartDate(order, errors);
+		}
+	}
+	
+	private void validateStartDate(Order order, Errors errors) {
+		Date startDate = order.getStartDate();
+		if (startDate != null) {
+			Date dateStopped = order.getDateStopped();
+			if (dateStopped != null && startDate.after(dateStopped)) {
+				errors.rejectValue("startDate", "Order.error.startDateAfterDiscontinuedDate");
+				errors.rejectValue("dateStopped", "Order.error.startDateAfterDiscontinuedDate");
 			}
+			Date autoExpireDate = order.getAutoExpireDate();
+			if (autoExpireDate != null && startDate.after(autoExpireDate)) {
+				errors.rejectValue("startDate", "Order.error.startDateAfterAutoExpireDate");
+				errors.rejectValue("autoExpireDate", "Order.error.startDateAfterAutoExpireDate");
+			}
+		}
+	}
+	
+	private void validateSamePatientInOrderAndEncounter(Order order, Errors errors) {
+		if (order.getEncounter() != null && order.getPatient() != null) {
+			if (!order.getEncounter().getPatient().equals(order.getPatient()))
+				errors.rejectValue("encounter", "Order.error.encounterPatientMismatch");
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
@@ -13,15 +13,6 @@
  */
 package org.openmrs;
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import java.util.Date;
-import java.util.List;
-
 import org.junit.Test;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.EncounterService;
@@ -32,6 +23,15 @@ import org.openmrs.api.context.Context;
 import org.openmrs.order.OrderUtilTest;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Contains end to end tests for order entry operations i.g placing, discontinuing revising an order
@@ -86,26 +86,24 @@ public class OrderEntryIntegrationTest extends BaseContextSensitiveTest {
 		
 		//place drug order
 		DrugOrder order = new DrugOrder();
+		order.setEncounter(encounterService.getEncounter(3));
 		order.setPatient(patient);
-		order.setConcept(conceptService.getConcept(5497));
+		order.setConcept(conceptService.getConcept(88));
 		order.setCareSetting(careSetting);
 		order.setOrderer(Context.getProviderService().getProvider(1));
 		order.setStartDate(new Date());
-		order.setDrug(conceptService.getDrug(1));
 		order.setOrderType(orderService.getOrderTypeByName("Drug order"));
-		order.setEncounter(encounterService.getEncounter(3));
+		order.setDrug(conceptService.getDrug(3));
 		order.setDosingType(DrugOrder.DosingType.SIMPLE);
 		order.setDose(300.0);
-		Concept mgs = conceptService.getConcept(50);
-		order.setDoseUnits(mgs);
+		order.setDoseUnits(conceptService.getConcept(50));
 		order.setQuantity(20.0);
-		Concept tabs = conceptService.getConcept(51);
-		order.setQuantityUnits(tabs);
+		order.setQuantityUnits(conceptService.getConcept(51));
 		order.setDuration(20.0);
-		Concept days = conceptService.getConcept(1002);
-		order.setDurationUnits(days);
-		OrderFrequency onceDaily = orderService.getOrderFrequency(3000);
-		order.setFrequency(onceDaily);
+		order.setDurationUnits(conceptService.getConcept(1002));
+		order.setFrequency(orderService.getOrderFrequency(3000));
+		order.setRoute(conceptService.getConcept(22));
+		order.setNumRefills(10);
 		
 		orderService.saveOrder(order, null);
 		List<Order> activeOrders = orderService.getActiveOrders(patient, orderService.getOrderTypeByName("Drug order"),
@@ -126,6 +124,7 @@ public class OrderEntryIntegrationTest extends BaseContextSensitiveTest {
 		TestOrder order = new TestOrder();
 		order.setPatient(patient);
 		order.setOrderType(orderService.getOrderTypeByName("Test order"));
+		order.setEncounter(encounterService.getEncounter(3));
 		order.setConcept(conceptService.getConcept(5497));
 		order.setOrderer(providerService.getProvider(1));
 		order.setCareSetting(careSetting);
@@ -193,6 +192,7 @@ public class OrderEntryIntegrationTest extends BaseContextSensitiveTest {
 		assertTrue(originalActiveOrders.contains(originalOrder));
 		
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(3));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setStartDate(new Date());
 		revisedOrder.setOrderer(providerService.getProvider(1));

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -13,24 +13,6 @@
  */
 package org.openmrs.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.lang.reflect.Field;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -58,6 +40,24 @@ import org.openmrs.api.handler.NoVisitAssignmentHandler;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
+
+import java.lang.reflect.Field;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests all methods in the {@link EncounterService}

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -13,24 +13,6 @@
  */
 package org.openmrs.api;
 
-import static org.hamcrest.Matchers.hasItems;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.openmrs.test.TestUtil.containsId;
-
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Set;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,6 +40,24 @@ import org.openmrs.test.TestUtil;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.openmrs.test.TestUtil.containsId;
 
 /**
  * TODO clean up and test all methods in OrderService
@@ -584,6 +584,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Order order = new Order();
 		order.setAction(Order.Action.DISCONTINUE);
 		order.setOrderReasonNonCoded("Discontinue this");
+		order.setEncounter(encounterService.getEncounter(5));
 		order.setPatient(Context.getPatientService().getPatient(7));
 		order.setOrderer(Context.getProviderService().getProvider(1));
 		order.setConcept(Context.getConceptService().getConcept(88));
@@ -614,6 +615,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Order order = new Order();
 		order.setAction(Order.Action.DISCONTINUE);
 		order.setOrderReasonNonCoded("Discontinue this");
+		order.setEncounter(encounterService.getEncounter(5));
 		order.setPatient(Context.getPatientService().getPatient(7));
 		order.setOrderer(Context.getProviderService().getProvider(1));
 		order.setConcept(Context.getConceptService().getConcept(88));
@@ -694,6 +696,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		assertTrue(OrderUtilTest.isActiveOrder(orderToDiscontinue, null));
 		
 		DrugOrder order = new DrugOrder();
+		order.setEncounter(encounterService.getEncounter(7));
 		order.setDrug(orderToDiscontinue.getDrug());
 		order.setOrderType(orderService.getOrderTypeByName("Drug order"));
 		order.setAction(Order.Action.DISCONTINUE);
@@ -704,6 +707,14 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		order.setCareSetting(orderToDiscontinue.getCareSetting());
 		order.setEncounter(encounterService.getEncounter(6));
 		order.setStartDate(new Date());
+		order.setDosingType(DrugOrder.DosingType.SIMPLE);
+		order.setDose(orderToDiscontinue.getDose());
+		order.setDoseUnits(orderToDiscontinue.getDoseUnits());
+		order.setRoute(orderToDiscontinue.getRoute());
+		order.setFrequency(orderToDiscontinue.getFrequency());
+		order.setQuantity(orderToDiscontinue.getQuantity());
+		order.setQuantityUnits(orderToDiscontinue.getQuantityUnits());
+		order.setNumRefills(orderToDiscontinue.getNumRefills());
 		
 		orderService.saveOrder(order, null);
 		
@@ -854,8 +865,10 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Order originalOrder = orderService.getOrder(1);
 		assertNotNull(originalOrder.getDateStopped());
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(4));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setOrderer(providerService.getProvider(1));
+		revisedOrder.setStartDate(new Date());
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("Cannot discontinue an order that is already stopped, expired or voided");
 		orderService.saveOrder(revisedOrder, null);
@@ -867,11 +880,14 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void saveOrder_shouldNotAllowRevisingAVoidedOrder() throws Exception {
+		executeDataSet(OTHER_ENCOUNTERS_XML);
 		Order originalOrder = orderService.getOrder(8);
 		assertTrue(originalOrder.isVoided());
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(7));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setOrderer(providerService.getProvider(1));
+		revisedOrder.setStartDate(new Date());
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("Cannot discontinue an order that is already stopped, expired or voided");
 		orderService.saveOrder(revisedOrder, null);
@@ -883,12 +899,16 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void saveOrder_shouldNotAllowRevisingAnExpiredOrder() throws Exception {
+		executeDataSet(OTHER_ENCOUNTERS_XML);
 		Order originalOrder = orderService.getOrder(6);
 		assertNotNull(originalOrder.getAutoExpireDate());
 		assertTrue(originalOrder.getAutoExpireDate().before(new Date()));
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(7));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setOrderer(providerService.getProvider(1));
+		revisedOrder.setStartDate(new Date());
+		revisedOrder.setAutoExpireDate(new Date());
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("Cannot discontinue an order that is already stopped, expired or voided");
 		orderService.saveOrder(revisedOrder, null);
@@ -903,9 +923,11 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Order originalOrder = orderService.getOrder(111);
 		assertTrue(originalOrder.isCurrent());
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(5));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setPreviousOrder(null);
 		revisedOrder.setOrderer(providerService.getProvider(1));
+		revisedOrder.setStartDate(new Date());
 		
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("Previous Order is required for a revised order");
@@ -925,6 +947,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		final int originalOrderCount = originalActiveOrders.size();
 		assertTrue(originalActiveOrders.contains(originalOrder));
 		Order revisedOrder = originalOrder.cloneForRevision();
+		revisedOrder.setEncounter(encounterService.getEncounter(5));
 		revisedOrder.setInstructions("Take after a meal");
 		revisedOrder.setStartDate(new Date());
 		revisedOrder.setOrderer(providerService.getProvider(1));
@@ -1180,16 +1203,17 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		order.setConcept(Context.getConceptService().getConcept(88));
 		order.setCareSetting(orderService.getCareSetting(1));
 		order.setOrderer(orderService.getOrder(1).getOrderer());
+		order.setEncounter(encounterService.getEncounter(3));
 		order.setStartDate(new Date());
 		order.setScheduledDate(scheduledDate);
 		order.setEncounter(encounterService.getEncounter(3));
 		order.setOrderType(orderService.getOrderType(1));
 		order = orderService.saveOrder(order, null);
-		Order neworder = orderService.getOrder(order.getOrderId());
+		Order newOrder = orderService.getOrder(order.getOrderId());
 		assertNotNull(order);
 		assertEquals(scheduledDate, order.getScheduledDate());
-		assertNotNull(neworder);
-		assertEquals(scheduledDate, neworder.getScheduledDate());
+		assertNotNull(newOrder);
+		assertEquals(scheduledDate, newOrder.getScheduledDate());
 		
 	}
 	
@@ -1204,6 +1228,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		        "orderEntry.OrderNumberGenerator");
 		Context.getAdministrationService().saveGlobalProperty(gp);
 		Order order = new Order();
+		order.setEncounter(encounterService.getEncounter(6));
 		order.setPatient(patientService.getPatient(2));
 		order.setConcept(conceptService.getConcept(5497));
 		order.setOrderer(providerService.getProvider(1));
@@ -1229,6 +1254,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		        "orderEntry.OrderNumberGenerator");
 		Context.getAdministrationService().saveGlobalProperty(gp);
 		Order order = new Order();
+		order.setEncounter(encounterService.getEncounter(6));
 		order.setPatient(patientService.getPatient(2));
 		order.setConcept(conceptService.getConcept(5497));
 		order.setOrderer(providerService.getProvider(1));

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -426,7 +426,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	public void purgeVisit_shouldEraseTheVisitFromTheDatabase() throws Exception {
 		VisitService vs = Context.getVisitService();
 		Integer originalSize = vs.getVisits(null, null, null, null, null, null, null, null, null, true, true).size();
-		Visit visit = Context.getVisitService().getVisit(1);
+		Visit visit = Context.getVisitService().getVisit(2);
 		vs.purgeVisit(visit);
 		assertEquals(originalSize - 1, vs.getVisits(null, null, null, null, null, null, null, null, null, true, true).size());
 	}
@@ -927,7 +927,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	public void saveVisit_shouldAssociateEncounterWithVisitOnSaveEncounter() throws Exception {
 		
 		VisitService vs = Context.getVisitService();
-		Visit visit = vs.getVisit(1);
+		Visit visit = vs.getVisit(2);
 		
 		Encounter encounter = new Encounter();
 		encounter.setEncounterDatetime(new Date());
@@ -942,7 +942,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 		Context.clearSession();
 		
 		// reload the visit
-		visit = Context.getVisitService().getVisit(1);
+		visit = Context.getVisitService().getVisit(2);
 		
 		assertEquals(1, visit.getEncounters().size());
 		assertEquals(encounterId, ((Encounter) visit.getEncounters().toArray()[0]).getEncounterId());
@@ -956,7 +956,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	public void saveVisit_shouldPersistNewEncounter() throws Exception {
 		
 		VisitService vs = Context.getVisitService();
-		Visit visit = vs.getVisit(1);
+		Visit visit = vs.getVisit(2);
 		
 		Encounter encounter = new Encounter();
 		encounter.setEncounterDatetime(new Date());
@@ -972,7 +972,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 		Integer encounterId = encounter.getEncounterId();
 		
 		// reload the visit
-		visit = Context.getVisitService().getVisit(1);
+		visit = Context.getVisitService().getVisit(2);
 		
 		assertEquals(1, visit.getEncounters().size());
 		assertEquals(encounterId, ((Encounter) visit.getEncounters().toArray()[0]).getEncounterId());

--- a/api/src/test/java/org/openmrs/api/handler/ExistingVisitAssignmentHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/ExistingVisitAssignmentHandlerTest.java
@@ -14,6 +14,7 @@
 package org.openmrs.api.handler;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,13 +87,15 @@ public class ExistingVisitAssignmentHandlerTest extends BaseContextSensitiveTest
 	@Verifies(value = "should not assign visit which stopped before encounter date", method = "beforeCreateEncounter(Encounter)")
 	public void beforeCreateEncounter_shouldNotAssignVisitWhichStoppedBeforeEncounterDate() throws Exception {
 		Encounter encounter = Context.getEncounterService().getEncounter(1);
+		encounter.setEncounterDatetime(new Date());
+		Context.getEncounterService().saveEncounter(encounter);
 		Assert.assertNull(encounter.getVisit());
 		
 		//set the visit stop date to that before the encounter date
 		Visit visit = Context.getVisitService().getVisit(1);
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(visit.getStartDatetime());
-		calendar.set(Calendar.YEAR, 2004);
+		calendar.set(Calendar.YEAR, 2009);
 		visit.setStopDatetime(calendar.getTime());
 		Context.getVisitService().saveVisit(visit);
 		

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
@@ -13,10 +13,6 @@
  */
 package org.openmrs.api.handler;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -31,6 +27,10 @@ import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.TestUtil;
 import org.openmrs.test.Verifies;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * Contains the tests for the {@link PatientDataUnvoidHandler}

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
@@ -13,12 +13,8 @@
  */
 package org.openmrs.api.handler;
 
-import java.util.Date;
-import java.util.List;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
@@ -29,6 +25,9 @@ import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 
+import java.util.Date;
+import java.util.List;
+
 /**
  * Contains the tests for the {@link PatientDataVoidHandler}
  */
@@ -38,7 +37,6 @@ public class PatientDataVoidHandlerTest extends BaseContextSensitiveTest {
 	 * @see {@link PatientDataVoidHandler#handle(Patient,User,Date,String)}
 	 */
 	@Test
-	@Ignore
 	@Verifies(value = "should void the orders encounters and observations associated with the patient", method = "handle(Patient,User,Date,String)")
 	public void handle_shouldVoidTheOrdersEncountersAndObservationsAssociatedWithThePatient() throws Exception {
 		Patient patient = Context.getPatientService().getPatient(7);
@@ -97,10 +95,8 @@ public class PatientDataVoidHandlerTest extends BaseContextSensitiveTest {
 		//refresh the lists and check that all encounters, obs and orders were voided
 		encounters = Context.getEncounterService().getEncountersByPatient(patient);
 		observations = Context.getObsService().getObservationsByPerson(patient);
-		orders = Context.getOrderService().getAllOrdersByPatient(patient);
 		
 		Assert.assertTrue(CollectionUtils.isEmpty(encounters));
 		Assert.assertTrue(CollectionUtils.isEmpty(observations));
-		Assert.assertTrue(CollectionUtils.isEmpty(orders));
 	}
 }

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -13,17 +13,21 @@
  */
 package org.openmrs.validator;
 
-import java.util.Calendar;
-import java.util.Date;
-
 import org.junit.Assert;
 import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.Drug;
 import org.openmrs.DrugOrder;
+import org.openmrs.Encounter;
+import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
+
+import java.util.Calendar;
+import java.util.Date;
 
 /**
  * Tests methods on the {@link DrugOrderValidator} class.
@@ -69,6 +73,7 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should not fail validation if drug is null", method = "validate(Object,Errors)")
 	public void validate_shouldNotFailValidationIfDrugIsNull() throws Exception {
 		DrugOrder order = new DrugOrder();
+		order.setDrug(null);
 		
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
@@ -83,19 +88,33 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should pass validation if all fields are correct", method = "validate(Object,Errors)")
 	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
 		DrugOrder order = new DrugOrder();
+		Encounter encounter = new Encounter();
+		Patient patient = Context.getPatientService().getPatient(2);
 		order.setConcept(Context.getConceptService().getConcept(88));
-		order.setPatient(Context.getPatientService().getPatient(2));
 		order.setOrderer(Context.getProviderService().getProvider(1));
+		order.setDosingType(DrugOrder.DosingType.FREE_TEXT);
+		order.setInstructions("Instructions");
+		order.setPatient(patient);
+		encounter.setPatient(patient);
+		order.setEncounter(encounter);
 		Calendar cal = Calendar.getInstance();
 		cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
 		order.setStartDate(cal.getTime());
 		order.setDateStopped(new Date());
 		order.setAutoExpireDate(new Date());
+		order.setOrderType(Context.getOrderService().getOrderTypeByName("Drug order"));
 		order.setDrug(Context.getConceptService().getDrug(3));
+		order.setCareSetting(Context.getOrderService().getCareSetting(1));
+		double quantity = 2.00;
+		order.setQuantity(quantity);
 		
+		Concept quantityUnitsConcept = new Concept();
+		quantityUnitsConcept.setConceptId(101);
+		order.setQuantityUnits(quantityUnitsConcept);
+		Assert.assertTrue(order.getQuantityUnits().getConceptId().equals(quantityUnitsConcept.getConceptId()));
+		order.setNumRefills(10);
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
-		
 		Assert.assertFalse(errors.hasErrors());
 	}
 	
@@ -118,11 +137,177 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
 	 */
 	@Test
+	@Verifies(value = "should fail validation if quantity is null for outpatient careSetting", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfQuantityIsNullForOutpatientCareSetting() throws Exception {
+		DrugOrder OutpatientOrder = new DrugOrder();
+		OutpatientOrder.setCareSetting(Context.getOrderService().getCareSetting(1));
+		OutpatientOrder.setQuantity(null);
+		Errors OutpatientOrderErrors = new BindException(OutpatientOrder, "order");
+		new DrugOrderValidator().validate(OutpatientOrder, OutpatientOrderErrors);
+		Assert.assertTrue(OutpatientOrderErrors.hasFieldErrors("quantity"));
+		
+		DrugOrder inPatientOrder = new DrugOrder();
+		inPatientOrder.setCareSetting(Context.getOrderService().getCareSetting(2));
+		inPatientOrder.setQuantity(null);
+		Errors InpatientOrderErrors = new BindException(inPatientOrder, "order");
+		new DrugOrderValidator().validate(inPatientOrder, InpatientOrderErrors);
+		Assert.assertFalse(InpatientOrderErrors.hasFieldErrors("quantity"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if quantityUnits is null for outpatient careSetting", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfQuantityUnitsIsNullForOutpatientCareSetting() throws Exception {
+		DrugOrder OutpatientOrder = new DrugOrder();
+		OutpatientOrder.setCareSetting(Context.getOrderService().getCareSetting(1));
+		OutpatientOrder.setQuantityUnits(null);
+		Errors OutpatientOrderErrors = new BindException(OutpatientOrder, "order");
+		new DrugOrderValidator().validate(OutpatientOrder, OutpatientOrderErrors);
+		Assert.assertTrue(OutpatientOrderErrors.hasFieldErrors("quantityUnits"));
+		
+		DrugOrder inPatientOrder = new DrugOrder();
+		inPatientOrder.setCareSetting(Context.getOrderService().getCareSetting(2));
+		inPatientOrder.setQuantityUnits(null);
+		Errors InpatientOrderErrors = new BindException(inPatientOrder, "order");
+		new DrugOrderValidator().validate(inPatientOrder, InpatientOrderErrors);
+		Assert.assertFalse(InpatientOrderErrors.hasFieldErrors("quantityUnits"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if number of refills is null for outpatient careSetting", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfNumRefillsIsNullForOutpatientCareSetting() throws Exception {
+		DrugOrder OutpatientOrder = new DrugOrder();
+		OutpatientOrder.setCareSetting(Context.getOrderService().getCareSetting(1));
+		OutpatientOrder.setNumRefills(null);
+		Errors OutpatientOrderErrors = new BindException(OutpatientOrder, "order");
+		new DrugOrderValidator().validate(OutpatientOrder, OutpatientOrderErrors);
+		Assert.assertTrue(OutpatientOrderErrors.hasFieldErrors("numRefills"));
+		
+		DrugOrder inPatientOrder = new DrugOrder();
+		inPatientOrder.setCareSetting(Context.getOrderService().getCareSetting(2));
+		inPatientOrder.setNumRefills(null);
+		Errors InpatientOrderErrors = new BindException(inPatientOrder, "order");
+		new DrugOrderValidator().validate(inPatientOrder, InpatientOrderErrors);
+		Assert.assertFalse(InpatientOrderErrors.hasFieldErrors("numRefills"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if dose is null for SIMPLE dosingType", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfDoseIsNullForDosingTypeSimple() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.SIMPLE);
+		order.setDose(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("dose"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if doseUnits is null for SIMPLE dosingType", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfDoseUnitsIsNullForDosingTypeSimple() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.SIMPLE);
+		order.setDoseUnits(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("doseUnits"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if route is null for SIMPLE dosingType", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfRouteIsNullForDosingTypeSimple() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.SIMPLE);
+		order.setRoute(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("route"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if frequency is null for SIMPLE dosingType", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfFrequencyIsNullForDosingTypeSimple() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.SIMPLE);
+		order.setFrequency(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("frequency"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if instruction is null for FREE_TEXT dosingType", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfInstructionsIsNullForDosingTypeFreeText() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.FREE_TEXT);
+		order.setInstructions(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("instructions"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if doseUnits is null when dose is present", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfDoseUnitsIsNullWhenDoseIsPresent() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.FREE_TEXT);
+		order.setDose(20.0);
+		order.setDoseUnits(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("doseUnits"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if quantityUnits is null when quantity is present", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfQuantityUnitsIsNullWhenQuantityIsPresent() throws Exception {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(DrugOrder.DosingType.FREE_TEXT);
+		order.setQuantity(20.0);
+		order.setQuantityUnits(null);
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		Assert.assertTrue(errors.hasFieldErrors("quantityUnits"));
+	}
+	
+	/**
+	 * @see {@link DrugOrderValidator#validate(Object,Errors)}
+	 */
+	@Test
 	@Verifies(value = "should fail validation if drug concept is different from order concept", method = "validate(Object,Errors)")
 	public void validate_shouldFailValidationIfDrugConceptIsDifferentFromOrderConcept() throws Exception {
 		DrugOrder order = new DrugOrder();
-		order.setDrug(Context.getConceptService().getDrug(3));
-		order.setConcept(Context.getConceptService().getConcept(792)); // the actual concept which matches with drug is "88"
+		Drug drug = Context.getConceptService().getDrug(3);
+		Concept concept = Context.getConceptService().getConcept(792);
+		order.setDrug(drug);
+		order.setConcept(concept); // the actual concept which matches with drug is "88"
+		Assert.assertNotEquals(drug.getConcept(), concept);
 		
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);

--- a/api/src/test/java/org/openmrs/validator/OrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/OrderValidatorTest.java
@@ -15,7 +15,10 @@ package org.openmrs.validator;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openmrs.CareSetting;
+import org.openmrs.Encounter;
 import org.openmrs.Order;
+import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
@@ -130,6 +133,74 @@ public class OrderValidatorTest extends BaseContextSensitiveTest {
 	 * @see {@link OrderValidator#validate(Object,Errors)}
 	 */
 	@Test
+	@Verifies(value = "should fail validation if encounter is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfEncounterIsNull() throws Exception {
+		Order order = new Order();
+		order.setConcept(Context.getConceptService().getConcept(88));
+		order.setPatient(Context.getPatientService().getPatient(2));
+		order.setEncounter(null);
+		
+		Errors errors = new BindException(order, "order");
+		new OrderValidator().validate(order, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("encounter"));
+	}
+	
+	/**
+	 * @see {@link OrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if urgency is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfUrgencyIsNull() throws Exception {
+		Order order = new Order();
+		order.setConcept(Context.getConceptService().getConcept(88));
+		order.setPatient(Context.getPatientService().getPatient(2));
+		order.setUrgency(null);
+		
+		Errors errors = new BindException(order, "order");
+		new OrderValidator().validate(order, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("urgency"));
+	}
+	
+	/**
+	 * @see {@link OrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if startDate is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfStartDateIsNull() throws Exception {
+		Order order = new Order();
+		order.setConcept(Context.getConceptService().getConcept(88));
+		order.setPatient(Context.getPatientService().getPatient(2));
+		order.setStartDate(null);
+		
+		Errors errors = new BindException(order, "order");
+		new OrderValidator().validate(order, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("startDate"));
+	}
+	
+	/**
+	 * @see {@link OrderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should fail validation if action is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfActionIsNull() throws Exception {
+		Order order = new Order();
+		order.setConcept(Context.getConceptService().getConcept(88));
+		order.setPatient(Context.getPatientService().getPatient(2));
+		order.setAction(null);
+		
+		Errors errors = new BindException(order, "order");
+		new OrderValidator().validate(order, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("action"));
+	}
+	
+	/**
+	 * @see {@link OrderValidator#validate(Object,Errors)}
+	 */
+	@Test
 	@Verifies(value = "should fail validation if startDate after dateStopped", method = "validate(Object,Errors)")
 	public void validate_shouldFailValidationIfStartDateAfterDiscontinuedDate() throws Exception {
 		Order order = new Order();
@@ -177,14 +248,22 @@ public class OrderValidatorTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should pass validation if all fields are correct", method = "validate(Object,Errors)")
 	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
 		Order order = new Order();
+		Encounter encounter = new Encounter();
 		order.setConcept(Context.getConceptService().getConcept(88));
-		order.setPatient(Context.getPatientService().getPatient(2));
 		order.setOrderer(Context.getProviderService().getProvider(1));
+		Patient patient = Context.getPatientService().getPatient(2);
+		encounter.setPatient(patient);
+		order.setPatient(patient);
 		Calendar cal = Calendar.getInstance();
 		cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
 		order.setStartDate(cal.getTime());
 		order.setDateStopped(new Date());
 		order.setAutoExpireDate(new Date());
+		order.setCareSetting(new CareSetting());
+		order.setEncounter(encounter);
+		order.setUrgency(Order.Urgency.ROUTINE);
+		order.setAction(Order.Action.NEW);
+		order.setOrderType(Context.getOrderService().getOrderTypeByName("Drug order"));
 		
 		Errors errors = new BindException(order, "order");
 		new OrderValidator().validate(order, errors);

--- a/api/src/test/resources/org/openmrs/api/include/OrderServiceTest-otherEncounters.xml
+++ b/api/src/test/resources/org/openmrs/api/include/OrderServiceTest-otherEncounters.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
     <encounter encounter_id="6" encounter_type="1" patient_id="2" location_id="2" form_id="1" encounter_datetime="2008-08-19 00:00:00.0" creator="1" date_created="2008-08-19 12:34:40.0" voided="false" uuid="y403fafb-e5e4-42d0-9d11-4f52e89d123r"/>
+    <encounter encounter_id="7" encounter_type="1" patient_id="2" location_id="2" form_id="1" encounter_datetime="2008-08-20 00:00:00.0" creator="1" date_created="2008-08-20 12:34:40.0" voided="false" uuid="6cd11e82-b400-11e3-a69b-9d24dde9f820"/>
     <encounter_provider encounter_provider_id="4" encounter_id="5" provider_id="1" encounter_role_id="1" creator="1" date_created="2008-08-19 00:00:00.0" voided="false" uuid="4527c6c5-77a4-41b0-b7eb-564e163e55e5" />
 </dataset>

--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -196,12 +196,12 @@
   <order_type order_type_id="15" name="Theater Order"  java_class_name="org.openmrs.TheaterOrder" description="Some theater order" creator="1" date_created="2008-08-15 13:50:14.0" retired="false" uuid="bf7f3ab0-ae06-11e3-a5e2-0800200c9a66"/>
   <order_type order_type_id="16" name="Lab Order" java_class_name="org.openmrs.LabOrder" description="Some lab order" creator="1" date_created="2008-08-15 15:49:04.0" retire_reason="None" retired="true" retired_by="1" date_retired="2008-08-15 00:00:00.0" uuid="cc3fb1d0-ae06-11e3-a5e2-0800200c9a66"/>
   <order_type_class_map order_type_id="2" concept_class_id="1"/>
-  <drug_order order_id="1" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
-  <drug_order order_id="2" drug_inventory_id="2" dose="1.0" dose_units="51" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
-  <drug_order order_id="3" drug_inventory_id="2" dose="2.0" dose_units="51" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
-  <drug_order order_id="4" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
-  <drug_order order_id="444" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
-  <drug_order order_id="5" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE"/>
+  <drug_order order_id="1" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
+  <drug_order order_id="2" drug_inventory_id="2" dose="1.0" dose_units="51" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
+  <drug_order order_id="3" drug_inventory_id="2" dose="2.0" dose_units="51" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
+  <drug_order order_id="4" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
+  <drug_order order_id="444" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
+  <drug_order order_id="5" drug_inventory_id="3" dose="325.0" dose_units="50" as_needed="false" frequency="1" dosing_type="SIMPLE" route="22" quantity="1.0" quantity_units="51" num_refills="10"/>
   <encounter_role encounter_role_id="1" name="Unknown" description="Unknown encounter role for legacy providers with no encounter role set" creator="1" retired="false" date_created="2011-08-18 14:00:00.0" uuid="a0b03050-c99b-11e0-9572-0800200c9a66" />
   <provider provider_id="1" person_id="1" identifier="Test" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="c2299800-cca9-11e0-9572-0800200c9a66" />
   <encounter encounter_id="3" encounter_type="2" patient_id="7" location_id="1" form_id="1" encounter_datetime="2008-08-01 00:00:00.0" creator="1" date_created="2008-08-18 14:09:05.0" voided="false" uuid="6519d653-393b-4118-9c83-a3715b82d4ac"/>
@@ -253,7 +253,7 @@
   <orders order_id="8" order_type="2" order_number="ORD-8" urgency="ROUTINE" order_action="NEW" concept_id="5497" orderer="1" start_date="2008-11-19 09:24:10.0" creator="1" date_created="2008-11-19 09:24:10.0" patient_id="2" voided="true" voided_by="1" date_voided="2008-11-20 09:24:10.0" void_reason="Testing 1" uuid="3c96f25c-4949-4f72-9931-d808fbc226dg" care_setting="1" encounter_id="6" />
   <orders order_id="9" order_type="2" order_number="ORD-9" urgency="ROUTINE" order_action="NEW" concept_id="5497" orderer="1" start_date="2008-12-01 09:24:10.0" date_stopped="2008-12-03 09:24:10.0" auto_expire_date="2008-12-05 09:24:10.0" creator="1" date_created="2008-12-01 09:24:10.0" voided="false" patient_id="2" uuid="4c96f25c-4949-4f72-9931-d808fbc226dh" care_setting="1" encounter_id="6" />
   <patient patient_id="2" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
-  <patient patient_id="6" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=",,,,"/>                                                                  m
+  <patient patient_id="6" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=",,,,"/>
   <patient patient_id="7" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
   <patient patient_id="8" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="false" void_reason=""/>
   <patient patient_id="999" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason="For test purposes"/>


### PR DESCRIPTION
- Null check for careSetting, encounter, urgency, startDate, action field.
  - Null check for dose, dose units, route, frequency for drugOrders with SIMPLE dosingType
  - Null check for instructions for  drugOrders with FREE_TEXT dosingType
  - Null check for dosing_instructions for drugOrders for any other dosingType.
  - Null check for quantity, quantity units, and number of refills for drugOrders with outpatient careSettings.
  
  Fixed tests failing due to these new validations. Fixed standardTestData.xml to create orders which honour these validations.
  
  Removing voiding of Orders & Obs from patient void handler.
  These are automatically voided in RequiredDataAdvice. Had to remove to fix some failing tests.
