### PR TITLE
TRUNK-3569: add junit mock tests for PatientIdentifierValidator.checkIde...

### DIFF
--- a/api/src/test/java/org/openmrs/validator/PatientIdentifierValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PatientIdentifierValidatorTest.java
@@ -13,9 +13,19 @@
  */
 package org.openmrs.validator;
 
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+
+import java.util.Locale;
+
 import junit.framework.Assert;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.openmrs.Location;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
@@ -24,9 +34,10 @@ import org.openmrs.api.BlankIdentifierException;
 import org.openmrs.api.IdentifierNotUniqueException;
 import org.openmrs.api.InvalidCheckDigitException;
 import org.openmrs.api.InvalidIdentifierFormatException;
-import org.openmrs.api.PatientService;
 import org.openmrs.api.PatientIdentifierException;
+import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
+import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.test.BaseContextSensitiveTest;
@@ -38,6 +49,12 @@ import org.springframework.validation.Errors;
  * Tests methods on the {@link PatientIdentifierValidator} class.
  */
 public class PatientIdentifierValidatorTest extends BaseContextSensitiveTest {
+	
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+	
+	@Mock
+	MessageSourceService messageSourceService;
 	
 	/**
 	 * @see {@link PatientIdentifierValidator#validateIdentifier(PatientIdentifier)}
@@ -250,4 +267,50 @@ public class PatientIdentifierValidatorTest extends BaseContextSensitiveTest {
 		Assert.assertTrue(errors.hasFieldErrors("identifier"));
 		Assert.assertTrue(errors.hasFieldErrors("voidReason"));
 	}
+	
+	/**
+	 * @see {@link PatientIdentifierValidator#checkIdentifierAgainstFormat(String,String,String)}
+	 */
+	@Verifies(value = "include format in error message if no formatDescription is specified", method = "checkIdentifierAgainstFormat(String,String,String)")
+	@Test
+	public void checkIdentifierAgainstFormat_shouldIncludeFormatInErrorMessageIfNoFormatDescriptionIsSpecified()
+	        throws Exception {
+		
+		String format = "\\d+";
+		String formatDescription = null;
+		String expectedErrorMessage = "Identifier \"abc\" does not match : \"\\d+\"";
+		
+		Mockito.when(
+		    messageSourceService.getMessage(eq("PatientIdentifier.error.invalidFormat"),
+		        aryEq(new String[] { "abc", format }), isA(Locale.class))).thenReturn(expectedErrorMessage);
+		
+		expectedException.expect(InvalidIdentifierFormatException.class);
+		expectedException.expectMessage(expectedErrorMessage);
+		
+		PatientIdentifierValidator.checkIdentifierAgainstFormat("abc", format, formatDescription);
+		
+	}
+	
+	/**
+	 * @see {@link PatientIdentifierValidator#checkIdentifierAgainstFormat(String,String,String)}
+	 */
+	@Verifies(value = "include formatDescription in error message if specified", method = "checkIdentifierAgainstFormat(String,String,String)")
+	@Test
+	public void checkIdentifierAgainstFormat_shouldIncludeFormatDescriptionInErrorMessageIfSpecified() throws Exception {
+		
+		String format = "\\d+";
+		String formatDescription = "formatDescription";
+		String expectedErrorMessage = "Identifier \"abc\" does not match : \"formatDescription\"";
+		
+		Mockito.when(
+		    messageSourceService.getMessage(eq("PatientIdentifier.error.invalidFormat"), aryEq(new String[] { "abc",
+		            formatDescription }), isA(Locale.class))).thenReturn(expectedErrorMessage);
+		
+		expectedException.expect(InvalidIdentifierFormatException.class);
+		expectedException.expectMessage(expectedErrorMessage);
+		
+		PatientIdentifierValidator.checkIdentifierAgainstFormat("abc", format, formatDescription);
+		
+	}
+	
 }


### PR DESCRIPTION
Hi, this is my first attempt at a contribution to OpenMRS, which I came across a few days ago. The functionality request for TRUNK-3569 was completed and merged almost a year ago, but there were 2 junit tests needed to cover @should statements, which I have added. All tests pass when running mvn clean package.