### PR TITLE
TRUNK-4015: Application data directory should include web app name

### DIFF
--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -268,6 +268,9 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		String appDataDir = servletContext.getInitParameter("application.data.directory");
 		if (StringUtils.hasLength(appDataDir)) {
 			OpenmrsUtil.setApplicationDataDirectory(appDataDir);
+		} else if (!"openmrs".equalsIgnoreCase(WebConstants.WEBAPP_NAME)) {
+			OpenmrsUtil.setApplicationDataDirectory(OpenmrsUtil.getApplicationDataDirectory() + File.separator
+			        + WebConstants.WEBAPP_NAME);
 		}
 	}
 	

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
@@ -47,7 +47,7 @@ public class InitializationWizardModel {
 	 * Default database name to use unless user specifies another in the wizard or they are creating
 	 * a test installation
 	 */
-	public static final String DEFAULT_DATABASE_NAME = "openmrs";
+	public static final String DEFAULT_DATABASE_NAME = WebConstants.WEBAPP_NAME;
 	
 	/**
 	 * Records completed tasks and are displayed at the top of the page upon error

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -34,6 +34,10 @@
         <param-name>application.data.directory</param-name>
         <param-value></param-value>
     </context-param>
+    <context-param>
+    	<param-name>log4jExposeWebAppRoot</param-name>
+    	<param-value>false</param-value>
+    </context-param>
 	<!-- // End init parameters -->
 
     <context-param>


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-4015

Added feature to create different app data directory for different web apps as per the discussion in the ticket
Set log4jExposeWebAppRoot to false so to avoid webAppRootKey clashes per web app

Set default database name to webapp name e.g. test-deploy.war results into a database called test-deploy.
