### PR TITLE
TRUNK-4314 Person attribute type should save with format String if one is not specified

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -236,6 +236,10 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 			}
 		}
 		
+		if (type.getFormat() == null) {
+			type.setFormat("java.lang.String");
+		}
+		
 		return dao.savePersonAttributeType(type);
 	}
 	


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/TRUNK-4314

Modified PersonServiceImpl.savePersonAttributeType() so that "java.lang.String" will be assigned as the default format.
