### PR TITLE
TRUNK-4208 Gender and Birth date should not be required for persons linked to providers or users but to patients

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
+import org.springframework.validation.ValidationUtils;
 import org.openmrs.annotation.Handler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
@@ -83,6 +84,8 @@ public class PatientValidator extends PersonValidator {
 		super.validate(obj, errors);
 		
 		Patient patient = (Patient) obj;
+		
+		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "gender", "Person.gender.required");
 		
 		if (PatientIdentifierValidator.hasMoreThanOneIdentifierForSameIdentifierType(patient.getActiveIdentifiers())) {
 			errors.reject("error.duplicateIdentifierTypes");

--- a/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
@@ -168,4 +168,19 @@ public class PatientValidatorTest extends PersonValidatorTest {
 		
 		Assert.assertFalse(errors.hasErrors());
 	}
+	
+	/**
+	 * @see {@link org.openmrs.validator.PatientValidator#validate(Object,Errors)}
+	 * @verifies fail validation if gender is blank
+	 */
+	@Test
+	@Verifies(value = "should fail validation if gender is blank", method = "validate(Object,Errors)")
+	public void validate_shouldFailValidationIfGenderIsBlank() throws Exception {
+		Patient pa = new Patient(1);
+		Errors errors = new BindException(pa, "patient");
+		validator.validate(pa, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("gender"));
+	}
+	
 }

--- a/api/src/test/java/org/openmrs/validator/PersonValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PersonValidatorTest.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Patient;
+import org.openmrs.Person;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
@@ -96,21 +97,6 @@ public class PersonValidatorTest extends BaseContextSensitiveTest {
 	
 	/**
 	 * @see PersonValidator#validate(Object,Errors)
-	 * @verifies fail validation if gender is blank
-	 */
-	@Test
-	@Verifies(value = "should fail validation if gender is blank", method = "validate(Object,Errors)")
-	public void validate_shouldFailValidationIfGenderIsBlank() throws Exception {
-		Patient pa = new Patient(1);
-		Errors errors = new BindException(pa, "patient");
-		validator.validate(pa, errors);
-		
-		Assert.assertTrue(errors.hasFieldErrors("gender"));
-		
-	}
-	
-	/**
-	 * @see PersonValidator#validate(Object,Errors)
 	 * @verifies fail validation if voidReason is blank when patient is voided
 	 */
 	@Test
@@ -136,4 +122,20 @@ public class PersonValidatorTest extends BaseContextSensitiveTest {
 		validator.validate(pa, errors);
 		Assert.assertTrue(errors.hasFieldErrors("names"));
 	}
+	
+	/**
+	 * @see {@link org.openmrs.validator.PersonValidator#validate(Object,Errors)}
+	 * @verifies pass validation if gender is blank for Persons
+	 */
+	@Test
+	@Verifies(value = "should pass validation if gender is blank for Persons", method = "validate(Object,Errors)")
+	public void validate_shouldPassValidationIfGenderIsBlankForPersons() throws Exception {
+		Person person = new Person(1);
+		Errors errors = new BindException(person, "person");
+		PersonValidator personValidator = new PersonValidator();
+		personValidator.validate(person, errors);
+		
+		Assert.assertFalse(errors.hasFieldErrors("gender"));
+	}
+	
 }


### PR DESCRIPTION
As a part of this ticket, I have moved the gender/birthdate validation checks from PersonValidator to PatientValidator. I had to change the test data xml to also include birthdate for patients.

Summary:
- Moved the checks for gender from PersonValidator and put it in PatientValidator instead.
- Updated PatientValidator to check for the presence of birthdate.
- Updated tests which create Patients to set a birthdate.
- Updated the xml which is used to create test data for patients to include birthdate.
- Some refactoring in the validator to extract functionality into methods to make code cleaner.
