### PR TITLE
Avoid a null pointer exception when validating Stop Orders for DrugOrder...

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -167,6 +167,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 			//Check that patient, careSetting, concept and drug if is drug order have not changed
 			//we need to use a SQL query to by pass the hibernate cache
 			boolean isPreviousDrugOrder = DrugOrder.class.isAssignableFrom(previousOrder.getClass());
+			boolean previousOrderHasADrug = isPreviousDrugOrder && ((DrugOrder) order).getDrug() != null;
 			List<List<Object>> rows = dao.getOrderFromDatabase(previousOrder, isPreviousDrugOrder);
 			List<Object> rowData = rows.get(0);
 			if (!rowData.get(0).equals(previousOrder.getPatient().getPatientId())) {
@@ -175,12 +176,13 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 				throw new APIException("Cannot change the careSetting of an order");
 			} else if (!rowData.get(2).equals(previousOrder.getConcept().getConceptId())) {
 				throw new APIException("Cannot change the concept of an order");
-			} else if (isPreviousDrugOrder && !rowData.get(3).equals(((DrugOrder) previousOrder).getDrug().getDrugId())) {
+			} else if (isPreviousDrugOrder && previousOrderHasADrug
+			        && !rowData.get(3).equals(((DrugOrder) previousOrder).getDrug().getDrugId())) {
 				throw new APIException("Cannot change the drug of a drug order");
 			}
 			
 			//concept should be the same as on previous order, same applies to drug for drug orders
-			boolean isDrugOrderAndHasADrug = isDrugOrder && ((DrugOrder) order).getDrug() != null;
+			boolean isDrugOrderAndHasADrug = isDrugOrder && previousOrderHasADrug;
 			if (!OpenmrsUtil.nullSafeEquals(order.getConcept(), previousOrder.getConcept())) {
 				throw new APIException("The concept of the previous order and the new one order don't match");
 			} else if (isDrugOrderAndHasADrug) {


### PR DESCRIPTION
...s without a Drug

It is valid to have a DrugOrder without a Drug, as long as there is a Concept. The logic on lines 184-192 addresses that case. However, line 179 was throwing NPE's when trying to stop a DrugOrder without a Drug.

See pull request #1220 
