### PR TITLE
TRUNK-4485: Modifying provider search to make it configurable

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -25,12 +25,11 @@ import org.hibernate.criterion.MatchMode;
 import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
-import org.openmrs.Person;
-import org.openmrs.Provider;
-import org.openmrs.ProviderAttribute;
-import org.openmrs.ProviderAttributeType;
+import org.openmrs.*;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.ProviderDAO;
+import org.openmrs.util.OpenmrsConstants;
 
 import java.util.Collection;
 import java.util.List;
@@ -159,6 +158,20 @@ public class HibernateProviderDAO implements ProviderDAO {
 	}
 	
 	/**
+	 *
+	 * @return MatchMode.EXACT if set and MatchMode.START otherwise
+	 */
+	private MatchMode getMatchMode() {
+		String providerMatchMode = Context.getAdministrationService().getGlobalProperty(
+		    OpenmrsConstants.GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE);
+		
+		if (OpenmrsConstants.GLOBAL_PROPERTY_PROVIDER_SEARCH_EXACT.equalsIgnoreCase(providerMatchMode)) {
+			return MatchMode.EXACT;
+		}
+		return MatchMode.START;
+	}
+	
+	/**
 	 * Creates a Provider Criteria based on name
 	 *
 	 * @param name represents provider name
@@ -181,7 +194,7 @@ public class HibernateProviderDAO implements ProviderDAO {
 		criteria.createAlias("p.names", "personName", Criteria.LEFT_JOIN);
 		
 		Disjunction or = Restrictions.disjunction();
-		or.add(Restrictions.ilike("identifier", name, MatchMode.ANYWHERE));
+		or.add(Restrictions.ilike("identifier", name, getMatchMode()));
 		or.add(Restrictions.ilike("name", name, MatchMode.ANYWHERE));
 		
 		Conjunction and = Restrictions.conjunction();

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -845,6 +845,12 @@ public final class OpenmrsConstants {
 	
 	public static final String GLOBAL_PROPERTY_PATIENT_SEARCH_MATCH_START = "START";
 	
+	public static final String GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE = "providerSearch.matchMode";
+	
+	public static final String GLOBAL_PROPERTY_PROVIDER_SEARCH_START = "START";
+	
+	public static final String GLOBAL_PROPERTY_PROVIDER_SEARCH_EXACT = "EXACT";
+	
 	public static final String GLOBAL_PROPERTY_DEFAULT_SERIALIZER = "serialization.defaultSerializer";
 	
 	public static final String GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS = "hl7_processor.ignore_missing_patient_non_local";

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -8446,4 +8446,17 @@
         <comment>Changing duration column of drug_order to int</comment>
         <modifyDataType tableName="drug_order" columnName="duration" newDataType="int"/>
     </changeSet>
+
+    <changeSet id="201422091133-TRUNK-4485" author="willa">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT count(*) from global_property where property='providerSearch.matchMode'</sqlCheck>
+        </preConditions>
+        <comment>Adding providerSearch.matchMode global property</comment>
+        <insert tableName="global_property">
+            <column name="property">providerSearch.matchMode</column>
+            <column name="property_value">START</column>
+            <column name="Description">Specifies how provider identifiers are matched while searching for providers. Valid values are START or EXACT</column>
+            <column name="uuid">ec575208-4270-11e4-8ea4-d3a3b5a10740</column>
+        </insert>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This tickets aims to make search mode for providers when using identifier configurable through the global property. Instead of suing MatchMode.ANYWHERE, the code is modified to allow only EXACT and START.
