### PR TITLE
TRUNK-4212: Fix divide by zero error when repeatInterval=0, possible cau...

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
@@ -158,7 +158,7 @@ public class SchedulerUtil {
 	 * the JDK timer will run the task X number of times from the start time until now in order to
 	 * catch up. The assumption is that this is not the desired behavior -- we just want to execute
 	 * the task on its next execution time. For instance, say we had a scheduled task that ran every
-	 * 24 hours at midnight. In the database, the task would likely have a past start date (i.e.
+	 * 24 hours at midnight. In the database, the task would likely have a past start date (e.g.
 	 * 04/01/2006 12:00am). If we scheduled the task using the JDK Timer
 	 * scheduleAtFixedRate(TimerTask task, Date startDate, int interval) method and passed in the
 	 * start date above, the JDK Timer would execute this task once for every day between the start
@@ -186,16 +186,20 @@ public class SchedulerUtil {
 					return firstTime;
 				}
 				
-				// The time between successive runs (i.e. 24 hours)
+				// The time between successive runs (e.g. 24 hours)
 				long repeatInterval = taskDefinition.getRepeatInterval().longValue();
+				if (repeatInterval == 0) {
+					// task is one-shot so just return the start time
+					return firstTime;
+				}
 				
-				// Calculate time between the first time the process was run and right now (i.e. 3 days, 15 hours)
+				// Calculate time between the first time the process was run and right now (e.g. 3 days, 15 hours)
 				long betweenTime = currentTime.getTime() - firstTime.getTime();
 				
-				// Calculate the last time the task was run   (i.e. 15 hours ago)
+				// Calculate the last time the task was run   (e.g. 15 hours ago)
 				long lastTime = (betweenTime % (repeatInterval * 1000));
 				
-				// Calculate the time to add to the current time (i.e. 24 hours - 15 hours = 9 hours)
+				// Calculate the time to add to the current time (e.g. 24 hours - 15 hours = 9 hours)
 				long additional = ((repeatInterval * 1000) - lastTime);
 				
 				nextTime.setTime(new Date(currentTime.getTime() + additional));
@@ -204,7 +208,7 @@ public class SchedulerUtil {
 			}
 		}
 		catch (Exception e) {
-			log.error("Failed to get next execution time for " + taskDefinition.getName());
+			log.error("Failed to get next execution time for " + taskDefinition.getName(), e);
 		}
 		
 		return nextTime.getTime();

--- a/api/src/test/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImplTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Calendar;
 
 import org.junit.Test;
+import org.openmrs.api.context.Context;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.test.BaseContextSensitiveTest;
@@ -60,6 +61,10 @@ public class TimerSchedulerServiceImplTest extends BaseContextSensitiveTest {
 		
 		TimerSchedulerServiceImpl t = new TimerSchedulerServiceImpl();
 		clientTask = t.scheduleTask(taskDefinition);
+		
+		// without this commit there seems to be a table lock left on the SCHEDULER_TASK_CONFIG table, see TRUNK-4212
+		Context.flushSession();
+		getConnection().commit();
 		
 		// Assert that the clientTask is not null, i.e. the sheduleTask was able to successfully schedule in case of zero repeatInterval.
 		assertNotNull(


### PR DESCRIPTION
.Fix divide by zero error when repeatInterval=0, possible cause for test failure

TRUNK-4212: Commit task addition to database, possible cause of SchedulerServiceTest failure

TRUNK-4212: Turn on debug logging for the duration of SchedulerServiceTest, to try to diagnose intermittent test failures
