### PR TITLE
[TRUNK-3913] 1.7.x Backport of TRUNK-3351: Merging persons incorrectly handles addresses and names

### DIFF
--- a/api/src/test/java/org/openmrs/PersonAddressTest.java
+++ b/api/src/test/java/org/openmrs/PersonAddressTest.java
@@ -1,0 +1,176 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+package org.openmrs;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PersonAddressTest {
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressOneDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress1("crown street");
+		rileyStreetAddress.setAddress1("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressTwoDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress2("crown street");
+		rileyStreetAddress.setAddress2("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressThreeDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress3("crown street");
+		rileyStreetAddress.setAddress3("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressFourDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress4("crown street");
+		rileyStreetAddress.setAddress4("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressFiveDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress5("crown street");
+		rileyStreetAddress.setAddress5("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressSixDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress6("crown street");
+		rileyStreetAddress.setAddress6("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCityVillageDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCityVillage("faketown");
+		address1.setCityVillage("realtown");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCountyDistrictDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountyDistrict("fancy county");
+		address1.setCountyDistrict("omaha county");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCountryDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountry("australia");
+		address1.setCountry("zimbabwe");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyPostalCodeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setPostalCode("99999");
+		address1.setPostalCode("243234");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyStateProvinceDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountry("victoria");
+		address1.setCountry("tasmania");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyLatitudeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setLatitude("-23.33");
+		address1.setLatitude("43.3");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyLongitudeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setLongitude("-23.33");
+		address1.setLongitude("43.3");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyStartDateDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setStartDate(new Date(123l));
+		address1.setStartDate(new Date(1000000l));
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyEndDateDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setStartDate(new Date(123l));
+		address1.setStartDate(new Date(1000000l));
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/util/AddressMatcher.java
+++ b/api/src/test/java/org/openmrs/util/AddressMatcher.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util;
+
+import org.hamcrest.Description;
+import org.junit.internal.matchers.TypeSafeMatcher;
+import org.openmrs.PersonAddress;
+import org.openmrs.PersonName;
+
+import java.util.Set;
+
+public class AddressMatcher extends TypeSafeMatcher<Set<PersonAddress>> {
+	
+	private String address;
+	
+	public AddressMatcher(String address) {
+		this.address = address;
+	}
+	
+	@Override
+	public boolean matchesSafely(Set<PersonAddress> personAddresses) {
+		for (PersonAddress personAddress : personAddresses) {
+			if (personAddress.toString().equals(address)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(address);
+	}
+	
+	public static AddressMatcher containsAddress(String address) {
+		return new AddressMatcher(address);
+	}
+}

--- a/api/src/test/java/org/openmrs/util/NameMatcher.java
+++ b/api/src/test/java/org/openmrs/util/NameMatcher.java
@@ -1,0 +1,48 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util;
+
+import org.hamcrest.Description;
+import org.junit.internal.matchers.TypeSafeMatcher;
+import org.openmrs.PersonName;
+
+import java.util.Set;
+
+public class NameMatcher extends TypeSafeMatcher<Set<PersonName>> {
+	
+	private String fullName;
+	
+	public NameMatcher(String fullName) {
+		this.fullName = fullName;
+	}
+	
+	@Override
+	public boolean matchesSafely(Set<PersonName> personNames) {
+		for (PersonName personName : personNames) {
+			if (personName.getFullName().equals(fullName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(fullName);
+	}
+	
+	public static NameMatcher containsFullName(String fullName) {
+		return new NameMatcher(fullName);
+	}
+}

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-mergePatients.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-mergePatients.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <global_property property="patient.identifierRegex" property_value="^0*@SEARCH@([A-Z]+-[0-9])?$" uuid="c92cce6d-7e7d-4c53-a3c9-faaac17f8f8b"/>
+    <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="92ab9667-4686-49af-8be8-65a4b58fc49c"/>
+    <person person_id="10000" birthdate_estimated="0" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="61b38324-e2fd-4feb-95b7-9e9a2a4400df"/>
+    <person person_id="10001" birthdate_estimated="0" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="5c521595-4e12-46b0-8248-b8f2d3697766"/>
+    <patient patient_id="10000" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+    <patient patient_id="10001" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+    <patient_identifier patient_identifier_id="1" patient_id="10000" identifier="1234-4" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="e997ac86-4d8a-40f3-bedb-da84d35917b8"/>
+    <patient_identifier patient_identifier_id="2" patient_id="10001" identifier="12345-5" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="504c83c7-cfbf-4ae7-a4da-bdfa3236689f"/>
+    <person_address person_address_id="10000" person_id="10000" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" postal_code="1234" date_created="2005-01-01 00:00:00.0" voided="false" preferred="1"/>
+    <person_address person_address_id="10001" person_id="10000" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" state_province="Fakeland" date_created="2005-01-03 00:00:00.0" voided="false" preferred="0"/>
+    <person_address person_address_id="10002" person_id="10001" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" state_province="Fakeland" date_created="2005-01-01 00:00:00.0" voided="false" preferred="1"/>
+    <person_name person_name_id="1" preferred="false" person_id="10000" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="7e2acadc-5073-4a39-914a-debcbec8c1c9"/>
+    <person_name person_name_id="2" preferred="false" person_id="10000" prefix="President" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" family_name_suffix="Esq." creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="d531d4a2d-a97e-4673-80f8-ac8dd5ced083" />
+    <person_name person_name_id="3" preferred="false" person_id="10001" prefix="President" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" family_name_suffix="Esq." creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="c9714a2d-a97e-4673-80f8-ac8dd5ced083"/>
+</dataset>

--- a/src/api/org/openmrs/PersonAddress.java
+++ b/src/api/org/openmrs/PersonAddress.java
@@ -13,10 +13,11 @@
  */
 package org.openmrs;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+
+import static org.apache.commons.lang.StringUtils.defaultString;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsUtil;
@@ -85,9 +86,11 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	 */
 	@Override
 	public String toString() {
-		return "a1:" + getAddress1() + ", a2:" + getAddress2() + ", cv:" + getCityVillage() + ", sp:" + getStateProvince()
-		        + ", c:" + getCountry() + ", cd:" + getCountyDistrict() + ", nc:" + getNeighborhoodCell() + ", pc:"
-		        + getPostalCode() + ", lat:" + getLatitude() + ", long:" + getLongitude();
+		return new StringBuilder().append("a1:").append(getAddress1()).append(", a2:").append(getAddress2()).append(", cv:")
+		        .append(getCityVillage()).append(", sp:").append(getStateProvince()).append(", c:").append(getCountry())
+		        .append(", cd:").append(getCountyDistrict()).append(", nc:").append(getNeighborhoodCell()).append(", pc:")
+		        .append(getPostalCode()).append(", lat:").append(getLatitude()).append(", long:").append(getLongitude())
+		        .toString();
 	}
 	
 	/**
@@ -119,40 +122,19 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	 */
 	@SuppressWarnings("unchecked")
 	public boolean equalsContent(PersonAddress otherAddress) {
-		boolean returnValue = true;
-		
-		// these are the methods to compare. All are expected to be Strings
-		String[] methods = { "getAddress1", "getAddress2", "getCityVillage", "getNeighborhoodCell", "getCountyDistrict",
-		        "getTownshipDivision", "getRegion", "getSubregion", "getStateProvince", "getCountry", "getPostalCode",
-		        "getLatitude", "getLongitude" };
-		
-		Class addressClass = this.getClass();
-		
-		// loop over all of the selected methods and compare this and other
-		for (String methodName : methods) {
-			try {
-				Method method = addressClass.getMethod(methodName, new Class[] {});
-				
-				String thisValue = (String) method.invoke(this);
-				String otherValue = (String) method.invoke(otherAddress);
-				
-				if (otherValue != null && otherValue.length() > 0)
-					returnValue &= otherValue.equals(thisValue);
-				
-			}
-			catch (NoSuchMethodException e) {
-				log.warn("No such method for comparison " + methodName, e);
-			}
-			catch (IllegalAccessException e) {
-				log.error("Error while comparing addresses", e);
-			}
-			catch (InvocationTargetException e) {
-				log.error("Error while comparing addresses", e);
-			}
-			
-		}
-		
-		return returnValue;
+		return new EqualsBuilder().append(defaultString(otherAddress.getAddress1()), defaultString(address1))
+		        .append(defaultString(otherAddress.getAddress2()), defaultString(address2))
+		        .append(defaultString(otherAddress.getNeighborhoodCell()), defaultString(neighborhoodCell))
+		        .append(defaultString(otherAddress.getTownshipDivision()), defaultString(townshipDivision))
+		        .append(defaultString(otherAddress.getSubregion()), defaultString(subregion))
+		        .append(defaultString(otherAddress.getRegion()), defaultString(region))
+		        .append(defaultString(otherAddress.getCityVillage()), defaultString(cityVillage))
+		        .append(defaultString(otherAddress.getCountyDistrict()), defaultString(countyDistrict))
+		        .append(defaultString(otherAddress.getStateProvince()), defaultString(stateProvince))
+		        .append(defaultString(otherAddress.getCountry()), defaultString(country))
+		        .append(defaultString(otherAddress.getPostalCode()), defaultString(postalCode))
+		        .append(defaultString(otherAddress.getLatitude()), defaultString(latitude))
+		        .append(defaultString(otherAddress.getLongitude()), defaultString(longitude)).isEquals();
 	}
 	
 	/**

--- a/src/api/org/openmrs/PersonName.java
+++ b/src/api/org/openmrs/PersonName.java
@@ -13,12 +13,13 @@
  */
 package org.openmrs;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import static org.apache.commons.lang.StringUtils.defaultString;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsConstants;
@@ -97,7 +98,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * @should return false if obj has a missing person property
 	 * @should return true if properties are equal and have null person
 	 */
-	public boolean equals(Object obj) {
+	@Override
+    public boolean equals(Object obj) {
 		if (obj instanceof PersonName) {
 			PersonName pname = (PersonName) obj;
 			if (this.personNameId != null && pname.getPersonNameId() != null)
@@ -116,7 +118,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	/**
 	 * @see java.lang.Object#hashCode()
 	 */
-	public int hashCode() {
+	@Override
+    public int hashCode() {
 		if (this.getPersonNameId() == null)
 			return super.hashCode();
 		return this.getPersonNameId().hashCode();
@@ -134,38 +137,14 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 */
 	@SuppressWarnings("unchecked")
 	public boolean equalsContent(PersonName otherName) {
-		boolean returnValue = true;
-		
-		// these are the methods to compare. All are expected to be Strings
-		String[] methods = { "getGivenName", "getMiddleName", "getFamilyName" };
-		
-		Class nameClass = this.getClass();
-		
-		// loop over all of the selected methods and compare this and other
-		for (String methodName : methods) {
-			try {
-				Method method = nameClass.getMethod(methodName, new Class[] {});
-				
-				String thisValue = (String) method.invoke(this);
-				String otherValue = (String) method.invoke(otherName);
-				
-				if (otherValue != null && otherValue.length() > 0)
-					returnValue &= otherValue.equals(thisValue);
-				
-			}
-			catch (NoSuchMethodException e) {
-				log.warn("No such method for comparison " + methodName, e);
-			}
-			catch (IllegalAccessException e) {
-				log.error("Error while comparing names", e);
-			}
-			catch (InvocationTargetException e) {
-				log.error("Error while comparing names", e);
-			}
-			
-		}
-		
-		return returnValue;
+		return new EqualsBuilder().append(defaultString(otherName.getPrefix()), defaultString(prefix))
+		        .append(defaultString(otherName.getGivenName()), defaultString(givenName))
+		        .append(defaultString(otherName.getMiddleName()), defaultString(middleName))
+		        .append(defaultString(otherName.getFamilyNamePrefix()), defaultString(familyNamePrefix))
+		        .append(defaultString(otherName.getDegree()), defaultString(degree))
+		        .append(defaultString(otherName.getFamilyName()), defaultString(familyName))
+		        .append(defaultString(otherName.getFamilyName2()), defaultString(familyName2))
+		        .append(defaultString(otherName.getFamilyNameSuffix()), defaultString(familyNameSuffix)).isEquals();
 	}
 	
 	/**
@@ -223,7 +202,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @return Returns the dateVoided.
 	 */
-	@Element(required = false)
+	@Override
+    @Element(required = false)
 	public Date getDateVoided() {
 		return super.getDateVoided();
 	}
@@ -231,7 +211,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	/**
 	 * @param dateVoided The dateVoided to set.
 	 */
-	@Element(required = false)
+	@Override
+    @Element(required = false)
 	public void setDateVoided(Date dateVoided) {
 		super.setDateVoided(dateVoided);
 	}
@@ -254,7 +235,7 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	
 	/**
 	 * @return Returns the familyName.
-	 * @should return obscured name if obscure_patients is set to true 
+	 * @should return obscured name if obscure_patients is set to true
 	 */
 	@Element(data = true, required = false)
 	public String getFamilyName() {
@@ -442,7 +423,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	/**
 	 * @see #isVoided()
 	 */
-	@Attribute(required = true)
+	@Override
+    @Attribute(required = true)
 	public Boolean getVoided() {
 		return isVoided();
 	}
@@ -452,7 +434,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @param voided The voided to set.
 	 */
-	@Attribute(required = true)
+	@Override
+    @Attribute(required = true)
 	public void setVoided(Boolean voided) {
 		super.setVoided(voided);
 	}
@@ -462,7 +445,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @return Returns the voidedBy.
 	 */
-	@Element(required = false)
+	@Override
+    @Element(required = false)
 	public User getVoidedBy() {
 		return super.getVoidedBy();
 	}
@@ -472,7 +456,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @param voidedBy The voidedBy to set.
 	 */
-	@Element(required = false)
+	@Override
+    @Element(required = false)
 	public void setVoidedBy(User voidedBy) {
 		super.setVoidedBy(voidedBy);
 	}
@@ -482,7 +467,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @return Returns the voidReason.
 	 */
-	@Element(data = true, required = false)
+	@Override
+    @Element(data = true, required = false)
 	public String getVoidReason() {
 		return super.getVoidReason();
 	}
@@ -492,7 +478,8 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * 
 	 * @param voidReason The voidReason to set.
 	 */
-	@Element(data = true, required = false)
+	@Override
+    @Element(data = true, required = false)
 	public void setVoidReason(String voidReason) {
 		super.setVoidReason(voidReason);
 	}
@@ -535,9 +522,9 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
      */
     @Override
     public String toString() {
-    	// TODO find all uses of this toString() method and 
+    	// TODO find all uses of this toString() method and
     	// change them to use the getFullName() method.  This
-    	// to string should print out the #getPersonNameId() and 
+    	// to string should print out the #getPersonNameId() and
     	// all of the values for each part
     	
     	return getFullName();

--- a/src/api/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/src/api/org/openmrs/api/impl/PatientServiceImpl.java
@@ -770,14 +770,9 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		for (PersonName newName : notPreferred.getNames()) {
 			boolean containsName = false;
 			for (PersonName currentName : preferred.getNames()) {
-				String given = newName.getGivenName();
-				String middle = newName.getMiddleName();
-				String family = newName.getFamilyName();
-				
-				if ((given != null && given.equals(currentName.getGivenName()))
-						&& (middle != null && middle.equals(currentName.getMiddleName()))
-						&& (family != null && family.equals(currentName.getFamilyName()))) {
-					containsName = true;
+				containsName = currentName.equalsContent(newName);
+				if (containsName) {
+					break;
 				}
 			}
 			if (!containsName) {
@@ -799,14 +794,9 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		for (PersonAddress newAddress : notPreferred.getAddresses()) {
 			boolean containsAddress = false;
 			for (PersonAddress currentAddress : preferred.getAddresses()) {
-				String address1 = currentAddress.getAddress1();
-				String address2 = currentAddress.getAddress2();
-				String cityVillage = currentAddress.getCityVillage();
-				
-				if ((address1 != null && address1.equals(newAddress.getAddress1()))
-						&& (address2 != null && address2.equals(newAddress.getAddress2()))
-						&& (cityVillage != null && cityVillage.equals(newAddress.getCityVillage()))) {
-					containsAddress = true;
+				containsAddress = currentAddress.equalsContent(newAddress);
+				if (containsAddress) {
+				 	break;
 				}
 			}
 			if (!containsAddress) {

--- a/test/api/org/openmrs/PersonAddressTest.java
+++ b/test/api/org/openmrs/PersonAddressTest.java
@@ -1,0 +1,155 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+
+package org.openmrs;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class PersonAddressTest {
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressOneDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress1("crown street");
+		rileyStreetAddress.setAddress1("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressTwoDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress2("crown street");
+		rileyStreetAddress.setAddress2("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressThreeDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress3("crown street");
+		rileyStreetAddress.setAddress3("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressFourDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress4("crown street");
+		rileyStreetAddress.setAddress4("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressFiveDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress5("crown street");
+		rileyStreetAddress.setAddress5("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyAddressSixDiffers() {
+		PersonAddress rileyStreetAddress = new PersonAddress();
+		PersonAddress crownStreetAddress = new PersonAddress();
+		crownStreetAddress.setAddress6("crown street");
+		rileyStreetAddress.setAddress6("riley street");
+		
+		assertThat(crownStreetAddress.equalsContent(rileyStreetAddress), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCityVillageDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCityVillage("faketown");
+		address1.setCityVillage("realtown");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCountyDistrictDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountyDistrict("fancy county");
+		address1.setCountyDistrict("omaha county");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyCountryDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountry("australia");
+		address1.setCountry("zimbabwe");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyPostalCodeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setPostalCode("99999");
+		address1.setPostalCode("243234");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyStateProvinceDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setCountry("victoria");
+		address1.setCountry("tasmania");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyLatitudeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setLatitude("-23.33");
+		address1.setLatitude("43.3");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	@Test
+	public void equalsContent_shouldIndicateUnequalWhenOnlyLongitudeDiffers() {
+		PersonAddress address1 = new PersonAddress();
+		PersonAddress address2 = new PersonAddress();
+		address2.setLongitude("-23.33");
+		address1.setLongitude("43.3");
+		
+		assertThat(address2.equalsContent(address1), is(false));
+	}
+	
+	
+}

--- a/test/api/org/openmrs/PersonNameTest.java
+++ b/test/api/org/openmrs/PersonNameTest.java
@@ -13,7 +13,9 @@
  */
 package org.openmrs;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Date;
@@ -308,23 +310,145 @@ public class PersonNameTest {
 		
 		Assert.assertTrue(pn.compareTo(other) < 0);
 	}
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return true if all fields other than ID, person and preferred are equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnTrueIfAllFieldsOtherThanIdPersonAndPreferredAreEqual() throws Exception {
+		PersonName pn = new PersonName(1);
+		pn.setPrefix("Count");
+		pn.setGivenName("Adam");
+		pn.setMiddleName("Alex");
+		pn.setFamilyNamePrefix("family prefix");
+		pn.setFamilyName("Jones");
+		pn.setFamilyName2("Howard");
+		pn.setFamilyNameSuffix("Jr.");
+		pn.setDegree("Dr.");
+		pn.setPreferred(true);
+		pn.setPerson(new Person(999));
+		
+		PersonName other = new PersonName(2);
+		other.setPrefix("Count");
+		other.setGivenName("Adam");
+		other.setMiddleName("Alex");
+		other.setFamilyNamePrefix("family prefix");
+		other.setFamilyName("Jones");
+		other.setFamilyName2("Howard");
+		other.setFamilyNameSuffix("Jr.");
+		other.setDegree("Dr.");
+		other.setPreferred(false);
+		other.setPerson(new Person(111));
+		
+		assertThat(pn.equalsContent(other), is(true));
+	}
 	
 	/**
 	 * @see {@link PersonName#equalsContent(PersonName)}
 	 */
 	@Test
-	@Verifies(value = "should return true if given middle and family name are equal", method = "equalsContent(PersonName)")
-	public void equalsContent_shouldReturnTrueIfGivenMiddleAndFamilyNameAreEqual() throws Exception {
-		PersonName pn = new PersonName(1); // a different person name id than below
-		pn.setGivenName("Adam");
-		pn.setMiddleName("Alex");
-		pn.setFamilyName("Jones");
-		PersonName other = new PersonName(2); // a different person name id than above
-		other.setGivenName("Adam");
-		other.setMiddleName("Alex");
-		other.setFamilyName("Jones");
+	@Verifies(value = "should return false if suffixes are not equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnFalseIfSuffixesAreNotEqual() throws Exception {
+		PersonName nameWithSenior = new PersonName(1);
+		PersonName nameWithJunior = new PersonName(2);
 		
-		Assert.assertTrue(pn.equalsContent(other));
+		nameWithSenior.setFamilyNameSuffix("Sr.");
+		nameWithJunior.setFamilyNameSuffix("Jr.");
+		
+		assertThat(nameWithSenior.equalsContent(nameWithJunior), is(false));
+	}
+	
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return false if family name prefixes are not equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnFalseIfPrefixesAreNotEqual() throws Exception {
+		PersonName nameWithVanDer = new PersonName(1);
+		PersonName nameWithDe = new PersonName(2);
+		
+		nameWithVanDer.setFamilyNamePrefix("van der");
+		nameWithDe.setFamilyNamePrefix("de");
+		
+		assertThat(nameWithVanDer.equalsContent(nameWithDe), is(false));
+	}
+	
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return false if family name 2 is not equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnFalseIfFamilyName2IsNotEqual() throws Exception {
+		PersonName name1 = new PersonName(1);
+		PersonName name2 = new PersonName(2);
+		
+		name1.setFamilyName2("van der");
+		name2.setFamilyName2("de");
+		
+		assertThat(name1.equalsContent(name2), is(false));
+	}
+	
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return false if prefix is not equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnFalseIfPrefixIsNotEqual() throws Exception {
+		PersonName name1 = new PersonName(1);
+		PersonName name2 = new PersonName(2);
+		
+		name1.setPrefix("count");
+		name2.setPrefix("baron");
+		
+		assertThat(name1.equalsContent(name2), is(false));
+	}
+	
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return false if degrees are not equal", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnFalseIfDegreesAreNotEqual() throws Exception {
+		PersonName nameWithDoctor = new PersonName(1);
+		PersonName nameWithProfessor = new PersonName(2);
+		
+		nameWithDoctor.setDegree("Dr.");
+		nameWithProfessor.setFamilyNameSuffix("Prof.");
+		
+		assertThat(nameWithDoctor.equalsContent(nameWithProfessor), is(false));
+	}
+	
+	/**
+	 * @see {@link PersonName#equalsContent(PersonName)}
+	 */
+	@Test
+	@Verifies(value = "should return true if only difference in content fields is between null and empty string", method = "equalsContent(PersonName)")
+	public void equalsContent_shouldReturnTrueIfOnlyInContentFieldsDifferenceIsBetweenNullAndEmptyString() throws Exception {
+		PersonName pn = new PersonName(1);
+		pn.setPrefix("");
+		pn.setGivenName("");
+		pn.setMiddleName("");
+		pn.setFamilyNamePrefix("");
+		pn.setFamilyName("");
+		pn.setFamilyName2("");
+		pn.setFamilyNameSuffix("");
+		pn.setDegree("");
+		pn.setPreferred(true);
+		pn.setPerson(new Person(999));
+		
+		PersonName other = new PersonName(2);
+		other.setPrefix(null);
+		other.setGivenName(null);
+		other.setMiddleName(null);
+		other.setFamilyNamePrefix(null);
+		other.setFamilyName(null);
+		other.setFamilyName2(null);
+		other.setFamilyNameSuffix(null);
+		other.setDegree(null);
+		other.setPreferred(false);
+		other.setPerson(new Person(111));
+		
+		assertThat(pn.equalsContent(other), is(true));
 	}
 	
 	/**
@@ -335,10 +459,10 @@ public class PersonNameTest {
 	public void getFamilyName_shouldReturnObscuredNameIfObscure_patientsIsSetToTrue() throws Exception {
 		OpenmrsConstants.OBSCURE_PATIENTS = true;
 		
-		OpenmrsConstants.OBSCURE_PATIENTS_FAMILY_NAME = "family name";		
+		OpenmrsConstants.OBSCURE_PATIENTS_FAMILY_NAME = "family name";
 		Assert.assertEquals("family name", new PersonName().getFamilyName());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -353,7 +477,7 @@ public class PersonNameTest {
 		pn.setFamilyName2("a non-null name");
 		Assert.assertNull(pn.getFamilyName2());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -368,7 +492,7 @@ public class PersonNameTest {
 		pn.setFamilyNamePrefix("a non-null name");
 		Assert.assertNull(pn.getFamilyNamePrefix());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -383,7 +507,7 @@ public class PersonNameTest {
 		pn.setFamilyNameSuffix("a non-null name");
 		Assert.assertNull(pn.getFamilyNameSuffix());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -394,10 +518,10 @@ public class PersonNameTest {
 	public void getGivenName_shouldReturnObscuredNameIfObscure_patientsIsSetToTrue() throws Exception {
 		OpenmrsConstants.OBSCURE_PATIENTS = true;
 		
-		OpenmrsConstants.OBSCURE_PATIENTS_GIVEN_NAME = "given name";		
+		OpenmrsConstants.OBSCURE_PATIENTS_GIVEN_NAME = "given name";
 		Assert.assertEquals("given name", new PersonName().getGivenName());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -408,10 +532,10 @@ public class PersonNameTest {
 	public void getMiddleName_shouldReturnObscuredNameIfObscure_patientsIsSetToTrue() throws Exception {
 		OpenmrsConstants.OBSCURE_PATIENTS = true;
 		
-		OpenmrsConstants.OBSCURE_PATIENTS_MIDDLE_NAME = "middle name";		
+		OpenmrsConstants.OBSCURE_PATIENTS_MIDDLE_NAME = "middle name";
 		Assert.assertEquals("middle name", new PersonName().getMiddleName());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 	/**
@@ -426,7 +550,7 @@ public class PersonNameTest {
 		pn.setPrefix("a non-null name");
 		Assert.assertNull(pn.getPrefix());
 		
-		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup 
+		OpenmrsConstants.OBSCURE_PATIENTS = false; // cleanup
 	}
 	
 }

--- a/test/api/org/openmrs/api/include/PatientServiceTest-mergePatients.xml
+++ b/test/api/org/openmrs/api/include/PatientServiceTest-mergePatients.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <global_property property="patient.identifierRegex" property_value="^0*@SEARCH@([A-Z]+-[0-9])?$" uuid="c92cce6d-7e7d-4c53-a3c9-faaac17f8f8b"/>
+    <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="92ab9667-4686-49af-8be8-65a4b58fc49c"/>
+    <person person_id="10000" birthdate_estimated="0" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="61b38324-e2fd-4feb-95b7-9e9a2a4400df"/>
+    <person person_id="10001" birthdate_estimated="0" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="5c521595-4e12-46b0-8248-b8f2d3697766"/>
+    <patient patient_id="10000" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+    <patient patient_id="10001" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+    <patient_identifier patient_identifier_id="1" patient_id="10000" identifier="1234-4" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="e997ac86-4d8a-40f3-bedb-da84d35917b8"/>
+    <patient_identifier patient_identifier_id="2" patient_id="10001" identifier="12345-5" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="504c83c7-cfbf-4ae7-a4da-bdfa3236689f"/>
+    <person_address person_address_id="10000" person_id="10000" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" postal_code="1234" date_created="2005-01-01 00:00:00.0" voided="false" preferred="1"/>
+    <person_address person_address_id="10001" person_id="10000" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" state_province="Fakeland" date_created="2005-01-03 00:00:00.0" voided="false" preferred="0"/>
+    <person_address person_address_id="10002" person_id="10001" address1="Apartment ABC" address2="123 fake st" city_village="Faketown" state_province="Fakeland" date_created="2005-01-01 00:00:00.0" voided="false" preferred="1"/>
+    <person_name person_name_id="1" preferred="false" person_id="10000" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="7e2acadc-5073-4a39-914a-debcbec8c1c9"/>
+    <person_name person_name_id="2" preferred="false" person_id="10000" prefix="President" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" family_name_suffix="Esq." creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="d531d4a2d-a97e-4673-80f8-ac8dd5ced083" />
+    <person_name person_name_id="3" preferred="false" person_id="10001" prefix="President" given_name="John" middle_name="Fitzgerald" family_name="Kennedy" family_name_suffix="Esq." creator="1" date_created="2004-01-01 00:00:00.0" voided="false" uuid="c9714a2d-a97e-4673-80f8-ac8dd5ced083"/>
+</dataset>

--- a/test/api/org/openmrs/util/AddressMatcher.java
+++ b/test/api/org/openmrs/util/AddressMatcher.java
@@ -1,0 +1,49 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util;
+
+import org.hamcrest.Description;
+import org.junit.internal.matchers.TypeSafeMatcher;
+import org.openmrs.PersonAddress;
+import org.openmrs.PersonName;
+
+import java.util.Set;
+
+public class AddressMatcher extends TypeSafeMatcher<Set<PersonAddress>> {
+	
+	private String address;
+	
+	public AddressMatcher(String address) {
+		this.address = address;
+	}
+	
+	@Override
+	public boolean matchesSafely(Set<PersonAddress> personAddresses) {
+		for (PersonAddress personAddress : personAddresses) {
+			if (personAddress.toString().equals(address)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(address);
+	}
+	
+	public static AddressMatcher containsAddress(String address) {
+		return new AddressMatcher(address);
+	}
+}

--- a/test/api/org/openmrs/util/NameMatcher.java
+++ b/test/api/org/openmrs/util/NameMatcher.java
@@ -1,0 +1,48 @@
+/**
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.util;
+
+import org.hamcrest.Description;
+import org.junit.internal.matchers.TypeSafeMatcher;
+import org.openmrs.PersonName;
+
+import java.util.Set;
+
+public class NameMatcher extends TypeSafeMatcher<Set<PersonName>> {
+	
+	private String fullName;
+	
+	public NameMatcher(String fullName) {
+		this.fullName = fullName;
+	}
+	
+	@Override
+	public boolean matchesSafely(Set<PersonName> personNames) {
+		for (PersonName personName : personNames) {
+			if (personName.getFullName().equals(fullName)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		description.appendText(fullName);
+	}
+	
+	public static NameMatcher containsFullName(String fullName) {
+		return new NameMatcher(fullName);
+	}
+}


### PR DESCRIPTION
Resolved part of TRUNK-3913 with 1.7.x Backport for TRUNK-3351 
Merging persons incorrectly handles addresses and names

[TRUNK-3913] 1.7.x Backport of TRUNK-3351: Merging persons incorrectly handles addresses and names
