### PR TITLE
TRUNK-4329 Uploading no module results in exception page

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -465,7 +465,11 @@ public class ModuleFactory {
 			module = new ModuleFileParser(moduleFile).parse();
 		}
 		catch (ModuleException e) {
-			log.error("Error getting module object from file " + moduleFile.getName(), e);
+			if (moduleFile != null) {
+				log.error("Error getting module object from file " + moduleFile.getName(), e);
+				} else {
+					log.error("Module was null.", e);
+				}
 			throw e;
 		}
 		


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/TRUNK-4329

Added a check for null moduleFile to prevent an uncaught null pointer exception from being thrown when moduleFile.getName() is called.
