### PR TITLE
Trunk-4404: Make getDruge method case insensitive

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -388,7 +388,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 			searchCriteria.add(Restrictions.eq("drug.concept", concept));
 		}
 		if (drugName != null) {
-			searchCriteria.add(Restrictions.eq("drug.name", drugName));
+			searchCriteria.add(Restrictions.eq("drug.name", drugName).ignoreCase());
 		}
 		return (List<Drug>) searchCriteria.list();
 	}

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateConceptDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateConceptDAOTest.java
@@ -68,6 +68,24 @@ public class HibernateConceptDAOTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
+	 * @see HibernateConceptDAO#getDrugs(String,Concept,boolean)
+	 * @verifies returns a drug regardless of case sensitivity
+	 */
+	@Test
+	@Verifies(value = "return a drug if drug name is passed with upper or lower case", method = "getDrugs(String,Concept,boolean,boolean,boolean,Integer,Integer)")
+	public void getDrugs_shouldReturnDrugIf_EitherDrugNameIsUpperOrLowerCase() throws Exception {
+		Session session5 = sessionFactory.getCurrentSession();
+		session5.beginTransaction();
+		
+		List<Drug> drugList1 = dao.getDrugs("Triomune-30", null, true);
+		Assert.assertEquals(1, drugList1.size());
+		
+		List<Drug> drugList2 = dao.getDrugs("triomune-30", null, true);
+		Assert.assertEquals(1, drugList2.size());
+		
+	}
+	
+	/**
 	 * @see HibernateConceptDAO#getDrugs(String,Concept,boolean,boolean,boolean,Integer,Integer)
 	 * @verifies return a drug if phrase match drug_name No need to match both concept_name and
 	 *           drug_name


### PR DESCRIPTION
I changed so when hibernate does the getDrug for String drugName it is case insensitive.  I created a test case that verifies that it gets the drug whether it is lower case or upper case.
