### PR TITLE
TRUNK-4582: Set Concept for all ConceptAnswers

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/ConceptFormController.java
+++ b/web/src/main/java/org/openmrs/web/controller/ConceptFormController.java
@@ -257,6 +257,11 @@ public class ConceptFormController extends SimpleFormController {
 					concept.getCreator().getPersonName();
 				}
 				
+				// Set current concept in all concept answers
+				for (ConceptAnswer ca : concept.getAnswers()) {
+					ca.setConcept(concept);
+				}
+				
 				try {
 					errors.pushNestedPath("concept");
 					ValidateUtil.validate(concept, errors);


### PR DESCRIPTION
The binder creates ConceptAnswer objects for all the coded answers that are present in the form but doesn't set the Concept.

This patch loops over all the ConceptAnswers and sets the concept.