### PR TITLE
Add ability to view uuids to most objects TRUNK-2448

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/view/admin/concepts/conceptReferenceTermForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/concepts/conceptReferenceTermForm.jsp
@@ -175,12 +175,6 @@ $j(document).ready( function() {
                 </spring:bind>
             </td>
         </tr>
-        <tr>
-         <c:if test="${conceptReferenceTerm.conceptReferenceTermId != null}">
-           <th class="alignRight"><font color="#D0D0D0"><sub><openmrs:message code="general.uuid"/></sub></font></th>
-           <td colspan="${fn:length(locales)}"><font color="#D0D0D0"><sub>${conceptReferenceTerm.uuid}</sub></font></td>
-         </c:if>
-       </tr>
         </spring:nestedPath>
         <tr>
         	<th class="alignRight" valign="top" style="padding-top: 8px"><openmrs:message code="ConceptReferenceTerm.relatedTerms"/></th>
@@ -353,6 +347,12 @@ $j(document).ready( function() {
 			</td>
 		</tr>
 		</c:if>
+        <c:if test="${conceptReferenceTerm.conceptReferenceTermId != null}">
+            <tr>
+                <th class="alignRight"><font color="#D0D0D0"><sub><openmrs:message code="general.uuid"/></sub></font></th>
+                <td colspan="${fn:length(locales)}"><font color="#D0D0D0"><sub>${conceptReferenceTerm.uuid}</sub></font></td>
+            </tr>
+        </c:if>
        	<tr>
 			<th></th>
 			<td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
@@ -139,6 +139,12 @@
 			<td><openmrs:format user="${ visitAttributeType.creator }"/></td>
 		</tr>
 	</c:if>
+    <c:if test="${visitAttributeType.visitAttributeTypeId != null}">
+        <tr>
+            <td><font color="#D0D0D0"><sub><openmrs:message code="general.uuid"/></sub></font></td>
+            <td colspan="${fn:length(locales)}"><font color="#D0D0D0"><sub>${visitAttributeType.uuid}</sub></font></td>
+        </tr>
+    </c:if>
 </table>
 <br />
 


### PR DESCRIPTION
This pull request addresses last comments which dkayiwa put on https://github.com/openmrs/openmrs-core/pull/588.

Last comments are listed below :) 

Can you also add for Visit Attribute Types?
-Added(screen shot atttached in jira)

Can you also put the uuid for Reference Terms at the bottom?
-Moved below(screen shot atttached in jira)
