### PR TITLE
TRUNK-4490: EncounterValidator should validate presence of encounter type

### DIFF
--- a/api/src/main/java/org/openmrs/validator/EncounterValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterValidator.java
@@ -60,6 +60,7 @@ public class EncounterValidator implements Validator {
 	 *      org.springframework.validation.Errors)
 	 * @should fail if the patients for the visit and the encounter dont match
 	 * @should fail if patient is not set
+	 * @should fail if encounter type is not set
 	 * @should fail if encounter dateTime is after current dateTime
 	 * @should fail if encounter dateTime is before visit startDateTime
 	 * @should fail if encounter dateTime is after visit stopDateTime
@@ -76,6 +77,8 @@ public class EncounterValidator implements Validator {
 		Encounter encounter = (Encounter) obj;
 		
 		ValidationUtils.rejectIfEmpty(errors, "patient", "Encounter.error.patient.required", "Patient is required");
+		ValidationUtils.rejectIfEmpty(errors, "encounterType", "Encounter.error.encounterType.required",
+		    "Encounter type is Required");
 		if (encounter.getVisit() != null && !ObjectUtils.equals(encounter.getVisit().getPatient(), encounter.getPatient())) {
 			errors.rejectValue("visit", "Encounter.visit.patients.dontMatch",
 			    "The patient for the encounter and visit should be the same");

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -63,9 +63,12 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	
 	private VisitService visitService;
 	
+	private EncounterService encounterService;
+	
 	@Before
 	public void before() {
 		visitService = Context.getVisitService();
+		encounterService = Context.getEncounterService();
 		
 		// Allow overlapping visits. Ticket 3963 has introduced optional validation of start and stop dates
 		// based on concurrent visits of the same patient. Turning this validation on (i.e. not allowing
@@ -945,6 +948,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 		encounter.setEncounterDatetime(new Date());
 		encounter.setPatient(visit.getPatient());
 		encounter.setLocation(visit.getLocation());
+		encounter.setEncounterType(encounterService.getEncounterType(1));
 		visit.addEncounter(encounter);
 		
 		Context.getEncounterService().saveEncounter(encounter);

--- a/api/src/test/java/org/openmrs/validator/EncounterValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/EncounterValidatorTest.java
@@ -80,6 +80,18 @@ public class EncounterValidatorTest extends BaseContextSensitiveTest {
 	 * @see {@link EncounterValidator#validate(Object,Errors)}
 	 */
 	@Test
+	@Verifies(value = "should fail if encounter type is not set", method = "validate(Object,Errors)")
+	public void validate_shouldFailIfEncounterTypeIsNotSet() throws Exception {
+		Encounter encounter = new Encounter();
+		Errors errors = new BindException(encounter, "encounter");
+		new EncounterValidator().validate(encounter, errors);
+		Assert.assertTrue(errors.hasFieldErrors("encounterType"));
+	}
+	
+	/**
+	 * @see {@link EncounterValidator#validate(Object,Errors)}
+	 */
+	@Test
 	@Verifies(value = "should fail if encounter dateTime is before visit startDateTime", method = "validate(Object,Errors)")
 	public void validate_shouldFailIfEncounterDateTimeIsBeforeVisitStartDateTime() throws Exception {
 		Visit visit = Context.getVisitService().getVisit(1);

--- a/webapp/src/main/webapp/WEB-INF/messages.properties
+++ b/webapp/src/main/webapp/WEB-INF/messages.properties
@@ -997,6 +997,7 @@ Encounter.visit=Visit
 Encounter.visit.patients.dontMatch=The encounter and the visit it belongs to must both belong to the same patient
 Encounter.patientIdCannotBeNull=Patient Id cannot be null
 Encounter.error.patient.required=Patient is Required
+Encounter.error.encounterType.required=Encounter type is Required
 Encounter.error.encounterIdCannotBeNull=Encounter Id cannot be null
 Encounter.error.duplicateProviderEncounterRole=Provider cannot be added more than once for the same encounter role
 Encounter.cannot.save=Cannot save the encounter due to validation errors


### PR DESCRIPTION
@dkayiwa As mentioned in the ticket https://issues.openmrs.org/browse/TRUNK-4490

> There are few tests failing in ORUR01HandlerTest and HL7ServiceTest related to parsing hl7String. I couldn't find encounter type data in these strings. I would need help in fixing these tests
