### PR TITLE
TRUNK4391 - Have Xforms show form in Internet Explorer (IE) 9 and 10

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
@@ -1,6 +1,5 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <%@ page import="org.openmrs.web.WebConstants" %>
 <%

--- a/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
@@ -1,6 +1,5 @@
 <%@ page pageEncoding="UTF-8" contentType="text/html; charset=UTF-8" %>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-   "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 
 <%@ page import="org.openmrs.web.WebConstants" %>
 <%


### PR DESCRIPTION
This pull is to solve problem with Internet Explorer 9/10 unable to load Xforms module. The change is made in core because of the HTML doctype declared in Header.jsp of core module may cause some jsp pages of Xforms unable to run the formrunner javascript module in IE9/10. 
