### PR TITLE
TRUNK-4485: Making provider search match mode configurable.

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -29,8 +29,10 @@ import org.openmrs.Person;
 import org.openmrs.Provider;
 import org.openmrs.ProviderAttribute;
 import org.openmrs.ProviderAttributeType;
+import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.ProviderDAO;
+import org.openmrs.util.OpenmrsConstants;
 
 import java.util.Collection;
 import java.util.List;
@@ -158,6 +160,22 @@ public class HibernateProviderDAO implements ProviderDAO {
 		return providers;
 	}
 	
+	private MatchMode getMatchMode() {
+		String matchMode = Context.getAdministrationService().getGlobalProperty(
+		    OpenmrsConstants.GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE);
+		
+		if (MatchMode.START.toString().equalsIgnoreCase(matchMode)) {
+			return MatchMode.START;
+		}
+		if (MatchMode.ANYWHERE.toString().equalsIgnoreCase(matchMode)) {
+			return MatchMode.ANYWHERE;
+		}
+		if (MatchMode.END.toString().equalsIgnoreCase(matchMode)) {
+			return MatchMode.END;
+		}
+		return MatchMode.EXACT;
+	}
+	
 	/**
 	 * Creates a Provider Criteria based on name
 	 *
@@ -181,7 +199,7 @@ public class HibernateProviderDAO implements ProviderDAO {
 		criteria.createAlias("p.names", "personName", Criteria.LEFT_JOIN);
 		
 		Disjunction or = Restrictions.disjunction();
-		or.add(Restrictions.ilike("identifier", name, MatchMode.ANYWHERE));
+		or.add(Restrictions.ilike("identifier", name, getMatchMode()));
 		or.add(Restrictions.ilike("name", name, MatchMode.ANYWHERE));
 		
 		Conjunction and = Restrictions.conjunction();

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -845,6 +845,8 @@ public final class OpenmrsConstants {
 	
 	public static final String GLOBAL_PROPERTY_PATIENT_SEARCH_MATCH_START = "START";
 	
+	public static final String GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE = "providerSearch.matchMode";
+	
 	public static final String GLOBAL_PROPERTY_DEFAULT_SERIALIZER = "serialization.defaultSerializer";
 	
 	public static final String GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS = "hl7_processor.ignore_missing_patient_non_local";
@@ -1589,6 +1591,10 @@ public final class OpenmrsConstants {
 		        "Specifies the uuid of the concept set where its members represent the possible test specimen sources"));
 		
 		props.add(new GlobalProperty(GP_UNKNOWN_PROVIDER_UUID, "", "Specifies the uuid of the Unknown Provider account"));
+		
+		props
+		        .add(new GlobalProperty(GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE, "EXACT",
+		                "Specifies how provider identifiers are matched while searching for providers. Valid values are START,EXACT, END or ANYWHERE"));
 		
 		for (GlobalProperty gp : ModuleFactory.getGlobalProperties()) {
 			props.add(gp);


### PR DESCRIPTION
This is done using a global property with default value EXACT when searching using provider identifiers
