### PR TITLE
TRUNK-4411 Relaxed ProviderValidator to accept duplicate identifiers.

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ProviderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProviderValidator.java
@@ -67,8 +67,11 @@ public class ProviderValidator extends BaseCustomizableValidator implements Vali
 	 * @should be valid if only name is set
 	 * @should reject a provider if it has fewer than min occurs of an attribute
 	 * @should reject a provider if it has more than max occurs of an attribute
-     * @should pass if an identifier for a new or existing provider is a duplicate identifier
-     */
+	 * @should accept duplicate identifier if the existing provider is not retired
+	 * @should accept duplicate identifier if the existing provider is retired
+	 * @should accept a duplicate identifier for a new provider which is not retired
+	 * @should accept a duplicate identifier for a new provider which is retired
+	 */
 	public void validate(Object obj, Errors errors) throws APIException {
 		if (log.isDebugEnabled()) {
 			log.debug(this.getClass().getName() + ".validate...");

--- a/api/src/test/java/org/openmrs/validator/ProviderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ProviderValidatorTest.java
@@ -228,8 +228,8 @@ public class ProviderValidatorTest extends BaseContextSensitiveTest {
 	 * @see {@link ProviderValidator#validate(Object,Errors)}
 	 */
 	@Test
-	@Verifies(value = "should accept the identifier for an existing provider if it is changed to a duplicate value", method = "validate(Object,Errors)")
-	public void validate_shouldPassIfAnIdentifierForAnExistingProviderIsChangedToADuplicateValue() throws Exception {
+	@Verifies(value = "should accept duplicate identifier if the existing provider is not retired", method = "validate(Object,Errors)")
+	public void validate_shouldAcceptDuplicateIdentifierIfTheExistingProviderIsNotRetired() throws Exception {
 		executeDataSet(OTHERS_PROVIDERS_XML);
 		Provider duplicateProvider = providerService.getProvider(200);
 		
@@ -239,30 +239,13 @@ public class ProviderValidatorTest extends BaseContextSensitiveTest {
 		providerValidator.validate(existingProviderToEdit, errors);
 		Assert.assertFalse(errors.hasErrors());
 	}
-
-	/**
-	 * @see {@link ProviderValidator#validate(Object,Errors)}
-	 */
-	@Test
-	@Verifies(value = "should not reject a duplicate identifier for a new provider", method = "validate(Object,Errors)")
-	public void validate_shouldNotRejectADuplicateIdentifierForANewProvider() throws Exception {
-		Provider duplicateProvider = providerService.getProvider(1);
-		Assert.assertFalse(duplicateProvider.isRetired());
-		
-		Provider provider = new Provider();
-		provider.setIdentifier(duplicateProvider.getIdentifier());
-		provider.setName("name");
-		
-		providerValidator.validate(provider, errors);
-		Assert.assertFalse(errors.hasFieldErrors("identifier"));
-	}
 	
 	/**
 	 * @see {@link ProviderValidator#validate(Object,Errors)}
 	 */
 	@Test
-	@Verifies(value = "should accept duplicate identifier even if the existing provider is retired", method = "validate(Object,Errors)")
-	public void validate_shouldPassForADuplicateIdentifierIfTheExistingProviderIsRetired() throws Exception {
+	@Verifies(value = "should accept duplicate identifier if the existing provider is retired", method = "validate(Object,Errors)")
+	public void validate_shouldAcceptDuplicateIdentifierIfTheExistingProviderIsRetired() throws Exception {
 		executeDataSet(OTHERS_PROVIDERS_XML);
 		Provider duplicateRetiredProvider = providerService.getProvider(201);
 		Assert.assertTrue(duplicateRetiredProvider.isRetired());
@@ -278,8 +261,25 @@ public class ProviderValidatorTest extends BaseContextSensitiveTest {
 	 * @see {@link ProviderValidator#validate(Object,Errors)}
 	 */
 	@Test
-	@Verifies(value = "should pass if the provider we are validating has a duplicate identifier and is retired", method = "validate(Object,Errors)")
-	public void validate_shouldPassIfTheProviderWeAreValidatingHasADuplicateIdentifierAndIsRetired() throws Exception {
+	@Verifies(value = "should accept a duplicate identifier for a new provider which is not retired", method = "validate(Object,Errors)")
+	public void validate_shouldAcceptADuplicateIdentifierForANewProviderWhichIsNotRetired() throws Exception {
+		Provider duplicateProvider = providerService.getProvider(1);
+		Assert.assertFalse(duplicateProvider.isRetired());
+		
+		Provider provider = new Provider();
+		provider.setIdentifier(duplicateProvider.getIdentifier());
+		provider.setName("name");
+		
+		providerValidator.validate(provider, errors);
+		Assert.assertFalse(errors.hasFieldErrors("identifier"));
+	}
+	
+	/**
+	 * @see {@link ProviderValidator#validate(Object,Errors)}
+	 */
+	@Test
+	@Verifies(value = "should accept a duplicate identifier for a new provider which is retired", method = "validate(Object,Errors)")
+	public void validate_shouldAcceptADuplicateIdentifierForANewProviderWhichIsRetired() throws Exception {
 		executeDataSet(OTHERS_PROVIDERS_XML);
 		Provider duplicateProvider = providerService.getProvider(1);
 		Assert.assertFalse(duplicateProvider.isRetired());


### PR DESCRIPTION
- Removed the uniqueness check in the validator.
- Fixed ambiguous java docs (and fixed an error in the documentation).
- The validator only checks for the presence of a retired identifier(with reason for retiring).
- Removed test for unique checks as this behaviour is no longer supported..
- Renamed and fixed tests to accept duplicate entries for Provider identifier.
