### PR TITLE
TRUNK-4140: Substitute deprecated method call in HibernateContextDAO

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -13,7 +13,9 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import java.io.File;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -374,42 +376,49 @@ public class HibernateContextDAO implements ContextDAO {
 	 */
 	public void mergeDefaultRuntimeProperties(Properties runtimeProperties) {
 		
+		Map<Object, Object> cache = null; //declare a HashMap for do caching
 		// loop over runtime properties and precede each with "hibernate" if
 		// it isn't already
 		for (Map.Entry<Object, Object> entry : runtimeProperties.entrySet()) {
+			cache = new HashMap<Object, Object>(); // Instantiate a HashMap for do caching
 			Object key = entry.getKey();
 			String prop = (String) key;
 			String value = (String) entry.getValue();
 			log.trace("Setting property: " + prop + ":" + value);
 			if (!prop.startsWith("hibernate") && !runtimeProperties.containsKey("hibernate." + prop)) {
-				runtimeProperties.setProperty("hibernate." + prop, value);
+				cache.put("hibernate." + prop, value); // cache the changes to the HashMap
 			}
 		}
 		
+		copyCacheToRuntimeProperties(cache, runtimeProperties); // copy the cached changes to runtimeProperties
 		// load in the default hibernate properties from hibernate.default.properties
-		InputStream propertyStream = null;
 		try {
+			cache = new HashMap<Object, Object>(); // Instantiate a HashMap for do caching
 			Properties props = new Properties();
-			propertyStream = ConfigHelper.getResourceAsStream("/hibernate.default.properties");
-			OpenmrsUtil.loadProperties(props, propertyStream);
+			File file = new File(getClass().getClassLoader().getResource("/hibernate.default.properties").getFile());
+			OpenmrsUtil.loadProperties(props, file);
 			
 			// add in all default properties that don't exist in the runtime
 			// properties yet
 			for (Map.Entry<Object, Object> entry : props.entrySet()) {
 				if (!runtimeProperties.containsKey(entry.getKey())) {
-					runtimeProperties.put(entry.getKey(), entry.getValue());
+					cache.put(entry.getKey(), entry.getValue()); // cache the changes to the HashMap
 				}
 			}
 		}
-		finally {
-			try {
-				propertyStream.close();
-			}
-			catch (Exception e) {
-				// pass
-			}
+		catch (Throwable t) {
+
 		}
-		
+		copyCacheToRuntimeProperties(cache, runtimeProperties); //// copy the cached changes to runtimeProperties
+	}
+	
+	// copy the cached changed to the runtimeProperties
+	public void copyCacheToRuntimeProperties(Map<Object, Object> cache, Properties runtimeProperties) {
+		for (Map.Entry<Object, Object> entry : cache.entrySet()) {
+			Object prop = entry.getKey();
+			Object value = (String) entry.getValue();
+			runtimeProperties.setProperty((String) prop, (String) value);
+		}
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
@@ -13,6 +13,8 @@
  */
 package org.openmrs.api.db;
 
+import java.util.Properties;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -351,4 +353,12 @@ public class ContextDAOTest extends BaseContextSensitiveTest {
 		dao.authenticate("  ", "password");
 	}
 	
+	@Verifies(value = "should mergeDefaultRuntimeProperties", method = "mergeDefaultRuntimeProperties(Properties runtimeProperties)")
+	@Test
+	public void should_mergeDefaultRuntimeProperties() {
+		Properties propertiesForTest = new Properties();
+		propertiesForTest.setProperty("x", "y"); // adding properties for testing
+		dao.mergeDefaultRuntimeProperties(propertiesForTest);
+		Assert.assertNotNull(propertiesForTest.getProperty("hibernate.x")); // check whether "x" has been converted to "hibernate.x"
+	}
 }


### PR DESCRIPTION
removed "ConfigHelper.getResourceAsStream" deprecatede method.

added junit test "should_mergeDefaultRuntimeProperties()" in ContextDAOTest.java class. 
But when testing it throws java.util.ConcurrentModificationException.
as i read in http://docs.oracle.com/javase/6/docs/api/java/util/ConcurrentModificationException.html and http://stackoverflow.com/questions/1931180/how-do-i-synchronize-to-prevent-a-java-util-concurrentmodificationexception , the reason is , we change a element in a java Collection while we iterate through it .

One possible solution would be using ConcurrentHashMap. But here we use java.util.Property.

The other possible solution would be instead of changing the values while iterating through a collection, cache the changes and then copy them to the Collection.

I have used the latter approach here.
