### PR TITLE
"TRUNK-2758 Automated Error Report: NPE when creating patient without an identifier type"

### DIFF
--- a/src/api/org/openmrs/validator/PatientIdentifierValidator.java
+++ b/src/api/org/openmrs/validator/PatientIdentifierValidator.java
@@ -82,14 +82,14 @@ public class PatientIdentifierValidator implements Validator {
 		// Only validate if the PatientIdentifier is not voided
 		if (!pi.isVoided()) {
 			
+			// Check that this is a identifier is valid
+			validateIdentifier(pi.getIdentifier(), pi.getIdentifierType());
+			
 			// Check is already in use by another patient
 			if (Context.getPatientService().isIdentifierInUseByAnotherPatient(pi)) {
 				throw new IdentifierNotUniqueException("Identifier " + pi.getIdentifier()
 				        + " already in use by another patient");
 			}
-			
-			// Check that this is a identifier is valid
-			validateIdentifier(pi.getIdentifier(), pi.getIdentifierType());
 		}
 	}
 	


### PR DESCRIPTION
Checking if a PatientIdentifierType was unique before testing if it was valid caused the NullPointerException described in the ticket, so the check for a PatientIdentifierType was moved to occur before the uniqueness test.
