### PR TITLE
TRUNK-4109: Get observations by accession number

### DIFF
--- a/api/src/main/java/org/openmrs/api/ObsService.java
+++ b/api/src/main/java/org/openmrs/api/ObsService.java
@@ -409,6 +409,7 @@ public interface ObsService extends OpenmrsService {
 	 * @param includeVoidedObs true/false whether to also include the voided obs (required)
 	 * @param accessionNumber accession number (optional)
 	 * @return list of Observations that match all of the criteria given in the arguments
+	 * @since 1.12
 	 * @throws APIException
 	 * @should compare dates using lte and gte
 	 * @should get all obs assigned to given encounters
@@ -489,6 +490,7 @@ public interface ObsService extends OpenmrsService {
 	 * @param includeVoidedObs true/false whether to also include the voided obs (required)
 	 * @param accessionNumber accession number (optional)
 	 * @return list of Observations that match all of the criteria given in the arguments
+	 * @since 1.12
 	 * @throws APIException
 	 * @should compare dates using lte and gte
 	 * @should get the count of all obs assigned to given encounters


### PR DESCRIPTION
org.openmrs.api.ObsService#getObservations and
org.openmrs.api.ObsService#getObservationCount are now overloaded to support
specification of accession number.
If specified, only observations (or their count) with matching accession
number are returned.

See https://issues.openmrs.org/browse/TRUNK-4109

Unit tests for org.openmrs.api.ObsService#getObservations and
org.openmrs.api.ObsService#getObservationCount now use the new
(and most general) methods.
