### PR TITLE
Updated the h2 dependency version to 1.4.185

### DIFF
--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -87,7 +87,7 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		executeDataSet(ENC_INITIAL_DATA_XML);
 	}
 	
-	@Override
+	/*@Override
 	public Properties getRuntimeProperties() {
 		Properties props = super.getRuntimeProperties();
 		String url = props.getProperty(Environment.URL);
@@ -95,8 +95,8 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 			props.setProperty(Environment.URL, url + ";MVCC=TRUE");
 		}
 		return props;
-	}
-	
+	}*/
+
 	/**
 	 * @see {@link EncounterService#saveEncounter(Encounter)}
 	 */

--- a/pom.xml
+++ b/pom.xml
@@ -562,7 +562,7 @@
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>1.3.173</version>
+				<version>1.4.185</version>
 			</dependency>
 			<dependency>
 				<groupId>org.dbunit</groupId>


### PR DESCRIPTION
    Fix for TRUNK-4590 and TRUNK-4591
    When running under Java 1.8 the previous H2 version result in lock timeouts on EncounterServiceTest
        saveEncounter_shouldNotOverwriteObsAndOrdersCreatorOrDateCreated and
        saveEncounter_shouldSetDateStoppedOnTheOriginalAfterAddingReviseOrder.