### PR TITLE
TRUNK-3654: ModuleUtil should not treat SNAPSHOT as 999.

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -248,6 +248,13 @@ public class ModuleUtil {
 	 * @should return false when required version with wild card on one end beyond openmrs version
 	 * @should return false when single entry required version beyond openmrs version
 	 * @should allow release type in the version
+	 * @should match when revision number is below maximum revision number
+	 * @should not match when revision number is above maximum revision number
+	 * @should correctly set upper and lower limit for versionRange with qualifiers and wild card
+	 * @should match when version has wild card plus qualifier and is within boundary
+	 * @should not match when version has wild card plus qualifier and is outside boundary
+	 * @should match when version has wild card and is within boundary
+	 * @should not match when version has wild card and is outside boundary
 	 */
 	public static boolean matchRequiredVersions(String version, String versionRange) {
 		if (versionRange != null && !versionRange.equals("")) {
@@ -283,10 +290,9 @@ public class ModuleUtil {
 					if (lowerBound.indexOf("*") > 0)
 						lowerBound = lowerBound.replaceAll("\\*", "0");
 					
-					// if the upper contains "*" then change it to 999
-					// assuming 999 will be the max revision number for openmrs
+					// if the upper contains "*" then change it to maxRevisionNumber
 					if (upperBound.indexOf("*") > 0)
-						upperBound = upperBound.replaceAll("\\*", "999");
+						upperBound = upperBound.replaceAll("\\*", Integer.toString(Integer.MAX_VALUE));
 					
 					int lowerReturn = compareVersion(version, lowerBound);
 					
@@ -393,8 +399,8 @@ public class ModuleUtil {
 			for (int x = 0; x < versions.size(); x++) {
 				String verNum = versions.get(x).trim();
 				String valNum = values.get(x).trim();
-				Integer ver = NumberUtils.toInt(verNum, 0);
-				Integer val = NumberUtils.toInt(valNum, 0);
+				Long ver = NumberUtils.toLong(verNum, 0);
+				Long val = NumberUtils.toLong(valNum, 0);
 				
 				int ret = ver.compareTo(val);
 				if (ret != 0) {

--- a/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
@@ -272,6 +272,89 @@ public class ModuleUtilTest extends BaseContextMockTest {
 	}
 	
 	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should match when revision number is below maximum revision number", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldMatchWhenRevisionNumberIsBelowMaximumRevisionNumber() {
+		String openmrsVersion = "1.4.1111";
+		String requiredVersion = "1.4.*";
+		Assert.assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should not match when revision number is above maximum revision number", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldNotMatchWhenRevisionNumberIsAboveMaximumRevisionNumber() {
+		Long revisionNumber = (long) Integer.MAX_VALUE + 2;
+		String openmrsVersion = "1.4." + revisionNumber;
+		String requiredVersion = "1.4.*";
+		Assert.assertFalse(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should not match when version has wild card and is outside boundary", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldNotMatchWhenVersionHasWildCardAndIsOutsideBoundary() {
+		String openmrsVersion = "1.*.4";
+		String requiredVersion = "1.4.0 - 1.4.10";
+		Assert.assertFalse(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should match when version has wild card and is within boundary", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldMatchWhenVersionHasWildCardAndIsWithinBoundary() {
+		String openmrsVersion = "1.4.*";
+		String requiredVersion = "1.4.0 - 1.4.10";
+		Assert.assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should not match when version has wild card plus qualifier and is outside boundary", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldNotMatchWhenVersionHasWildPlusQualifierCardAndIsOutsideBoundary() {
+		String openmrsVersion = "1.*.4-SNAPSHOT";
+		String requiredVersion = "1.4.0 - 1.4.10";
+		Assert.assertFalse(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should match when version has wild card plus qualifier and is within boundary", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldMatchWhenVersionHasWildCardPlusQualifierAndIsWithinBoundary() {
+		String openmrsVersion = "1.4.*-SNAPSHOT";
+		String requiredVersion = "1.4.0 - 1.4.10";
+		Assert.assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
+	 * @see {@link ModuleUtil#matchRequiredVersions(String,String)}
+	 */
+	@Test
+	@Verifies(value = "should correctly set upper and lower limit for versionRange with qualifiers and wild card", method = "matchRequiredVersions(String version, String versionRange)")
+	public void matchRequiredVersions_shouldCorrectlySetUpperAndLoweLimitForVersionRangeWithQualifiersAndWildCard() {
+		String openmrsVersion = "1.4.11111";
+		String requiredVersion = "1.4.200 - 1.4.*-SNAPSHOT";
+		Long revisionNumber = (long) Integer.MAX_VALUE + 2;
+		Assert.assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+		requiredVersion = "1.4.*-SNAPSHOT - 1.4.*";
+		Assert.assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+		openmrsVersion = "1.4." + revisionNumber;
+		Assert.assertFalse(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
+	
+	/**
 	 * @see {@link org.openmrs.module.ModuleUtil#getPathForResource(org.openmrs.module.Module,String)}
 	 */
 	@Test


### PR DESCRIPTION
Changed max revision number to Integer.MAX_VALUE and added some test for this change

Added back the lines that stipped off modifiers/qualifiers in the loop

Added back isVersionWithQualifiers() method

Removed variable for maxRevision
