### PR TITLE
GCI-9: Literal boolean values should not be used in condition expressions

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -714,7 +714,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			return exactName;
 		}
 		
-		if (exact == false) {
+		if (!exact) {
 			Locale broaderLocale = new Locale(locale.getLanguage());
 			ConceptName name = getNameInLocale(broaderLocale);
 			return name;

--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -181,8 +181,8 @@ public class Encounter extends BaseOpenmrsData implements java.io.Serializable {
 		
 		if (obsParent.hasGroupMembers()) {
 			for (Obs child : obsParent.getGroupMembers()) {
-				if (child.isVoided() == false) {
-					if (child.isObsGrouping() == false) {
+				if (!child.isVoided()) {
+					if (!child.isObsGrouping()) {
 						leaves.add(child);
 					} else {
 						// recurse if this is a grouping obs
@@ -190,7 +190,7 @@ public class Encounter extends BaseOpenmrsData implements java.io.Serializable {
 					}
 				}
 			}
-		} else if (obsParent.isVoided() == false) {
+		} else if (!obsParent.isVoided()) {
 			leaves.add(obsParent);
 		}
 		

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -1003,7 +1003,7 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 				} else {
 					if (getConcept() instanceof ConceptNumeric) {
 						ConceptNumeric cn = (ConceptNumeric) getConcept();
-						if (cn.isPrecise() != true) {
+						if (!cn.isPrecise()) {
 							double d = getValueNumeric();
 							int i = (int) d;
 							return Integer.toString(i);

--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -319,7 +319,7 @@ public class Patient extends Person implements java.io.Serializable {
 		if (getIdentifiers() != null) {
 			List<PatientIdentifier> nonPreferred = new LinkedList<PatientIdentifier>();
 			for (PatientIdentifier pi : getIdentifiers()) {
-				if (pi.isVoided() == false) {
+				if (!pi.isVoided()) {
 					if (pi.isPreferred()) {
 						ids.add(pi);
 					} else {
@@ -346,7 +346,7 @@ public class Patient extends Person implements java.io.Serializable {
 		List<PatientIdentifier> ids = new Vector<PatientIdentifier>();
 		if (getIdentifiers() != null) {
 			for (PatientIdentifier pi : getIdentifiers()) {
-				if (pi.isVoided() == false && pit.equals(pi.getIdentifierType())) {
+				if (!pi.isVoided() && pit.equals(pi.getIdentifierType())) {
 					ids.add(pi);
 				}
 			}

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -413,7 +413,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 				
 				// if the to-be-added attribute isn't already voided itself
 				// and if we have the same type, different value
-				if (newAttribute.isVoided() == false || newIsNull) {
+				if (!newAttribute.isVoided() || newIsNull) {
 					if (currentAttribute.getCreator() != null) {
 						currentAttribute.voidAttribute("New value: " + newAttribute.getValue());
 					} else {

--- a/api/src/main/java/org/openmrs/Program.java
+++ b/api/src/main/java/org/openmrs/Program.java
@@ -163,7 +163,7 @@ public class Program extends BaseOpenmrsMetadata implements java.io.Serializable
 	public Set<ProgramWorkflow> getWorkflows() {
 		Set<ProgramWorkflow> ret = new HashSet<ProgramWorkflow>();
 		for (ProgramWorkflow workflow : getAllWorkflows()) {
-			if (workflow.isRetired() == false) {
+			if (!workflow.isRetired()) {
 				ret.add(workflow);
 			}
 		}

--- a/api/src/main/java/org/openmrs/User.java
+++ b/api/src/main/java/org/openmrs/User.java
@@ -145,7 +145,7 @@ public class User extends BaseOpenmrsMetadata implements java.io.Serializable, A
 	 *         user is a superUser
 	 */
 	public boolean hasRole(String r, boolean ignoreSuperUser) {
-		if (ignoreSuperUser == false) {
+		if (!ignoreSuperUser) {
 			if (isSuperUser()) {
 				return true;
 			}

--- a/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
@@ -95,7 +95,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 				}
 			}
 			
-			if (requireAll == false) {
+			if (!requireAll) {
 				// If there's no match, then we know there are privileges and
 				// that the user didn't have any of them. The user is not
 				// authorized to access the method
@@ -105,7 +105,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 		} else if (attributes.hasAuthorizedAnnotation(method)) {
 			// if there are no privileges defined, just require that 
 			// the user be authenticated
-			if (Context.isAuthenticated() == false) {
+			if (!Context.isAuthenticated()) {
 				throwUnauthorized(user, method);
 			}
 		}

--- a/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
@@ -81,7 +81,7 @@ public class LoggingAdvice implements MethodInterceptor {
 			output.append("In method ").append(method.getDeclaringClass().getSimpleName()).append(".").append(name);
 			
 			// print the argument values unless we're ignoring all
-			if (loggingAnnotation == null || loggingAnnotation.ignoreAllArgumentValues() == false) {
+			if (loggingAnnotation == null || !loggingAnnotation.ignoreAllArgumentValues()) {
 				
 				int x;
 				Class<?>[] types = method.getParameterTypes();

--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -829,7 +829,7 @@ public class ServiceContext implements ApplicationContextAware {
 		// loader or the system class loader depending on if we're in a testing
 		// environment or not (system == testing, openmrs == normal)
 		try {
-			if (useSystemClassLoader == false) {
+			if (!useSystemClassLoader) {
 				cls = OpenmrsClassLoader.getInstance().loadClass(classString);
 				
 				if (cls != null && log.isDebugEnabled()) {
@@ -839,7 +839,7 @@ public class ServiceContext implements ApplicationContextAware {
 					}
 					catch (Exception e) { /*pass*/}
 				}
-			} else if (useSystemClassLoader == true) {
+			} else if (useSystemClassLoader) {
 				try {
 					cls = Class.forName(classString);
 					if (log.isDebugEnabled()) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -218,7 +218,7 @@ public class HibernateFormDAO implements FormDAO {
 		// if we ended up removing all of the formfields, check to see if we're
 		// in a "force" situation
 		if (formFields.size() < 1) {
-			if (force == false) {
+			if (!force) {
 				return backupPlan;
 			} else {
 				log.debug(err);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientSetDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientSetDAO.java
@@ -2109,7 +2109,7 @@ public class HibernatePatientSetDAO implements PatientSetDAO {
 			sb.append(" and orderReason.id in (:orderReasonIdList) ");
 		}
 		if (discontinued != null) {
-			if (discontinued == true) {
+			if (discontinued) {
 				if (stopDateFrom != null && stopDateTo != null) {
 					sb.append(" and dateStopped between :stopDateFrom and :stopDateTo ");
 				} else {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
@@ -259,7 +259,7 @@ public class HibernatePersonDAO implements PersonDAO {
 		
 		personSearchCriteria.addAliasForName(criteria);
 		personSearchCriteria.addAliasForAttribute(criteria);
-		if (voided == null || voided == false)
+		if (voided == null || !voided)
 			criteria.add(Restrictions.eq("personVoided", false));
 		if (dead != null) {
 			criteria.add(Restrictions.eq("dead", dead));

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PersonSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PersonSearchCriteria.java
@@ -30,7 +30,7 @@ public class PersonSearchCriteria {
 	}
 	
 	Criterion prepareCriterionForAttribute(String value, Boolean voided, MatchMode matchMode) {
-		if (voided == null || voided == false)
+		if (voided == null || !voided)
 			return Restrictions.conjunction().add(Restrictions.eq("attributeType.searchable", true)).add(
 			    Restrictions.eq("attribute.voided", false)).add(Restrictions.ilike("attribute.value", value, matchMode));
 		else
@@ -39,7 +39,7 @@ public class PersonSearchCriteria {
 	}
 	
 	Criterion prepareCriterionForName(String value, Boolean voided) {
-		if (voided == null || voided == false)
+		if (voided == null || !voided)
 			return Restrictions.conjunction().add(Restrictions.eq("name.voided", false)).add(
 			    Restrictions.disjunction().add(Restrictions.ilike("name.givenName", value, MatchMode.START)).add(
 			        Restrictions.ilike("name.middleName", value, MatchMode.START)).add(

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -326,7 +326,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		}
 		
 		// only do this if the concept isn't retired already
-		if (concept.isRetired() == false) {
+		if (!concept.isRetired()) {
 			checkIfLocked();
 			
 			concept.setRetired(true);
@@ -598,7 +598,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	@Deprecated
 	@Transactional(readOnly = true)
 	public List<Drug> getDrugs(Concept concept, boolean includeRetired) {
-		if (includeRetired == true) {
+		if (includeRetired) {
 			throw new APIException("Getting retired drugs is no longer an options.  Use the getAllDrugs() method for that");
 		}
 		
@@ -622,7 +622,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	@Deprecated
 	@Transactional(readOnly = true)
 	public List<Drug> findDrugs(String phrase, boolean includeRetired) {
-		if (includeRetired == true) {
+		if (includeRetired) {
 			throw new APIException("Getting retired drugs is no longer an options.  Use the getAllDrugs() method for that");
 		}
 		

--- a/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
@@ -691,7 +691,7 @@ public class FormServiceImpl extends BaseOpenmrsService implements FormService {
 	 * @see org.openmrs.api.FormService#purgeField(org.openmrs.Field, boolean)
 	 */
 	public void purgeField(Field field, boolean cascade) throws APIException {
-		if (cascade == true) {
+		if (cascade) {
 			throw new APIException("Not Yet Implemented");
 		} else {
 			dao.deleteField(field);
@@ -710,7 +710,7 @@ public class FormServiceImpl extends BaseOpenmrsService implements FormService {
 	 * @see org.openmrs.api.FormService#purgeForm(org.openmrs.Form, boolean)
 	 */
 	public void purgeForm(Form form, boolean cascade) throws APIException {
-		if (cascade == true) {
+		if (cascade) {
 			throw new APIException("Not Yet Implemented");
 		}
 		
@@ -733,7 +733,7 @@ public class FormServiceImpl extends BaseOpenmrsService implements FormService {
 	 * @see org.openmrs.api.FormService#retireField(org.openmrs.Field)
 	 */
 	public Field retireField(Field field) throws APIException {
-		if (field.getRetired() == false) {
+		if (!field.getRetired()) {
 			field.setRetired(true);
 			return Context.getFormService().saveField(field);
 		} else {
@@ -819,7 +819,7 @@ public class FormServiceImpl extends BaseOpenmrsService implements FormService {
 	 * @see org.openmrs.api.FormService#unretireField(org.openmrs.Field)
 	 */
 	public Field unretireField(Field field) throws APIException {
-		if (field.getRetired() == true) {
+		if (field.getRetired()) {
 			field.setRetired(false);
 			return Context.getFormService().saveField(field);
 		} else {

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -213,7 +213,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 	 * @see org.openmrs.api.ObsService#purgeObs(org.openmrs.Obs, boolean)
 	 */
 	public void purgeObs(Obs obs, boolean cascade) throws APIException {
-		if (purgeComplexData(obs) == false) {
+		if (!purgeComplexData(obs)) {
 			throw new APIException("Unable to purge complex data for obs: " + obs);
 		}
 		
@@ -505,7 +505,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 	@Deprecated
 	@Transactional(readOnly = true)
 	public Set<Obs> getObservations(Person who, boolean includeVoided) {
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Voided observations are no longer allowed to be queried");
 		}
 		

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -395,7 +395,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Transactional(readOnly = true)
 	public List<Patient> getPatientsByIdentifier(String identifier, boolean includeVoided) throws APIException {
 		
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Searching on voided patients is no longer allowed");
 		}
 		
@@ -410,7 +410,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Transactional(readOnly = true)
 	public List<Patient> getPatientsByIdentifierPattern(String identifier, boolean includeVoided) throws APIException {
 		
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Searching on voided patients is no longer allowed");
 		}
 		
@@ -434,7 +434,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Transactional(readOnly = true)
 	public List<Patient> getPatientsByName(String name, boolean includeVoided) throws APIException {
 		
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Searching on voided patients is no longer allowed");
 		}
 		
@@ -543,7 +543,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	public List<PatientIdentifier> getPatientIdentifiers(String identifier, PatientIdentifierType patientIdentifierType,
 	        boolean includeVoided) throws APIException {
 		
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Searching on voided identifiers is no longer allowed");
 		}
 		
@@ -704,7 +704,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Deprecated
 	@Transactional(readOnly = true)
 	public List<Patient> findPatients(String query, boolean includeVoided) throws APIException {
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("Searching on voided patients is no longer allowed");
 		}
 		

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -577,7 +577,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User, boolean)
 	 */
 	public void purgeUser(User user, boolean cascade) throws APIException {
-		if (cascade == true) {
+		if (cascade) {
 			throw new APIException("I don't think we want to cascade here");
 		}
 		

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -921,7 +921,7 @@ public class ModuleFactory {
 					log.info("Global property " + key + " was not found. Creating one now.");
 					gp = new GlobalProperty(key, version, description);
 					as.saveGlobalProperty(gp);
-				} else if (gp.getPropertyValue().equals(version) == false) {
+				} else if (!gp.getPropertyValue().equals(version)) {
 					log.info("Updating global property " + key + " to version: " + version);
 					gp.setDescription(description);
 					gp.setPropertyValue(version);
@@ -1093,7 +1093,7 @@ public class ModuleFactory {
 				}
 			}
 			
-			if (skipOverStartedProperty == false && !Context.isRefreshingContext()) {
+			if (!skipOverStartedProperty && !Context.isRefreshingContext()) {
 				saveGlobalProperty(moduleId + ".started", "false", getGlobalPropertyStartedDescription(moduleId));
 			}
 			
@@ -1254,7 +1254,7 @@ public class ModuleFactory {
 		
 		// if this pointId doesn't contain the separator character, search
 		// for this point prepended with each MEDIA TYPE
-		if (pointId.contains(Extension.extensionIdSeparator) == false) {
+		if (!pointId.contains(Extension.extensionIdSeparator)) {
 			for (MEDIA_TYPE mediaType : Extension.MEDIA_TYPE.values()) {
 				
 				// get all extensions for this type and point id
@@ -1263,7 +1263,7 @@ public class ModuleFactory {
 				// 'extensions' should be a unique list
 				if (tmpExtensions != null) {
 					for (Extension ext : tmpExtensions) {
-						if (extensions.contains(ext) == false) {
+						if (!extensions.contains(ext)) {
 							extensions.add(ext);
 						}
 					}

--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -517,7 +517,7 @@ public class ModuleUtil {
 				if (name == null || jarEntry.getName().startsWith(name)) {
 					String entryName = jarEntry.getName();
 					// trim out the name path from the name of the new file
-					if (keepFullPath == false && name != null) {
+					if (!keepFullPath && name != null) {
 						entryName = entryName.replaceFirst(name, "");
 					}
 					

--- a/api/src/main/java/org/openmrs/scheduler/tasks/CheckInternetConnectivityTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/CheckInternetConnectivityTask.java
@@ -49,7 +49,7 @@ public class CheckInternetConnectivityTask extends AbstractTask {
 		}
 		catch (IOException ioe) {
 			try {
-				if (Context.isAuthenticated() == false) {
+				if (!Context.isAuthenticated()) {
 					authenticate();
 				}
 				String text = "At " + new Date() + " there was an error reported connecting to the internet address " + url

--- a/api/src/main/java/org/openmrs/util/DatabaseUtil.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUtil.java
@@ -120,7 +120,7 @@ public class DatabaseUtil {
 		try {
 			ps = conn.prepareStatement(sql);
 			
-			if (dataManipulation == true) {
+			if (dataManipulation) {
 				Integer i = ps.executeUpdate();
 				List<Object> row = new Vector<Object>();
 				row.add(i);

--- a/web/src/main/java/org/openmrs/module/web/taglib/ExtensionPointTag.java
+++ b/web/src/main/java/org/openmrs/module/web/taglib/ExtensionPointTag.java
@@ -147,7 +147,7 @@ public class ExtensionPointTag extends TagSupport implements BodyTag {
 			extensions = validExtensions.iterator();
 		}
 		
-		if (extensions == null || extensions.hasNext() == false) {
+		if (extensions == null || !extensions.hasNext()) {
 			extensions = null;
 			return SKIP_BODY;
 		} else {
@@ -195,7 +195,7 @@ public class ExtensionPointTag extends TagSupport implements BodyTag {
 			
 			// set up and apply the status variable
 			status.put(STATUS_FIRST, index == 0);
-			status.put(STATUS_LAST, extensions.hasNext() == false);
+			status.put(STATUS_LAST, !extensions.hasNext());
 			status.put(STATUS_INDEX, index++);
 			pageContext.setAttribute(varStatus, status);
 		} else {

--- a/web/src/main/java/org/openmrs/notification/web/controller/AlertFormController.java
+++ b/web/src/main/java/org/openmrs/notification/web/controller/AlertFormController.java
@@ -83,7 +83,7 @@ public class AlertFormController extends SimpleFormController {
 		try {
 			// check that the user has the right privileges here because
 			// we are giving them a proxy privilege in the line following this
-			if (Context.hasPrivilege(PrivilegeConstants.MANAGE_ALERTS) == false) {
+			if (!Context.hasPrivilege(PrivilegeConstants.MANAGE_ALERTS)) {
 				throw new APIAuthenticationException("Must be logged in as user with alerts privileges");
 			}
 			

--- a/web/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
@@ -427,7 +427,7 @@ public class ShortPatientFormController {
 				}
 				
 				// if no relationship was found, create a stub one now
-				if (relationshipFound == false) {
+				if (!relationshipFound) {
 					Relationship relationshipStub = new Relationship();
 					relationshipStub.setRelationshipType(relationshipType);
 					if (aIsToB) {

--- a/web/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
+++ b/web/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
@@ -285,7 +285,7 @@ public class DWRConceptService {
 	public List<Object> findConceptAnswers(String text, Integer conceptId, boolean includeVoided, boolean includeDrugConcepts)
 	        throws Exception {
 		
-		if (includeVoided == true) {
+		if (includeVoided) {
 			throw new APIException("You should not include voideds in the search.");
 		}
 		
@@ -409,7 +409,7 @@ public class DWRConceptService {
 		// If there are no drugs to choose from, this will be automatically
 		// selected
 		// by the openmrsSearch.fillTable(objs) function
-		if (showConcept == true) {
+		if (showConcept) {
 			ConceptDrugListItem thisConcept = new ConceptDrugListItem(null, conceptId, concept.getName(locale, false)
 			        .getName());
 			items.add(thisConcept);
@@ -419,7 +419,7 @@ public class DWRConceptService {
 		List<Drug> drugs = cs.getDrugsByConcept(concept);
 		
 		// if there are drugs to choose from, add some instructions
-		if (drugs.size() > 0 && showConcept == true) {
+		if (drugs.size() > 0 && showConcept) {
 			items.add("Or choose a form of " + concept.getName(locale, false).getName());
 		}
 		
@@ -432,7 +432,7 @@ public class DWRConceptService {
 	}
 	
 	public List<Object> findDrugs(String phrase, boolean includeRetired) throws APIException {
-		if (includeRetired == true) {
+		if (includeRetired) {
 			throw new APIException("You should not include voideds in the search.");
 		}
 		Locale locale = Context.getLocale();

--- a/web/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
+++ b/web/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
@@ -101,7 +101,7 @@ public class DWREncounterService {
 				// user searched on a number.  Insert concept with corresponding encounterId
 				Encounter e = es.getEncounter(Integer.valueOf(phrase));
 				if (e != null && (patientId == null || patientId.equals(e.getPatient().getPatientId()))) {
-					if (!e.isVoided() || includeVoided == true) {
+					if (!e.isVoided() || includeVoided) {
 						encs.add(e);
 					}
 				}
@@ -158,7 +158,7 @@ public class DWREncounterService {
 					// user searched on a number
 					Encounter e = es.getEncounter(Integer.valueOf(phrase));
 					if (e != null) {
-						if (!e.isVoided() || includeVoided == true) {
+						if (!e.isVoided() || includeVoided) {
 							encounterCount++;
 						}
 					}

--- a/web/src/main/java/org/openmrs/web/dwr/FieldListItem.java
+++ b/web/src/main/java/org/openmrs/web/dwr/FieldListItem.java
@@ -79,7 +79,7 @@ public class FieldListItem {
 			}
 			table = field.getTableName();
 			attribute = field.getAttributeName();
-			selectMultiple = field.isSelectMultiple() == true ? "yes" : "no";
+			selectMultiple = field.isSelectMultiple() ? "yes" : "no";
 			//if (field.getCreator() != null)
 			//	creator = field.getCreator().getFirstName() + " " + field.getCreator().getLastName();
 			//if (field.getChangedBy() != null)

--- a/web/src/main/java/org/openmrs/web/dwr/FormFieldListItem.java
+++ b/web/src/main/java/org/openmrs/web/dwr/FormFieldListItem.java
@@ -61,7 +61,7 @@ public class FormFieldListItem {
 			pageNumber = ff.getPageNumber();
 			minOccurs = ff.getMinOccurs();
 			maxOccurs = ff.getMaxOccurs();
-			required = ff.isRequired() == true ? "yes" : "no";
+			required = ff.isRequired() ? "yes" : "no";
 			if (ff.getCreator() != null) {
 				creator = ff.getCreator().getPersonName().getFullName();
 			}

--- a/web/src/main/java/org/openmrs/web/servlet/QuickReportServlet.java
+++ b/web/src/main/java/org/openmrs/web/servlet/QuickReportServlet.java
@@ -285,7 +285,7 @@ public class QuickReportServlet extends HttpServlet {
 		
 		List<Obs> obs = new Vector<Obs>();
 		for (Obs o : allObs) {
-			if (o.getVoided() == true) {
+			if (o.getVoided()) {
 				obs.add(o);
 			}
 		}

--- a/web/src/main/java/org/openmrs/web/servlet/SampleFlowsheetServlet.java
+++ b/web/src/main/java/org/openmrs/web/servlet/SampleFlowsheetServlet.java
@@ -54,7 +54,7 @@ public class SampleFlowsheetServlet extends HttpServlet {
 			return;
 		}
 		
-		if (Context.isAuthenticated() == false || !Context.hasPrivilege(PrivilegeConstants.VIEW_PATIENTS)
+		if (!Context.isAuthenticated() || !Context.hasPrivilege(PrivilegeConstants.VIEW_PATIENTS)
 		        || !Context.hasPrivilege(PrivilegeConstants.VIEW_OBS)) {
 			session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "Privileges required: " + PrivilegeConstants.VIEW_PATIENTS
 			        + " and " + PrivilegeConstants.VIEW_OBS);

--- a/web/src/main/java/org/openmrs/web/taglib/ForEachRecordTag.java
+++ b/web/src/main/java/org/openmrs/web/taglib/ForEachRecordTag.java
@@ -180,7 +180,7 @@ public class ForEachRecordTag extends BodyTagSupport {
 			}
 		}
 		
-		if (records == null || records.hasNext() == false) {
+		if (records == null || !records.hasNext()) {
 			records = null;
 			return SKIP_BODY;
 		} else {

--- a/web/src/main/java/org/openmrs/web/taglib/FormatDateTag.java
+++ b/web/src/main/java/org/openmrs/web/taglib/FormatDateTag.java
@@ -109,7 +109,7 @@ public class FormatDateTag extends TagSupport {
 			}
 		}
 		
-		if (dateWasSet == false && date == null) {
+		if (!dateWasSet && date == null) {
 			log.warn("Both 'date' and 'path' cannot be null.  Page: " + pageContext.getPage() + " localname:"
 			        + pageContext.getRequest().getLocalName() + " rd:" + pageContext.getRequest().getRequestDispatcher(""));
 			return SKIP_BODY;

--- a/web/src/main/java/org/openmrs/web/taglib/RequireTag.java
+++ b/web/src/main/java/org/openmrs/web/taglib/RequireTag.java
@@ -154,7 +154,7 @@ public class RequireTag extends TagSupport {
 		if (differentIpAddresses(session_ip_addr, request_ip_addr)) {
 			errorOccurred = true;
 			// stops warning message in IE when refreshing repeatedly
-			if ("0.0.0.0".equals(request_ip_addr) == false) {
+			if (!"0.0.0.0".equals(request_ip_addr)) {
 				log.warn("Invalid ip addr: expected " + session_ip_addr + ", but found: " + request_ip_addr);
 				httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "require.ip_addr");
 			}


### PR DESCRIPTION
Fixed all lines marked ["Literal boolean values should not be used in condition expressions"](https://ci.openmrs.org/sonar/drilldown/issues/1865?&rule=squid%3AS1125&rule_sev=MINOR&severity=MINOR) by Sonar. 

Melange task: http://www.google-melange.com/gci/task/view/google/gci2014/5531069453434880