### PR TITLE
Switch statements should end with a default case

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -115,6 +115,8 @@ public class PatientSearchCriteria {
 				criteria.add(prepareCriterionForIdentifier(identifier, identifierTypes, matchIdentifierExactly));
 				break;
 			
+			default:
+				break;
 		}
 		
 		criteria.add(Restrictions.eq("voided", false));


### PR DESCRIPTION
Fixed:
-- Switch statements should end with a default case

Ticket: https://issues.openmrs.org/browse/GCI-9