### PR TITLE
TRUNK-4315: Added check for newly created providers and edited test vali...

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ProviderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProviderValidator.java
@@ -89,6 +89,11 @@ public class ProviderValidator extends BaseCustomizableValidator implements Vali
 			errors.rejectValue("name", "Provider.error.personOrName.required");
 		}
 		
+		if (provider.getId() == null) {
+			if (provider.getPerson() != null && StringUtils.isNotBlank(provider.getName())) {
+				errors.rejectValue("name", "Provider.error.personOrName.required");
+			}
+		}
 		//if this is a retired existing provider, skip this
 		//check if this provider has a unique identifier
 		boolean isUnique = Context.getProviderService().isProviderIdentifierUnique(provider);

--- a/api/src/test/java/org/openmrs/validator/ProviderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ProviderValidatorTest.java
@@ -142,8 +142,8 @@ public class ProviderValidatorTest extends BaseContextSensitiveTest {
 		providerValidator.validate(provider, errors);
 		
 		//then
-		Assert.assertFalse(errors.hasErrors());
-		Assert.assertFalse(errors.hasFieldErrors("name"));
+		Assert.assertTrue(errors.hasErrors());
+		Assert.assertTrue(errors.hasFieldErrors("name"));
 	}
 	
 	/**


### PR DESCRIPTION
TRUNK-4315: Added check for newly created providers

https://issues.openmrs.org/browse/TRUNK-4315

The check adds an error message if both provider name and person id are specified.
I modified the validate_shouldNeverHaveBothPersonAndNameSet() test because the stub violates the above rule
and therefore an error should be displayed to the user
