### PR TITLE
TRUNK-4212 SchedulerServiceTest fails depending on thread scheduling

### DIFF
--- a/api/src/test/java/org/openmrs/scheduler/SchedulerServiceTest.java
+++ b/api/src/test/java/org/openmrs/scheduler/SchedulerServiceTest.java
@@ -17,35 +17,36 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.scheduler.tasks.AbstractTask;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.util.OpenmrsClassLoader;
-import org.springframework.util.StringUtils;
 
 /**
- * TODO test all methods in ScheduleService
+ * TODO test all methods in SchedulerService
  */
 public class SchedulerServiceTest extends BaseContextSensitiveTest {
 	
-	private static Log log = LogFactory.getLog(SchedulerServiceTest.class);
-	
 	// so that we can guarantee tests running accurately instead of tests interfering with the next
-	public final Integer SAVE_TASK_LOCK = new Integer(1);
+	public final Integer TASK_TEST_METHOD_LOCK = new Integer(1);
 	
-	// each task provides a key that will be used in this map.  The value is the output
-	private static Map<String, String> output = new HashMap<String, String>();
+	// used to check for concurrent task execution. Only initialized by code protected by TASK_TEST_METHOD_LOCK.
+	public static CountDownLatch latch;
+	
+	public static AtomicBoolean awaitFailed = new AtomicBoolean(false);
+	
+	public static AtomicBoolean consecutiveInitResult = new AtomicBoolean(false);
+	
+	// time to wait for concurrent tasks to execute, should only wait this long if there's a test failure
+	public static final long CONCURRENT_TASK_WAIT_MS = 30000;
 	
 	@Before
 	public void setUp() throws Exception {
@@ -63,7 +64,7 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void shouldResolveValidTaskClass() throws Exception {
 		String className = "org.openmrs.scheduler.tasks.TestTask";
-		Class c = OpenmrsClassLoader.getInstance().loadClass(className);
+		Class<?> c = OpenmrsClassLoader.getInstance().loadClass(className);
 		Object o = c.newInstance();
 		if (o instanceof Task)
 			assertTrue("Class " + className + " is a valid Task", true);
@@ -74,7 +75,7 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 	@Test(expected = ClassNotFoundException.class)
 	public void shouldNotResolveInvalidClass() throws Exception {
 		String className = "org.openmrs.scheduler.tasks.InvalidTask";
-		Class c = OpenmrsClassLoader.getInstance().loadClass(className);
+		Class<?> c = OpenmrsClassLoader.getInstance().loadClass(className);
 		Object o = c.newInstance();
 		if (o instanceof Task)
 			fail("Class " + className + " is not supposed to be a valid Task");
@@ -82,186 +83,134 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 			assertTrue("Class " + className + " is not a valid Task", true);
 	}
 	
-	/**
-	 * Longer running class used to demonstrate tasks running concurrently
-	 */
-	public static class ExecutePrintingTask extends AbstractTask {
-		
-		public void execute() {
-			String outputKey = getTaskDefinition().getProperty("outputKey");
-			appendOutput(outputKey, getTaskDefinition().getProperty("id"));
-			
-			try {
-				Thread.sleep(Integer.valueOf(getTaskDefinition().getProperty("delay")));
-			}
-			catch (InterruptedException e) {
-				log.error("Error generated", e);
-			}
-			
-			appendOutput(outputKey, getTaskDefinition().getProperty("id"));
-			
-		}
-	}
-	
-	/**
-	 * Helper method to append the given text to the "output" static variable map
-	 * <br/>
-	 * Map will contain string like "text, text1, text2"
-	 * 
-	 * @param outputKey the key for the "output" map
-	 * @param the text to append to the value in the output map with the given key
-	 */
-	public synchronized static void appendOutput(String outputKey, String appendText) {
-		if (StringUtils.hasLength(output.get(outputKey)))
-			output.put(outputKey, output.get(outputKey) + ", " + appendText);
-		else
-			output.put(outputKey, appendText);
+	private TaskDefinition makeRepeatingTaskThatStartsImmediately(String taskClassName) {
+		TaskDefinition taskDef = new TaskDefinition();
+		taskDef.setTaskClass(taskClassName);
+		taskDef.setStartOnStartup(false);
+		taskDef.setStartTime(null);
+		taskDef.setName("name");
+		taskDef.setRepeatInterval(CONCURRENT_TASK_WAIT_MS * 10); // latch should timeout before task ever repeats
+		// save task definition to generate a unique ID, otherwise the scheduler thinks they're duplicates and tries to shut one down
+		Context.getSchedulerService().saveTaskDefinition(taskDef);
+		return taskDef;
 	}
 	
 	/**
 	 * Demonstrates concurrent running for tasks
-	 * 
-	 * <pre>
-	 *             |
-	 * SampleTask2 |    ----
-	 * SampleTask1 |------------
-	 *             |_____________ time
-	 *              ^   ^   ^   ^
-	 * Output:     S-1 S-2 E-2 E-1
-	 * </pre>
 	 */
 	@Test
-	@Ignore("TRUNK-4212 SchedulerServiceTest fails depending on thread scheduling")
 	public void shouldAllowTwoTasksToRunConcurrently() throws Exception {
-		SchedulerService schedulerService = Context.getSchedulerService();
+		TaskDefinition t1 = makeRepeatingTaskThatStartsImmediately(LatchExecuteTask.class.getName());
+		TaskDefinition t2 = makeRepeatingTaskThatStartsImmediately(LatchExecuteTask.class.getName());
 		
-		TaskDefinition t1 = new TaskDefinition();
-		t1.setId(1);
-		t1.setStartOnStartup(false);
-		t1.setStartTime(null);
-		t1.setTaskClass(ExecutePrintingTask.class.getName());
-		t1.setProperty("id", "TASK-1");
-		t1.setProperty("delay", "400"); // must be longer than t2's delay
-		t1.setProperty("outputKey", "shouldAllowTwoTasksToRunConcurrently");
-		t1.setName("name");
-		t1.setRepeatInterval(5000l);
-		
-		TaskDefinition t2 = new TaskDefinition();
-		t2.setId(2);
-		t2.setStartOnStartup(false);
-		t2.setStartTime(null);
-		t2.setTaskClass(ExecutePrintingTask.class.getName());
-		t2.setProperty("id", "TASK-2");
-		t2.setProperty("delay", "100"); // must be shorter than t1's delay
-		t2.setProperty("outputKey", "shouldAllowTwoTasksToRunConcurrently");
-		t2.setName("name");
-		t2.setRepeatInterval(5000l);
-		
-		synchronized (SAVE_TASK_LOCK) {
-			schedulerService.scheduleTask(t1);
-			Thread.sleep(50); // so t2 doesn't start before t1 due to random millisecond offsets
-			schedulerService.scheduleTask(t2);
-			Thread.sleep(2500); // must be longer than t2's delay
-			assertEquals("TASK-1, TASK-2, TASK-2, TASK-1", output.get("shouldAllowTwoTasksToRunConcurrently"));
-		}
-	}
-	
-	/**
-	 * Longer init'ing class for concurrent init test
-	 */
-	public static class SimpleTask extends AbstractTask {
-		
-		public void initialize(TaskDefinition config) {
-			String outputKey = config.getProperty("outputKey");
-			appendOutput(outputKey, config.getProperty("id"));
-			
-			super.initialize(config);
-			try {
-				// must be less than delay before printing
-				Thread.sleep(Integer.valueOf(config.getProperty("delay")));
-			}
-			catch (InterruptedException e) {
-				log.error("Error generated", e);
-			}
-			
-			appendOutput(outputKey, config.getProperty("id"));
-		}
-		
-		public void execute() {
-		}
+		checkTasksRunConcurrently(t1, t2);
 	}
 	
 	/**
 	 * Demonstrates concurrent initializing for tasks
-	 * 
-	 * <pre>
-	 *             |
-	 * SampleTask4 |    ----
-	 * SampleTask3 |------------
-	 *             |_____________ time
-	 *              ^   ^   ^   ^
-	 * Output:     S-3 S-4 E-4 E-3
-	 * </pre>
 	 */
 	@Test
-	@Ignore("TRUNK-4212 SchedulerServiceTest fails depending on thread scheduling")
 	public void shouldAllowTwoTasksInitMethodsToRunConcurrently() throws Exception {
-		SchedulerService schedulerService = Context.getSchedulerService();
+		TaskDefinition t3 = makeRepeatingTaskThatStartsImmediately(LatchInitializeTask.class.getName());
+		TaskDefinition t4 = makeRepeatingTaskThatStartsImmediately(LatchInitializeTask.class.getName());
 		
-		TaskDefinition t3 = new TaskDefinition();
-		t3.setStartOnStartup(false);
-		t3.setStartTime(null); // so it starts immediately
-		t3.setTaskClass(SimpleTask.class.getName());
-		t3.setProperty("id", "TASK-3");
-		t3.setProperty("delay", "300"); // must be longer than t4's delay
-		t3.setProperty("outputKey", "shouldAllowTwoTasksInitMethodsToRunConcurrently");
-		t3.setName("name");
-		t3.setRepeatInterval(5000l);
-		
-		TaskDefinition t4 = new TaskDefinition();
-		t4.setStartOnStartup(false);
-		t4.setStartTime(null); // so it starts immediately
-		t4.setTaskClass(SimpleTask.class.getName());
-		t4.setProperty("id", "TASK-4");
-		t4.setProperty("delay", "100");
-		t4.setProperty("outputKey", "shouldAllowTwoTasksInitMethodsToRunConcurrently");
-		t4.setName("name");
-		t4.setRepeatInterval(5000l);
-		
-		// both of these tasks start immediately
-		synchronized (SAVE_TASK_LOCK) {
-			schedulerService.scheduleTask(t3); // starts first, ends last
-			schedulerService.scheduleTask(t4); // starts last, ends first
-		}
-		Thread.sleep(500); // must be greater than task3 delay so that it prints out its end
-		assertEquals("TASK-3, TASK-4, TASK-4, TASK-3", output.get("shouldAllowTwoTasksInitMethodsToRunConcurrently"));
-		
-		// cleanup
-		schedulerService.shutdownTask(t3);
-		schedulerService.shutdownTask(t4);
+		checkTasksRunConcurrently(t3, t4);
 	}
 	
-	public static class SampleTask5 extends AbstractTask {
+	private void checkTasksRunConcurrently(TaskDefinition t1, TaskDefinition t2) throws SchedulerException,
+	        InterruptedException {
+		
+		SchedulerService schedulerService = Context.getSchedulerService();
+		
+		// synchronized on a class level object in case a test runner is running test methods concurrently
+		synchronized (TASK_TEST_METHOD_LOCK) {
+			latch = new CountDownLatch(2);
+			awaitFailed.set(false);
+
+			schedulerService.scheduleTask(t1);
+			schedulerService.scheduleTask(t2);
+			
+			// wait for the tasks to call countDown()
+			assertTrue("methods ran consecutively or not at all", latch
+			        .await(CONCURRENT_TASK_WAIT_MS, TimeUnit.MILLISECONDS));
+			// the main await() didn't fail so both tasks ran and called countDown(), 
+			// but if the first await() failed and the latch still reached 0 then the tasks must have been running consecutively 
+			assertTrue("methods ran consecutively", !awaitFailed.get());
+		}
+		schedulerService.shutdownTask(t1);
+		schedulerService.shutdownTask(t2);
+	}
+	
+	public abstract static class LatchTask extends AbstractTask {
+		
+		protected void waitForLatch() {
+			try {
+				latch.countDown();
+				// wait here until the other task thread(s) also countDown the latch
+				// if they do then they must be executing concurrently with this task
+				if (!latch.await(CONCURRENT_TASK_WAIT_MS, TimeUnit.MILLISECONDS)) {
+					// this wait timed out, record it as otherwise the next
+					// task(s) could execute consecutively rather than concurrently 
+					awaitFailed.set(true);
+				}
+			}
+			catch (InterruptedException ignored) {}
+		}
+	}
+	
+	/**
+	 * task that waits in its initialize method until all other tasks on the same latch have called
+	 * initialize()
+	 */
+	public static class LatchInitializeTask extends LatchTask {
 		
 		public void initialize(TaskDefinition config) {
-			
-			String outputKey = config.getProperty("outputKey");
-			appendOutput(outputKey, "INIT-START-5");
-			
 			super.initialize(config);
-			try {
-				Thread.sleep(700);
-			}
-			catch (InterruptedException e) {
-				log.error("Error generated", e);
-			}
-			
-			appendOutput(outputKey, "INIT-END-5");
+			waitForLatch();
 		}
 		
 		public void execute() {
-			String outputKey = getTaskDefinition().getProperty("outputKey");
-			appendOutput(outputKey, "IN EXECUTE");
+		}
+	}
+	
+	/**
+	 * task that waits in its execute method until all other tasks on the same latch have called
+	 * execute()
+	 */
+	public static class LatchExecuteTask extends LatchTask {
+		
+		public void initialize(TaskDefinition config) {
+			super.initialize(config);
+		}
+		
+		public void execute() {
+			waitForLatch();
+		}
+	}
+	
+	/**
+	 * task that checks for its execute method running at the same time as its initialize method
+	 */
+	public static class InitSequenceTestTask extends AbstractTask {
+		
+		public void initialize(TaskDefinition config) {
+			
+			super.initialize(config);
+			
+			// wait for any other thread to run the execute method
+			try {
+				Thread.sleep(700);
+			}
+			catch (InterruptedException ignored) {}
+			
+			// set to false if execute() method was running concurrently and has cleared the latch
+			consecutiveInitResult.set(latch.getCount() != 0);
+		}
+		
+		@Override
+		public void execute() {
+			// clear the latch to signal the main thread
+			latch.countDown();
 		}
 	}
 	
@@ -269,34 +218,29 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 	 * Demonstrates that initialization of a task is accomplished before its execution without
 	 * interleaving, which is a non-trivial behavior in the presence of a threaded initialization
 	 * method (as implemented in TaskThreadedInitializationWrapper)
-	 * 
-	 * <pre>
-	 *             |
-	 * SampleTask5 |------------
-	 *             |_____________ time
-	 *              ^   ^   ^   ^
-	 * Output:     IS  IE   S   E
-	 * </pre>
 	 */
 	@Test
 	public void shouldNotAllowTaskExecuteToRunBeforeInitializationIsComplete() throws Exception {
 		SchedulerService schedulerService = Context.getSchedulerService();
 		
 		TaskDefinition t5 = new TaskDefinition();
-		t5.setId(5);
 		t5.setStartOnStartup(false);
 		t5.setStartTime(null); // immediate start
-		t5.setTaskClass(SampleTask5.class.getName());
-		t5.setProperty("outputKey", "shouldNotAllowTaskExecuteToRunBeforeInitializationIsComplete");
+		t5.setTaskClass(InitSequenceTestTask.class.getName());
 		t5.setName("name");
-		t5.setRepeatInterval(5000l);
+		t5.setRepeatInterval(CONCURRENT_TASK_WAIT_MS * 4);
 		
-		synchronized (SAVE_TASK_LOCK) {
+		synchronized (TASK_TEST_METHOD_LOCK) {
+			// wait for the task to complete
+			latch = new CountDownLatch(1);
+			consecutiveInitResult.set(false);
+			schedulerService.saveTaskDefinition(t5);
 			schedulerService.scheduleTask(t5);
-			Thread.sleep(2500);
-			assertEquals("INIT-START-5, INIT-END-5, IN EXECUTE", output
-			        .get("shouldNotAllowTaskExecuteToRunBeforeInitializationIsComplete"));
+			assertTrue("Init and execute methods should run consecutively", latch.await(CONCURRENT_TASK_WAIT_MS,
+			    TimeUnit.MILLISECONDS)
+			        && consecutiveInitResult.get());
 		}
+		schedulerService.shutdownTask(t5);
 	}
 	
 	@Test
@@ -307,10 +251,10 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		final String TASK_NAME = "This is my test! 123459876";
 		def.setName(TASK_NAME);
 		def.setStartOnStartup(false);
-		def.setRepeatInterval(10L);
-		def.setTaskClass(ExecutePrintingTask.class.getName());
+		def.setRepeatInterval(10000000L);
+		def.setTaskClass(LatchExecuteTask.class.getName());
 		
-		synchronized (SAVE_TASK_LOCK) {
+		synchronized (TASK_TEST_METHOD_LOCK) {
 			int size = service.getRegisteredTasks().size();
 			service.saveTask(def);
 			Assert.assertEquals(size + 1, service.getRegisteredTasks().size());
@@ -325,12 +269,8 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 	 */
 	public static class BareTask implements Task {
 		
-		public static ArrayList outputList = new ArrayList();
-		
 		public void execute() {
-			synchronized (outputList) {
-				outputList.add("TEST");
-			}
+			latch.countDown();
 		}
 		
 		public TaskDefinition getTaskDefinition() {
@@ -359,7 +299,6 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		SchedulerService schedulerService = Context.getSchedulerService();
 		
 		TaskDefinition td = new TaskDefinition();
-		td.setId(10);
 		td.setName("Task");
 		td.setStartOnStartup(false);
 		td.setTaskClass(BareTask.class.getName());
@@ -367,12 +306,12 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		td.setName("name");
 		td.setRepeatInterval(5000l);
 		
-		synchronized (SAVE_TASK_LOCK) {
+		synchronized (TASK_TEST_METHOD_LOCK) {
+			latch = new CountDownLatch(1);
+			schedulerService.saveTaskDefinition(td);
 			schedulerService.scheduleTask(td);
+			assertTrue(latch.await(CONCURRENT_TASK_WAIT_MS, TimeUnit.MILLISECONDS));
 		}
-		Thread.sleep(500);
-		
-		assertTrue(BareTask.outputList.contains("TEST"));
 	}
 	
 	/**
@@ -407,8 +346,8 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		td.setTaskClass(SessionTask.class.getName());
 		td.setStartTime(null);
 		td.setRepeatInterval(new Long(0));//0 indicates single execution
-		synchronized (SAVE_TASK_LOCK) {
-			service.saveTask(td);
+		synchronized (TASK_TEST_METHOD_LOCK) {
+			service.saveTaskDefinition(td);
 			service.scheduleTask(td);
 		}
 		
@@ -416,8 +355,9 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		td = service.getTaskByName(NAME);
 		
 		// sleep a while until the task has executed, up to 30 times
-		for (int x = 0; x < 30 && (actualExecutionTime == null || td.getLastExecutionTime() == null); x++)
+		for (int x = 0; x < 30 && (actualExecutionTime == null || td.getLastExecutionTime() == null); x++) {
 			Thread.sleep(200);
+		}
 		
 		Assert
 		        .assertNotNull(


### PR DESCRIPTION
This is a rewrite of most of the test as it had a lot of race conditions arising from assumptions that thread order of execution was nice and reliable. 
