### PR TITLE
TRUNK-3780 Searching for patient with patient name/new feature

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -864,7 +864,7 @@ public final class OpenmrsConstants {
 	
 	public static final String GLOBAL_PROPERTY_MIN_SEARCH_CHARACTERS = "minSearchCharacters";
 	
-	public static final int GLOBAL_PROPERTY_DEFAULT_MIN_SEARCH_CHARACTERS = 3;
+	public static final int GLOBAL_PROPERTY_DEFAULT_MIN_SEARCH_CHARACTERS = 2;
 	
 	public static final String GLOBAL_PROPERTY_DEFAULT_LOCALE = "default_locale";
 	
@@ -1393,7 +1393,7 @@ public final class OpenmrsConstants {
 		                "",
 		                "Comma separated list of the RelationshipTypes to show on the new/short patient form.  The list is defined like '3a, 4b, 7a'.  The number is the RelationshipTypeId and the 'a' vs 'b' part is which side of the relationship is filled in by the user."));
 		
-		props.add(new GlobalProperty(GLOBAL_PROPERTY_MIN_SEARCH_CHARACTERS, "3",
+		props.add(new GlobalProperty(GLOBAL_PROPERTY_MIN_SEARCH_CHARACTERS, "2",
 		        "Number of characters user must input before searching is started."));
 		
 		props

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -550,8 +550,8 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		initializeInMemoryDatabase();
 		executeDataSet(FIND_PATIENTS_XML);
 		
-		// make sure the default of "3" kicks in and blocks any results
-		assertEquals(0, Context.getPatientService().getPatients("Je").size());
+		// make sure the default of "2" kicks in and blocks any results
+		assertEquals(0, Context.getPatientService().getPatients("J").size());
 		
 		Context.clearSession();
 		Context.getAdministrationService().saveGlobalProperty(
@@ -559,18 +559,6 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		
 		// there is a patient will middle name "F", so this should generate a hit.
 		assertEquals(1, Context.getPatientService().getPatients("F").size());
-	}
-	
-	/**
-	 * @see {@link PatientService#getPatients(String)}
-	 */
-	@Test
-	@Verifies(value = "should allow search of two character name", method = "getPatients(String)")
-	public void getPatients_shouldAllowExactSearchOfForTwoCharacterName() throws Exception {
-		initializeInMemoryDatabase();
-		executeDataSet(FIND_PATIENTS_XML);
-		List<Patient> patientList = Context.getPatientService().getPatients("Ho");
-		assertEquals(1, patientList.size());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/db/hibernate/PatientSearchCriteriaTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/PatientSearchCriteriaTest.java
@@ -107,7 +107,7 @@ public class PatientSearchCriteriaTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void isShortName_shouldRecogniseShortName() throws Exception {
-		Assert.assertTrue(patientSearchCriteria.isShortName("Jo"));
+		Assert.assertTrue(patientSearchCriteria.isShortName("J"));
 	}
 	
 	/**
@@ -116,7 +116,7 @@ public class PatientSearchCriteriaTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void isShortName_shouldRecogniseLongName() throws Exception {
-		Assert.assertFalse(patientSearchCriteria.isShortName("Jonathan"));
+		Assert.assertFalse(patientSearchCriteria.isShortName("Jo"));
 	}
 	
 	/**

--- a/webapp/src/main/webapp/WEB-INF/view/scripts/openmrsmessages.js.withjstl
+++ b/webapp/src/main/webapp/WEB-INF/view/scripts/openmrsmessages.js.withjstl
@@ -3,7 +3,7 @@
 var omsgs = new Array();
 var gp = new Array();
 var userProperties = new Array();
-omsgs.minSearchCharactersGP="<openmrs:globalProperty key="minSearchCharacters" defaultValue="3"/>";
+omsgs.minSearchCharactersGP="<openmrs:globalProperty key="minSearchCharacters" defaultValue="2"/>";
 omsgs.datePattern="<openmrs:datePattern />";
 omsgs.name="<openmrs:message javaScriptEscape="true" code="general.name"/>";
 omsgs.addNewPatient="<openmrs:message javaScriptEscape="true" code="Patient.addNew"/>";


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-3780
These are our minimal possible changes to fix this. We tested in the webapp and minSearchCharacters (in Administration/Advanced Settings) was indeed now 2, allowing 2-character prefix search as requested. If this change is alright, then we can also add more comprehensive tests.

Possible optimizations could be: prioritizing exact match listed before prefix match before substring match, allowing user to choose between exact/prefix/substring match, or phonetic match.

How does that sound?
Christopher Hay and Katherine Ye
