### PR TITLE
Fix TRUNK-4380 Location parent not displayed:

### DIFF
--- a/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
@@ -123,7 +123,7 @@ public class MessageSourceServiceImpl implements MessageSourceService {
 	 */
 	public String getMessage(String code, Object[] args, Locale locale) throws NoSuchMessageException {
 		if (StringUtils.isBlank(code)) {
-			return "";
+			return StringUtils.EMPTY;
 		}
 		
 		return activeMessageSource.getMessage(code, args, code, locale);
@@ -134,8 +134,8 @@ public class MessageSourceServiceImpl implements MessageSourceService {
 	 *      java.lang.Object[], java.lang.String, java.util.Locale)
 	 */
 	public String getMessage(String code, Object[] args, String defaultMessage, Locale locale) {
-		if (StringUtils.isBlank(code)) {
-			return "";
+		if (StringUtils.isBlank(code) && StringUtils.isBlank(defaultMessage)) {
+			return StringUtils.EMPTY;
 		}
 		
 		return activeMessageSource.getMessage(code, args, defaultMessage, locale);


### PR DESCRIPTION
OpenmrsMessageTag was ignoring the text attribute when code was null, as used in locationTree.tag.
