### PR TITLE
TRUNK-4474: Added Core Global Property for representing Unknown Concept

### DIFF
--- a/api/src/main/java/org/openmrs/api/ConceptService.java
+++ b/api/src/main/java/org/openmrs/api/ConceptService.java
@@ -1292,6 +1292,14 @@ public interface ConceptService extends OpenmrsService {
 	public Concept getFalseConcept();
 	
 	/**
+	 * Returns the UNKNOWN concept
+	 * 
+	 * @return unknown concept
+	 * @should return the unknown concept
+	 */
+	public Concept getUnknownConcept();
+	
+	/**
 	 * Changes the datatype of a concept from boolean to coded when it has observations it is
 	 * associated to.
 	 * 

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -87,6 +87,8 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	
 	private static Concept falseConcept;
 	
+	private static Concept unknownConcept;
+	
 	/**
 	 * @see org.openmrs.api.ConceptService#setConceptDAO(org.openmrs.api.db.ConceptDAO)
 	 */
@@ -1401,6 +1403,26 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		}
 		
 		return trueConcept;
+	}
+	
+	/**
+	 * @see org.openmrs.api.ConceptService#getUnknownConcept()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Concept getUnknownConcept() {
+		if (unknownConcept == null) {
+			try {
+				unknownConcept = Context.getConceptService().getConcept(
+				    Integer.parseInt(Context.getAdministrationService().getGlobalProperty(
+				        OpenmrsConstants.GLOBAL_PROPERTY_UNKNOWN_CONCEPT)));
+			}
+			catch (NumberFormatException e) {
+				log.warn("Concept id for unknown concept should be a number");
+			}
+		}
+		
+		return unknownConcept;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -859,6 +859,8 @@ public final class OpenmrsConstants {
 	
 	public static final String GLOBAL_PROPERTY_FALSE_CONCEPT = "concept.false";
 	
+	public static final String GLOBAL_PROPERTY_UNKNOWN_CONCEPT = "concept.unknown";
+	
 	public static final String GLOBAL_PROPERTY_LOCATION_WIDGET_TYPE = "location.field.style";
 	
 	public static final String GLOBAL_PROPERTY_REPORT_BUG_URL = "reportProblem.url";

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -1217,6 +1217,17 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
+	 * @see {@link ConceptService#getUnknownConcept()}
+	 */
+	@Test
+	@Verifies(value = "should return the unknown concept", method = "getUnknownConcept()")
+	public void getUnknownConcept_shouldReturnTheUnknownConcept() throws Exception {
+		createUnknownConceptGlobalProperty();
+		Assert.assertNotNull(conceptService.getUnknownConcept());
+		Assert.assertEquals(9, conceptService.getUnknownConcept().getId().intValue());
+	}
+	
+	/**
 	 * @see {@link ConceptService#getConceptDatatypeByName(String)}
 	 */
 	@Test
@@ -1317,6 +1328,15 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		        "Concept id of the concept defining the TRUE boolean concept");
 		Context.getAdministrationService().saveGlobalProperty(trueConceptGlobalProperty);
 		Context.getAdministrationService().saveGlobalProperty(falseConceptGlobalProperty);
+	}
+	
+	/**
+	 * Utility method that creates the global property concept.unknown'
+	 */
+	private static void createUnknownConceptGlobalProperty() {
+		GlobalProperty unknownConceptGlobalProperty = new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_UNKNOWN_CONCEPT,
+		        "9", "Concept id of the concept defining the UNKNOWN concept");
+		Context.getAdministrationService().saveGlobalProperty(unknownConceptGlobalProperty);
 	}
 	
 	/**


### PR DESCRIPTION
Parsed concept id for concept.unknown as an integer (as was done for concept.true and concept.false). Not sure if it should support other data types as well.