### PR TITLE
GCI-9 - Collections.emptyList(),emptyMap() and emptySet() should be used instead and Empty statements should be removed

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -684,7 +684,7 @@ public class ServiceContext implements ApplicationContextAware {
 	@SuppressWarnings("unchecked")
 	private Set<Advisor> getAddedAdvisors(Class cls) {
 		Set<Advisor> result = addedAdvisors.get(cls);
-		return result == null ? Collections.EMPTY_SET : result;
+		return (Set<Advisor>) (result == null ? Collections.emptySet() : result);
 	}
 	
 	/**
@@ -712,7 +712,7 @@ public class ServiceContext implements ApplicationContextAware {
 	@SuppressWarnings("unchecked")
 	private Set<Advice> getAddedAdvice(Class cls) {
 		Set<Advice> result = addedAdvice.get(cls);
-		return result == null ? Collections.EMPTY_SET : result;
+		return (Set<Advice>) (result == null ? Collections.emptySet() : result);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -2032,7 +2032,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			throw new APIException("ConceptSource is required");
 		}
 		if (withAnyOfTheseTypes == null) {
-			withAnyOfTheseTypes = Collections.EMPTY_LIST;
+			withAnyOfTheseTypes = Collections.emptyList();
 		}
 		return dao.getDrugsByMapping(code, conceptSource, withAnyOfTheseTypes, includeRetired);
 	}
@@ -2049,7 +2049,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			throw new APIException("ConceptSource is required");
 		}
 		if (withAnyOfTheseTypesOrOrderOfPreference == null) {
-			withAnyOfTheseTypesOrOrderOfPreference = Collections.EMPTY_LIST;
+			withAnyOfTheseTypesOrOrderOfPreference = Collections.emptyList();
 		}
 		return dao.getDrugByMapping(code, conceptSource, withAnyOfTheseTypesOrOrderOfPreference);
 	}
@@ -2064,14 +2064,14 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	        Integer start, Integer length) {
 		List<ConceptClass> mappedClasses = getConceptClassesOfOrderTypes();
 		if (mappedClasses.isEmpty()) {
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		}
 		if (locales == null) {
 			locales = new ArrayList<Locale>();
 			locales.add(Context.getLocale());
 		}
-		return dao.getConcepts(phrase, locales, false, mappedClasses, Collections.EMPTY_LIST, Collections.EMPTY_LIST,
-		    Collections.EMPTY_LIST, null, start, length);
+		return dao.getConcepts(phrase, locales, false, mappedClasses, (List) Collections.emptyList(), (List) Collections
+			.emptyList(), (List) Collections.emptyList(), null, start, length);
 	}
 	
 	private List<ConceptClass> getConceptClassesOfOrderTypes() {

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -264,7 +264,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			ConceptName possiblePreferredName = concept.getPreferredName(locale);
 			
 			if (possiblePreferredName != null) {
-				; //do nothing yet, but stick around to setLocalePreferred(true)
+				//do nothing yet, but stick around to setLocalePreferred(true)
 			} else if (concept.getFullySpecifiedName(locale) != null) {
 				possiblePreferredName = concept.getFullySpecifiedName(locale);
 			} else if (!CollectionUtils.isEmpty(concept.getSynonyms(locale))) {

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -378,7 +378,6 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		// ignore this patient (loop until no changes made)
 		while (patients.remove(ignorePatient)) {}
-		;
 		
 		if (patients.size() > 0) {
 			return patients.get(0);

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -246,7 +246,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	public List<Visit> getVisitsByPatient(Patient patient) throws APIException {
 		//Don't bother to hit the database
 		if (patient == null || patient.getId() == null) {
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		}
 		
 		return Context.getVisitService().getVisits(null, Collections.singletonList(patient), null, null, null, null, null,
@@ -271,7 +271,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	public List<Visit> getVisitsByPatient(Patient patient, boolean includeInactive, boolean includeVoided)
 	        throws APIException {
 		if (patient == null || patient.getId() == null) {
-			return Collections.EMPTY_LIST;
+			return Collections.emptyList();
 		}
 		
 		return dao.getVisits(null, Collections.singletonList(patient), null, null, null, null, null, null, null,

--- a/api/src/main/java/org/openmrs/module/ModuleMustStartException.java
+++ b/api/src/main/java/org/openmrs/module/ModuleMustStartException.java
@@ -31,5 +31,5 @@ public abstract class ModuleMustStartException extends RuntimeException {
 	
 	public ModuleMustStartException(String msg) {
 		super(msg);
-	};
+	}
 }

--- a/api/src/main/java/org/openmrs/reporting/export/DataExportFunctions.java
+++ b/api/src/main/java/org/openmrs/reporting/export/DataExportFunctions.java
@@ -416,7 +416,6 @@ public class DataExportFunctions {
 				type = encounterService.getEncounterType(Integer.valueOf(typeName));
 			}
 			catch (Exception e) { /* pass */}
-			;
 			
 			if (type == null) {
 				type = encounterService.getEncounterType(typeName);
@@ -488,7 +487,6 @@ public class DataExportFunctions {
 				type = encounterService.getEncounterType(Integer.valueOf(typeName));
 			}
 			catch (Exception e) { /* pass */}
-			;
 			
 			if (type == null) {
 				type = encounterService.getEncounterType(typeName);

--- a/api/src/main/java/org/openmrs/util/Format.java
+++ b/api/src/main/java/org/openmrs/util/Format.java
@@ -30,7 +30,7 @@ public class Format {
 	
 	public enum FORMAT_TYPE {
 		DATE, TIME, TIMESTAMP
-	};
+	}
 	
 	public static String formatPercentage(double pct) {
 		return NumberFormat.getPercentInstance().format(pct);

--- a/web/src/main/java/org/openmrs/web/controller/form/FormFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/form/FormFormController.java
@@ -208,7 +208,7 @@ public class FormFormController extends SimpleFormController {
 					form = fs.getForm(Integer.valueOf(formId));
 				}
 				catch (NumberFormatException e) {
-					;
+
 				} //If formId has no readable value defaults to the case where form==null
 			}
 		}

--- a/web/src/main/java/org/openmrs/web/controller/user/RoleFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/user/RoleFormController.java
@@ -83,7 +83,7 @@ public class RoleFormController extends SimpleFormController {
 		
 		String[] privileges = request.getParameterValues("privileges");
 		if (privileges == null) {
-			role.setPrivileges(Collections.EMPTY_SET);
+			role.setPrivileges((Set) (Collections.emptySet()));
 		}
 		
 		return super.processFormSubmission(request, response, role, errors);

--- a/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
@@ -238,7 +238,6 @@ public abstract class StartupFilter implements Filter {
 		Object locale = referenceMap.get(FilterUtil.LOCALE_ATTRIBUTE);
 		ToolContext toolContext = getToolContext(locale != null ? locale.toString() : Context.getLocale().toString());
 		VelocityContext velocityContext = new VelocityContext(toolContext);
-		;
 		
 		for (Map.Entry<String, Object> entry : referenceMap.entrySet()) {
 			velocityContext.put(entry.getKey(), entry.getValue());


### PR DESCRIPTION
... of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

GCI-9
Collections.emptyList(),emptyMap() and emptySet() should be used instead
of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET