### PR TITLE
TRUNK-3850: Deleted for loop in validate method in ProgramValidator.java

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ProgramValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProgramValidator.java
@@ -61,15 +61,16 @@ public class ProgramValidator implements Validator {
 		} else {
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "error.name");
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "error.description.required");
+			/*
 			List<Program> programs = Context.getProgramWorkflowService().getAllPrograms(false);
 			for (Program program : programs) {
 				if (program.getName().equals(p.getName()) && !program.getUuid().equals(p.getUuid())) {
 					errors.rejectValue("name", "general.error.nameAlreadyInUse");
 					break;
 				} else {
-					Context.evictFromSession(program);
+					//Context.evictFromSession(program);
 				}
-			}
+			}*/
 			
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "concept", "error.concept");
 		}


### PR DESCRIPTION
Commented out the for-loop listed, yet all the unit tests still passed. This could be an indication that the for-loop was unnecessary, or that the unit tests currently implemented are insufficient.
