### PR TITLE
Resolve Xform module from getting blank screen when use IE9/10

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
@@ -1,6 +1,5 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <%@ page import="org.openmrs.web.WebConstants" %>
 <%

--- a/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
@@ -1,6 +1,5 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <%@ page import="org.openmrs.web.WebConstants" %>
 <%


### PR DESCRIPTION
This pull is to resolve issue with xforms getting blank screen when using IE9/10. As most pages from modules (including xforms) use the header.jsp from openmrs-core as their header, the <!DOCTYPE> tag from header.jsp in openmrs-core specifies the <!DOCTYPE> of the modules jsp page. For some reason, I found the current DOCTYPE in header.jsp : 
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> 
causes IE9/10 to fail to load the script formrunner.nocache.js of Xform module. When changing the DOCTYPE to 
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
, IE9/10 loads xforms properly
