### PR TITLE
[#TRUNK-3484] visit handlers need to accept uuids in visits.encounterTypeToVisitTypeMapping global propery for both encounter type and visit type

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -8447,7 +8447,7 @@
         <modifyDataType tableName="drug_order" columnName="duration" newDataType="int"/>
     </changeSet>
     
-    <changeSet id="201409230113-TRUNK-3484" author="k-joseph" dbms="mysql">
+    <changeSet id="201409230113-TRUNK-3484" author="k-joseph">
 		<preConditions onFail="MARK_RAN">
                 <sqlCheck expectedResult="1">
                     SELECT count(*) FROM global_property WHERE property ='visits.encounterTypeToVisitTypeMapping'


### PR DESCRIPTION
Updated the GP value in the database as well|https://issues.openmrs.org/browse/TRUNK-3484
