### PR TITLE
TRUNK-3335 - Retired Provider Attribute Types should not be shown when adding/editing providers

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
@@ -112,7 +112,7 @@ public class ProviderFormController {
 	
 	@ModelAttribute("providerAttributeTypes")
 	public List<ProviderAttributeType> getProviderAttributeTypes() throws Exception {
-		return Context.getProviderService().getAllProviderAttributeTypes(false);
+		return Context.getProviderService().getAllProviderAttributeTypes(true);
 	}
 	
 	@RequestMapping(method = RequestMethod.GET)

--- a/webapp/src/main/webapp/WEB-INF/tags/attributesForType.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/attributesForType.tag
@@ -1,4 +1,5 @@
 <%@tag import="java.util.List"%>
+<%@tag import="java.util.ArrayList"%>
 <%@tag import="org.openmrs.attribute.Attribute"%>
 
 <%@ include file="/WEB-INF/template/include.jsp" %>
@@ -8,11 +9,43 @@
 <%@ attribute name="customizable" required="true" type="org.openmrs.customdatatype.Customizable" %>
 <%
 List<Attribute> existing = customizable.getActiveAttributes(attributeType);
+List<Integer> excludedAttributesIndexes = new ArrayList<Integer>();
+Boolean notEmptyRetired = false;
 int howManyToShow = attributeType.getMaxOccurs() == null ? 1 : attributeType.getMaxOccurs();
-howManyToShow = Math.max(howManyToShow, existing.size());
+howManyToShow = Math.max(howManyToShow, existing.size() );
+if (attributeType.isRetired()) {
+    Attribute val = null;
+    for(int i = 0; i < existing.size(); i++) {
+            val = existing.get(i);
+            if (val != null && val.getId() != null && !val.getValueReference().trim().isEmpty()) {
+                notEmptyRetired = true;
+            }
+            else {
+                excludedAttributesIndexes.add(i);
+            }
+    }
+    for (int i = 0; i < excludedAttributesIndexes.size(); i++) {
+        existing.remove(excludedAttributesIndexes.get(i));
+    }
+    if (notEmptyRetired) {
+        howManyToShow = existing.size();
+    }
+    else {
+        howManyToShow = 0;
+    }
+}
 %>
 <tr>
-    <th>${ attributeType.name }</th>
+     <c:choose>
+        <c:when test="${ attributeType.retired }" >
+            <c:if test= "<%= notEmptyRetired %>" >
+                <th><del>${ attributeType.name }</del></th>
+            </c:if>
+        </c:when>
+        <c:otherwise>
+            <th>${ attributeType.name }</th>
+        </c:otherwise>
+     </c:choose>
     <td>
 <% for (int i = 0; i < howManyToShow; ++i) {
 	Attribute val = null;


### PR DESCRIPTION
fixed, displaying all non voided attributes, even the attribute type is retired
