### PR TITLE
GCI-9: Useless parentheses around expressions should be removed to prevent any misunderstanding

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptNumeric.java
+++ b/api/src/main/java/org/openmrs/ConceptNumeric.java
@@ -258,7 +258,7 @@ public class ConceptNumeric extends Concept implements java.io.Serializable {
 	 */
 	@Override
 	public boolean isNumeric() {
-		return (getDatatype().getName().equals("Numeric"));
+		return getDatatype().getName().equals("Numeric");
 	}
 	
 	/**
@@ -286,6 +286,6 @@ public class ConceptNumeric extends Concept implements java.io.Serializable {
 	}
 	
 	public Boolean isAllowDecimal() {
-		return (allowDecimal == null ? false : allowDecimal);
+		return allowDecimal == null ? false : allowDecimal;
 	}
 }

--- a/api/src/main/java/org/openmrs/ConceptReferenceTermMap.java
+++ b/api/src/main/java/org/openmrs/ConceptReferenceTermMap.java
@@ -119,7 +119,7 @@ public class ConceptReferenceTermMap extends BaseConceptMap implements Serializa
 		}
 		ConceptReferenceTermMap rhs = (ConceptReferenceTermMap) obj;
 		if (this.conceptReferenceTermMapId != null && rhs.conceptReferenceTermMapId != null) {
-			return (this.conceptReferenceTermMapId.equals(rhs.conceptReferenceTermMapId));
+			return this.conceptReferenceTermMapId.equals(rhs.conceptReferenceTermMapId);
 		}
 		
 		return this == obj;

--- a/api/src/main/java/org/openmrs/ConceptStateConversion.java
+++ b/api/src/main/java/org/openmrs/ConceptStateConversion.java
@@ -56,8 +56,8 @@ public class ConceptStateConversion extends BaseOpenmrsObject implements java.io
 	
 	/** @see Object#toString() */
 	public String toString() {
-		return ("ConceptStateConversion: Concept[" + concept + "] results in State [" + programWorkflowState
-		        + "] for workflow [" + programWorkflow + "]");
+		return "ConceptStateConversion: Concept[" + concept + "] results in State [" + programWorkflowState
+		        + "] for workflow [" + programWorkflow + "]";
 	}
 	
 	// ******************

--- a/api/src/main/java/org/openmrs/FormField.java
+++ b/api/src/main/java/org/openmrs/FormField.java
@@ -268,7 +268,7 @@ public class FormField extends BaseOpenmrsMetadata implements java.io.Serializab
 	 * @return Returns the required status.
 	 */
 	public Boolean isRequired() {
-		return (required == null ? false : required);
+		return required == null ? false : required;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -1013,11 +1013,11 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 					}
 				}
 			} else if (abbrev.equals("DT")) {
-				return (getValueDatetime() == null ? "" : dateFormat.format(getValueDatetime()));
+				return getValueDatetime() == null ? "" : dateFormat.format(getValueDatetime());
 			} else if (abbrev.equals("TM")) {
-				return (getValueDatetime() == null ? "" : Format.format(getValueDatetime(), locale, FORMAT_TYPE.TIME));
+				return getValueDatetime() == null ? "" : Format.format(getValueDatetime(), locale, FORMAT_TYPE.TIME);
 			} else if (abbrev.equals("TS")) {
-				return (getValueDatetime() == null ? "" : Format.format(getValueDatetime(), locale, FORMAT_TYPE.TIMESTAMP));
+				return getValueDatetime() == null ? "" : Format.format(getValueDatetime(), locale, FORMAT_TYPE.TIMESTAMP);
 			} else if (abbrev.equals("ST")) {
 				return getValueText();
 			} else if (abbrev.equals("ED") && getValueComplex() != null) {

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -589,7 +589,7 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	 * @since 1.9
 	 */
 	public Boolean isActive() {
-		return (this.endDate == null);
+		return this.endDate == null;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ProgramWorkflowState.java
+++ b/api/src/main/java/org/openmrs/ProgramWorkflowState.java
@@ -55,7 +55,7 @@ public class ProgramWorkflowState extends BaseOpenmrsMetadata implements Seriali
 	
 	/** @see Object#toString() */
 	public String toString() {
-		return ("State " + getConcept().getName() + " initial=" + getInitial() + " terminal=" + getTerminal());
+		return "State " + getConcept().getName() + " initial=" + getInitial() + " terminal=" + getTerminal();
 	}
 	
 	// ******************

--- a/api/src/main/java/org/openmrs/Role.java
+++ b/api/src/main/java/org/openmrs/Role.java
@@ -186,7 +186,7 @@ public class Role extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @return true/false whether this role inherits from other roles
 	 */
 	public boolean inheritsRoles() {
-		return (getInheritedRoles() != null && getInheritedRoles().size() > 0);
+		return getInheritedRoles() != null && getInheritedRoles().size() > 0;
 	}
 	
 	/**
@@ -278,7 +278,7 @@ public class Role extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @since 1.9
 	 */
 	public boolean hasChildRoles() {
-		return (getChildRoles() != null && getChildRoles().size() > 0);
+		return getChildRoles() != null && getChildRoles().size() > 0;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Tribe.java
+++ b/api/src/main/java/org/openmrs/Tribe.java
@@ -58,7 +58,7 @@ public class Tribe implements java.io.Serializable {
 		if (obj instanceof Tribe) {
 			Tribe t = (Tribe) obj;
 			if (this.getTribeId() != null && t.getTribeId() != null) {
-				return (this.getTribeId().equals(t.getTribeId()));
+				return this.getTribeId().equals(t.getTribeId());
 			}
 			/*return (this.getName().matches(t.getName()) &&
 					this.isRetired() == t.isRetired()); */

--- a/api/src/main/java/org/openmrs/module/ModuleConditionalResource.java
+++ b/api/src/main/java/org/openmrs/module/ModuleConditionalResource.java
@@ -56,19 +56,23 @@ public class ModuleConditionalResource {
 	
 	@Override
 	public boolean equals(Object o) {
-		if (this == o)
+		if (this == o) {
 			return true;
-		if (o == null || getClass() != o.getClass())
+		}
+		if (o == null || getClass() != o.getClass()) {
 			return false;
-		
+		}
 		ModuleConditionalResource that = (ModuleConditionalResource) o;
 		
-		if (modules != null ? !modules.equals(that.modules) : that.modules != null)
+		if (modules != null ? !modules.equals(that.modules) : that.modules != null) {
 			return false;
-		if (openmrsVersion != null ? !openmrsVersion.equals(that.openmrsVersion) : that.openmrsVersion != null)
+		}
+		if (openmrsVersion != null ? !openmrsVersion.equals(that.openmrsVersion) : that.openmrsVersion != null) {
 			return false;
-		if (path != null ? !path.equals(that.path) : that.path != null)
+		}
+		if (path != null ? !path.equals(that.path) : that.path != null) {
 			return false;
+		}
 		
 		return true;
 	}
@@ -111,17 +115,20 @@ public class ModuleConditionalResource {
 		
 		@Override
 		public boolean equals(Object o) {
-			if (this == o)
+			if (this == o) {
 				return true;
-			if (o == null || getClass() != o.getClass())
+			}
+			if (o == null || getClass() != o.getClass()) {
 				return false;
-			
+			}
 			ModuleAndVersion that = (ModuleAndVersion) o;
 			
-			if (moduleId != null ? !moduleId.equals(that.moduleId) : that.moduleId != null)
+			if (moduleId != null ? !moduleId.equals(that.moduleId) : that.moduleId != null) {
 				return false;
-			if (version != null ? !version.equals(that.version) : that.version != null)
+			}
+			if (version != null ? !version.equals(that.version) : that.version != null) {
 				return false;
+			}	
 			
 			return true;
 		}


### PR DESCRIPTION
Make progress on Sonar's [Useless parentheses around expressions should be removed to prevent any misunderstanding](https://ci.openmrs.org/sonar/drilldown/issues/1865?rids%5B%5D=1868&rids%5B%5D=1873&rule=squid%3AUselessParenthesesCheck&rule_sev=MAJOR&severity=MAJOR#). 

Melange task: https://www.google-melange.com/gci/task/view/google/gci2014/5708233700278272