### PR TITLE
change spring version to 4.1.4RELEASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 ### Maven ###
 target/
+pom.xml.versionsBackup
 #############
 
 ### Eclipse ###

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <groupId>org.openmrs</groupId>
       <artifactId>openmrs</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.0.SPRING-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.openmrs.api</groupId>

--- a/api/src/main/java/org/springframework/test/annotation/NotTransactional.java
+++ b/api/src/main/java/org/springframework/test/annotation/NotTransactional.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Test annotation to indicate that a method is <i>not transactional</i>.
+ *
+ * @author Rod Johnson
+ * @author Sam Brannen
+ * @since 2.0
+ * @deprecated as of Spring 3.0, in favor of moving the non-transactional test
+ * method to a separate (non-transactional) test class or to a
+ * {@link org.springframework.test.context.transaction.BeforeTransaction
+ * &#64;BeforeTransaction} or
+ * {@link org.springframework.test.context.transaction.AfterTransaction
+ * &#64;AfterTransaction} method.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Deprecated
+public @interface NotTransactional {}

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -44,7 +44,7 @@ import org.openmrs.util.OpenmrsConstants;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.interceptor.DefaultKeyGenerator;
+import org.springframework.cache.interceptor.SimpleKeyGenerator;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 
@@ -858,7 +858,7 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	
 	private List<Locale> getCachedSearchLocalesForCurrentUser() {
 		Object[] params = { Context.getLocale(), Context.getAuthenticatedUser() };
-		Object key = (new DefaultKeyGenerator()).generate(null, null, params);
+		Object key = (new SimpleKeyGenerator()).generate(null, null, params);
 		return (List<Locale>) cacheManager.getCache("userSearchLocales").get(key).get();
 	}
 	

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openmrs</groupId>
 	<artifactId>openmrs</artifactId>
-	<version>1.12.0-SNAPSHOT</version>
+	<version>1.12.0.SPRING-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>OpenMRS</name>
 	<description>Master project for the modules of OpenMRS</description>
@@ -89,8 +89,8 @@
 
 			<dependency>
 				<groupId>javax.servlet</groupId>
-				<artifactId>servlet-api</artifactId>
-				<version>2.5</version>
+				<artifactId>javax.servlet-api</artifactId>
+				<version>3.0.1</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
@@ -1105,7 +1105,7 @@
 		<openmrs.version.shortnumericonly>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</openmrs.version.shortnumericonly>
         <openmrs.version>${project.version}</openmrs.version>
 
-		<springVersion>3.2.7.RELEASE</springVersion>
+		<springVersion>4.1.4.RELEASE</springVersion>
 		<hibernateVersion>3.6.5.Final</hibernateVersion>
 		<customArgLineForTesting />
 		

--- a/release-test/pom.xml
+++ b/release-test/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.openmrs</groupId>
 		<artifactId>openmrs</artifactId>
-		<version>1.12.0-SNAPSHOT</version>
+		<version>1.12.0.SPRING-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openmrs-release-test</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <groupId>org.openmrs</groupId>
       <artifactId>openmrs</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.0.SPRING-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.openmrs.test</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <groupId>org.openmrs</groupId>
         <artifactId>openmrs</artifactId>
-        <version>1.12.0-SNAPSHOT</version>
+        <version>1.12.0.SPRING-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openmrs.tools</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <groupId>org.openmrs</groupId>
       <artifactId>openmrs</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.0.SPRING-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.openmrs.web</groupId>
@@ -30,7 +30,7 @@
       </dependency>
       <dependency>
          <groupId>javax.servlet</groupId>
-         <artifactId>servlet-api</artifactId>
+         <artifactId>javax.servlet-api</artifactId>
       </dependency>
       <dependency>
          <groupId>javax.servlet</groupId>

--- a/web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
+++ b/web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.converter.json;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.codehaus.jackson.JsonEncoding;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.codehaus.jackson.map.type.TypeFactory;
+import org.codehaus.jackson.type.JavaType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.GenericHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.util.Assert;
+
+/**
+ * Implementation of {@link org.springframework.http.converter.HttpMessageConverter HttpMessageConverter}
+ * that can read and write JSON using <a href="http://jackson.codehaus.org/">Jackson's</a> {@link ObjectMapper}.
+ *
+ * <p>This converter can be used to bind to typed beans, or untyped {@link java.util.HashMap HashMap} instances.
+ *
+ * <p>By default, this converter supports {@code application/json}. This can be overridden by setting the
+ * {@link #setSupportedMediaTypes(List) supportedMediaTypes} property.
+ *
+ * @author Arjen Poutsma
+ * @since 3.0
+ * @see org.springframework.web.servlet.view.json.MappingJacksonJsonView
+ */
+public class MappingJacksonHttpMessageConverter extends AbstractHttpMessageConverter<Object> implements GenericHttpMessageConverter<Object> {
+	
+	public static final Charset DEFAULT_CHARSET = Charset.forName("UTF-8");
+	
+	private ObjectMapper objectMapper = new ObjectMapper();
+	
+	private String jsonPrefix;
+	
+	private Boolean prettyPrint;
+	
+	/**
+	 * Construct a new {@code MappingJacksonHttpMessageConverter}.
+	 */
+	public MappingJacksonHttpMessageConverter() {
+		super(new MediaType("application", "json", DEFAULT_CHARSET), new MediaType("application", "*+json", DEFAULT_CHARSET));
+	}
+	
+	/**
+	 * Set the {@code ObjectMapper} for this view. If not set, a default
+	 * {@link ObjectMapper#ObjectMapper() ObjectMapper} is used.
+	 * <p>Setting a custom-configured {@code ObjectMapper} is one way to take further control of the JSON
+	 * serialization process. For example, an extended {@link org.codehaus.jackson.map.SerializerFactory}
+	 * can be configured that provides custom serializers for specific types. The other option for refining
+	 * the serialization process is to use Jackson's provided annotations on the types to be serialized,
+	 * in which case a custom-configured ObjectMapper is unnecessary.
+	 */
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "ObjectMapper must not be null");
+		this.objectMapper = objectMapper;
+		configurePrettyPrint();
+	}
+	
+	private void configurePrettyPrint() {
+		if (this.prettyPrint != null) {
+			this.objectMapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, this.prettyPrint);
+		}
+	}
+	
+	/**
+	 * Return the underlying {@code ObjectMapper} for this view.
+	 */
+	public ObjectMapper getObjectMapper() {
+		return this.objectMapper;
+	}
+	
+	/**
+	 * Specify a custom prefix to use for this view's JSON output.
+	 * Default is none.
+	 * @see #setPrefixJson
+	 */
+	public void setJsonPrefix(String jsonPrefix) {
+		this.jsonPrefix = jsonPrefix;
+	}
+	
+	/**
+	 * Indicate whether the JSON output by this view should be prefixed with "{} &&". Default is false.
+	 * <p>Prefixing the JSON string in this manner is used to help prevent JSON Hijacking.
+	 * The prefix renders the string syntactically invalid as a script so that it cannot be hijacked.
+	 * This prefix does not affect the evaluation of JSON, but if JSON validation is performed on the
+	 * string, the prefix would need to be ignored.
+	 * @see #setJsonPrefix
+	 */
+	public void setPrefixJson(boolean prefixJson) {
+		this.jsonPrefix = (prefixJson ? "{} && " : null);
+	}
+	
+	/**
+	 * Whether to use the {@link org.codehaus.jackson.impl.DefaultPrettyPrinter} when writing JSON.
+	 * This is a shortcut for setting up an {@code ObjectMapper} as follows:
+	 * <pre>
+	 * ObjectMapper mapper = new ObjectMapper();
+	 * mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+	 * converter.setObjectMapper(mapper);
+	 * </pre>
+	 * <p>The default value is {@code false}.
+	 */
+	public void setPrettyPrint(boolean prettyPrint) {
+		this.prettyPrint = prettyPrint;
+		configurePrettyPrint();
+	}
+	
+	@Override
+	public boolean canRead(Class<?> clazz, MediaType mediaType) {
+		return canRead(clazz, null, mediaType);
+	}
+	
+	public boolean canRead(Type type, Class<?> contextClass, MediaType mediaType) {
+		JavaType javaType = getJavaType(type, contextClass);
+		return (this.objectMapper.canDeserialize(javaType) && canRead(mediaType));
+	}
+	
+	@Override
+	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+		return (this.objectMapper.canSerialize(clazz) && canWrite(mediaType));
+	}
+	
+	@Override
+	protected boolean supports(Class<?> clazz) {
+		// should not be called, since we override canRead/Write instead
+		throw new UnsupportedOperationException();
+	}
+	
+	@Override
+	protected Object readInternal(Class<?> clazz, HttpInputMessage inputMessage) throws IOException,
+	        HttpMessageNotReadableException {
+		
+		JavaType javaType = getJavaType(clazz, null);
+		return readJavaType(javaType, inputMessage);
+	}
+	
+	public Object read(Type type, Class<?> contextClass, HttpInputMessage inputMessage) throws IOException,
+	        HttpMessageNotReadableException {
+		
+		JavaType javaType = getJavaType(type, contextClass);
+		return readJavaType(javaType, inputMessage);
+	}
+	
+	private Object readJavaType(JavaType javaType, HttpInputMessage inputMessage) {
+		try {
+			return this.objectMapper.readValue(inputMessage.getBody(), javaType);
+		}
+		catch (IOException ex) {
+			throw new HttpMessageNotReadableException("Could not read JSON: " + ex.getMessage(), ex);
+		}
+	}
+	
+	@Override
+	protected void writeInternal(Object object, HttpOutputMessage outputMessage) throws IOException,
+	        HttpMessageNotWritableException {
+		
+		JsonEncoding encoding = getJsonEncoding(outputMessage.getHeaders().getContentType());
+		JsonGenerator jsonGenerator = this.objectMapper.getJsonFactory().createJsonGenerator(outputMessage.getBody(),
+		    encoding);
+		
+		// A workaround for JsonGenerators not applying serialization features
+		// https://github.com/FasterXML/jackson-databind/issues/12
+		if (this.objectMapper.getSerializationConfig().isEnabled(SerializationConfig.Feature.INDENT_OUTPUT)) {
+			jsonGenerator.useDefaultPrettyPrinter();
+		}
+		
+		try {
+			if (this.jsonPrefix != null) {
+				jsonGenerator.writeRaw(this.jsonPrefix);
+			}
+			this.objectMapper.writeValue(jsonGenerator, object);
+		}
+		catch (JsonProcessingException ex) {
+			throw new HttpMessageNotWritableException("Could not write JSON: " + ex.getMessage(), ex);
+		}
+	}
+	
+	/**
+	 * Return the Jackson {@link JavaType} for the specified type and context class.
+	 * <p>The default implementation returns {@link TypeFactory#type(java.lang.reflect.Type)}
+	 * or {@code TypeFactory.type(type, TypeFactory.type(contextClass))},
+	 * but this can be overridden in subclasses, to allow for custom generic collection handling.
+	 * For instance:
+	 * <pre class="code">
+	 * protected JavaType getJavaType(Type type) {
+	 *   if (type instanceof Class && List.class.isAssignableFrom((Class)type)) {
+	 *     return TypeFactory.collectionType(ArrayList.class, MyBean.class);
+	 *   } else {
+	 *     return super.getJavaType(type);
+	 *   }
+	 * }
+	 * </pre>
+	 * @param type the type to return the java type for
+	 * @param contextClass a context class for the target type, for example a class
+	 * in which the target type appears in a method signature, can be {@code null}
+	 * @return the java type
+	 */
+	protected JavaType getJavaType(Type type, Class<?> contextClass) {
+		return (contextClass != null) ? TypeFactory.type(type, TypeFactory.type(contextClass)) : TypeFactory.type(type);
+	}
+	
+	/**
+	 * Determine the JSON encoding to use for the given content type.
+	 * @param contentType the media type as requested by the caller
+	 * @return the JSON encoding to use (never {@code null})
+	 */
+	protected JsonEncoding getJsonEncoding(MediaType contentType) {
+		if (contentType != null && contentType.getCharSet() != null) {
+			Charset charset = contentType.getCharSet();
+			for (JsonEncoding encoding : JsonEncoding.values()) {
+				if (charset.name().equals(encoding.getJavaName())) {
+					return encoding;
+				}
+			}
+		}
+		return JsonEncoding.UTF8;
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/servlet/mvc/AbstractFormController.java
+++ b/web/src/main/java/org/springframework/web/servlet/mvc/AbstractFormController.java
@@ -1,0 +1,665 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc;
+
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.web.HttpSessionRequiredException;
+import org.springframework.web.bind.ServletRequestDataBinder;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * <p>Form controller that auto-populates a form bean from the request.
+ * This, either using a new bean instance per request, or using the same bean
+ * when the {@code sessionForm} property has been set to {@code true}.</p>
+ *
+ * <p>This class is the base class for both framework subclasses such as
+ * {@link SimpleFormController} and {@link AbstractWizardFormController}
+ * and custom form controllers that you may provide yourself.</p>
+ *
+ * <p>A form-input view and an after-submission view have to be provided
+ * programmatically. To provide those views using configuration properties,
+ * use the {@link SimpleFormController}.</p>
+ *
+ * <p>Subclasses need to override {@code showForm} to prepare the form view,
+ * and {@code processFormSubmission} to handle submit requests. For the latter,
+ * binding errors like type mismatches will be reported via the given "errors" holder.
+ * For additional custom form validation, a validator (property inherited from
+ * BaseCommandController) can be used, reporting via the same "errors" instance.</p>
+ *
+ * <p>Comparing this Controller to the Struts notion of the {@code Action}
+ * shows us that with Spring, you can use any ordinary JavaBeans or database-
+ * backed JavaBeans without having to implement a framework-specific class
+ * (like Struts' {@code ActionForm}). More complex properties of JavaBeans
+ * (Dates, Locales, but also your own application-specific or compound types)
+ * can be represented and submitted to the controller, by using the notion of
+ * a {@code java.beans.PropertyEditor}. For more information on that
+ * subject, see the workflow of this controller and the explanation of the
+ * {@link BaseCommandController}.</p>
+ *
+ * <p><b><a name="workflow">Workflow
+ * (<a href="BaseCommandController.html#workflow">and that defined by superclass</a>):</b><br>
+ * <ol>
+ *  <li><b>The controller receives a request for a new form (typically a GET).</b></li>
+ *  <li>Call to {@link #formBackingObject formBackingObject()} which by default,
+ *      returns an instance of the commandClass that has been configured
+ *      (see the properties the superclass exposes), but can also be overridden
+ *      to e.g. retrieve an object from the database (that needs to be modified
+ * using the form).</li>
+ *  <li>Call to {@link #initBinder initBinder()} which allows you to register
+ *      custom editors for certain fields (often properties of non-primitive
+ *      or non-String types) of the command class. This will render appropriate
+ *      Strings for those property values, e.g. locale-specific date strings.</li>
+ *  <li><em>Only if {@code bindOnNewForm} is set to {@code true}</em>, then
+ *      {@link org.springframework.web.bind.ServletRequestDataBinder ServletRequestDataBinder}
+ *      gets applied to populate the new form object with initial request parameters and the
+ *      {@link #onBindOnNewForm(HttpServletRequest, Object, BindException)} callback method is
+ *      called. <em>Note:</em> any defined Validators are not applied at this point, to allow
+ *      partial binding. However be aware that any Binder customizations applied via
+ *      initBinder() (such as
+ *      {@link org.springframework.validation.DataBinder#setRequiredFields(String[])} will
+ *      still apply. As such, if using bindOnNewForm=true and initBinder() customizations are
+ *      used to validate fields instead of using Validators, in the case that only some fields
+ *      will be populated for the new form, there will potentially be some bind errors for
+ *      missing fields in the errors object. Any view (JSP, etc.) that displays binder errors
+ *      needs to be intelligent and for this case take into account whether it is displaying the
+ *      initial form view or subsequent post results, skipping error display for the former.</li>
+ *  <li>Call to {@link #showForm(HttpServletRequest, HttpServletResponse, BindException) showForm()}
+ *      to return a View that should be rendered (typically the view that renders
+ *      the form). This method has to be implemented in subclasses.</li>
+ *  <li>The showForm() implementation will call {@link #referenceData referenceData()},
+ *      which you can implement to provide any relevant reference data you might need
+ *      when editing a form (e.g. a List of Locale objects you're going to let the
+ *      user select one from).</li>
+ *  <li>Model gets exposed and view gets rendered, to let the user fill in the form.</li>
+ *  <li><b>The controller receives a form submission (typically a POST).</b>
+ *      To use a different way of detecting a form submission, override the
+ *      {@link #isFormSubmission isFormSubmission} method.
+ *      </li>
+ *  <li>If {@code sessionForm} is not set, {@link #formBackingObject formBackingObject()}
+ *      is called to retrieve a form object. Otherwise, the controller tries to
+ *      find the command object which is already bound in the session. If it cannot
+ *      find the object, it does a call to {@link #handleInvalidSubmit handleInvalidSubmit}
+ *      which - by default - tries to create a new form object and resubmit the form.</li>
+ *  <li>The {@link org.springframework.web.bind.ServletRequestDataBinder ServletRequestDataBinder}
+ *      gets applied to populate the form object with current request parameters.
+ *  <li>Call to {@link #onBind onBind(HttpServletRequest, Object, Errors)} which allows
+ *      you to do custom processing after binding but before validation (e.g. to manually
+ *      bind request parameters to bean properties, to be seen by the Validator).</li>
+ *  <li>If {@code validateOnBinding} is set, a registered Validator will be invoked.
+ *      The Validator will check the form object properties, and register corresponding
+ *      errors via the given {@link org.springframework.validation.Errors Errors}</li> object.
+ *  <li>Call to {@link #onBindAndValidate onBindAndValidate()} which allows you
+ *      to do custom processing after binding and validation (e.g. to manually
+ *      bind request parameters, and to validate them outside a Validator).</li>
+ *  <li>Call {@link #processFormSubmission(HttpServletRequest, HttpServletResponse,
+ *      Object, BindException) processFormSubmission()} to process the submission, with
+ *      or without binding errors. This method has to be implemented in subclasses.</li>
+ * </ol>
+ * </p>
+ *
+ * <p>In session form mode, a submission without an existing form object in the
+ * session is considered invalid, like in case of a resubmit/reload by the browser.
+ * The {@link #handleInvalidSubmit handleInvalidSubmit} method is invoked then,
+ * by default trying to resubmit. It can be overridden in subclasses to show
+ * corresponding messages or to redirect to a new form, in order to avoid duplicate
+ * submissions. The form object in the session can be considered a transaction
+ * token in that case.</p>
+ *
+ * <p>Note that views should never retrieve form beans from the session but always
+ * from the request, as prepared by the form controller. Remember that some view
+ * technologies like Velocity cannot even access a HTTP session.</p>
+ *
+ * <p><b><a name="config">Exposed configuration properties</a>
+ * (<a href="BaseCommandController.html#config">and those defined by superclass</a>):</b><br>
+ * <table border="1">
+ *  <tr>
+ *      <td><b>name</b></td>
+ *      <td><b>default</b></td>
+ *      <td><b>description</b></td>
+ *  </tr>
+ *  <tr>
+ *      <td>bindOnNewForm</td>
+ *      <td>false</td>
+ *      <td>Indicates whether to bind servlet request parameters when
+ *          creating a new form. Otherwise, the parameters will only be
+ *          bound on form submission attempts.</td>
+ *  </tr>
+ *  <tr>
+ *      <td>sessionForm</td>
+ *      <td>false</td>
+ *      <td>Indicates whether the form object should be kept in the session
+ *          when a user asks for a new form. This allows you e.g. to retrieve
+ *          an object from the database, let the user edit it, and then persist
+ *          it again. Otherwise, a new command object will be created for each
+ *          request (even when showing the form again after validation errors).</td>
+ *  </tr>
+ * </table>
+ * </p>
+ *
+ * @author Rod Johnson
+ * @author Juergen Hoeller
+ * @author Alef Arendsen
+ * @author Rob Harrop
+ * @author Colin Sampaleanu
+ * @see #showForm(HttpServletRequest, HttpServletResponse, BindException)
+ * @see #processFormSubmission
+ * @see SimpleFormController
+ * @see AbstractWizardFormController
+ * @deprecated as of Spring 3.0, in favor of annotated controllers
+ */
+@Deprecated
+public abstract class AbstractFormController extends BaseCommandController {
+	
+	private boolean bindOnNewForm = false;
+	
+	private boolean sessionForm = false;
+	
+	/**
+	 * Create a new AbstractFormController.
+	 * <p>Subclasses should set the following properties, either in the constructor
+	 * or via a BeanFactory: commandName, commandClass, bindOnNewForm, sessionForm.
+	 * Note that "commandClass" doesn't need to be set when overriding
+	 * {@link #formBackingObject}, since the latter determines the class anyway.
+	 * <p>"cacheSeconds" is by default set to 0 (-> no caching for all form controllers).
+	 * @see #setCommandName
+	 * @see #setCommandClass
+	 * @see #setBindOnNewForm
+	 * @see #setSessionForm
+	 * @see #formBackingObject
+	 */
+	public AbstractFormController() {
+		setCacheSeconds(0);
+	}
+	
+	/**
+	 * Set whether request parameters should be bound to the form object
+	 * in case of a non-submitting request, that is, a new form.
+	 */
+	public final void setBindOnNewForm(boolean bindOnNewForm) {
+		this.bindOnNewForm = bindOnNewForm;
+	}
+	
+	/**
+	 * Return {@code true} if request parameters should be bound in case of a new form.
+	 */
+	public final boolean isBindOnNewForm() {
+		return this.bindOnNewForm;
+	}
+	
+	/**
+	 * Activate/deactivate session form mode. In session form mode,
+	 * the form is stored in the session to keep the form object instance
+	 * between requests, instead of creating a new one on each request.
+	 * <p>This is necessary for either wizard-style controllers that populate a
+	 * single form object from multiple pages, or forms that populate a persistent
+	 * object that needs to be identical to allow for tracking changes.
+	 * <p>Please note that the {@link AbstractFormController} class (and all
+	 * subclasses of it unless stated to the contrary) do <i>not</i> support
+	 * the notion of a conversation. This is important in the context of this
+	 * property, because it means that there is only <i>one</i> form per session:
+	 * this means that if session form mode is activated and a user opens up
+	 * say two tabs in their browser and attempts to edit two distinct objects
+	 * using the same form, then the <i>shared</i> session state can potentially
+	 * (and most probably will) be overwritten by the last tab to be opened,
+	 * which can lead to errors when either of the forms in each is finally
+	 * submitted.
+	 * <p>If you need to have per-form, per-session state management (that is,
+	 * stateful web conversations), the recommendation is to use
+	 * <a href="http://www.springframework.org/webflow">Spring WebFlow</a>,
+	 * which has full support for conversations and has a much more flexible
+	 * usage model overall.
+	 * @param sessionForm {@code true} if session form mode is to be activated
+	 */
+	public final void setSessionForm(boolean sessionForm) {
+		this.sessionForm = sessionForm;
+	}
+	
+	/**
+	 * Return {@code true} if session form mode is activated.
+	 */
+	public final boolean isSessionForm() {
+		return this.sessionForm;
+	}
+	
+	/**
+	 * Handles two cases: form submissions and showing a new form.
+	 * Delegates the decision between the two to {@link #isFormSubmission},
+	 * always treating requests without existing form session attribute
+	 * as new form when using session form mode.
+	 * @see #isFormSubmission
+	 * @see #showNewForm
+	 * @see #processFormSubmission
+	 */
+	@Override
+	protected ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
+		// Form submission or new form to show?
+		if (isFormSubmission(request)) {
+			// Fetch form object from HTTP session, bind, validate, process submission.
+			try {
+				Object command = getCommand(request);
+				ServletRequestDataBinder binder = bindAndValidate(request, command);
+				BindException errors = new BindException(binder.getBindingResult());
+				return processFormSubmission(request, response, command, errors);
+			}
+			catch (HttpSessionRequiredException ex) {
+				// Cannot submit a session form if no form object is in the session.
+				if (logger.isDebugEnabled()) {
+					logger.debug("Invalid submit detected: " + ex.getMessage());
+				}
+				return handleInvalidSubmit(request, response);
+			}
+		}
+
+		else {
+			// New form to show: render form view.
+			return showNewForm(request, response);
+		}
+	}
+	
+	/**
+	 * Determine if the given request represents a form submission.
+	 * <p>The default implementation treats a POST request as form submission.
+	 * Note: If the form session attribute doesn't exist when using session form
+	 * mode, the request is always treated as new form by handleRequestInternal.
+	 * <p>Subclasses can override this to use a custom strategy, e.g. a specific
+	 * request parameter (assumably a hidden field or submit button name).
+	 * @param request current HTTP request
+	 * @return if the request represents a form submission
+	 */
+	protected boolean isFormSubmission(HttpServletRequest request) {
+		return "POST".equals(request.getMethod());
+	}
+	
+	/**
+	 * Return the name of the HttpSession attribute that holds the form object
+	 * for this form controller.
+	 * <p>The default implementation delegates to the {@link #getFormSessionAttributeName()}
+	 * variant without arguments.
+	 * @param request current HTTP request
+	 * @return the name of the form session attribute, or {@code null} if not in session form mode
+	 * @see #getFormSessionAttributeName
+	 * @see javax.servlet.http.HttpSession#getAttribute
+	 */
+	protected String getFormSessionAttributeName(HttpServletRequest request) {
+		return getFormSessionAttributeName();
+	}
+	
+	/**
+	 * Return the name of the HttpSession attribute that holds the form object
+	 * for this form controller.
+	 * <p>Default is an internal name, of no relevance to applications, as the form
+	 * session attribute is not usually accessed directly. Can be overridden to use
+	 * an application-specific attribute name, which allows other code to access
+	 * the session attribute directly.
+	 * @return the name of the form session attribute
+	 * @see javax.servlet.http.HttpSession#getAttribute
+	 */
+	protected String getFormSessionAttributeName() {
+		return getClass().getName() + ".FORM." + getCommandName();
+	}
+	
+	/**
+	 * Show a new form. Prepares a backing object for the current form
+	 * and the given request, including checking its validity.
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @return the prepared form view
+	 * @throws Exception in case of an invalid new form object
+	 * @see #getErrorsForNewForm
+	 */
+	protected final ModelAndView showNewForm(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
+		logger.debug("Displaying new form");
+		return showForm(request, response, getErrorsForNewForm(request));
+	}
+	
+	/**
+	 * Create a BindException instance for a new form.
+	 * Called by {@link #showNewForm}.
+	 * <p>Can be used directly when intending to show a new form but with
+	 * special errors registered on it (for example, on invalid submit).
+	 * Usually, the resulting BindException will be passed to
+	 * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException)},
+	 * after registering the errors on it.
+	 * @param request current HTTP request
+	 * @return the BindException instance
+	 * @throws Exception in case of an invalid new form object
+	 * @see #showNewForm
+	 * @see #showForm(HttpServletRequest, HttpServletResponse, BindException)
+	 * @see #handleInvalidSubmit
+	 */
+	protected final BindException getErrorsForNewForm(HttpServletRequest request) throws Exception {
+		// Create form-backing object for new form.
+		Object command = formBackingObject(request);
+		if (command == null) {
+			throw new ServletException("Form object returned by formBackingObject() must not be null");
+		}
+		if (!checkCommand(command)) {
+			throw new ServletException("Form object returned by formBackingObject() must match commandClass");
+		}
+		
+		// Bind without validation, to allow for prepopulating a form, and for
+		// convenient error evaluation in views (on both first attempt and resubmit).
+		ServletRequestDataBinder binder = createBinder(request, command);
+		BindException errors = new BindException(binder.getBindingResult());
+		if (isBindOnNewForm()) {
+			logger.debug("Binding to new form");
+			binder.bind(request);
+			onBindOnNewForm(request, command, errors);
+		}
+		
+		// Return BindException object that resulted from binding.
+		return errors;
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding for a new form.
+	 * Called when preparing a new form if {@code bindOnNewForm} is {@code true}.
+	 * <p>The default implementation delegates to {@code onBindOnNewForm(request, command)}.
+	 * @param request current HTTP request
+	 * @param command the command object to perform further binding on
+	 * @param errors validation errors holder, allowing for additional
+	 * custom registration of binding errors
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #onBindOnNewForm(javax.servlet.http.HttpServletRequest, Object)
+	 * @see #setBindOnNewForm
+	 */
+	protected void onBindOnNewForm(HttpServletRequest request, Object command, BindException errors) throws Exception {
+		
+		onBindOnNewForm(request, command);
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding for a new form.
+	 * <p>Called by the default implementation of the
+	 * {@link #onBindOnNewForm(HttpServletRequest, Object, BindException)} variant
+	 * with all parameters, after standard binding when displaying the form view.
+	 * Only called if {@code bindOnNewForm} is set to {@code true}.
+	 * <p>The default implementation is empty.
+	 * @param request current HTTP request
+	 * @param command the command object to perform further binding on
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #onBindOnNewForm(HttpServletRequest, Object, BindException)
+	 * @see #setBindOnNewForm(boolean)
+	 */
+	protected void onBindOnNewForm(HttpServletRequest request, Object command) throws Exception {
+	}
+	
+	/**
+	 * Return the form object for the given request.
+	 * <p>Calls {@link #formBackingObject} if not in session form mode.
+	 * Else, retrieves the form object from the session. Note that the form object
+	 * gets removed from the session, but it will be re-added when showing the
+	 * form for resubmission.
+	 * @param request current HTTP request
+	 * @return object form to bind onto
+	 * @throws org.springframework.web.HttpSessionRequiredException
+	 * if a session was expected but no active session (or session form object) found
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #formBackingObject
+	 */
+	@Override
+	protected final Object getCommand(HttpServletRequest request) throws Exception {
+		// If not in session-form mode, create a new form-backing object.
+		if (!isSessionForm()) {
+			return formBackingObject(request);
+		}
+		
+		// Session-form mode: retrieve form object from HTTP session attribute.
+		HttpSession session = request.getSession(false);
+		if (session == null) {
+			throw new HttpSessionRequiredException("Must have session when trying to bind (in session-form mode)");
+		}
+		String formAttrName = getFormSessionAttributeName(request);
+		Object sessionFormObject = session.getAttribute(formAttrName);
+		if (sessionFormObject == null) {
+			throw new HttpSessionRequiredException("Form object not found in session (in session-form mode)");
+		}
+		
+		// Remove form object from HTTP session: we might finish the form workflow
+		// in this request. If it turns out that we need to show the form view again,
+		// we'll re-bind the form object to the HTTP session.
+		if (logger.isDebugEnabled()) {
+			logger.debug("Removing form session attribute [" + formAttrName + "]");
+		}
+		session.removeAttribute(formAttrName);
+		
+		return currentFormObject(request, sessionFormObject);
+	}
+	
+	/**
+	 * Retrieve a backing object for the current form from the given request.
+	 * <p>The properties of the form object will correspond to the form field values
+	 * in your form view. This object will be exposed in the model under the specified
+	 * command name, to be accessed under that name in the view: for example, with
+	 * a "spring:bind" tag. The default command name is "command".
+	 * <p>Note that you need to activate session form mode to reuse the form-backing
+	 * object across the entire form workflow. Else, a new instance of the command
+	 * class will be created for each submission attempt, just using this backing
+	 * object as template for the initial form.
+	 * <p>The default implementation calls {@link #createCommand()},
+	 * creating a new empty instance of the specified command class.
+	 * Subclasses can override this to provide a preinitialized backing object.
+	 * @param request current HTTP request
+	 * @return the backing object
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #setCommandName
+	 * @see #setCommandClass
+	 * @see #createCommand
+	 */
+	protected Object formBackingObject(HttpServletRequest request) throws Exception {
+		return createCommand();
+	}
+	
+	/**
+	 * Return the current form object to use for binding and further processing,
+	 * based on the passed-in form object as found in the HttpSession.
+	 * <p>The default implementation simply returns the session form object as-is.
+	 * Subclasses can override this to post-process the session form object,
+	 * for example reattaching it to a persistence manager.
+	 * @param sessionFormObject the form object retrieved from the HttpSession
+	 * @return the form object to use for binding and further processing
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected Object currentFormObject(HttpServletRequest request, Object sessionFormObject) throws Exception {
+		return sessionFormObject;
+	}
+	
+	/**
+	 * Prepare the form model and view, including reference and error data.
+	 * Can show a configured form page, or generate a form view programmatically.
+	 * <p>A typical implementation will call
+	 * {@code showForm(request, errors, "myView")}
+	 * to prepare the form view for a specific view name, returning the
+	 * ModelAndView provided there.
+	 * <p>For building a custom ModelAndView, call {@code errors.getModel()}
+	 * to populate the ModelAndView model with the command and the Errors instance,
+	 * under the specified command name, as expected by the "spring:bind" tag.
+	 * You also need to include the model returned by {@link #referenceData}.
+	 * <p>Note: If you decide to have a "formView" property specifying the
+	 * view name, consider using SimpleFormController.
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param errors validation errors holder
+	 * @return the prepared form view, or {@code null} if handled directly
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #showForm(HttpServletRequest, BindException, String)
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 * @see #referenceData(HttpServletRequest, Object, Errors)
+	 * @see SimpleFormController#setFormView
+	 */
+	protected abstract ModelAndView showForm(HttpServletRequest request, HttpServletResponse response, BindException errors)
+	        throws Exception;
+	
+	/**
+	 * Prepare model and view for the given form, including reference and errors.
+	 * <p>In session form mode: Re-puts the form object in the session when
+	 * returning to the form, as it has been removed by getCommand.
+	 * <p>Can be used in subclasses to redirect back to a specific form page.
+	 * @param request current HTTP request
+	 * @param errors validation errors holder
+	 * @param viewName name of the form view
+	 * @return the prepared form view
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected final ModelAndView showForm(HttpServletRequest request, BindException errors, String viewName)
+	        throws Exception {
+		
+		return showForm(request, errors, viewName, null);
+	}
+	
+	/**
+	 * Prepare model and view for the given form, including reference and errors,
+	 * adding a controller-specific control model.
+	 * <p>In session form mode: Re-puts the form object in the session when returning
+	 * to the form, as it has been removed by getCommand.
+	 * <p>Can be used in subclasses to redirect back to a specific form page.
+	 * @param request current HTTP request
+	 * @param errors validation errors holder
+	 * @param viewName name of the form view
+	 * @param controlModel model map containing controller-specific control data
+	 * (e.g. current page in wizard-style controllers or special error message)
+	 * @return the prepared form view
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected final ModelAndView showForm(HttpServletRequest request, BindException errors, String viewName, Map controlModel)
+	        throws Exception {
+		
+		// In session form mode, re-expose form object as HTTP session attribute.
+		// Re-binding is necessary for proper state handling in a cluster,
+		// to notify other nodes of changes in the form object.
+		if (isSessionForm()) {
+			String formAttrName = getFormSessionAttributeName(request);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Setting form session attribute [" + formAttrName + "] to: " + errors.getTarget());
+			}
+			request.getSession().setAttribute(formAttrName, errors.getTarget());
+		}
+		
+		// Fetch errors model as starting point, containing form object under
+		// "commandName", and corresponding Errors instance under internal key.
+		Map model = errors.getModel();
+		
+		// Merge reference data into model, if any.
+		Map referenceData = referenceData(request, errors.getTarget(), errors);
+		if (referenceData != null) {
+			model.putAll(referenceData);
+		}
+		
+		// Merge control attributes into model, if any.
+		if (controlModel != null) {
+			model.putAll(controlModel);
+		}
+		
+		// Trigger rendering of the specified view, using the final model.
+		return new ModelAndView(viewName, model);
+	}
+	
+	/**
+	 * Create a reference data map for the given request, consisting of
+	 * bean name/bean instance pairs as expected by ModelAndView.
+	 * <p>The default implementation returns {@code null}.
+	 * Subclasses can override this to set reference data used in the view.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder
+	 * @return a Map with reference data entries, or {@code null} if none
+	 * @throws Exception in case of invalid state or arguments
+	 * @see ModelAndView
+	 */
+	protected Map referenceData(HttpServletRequest request, Object command, Errors errors) throws Exception {
+		return null;
+	}
+	
+	/**
+	 * Process form submission request. Called by {@link #handleRequestInternal}
+	 * in case of a form submission, with or without binding errors. Implementations
+	 * need to proceed properly, typically showing a form view in case of binding
+	 * errors or performing a submit action else.
+	 * <p>Subclasses can implement this to provide custom submission handling like
+	 * triggering a custom action. They can also provide custom validation and call
+	 * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException)}
+	 * or proceed with the submission accordingly.
+	 * <p>For a success view, call {@code errors.getModel()} to populate the
+	 * ModelAndView model with the command and the Errors instance, under the
+	 * specified command name, as expected by the "spring:bind" tag. For a form view,
+	 * simply return the ModelAndView object provided by
+	 * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException)}.
+	 * @param request current servlet request
+	 * @param response current servlet response
+	 * @param command form object with request parameters bound onto it
+	 * @param errors holder without errors (subclass can add errors if it wants to)
+	 * @return the prepared model and view, or {@code null}
+	 * @throws Exception in case of errors
+	 * @see #handleRequestInternal
+	 * @see #isFormSubmission
+	 * @see #showForm(HttpServletRequest, HttpServletResponse, BindException)
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 */
+	protected abstract ModelAndView processFormSubmission(HttpServletRequest request, HttpServletResponse response,
+	        Object command, BindException errors) throws Exception;
+	
+	/**
+	 * Handle an invalid submit request, e.g. when in session form mode but no form object
+	 * was found in the session (like in case of an invalid resubmit by the browser).
+	 * <p>The default implementation simply tries to resubmit the form with a new
+	 * form object. This should also work if the user hit the back button, changed
+	 * some form data, and resubmitted the form.
+	 * <p>Note: To avoid duplicate submissions, you need to override this method.
+	 * Either show some "invalid submit" message, or call {@link #showNewForm} for
+	 * resetting the form (prepopulating it with the current values if "bindOnNewForm"
+	 * is true). In this case, the form object in the session serves as transaction token.
+	 * <pre>
+	 * protected ModelAndView handleInvalidSubmit(HttpServletRequest request, HttpServletResponse response) throws Exception {
+	 *   return showNewForm(request, response);
+	 * }</pre>
+	 * You can also show a new form but with special errors registered on it:
+	 * <pre class="code">
+	 * protected ModelAndView handleInvalidSubmit(HttpServletRequest request, HttpServletResponse response) throws Exception {
+	 *   BindException errors = getErrorsForNewForm(request);
+	 *   errors.reject("duplicateFormSubmission", "Duplicate form submission");
+	 *   return showForm(request, response, errors);
+	 * }</pre>
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @return a prepared view, or {@code null} if handled directly
+	 * @throws Exception in case of errors
+	 * @see #showNewForm
+	 * @see #getErrorsForNewForm
+	 * @see #showForm(HttpServletRequest, HttpServletResponse, BindException)
+	 * @see #setBindOnNewForm
+	 */
+	protected ModelAndView handleInvalidSubmit(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
+		Object command = formBackingObject(request);
+		ServletRequestDataBinder binder = bindAndValidate(request, command);
+		BindException errors = new BindException(binder.getBindingResult());
+		return processFormSubmission(request, response, command, errors);
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/servlet/mvc/AbstractWizardFormController.java
+++ b/web/src/main/java/org/springframework/web/servlet/mvc/AbstractWizardFormController.java
@@ -1,0 +1,734 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.util.WebUtils;
+
+/**
+ * Form controller for typical wizard-style workflows.
+ *
+ * <p>In contrast to classic forms, wizards have more than one form view page.
+ * Therefore, there are various actions instead of one single submit action:
+ * <ul>
+ * <li>finish: trying to leave the wizard successfully, that is, perform its
+ * final action, and thus requiring a valid state;
+ * <li>cancel: leaving the wizard without performing its final action, and
+ * thus without regard to the validity of its current state;
+ * <li>page change: showing another wizard page, e.g. the next or previous
+ * one, with regard to "dirty back" and "dirty forward".
+ * </ul>
+ *
+ * <p>Finish and cancel actions can be triggered by request parameters, named
+ * PARAM_FINISH ("_finish") and PARAM_CANCEL ("_cancel"), ignoring parameter
+ * values to allow for HTML buttons. The target page for page changes can be
+ * specified by PARAM_TARGET, appending the page number to the parameter name
+ * (e.g. "_target1"). The action parameters are recognized when triggered by
+ * image buttons too (via "_finish.x", "_abort.x", or "_target1.x").
+ *
+ * <p>The current page number will be stored in the session. It can also be
+ * specified as request parameter PARAM_PAGE ("_page") in order to properly handle
+ * usage of the back button in a browser: In this case, a submission will always
+ * contain the correct page number, even if the user submitted from an old view.
+ *
+ * <p>The page can only be changed if it validates correctly, except if a
+ * "dirty back" or "dirty forward" is allowed. At finish, all pages get
+ * validated again to guarantee a consistent state.
+ *
+ * <p>Note that a validator's default validate method is not executed when using
+ * this class! Rather, the {@link #validatePage} implementation should call
+ * special {@code validateXXX} methods that the validator needs to provide,
+ * validating certain pieces of the object. These can be combined to validate
+ * the elements of individual pages.
+ *
+ * <p>Note: Page numbering starts with 0, to be able to pass an array
+ * consisting of the corresponding view names to the "pages" bean property.
+ *
+ * @author Juergen Hoeller
+ * @since 25.04.2003
+ * @see #setPages
+ * @see #validatePage
+ * @see #processFinish
+ * @see #processCancel
+ * @deprecated as of Spring 3.0, in favor of annotated controllers
+ */
+@Deprecated
+public abstract class AbstractWizardFormController extends AbstractFormController {
+	
+	/**
+	 * Parameter triggering the finish action.
+	 * Can be called from any wizard page!
+	 */
+	public static final String PARAM_FINISH = "_finish";
+	
+	/**
+	 * Parameter triggering the cancel action.
+	 * Can be called from any wizard page!
+	 */
+	public static final String PARAM_CANCEL = "_cancel";
+	
+	/**
+	 * Parameter specifying the target page,
+	 * appending the page number to the name.
+	 */
+	public static final String PARAM_TARGET = "_target";
+	
+	/**
+	 * Parameter specifying the current page as value. Not necessary on
+	 * form pages, but allows to properly handle usage of the back button.
+	 * @see #setPageAttribute
+	 */
+	public static final String PARAM_PAGE = "_page";
+	
+	private String[] pages;
+	
+	private String pageAttribute;
+	
+	private boolean allowDirtyBack = true;
+	
+	private boolean allowDirtyForward = false;
+	
+	/**
+	 * Create a new AbstractWizardFormController.
+	 * <p>"sessionForm" is automatically turned on, "validateOnBinding"
+	 * turned off, and "cacheSeconds" set to 0 by the base class
+	 * (-> no caching for all form controllers).
+	 */
+	public AbstractWizardFormController() {
+		// AbstractFormController sets default cache seconds to 0.
+		super();
+		
+		// Always needs session to keep data from all pages.
+		setSessionForm(true);
+		
+		// Never validate everything on binding ->
+		// wizards validate individual pages.
+		setValidateOnBinding(false);
+	}
+	
+	/**
+	 * Set the wizard pages, i.e. the view names for the pages.
+	 * The array index is interpreted as page number.
+	 * @param pages view names for the pages
+	 */
+	public final void setPages(String[] pages) {
+		if (pages == null || pages.length == 0) {
+			throw new IllegalArgumentException("No wizard pages defined");
+		}
+		this.pages = pages;
+	}
+	
+	/**
+	 * Return the wizard pages, i.e. the view names for the pages.
+	 * The array index corresponds to the page number.
+	 * <p>Note that a concrete wizard form controller might override
+	 * {@link #getViewName(HttpServletRequest, Object, int)} to
+	 * determine the view name for each page dynamically.
+	 * @see #getViewName(javax.servlet.http.HttpServletRequest, Object, int)
+	 */
+	public final String[] getPages() {
+		return this.pages;
+	}
+	
+	/**
+	 * Return the number of wizard pages.
+	 * Useful to check whether the last page has been reached.
+	 * <p>Note that a concrete wizard form controller might override
+	 * {@link #getPageCount(HttpServletRequest, Object)} to determine
+	 * the page count dynamically. The default implementation of that extended
+	 * {@code getPageCount} variant returns the static page count as
+	 * determined by this {@code getPageCount()} method.
+	 * @see #getPageCount(javax.servlet.http.HttpServletRequest, Object)
+	 */
+	protected final int getPageCount() {
+		return this.pages.length;
+	}
+	
+	/**
+	 * Set the name of the page attribute in the model, containing
+	 * an Integer with the current page number.
+	 * <p>This will be necessary for single views rendering multiple view pages.
+	 * It also allows for specifying the optional "_page" parameter.
+	 * @param pageAttribute name of the page attribute
+	 * @see #PARAM_PAGE
+	 */
+	public final void setPageAttribute(String pageAttribute) {
+		this.pageAttribute = pageAttribute;
+	}
+	
+	/**
+	 * Return the name of the page attribute in the model.
+	 */
+	public final String getPageAttribute() {
+		return this.pageAttribute;
+	}
+	
+	/**
+	 * Set if "dirty back" is allowed, that is, if moving to a former wizard
+	 * page is allowed in case of validation errors for the current page.
+	 * @param allowDirtyBack if "dirty back" is allowed
+	 */
+	public final void setAllowDirtyBack(boolean allowDirtyBack) {
+		this.allowDirtyBack = allowDirtyBack;
+	}
+	
+	/**
+	 * Return whether "dirty back" is allowed.
+	 */
+	public final boolean isAllowDirtyBack() {
+		return this.allowDirtyBack;
+	}
+	
+	/**
+	 * Set if "dirty forward" is allowed, that is, if moving to a later wizard
+	 * page is allowed in case of validation errors for the current page.
+	 * @param allowDirtyForward if "dirty forward" is allowed
+	 */
+	public final void setAllowDirtyForward(boolean allowDirtyForward) {
+		this.allowDirtyForward = allowDirtyForward;
+	}
+	
+	/**
+	 * Return whether "dirty forward" is allowed.
+	 */
+	public final boolean isAllowDirtyForward() {
+		return this.allowDirtyForward;
+	}
+	
+	/**
+	 * Calls page-specific onBindAndValidate method.
+	 */
+	@Override
+	protected final void onBindAndValidate(HttpServletRequest request, Object command, BindException errors)
+	        throws Exception {
+		
+		onBindAndValidate(request, command, errors, getCurrentPage(request));
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding and validation.
+	 * Called on each submit, after standard binding but before page-specific
+	 * validation of this wizard form controller.
+	 * <p>Note: AbstractWizardFormController does not perform standand
+	 * validation on binding but rather applies page-specific validation
+	 * on processing the form submission.
+	 * @param request current HTTP request
+	 * @param command bound command
+	 * @param errors Errors instance for additional custom validation
+	 * @param page current wizard page
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #bindAndValidate
+	 * @see #processFormSubmission
+	 * @see org.springframework.validation.Errors
+	 */
+	protected void onBindAndValidate(HttpServletRequest request, Object command, BindException errors, int page)
+	        throws Exception {
+	}
+	
+	/**
+	 * Consider an explicit finish or cancel request as a form submission too.
+	 * @see #isFinishRequest(javax.servlet.http.HttpServletRequest)
+	 * @see #isCancelRequest(javax.servlet.http.HttpServletRequest)
+	 */
+	@Override
+	protected boolean isFormSubmission(HttpServletRequest request) {
+		return super.isFormSubmission(request) || isFinishRequest(request) || isCancelRequest(request);
+	}
+	
+	/**
+	 * Calls page-specific referenceData method.
+	 */
+	@Override
+	protected final Map referenceData(HttpServletRequest request, Object command, Errors errors) throws Exception {
+		
+		return referenceData(request, command, errors, getCurrentPage(request));
+	}
+	
+	/**
+	 * Create a reference data map for the given request, consisting of
+	 * bean name/bean instance pairs as expected by ModelAndView.
+	 * <p>The default implementation delegates to referenceData(HttpServletRequest, int).
+	 * Subclasses can override this to set reference data used in the view.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder
+	 * @param page current wizard page
+	 * @return a Map with reference data entries, or {@code null} if none
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #referenceData(HttpServletRequest, int)
+	 * @see ModelAndView
+	 */
+	protected Map referenceData(HttpServletRequest request, Object command, Errors errors, int page) throws Exception {
+		
+		return referenceData(request, page);
+	}
+	
+	/**
+	 * Create a reference data map for the given request, consisting of
+	 * bean name/bean instance pairs as expected by ModelAndView.
+	 * <p>The default implementation returns {@code null}.
+	 * Subclasses can override this to set reference data used in the view.
+	 * @param request current HTTP request
+	 * @param page current wizard page
+	 * @return a Map with reference data entries, or {@code null} if none
+	 * @throws Exception in case of invalid state or arguments
+	 * @see ModelAndView
+	 */
+	protected Map referenceData(HttpServletRequest request, int page) throws Exception {
+		return null;
+	}
+	
+	/**
+	 * Show the first page as form view.
+	 * <p>This can be overridden in subclasses, e.g. to prepare wizard-specific
+	 * error views in case of an Exception.
+	 */
+	@Override
+	protected ModelAndView showForm(HttpServletRequest request, HttpServletResponse response, BindException errors)
+	        throws Exception {
+		
+		return showPage(request, errors, getInitialPage(request, errors.getTarget()));
+	}
+	
+	/**
+	 * Prepare the form model and view, including reference and error data,
+	 * for the given page. Can be used in {@link #processFinish} implementations,
+	 * to show the corresponding page in case of validation errors.
+	 * @param request current HTTP request
+	 * @param errors validation errors holder
+	 * @param page number of page to show
+	 * @return the prepared form view
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected final ModelAndView showPage(HttpServletRequest request, BindException errors, int page) throws Exception {
+		
+		if (page >= 0 && page < getPageCount(request, errors.getTarget())) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Showing wizard page " + page + " for form bean '" + getCommandName() + "'");
+			}
+			
+			// Set page session attribute, expose overriding request attribute.
+			Integer pageInteger = new Integer(page);
+			String pageAttrName = getPageSessionAttributeName(request);
+			if (isSessionForm()) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("Setting page session attribute [" + pageAttrName + "] to: " + pageInteger);
+				}
+				request.getSession().setAttribute(pageAttrName, pageInteger);
+			}
+			request.setAttribute(pageAttrName, pageInteger);
+			
+			// Set page request attribute for evaluation by views.
+			Map controlModel = new HashMap();
+			if (this.pageAttribute != null) {
+				controlModel.put(this.pageAttribute, new Integer(page));
+			}
+			String viewName = getViewName(request, errors.getTarget(), page);
+			return showForm(request, errors, viewName, controlModel);
+		}
+
+		else {
+			throw new ServletException("Invalid wizard page number: " + page);
+		}
+	}
+	
+	/**
+	 * Return the page count for this wizard form controller.
+	 * The default implementation delegates to {@link #getPageCount()}.
+	 * <p>Can be overridden to dynamically adapt the page count.
+	 * @param request current HTTP request
+	 * @param command the command object as returned by formBackingObject
+	 * @return the current page count
+	 * @see #getPageCount
+	 */
+	protected int getPageCount(HttpServletRequest request, Object command) {
+		return getPageCount();
+	}
+	
+	/**
+	 * Return the name of the view for the specified page of this wizard form controller.
+	 * <p>The default implementation takes the view name from the {@link #getPages()} array.
+	 * <p>Can be overridden to dynamically switch the page view or to return view names
+	 * for dynamically defined pages.
+	 * @param request current HTTP request
+	 * @param command the command object as returned by formBackingObject
+	 * @param page the current page number
+	 * @return the current page count
+	 * @see #getPageCount
+	 */
+	protected String getViewName(HttpServletRequest request, Object command, int page) {
+		return getPages()[page];
+	}
+	
+	/**
+	 * Return the initial page of the wizard, that is, the page shown at wizard startup.
+	 * <p>The default implementation delegates to {@link #getInitialPage(HttpServletRequest)}.
+	 * @param request current HTTP request
+	 * @param command the command object as returned by formBackingObject
+	 * @return the initial page number
+	 * @see #getInitialPage(HttpServletRequest)
+	 * @see #formBackingObject
+	 */
+	protected int getInitialPage(HttpServletRequest request, Object command) {
+		return getInitialPage(request);
+	}
+	
+	/**
+	 * Return the initial page of the wizard, that is, the page shown at wizard startup.
+	 * <p>The default implementation returns 0 for first page.
+	 * @param request current HTTP request
+	 * @return the initial page number
+	 */
+	protected int getInitialPage(HttpServletRequest request) {
+		return 0;
+	}
+	
+	/**
+	 * Return the name of the HttpSession attribute that holds the page object
+	 * for this wizard form controller.
+	 * <p>The default implementation delegates to the {@link #getPageSessionAttributeName()}
+	 * variant without arguments.
+	 * @param request current HTTP request
+	 * @return the name of the form session attribute, or {@code null} if not in session form mode
+	 * @see #getPageSessionAttributeName
+	 * @see #getFormSessionAttributeName(javax.servlet.http.HttpServletRequest)
+	 * @see javax.servlet.http.HttpSession#getAttribute
+	 */
+	protected String getPageSessionAttributeName(HttpServletRequest request) {
+		return getPageSessionAttributeName();
+	}
+	
+	/**
+	 * Return the name of the HttpSession attribute that holds the page object
+	 * for this wizard form controller.
+	 * <p>Default is an internal name, of no relevance to applications, as the form
+	 * session attribute is not usually accessed directly. Can be overridden to use
+	 * an application-specific attribute name, which allows other code to access
+	 * the session attribute directly.
+	 * @return the name of the page session attribute
+	 * @see #getFormSessionAttributeName
+	 * @see javax.servlet.http.HttpSession#getAttribute
+	 */
+	protected String getPageSessionAttributeName() {
+		return getClass().getName() + ".PAGE." + getCommandName();
+	}
+	
+	/**
+	 * Handle an invalid submit request, e.g. when in session form mode but no form object
+	 * was found in the session (like in case of an invalid resubmit by the browser).
+	 * <p>The default implementation for wizard form controllers simply shows the initial page
+	 * of a new wizard form. If you want to show some "invalid submit" message, you need
+	 * to override this method.
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @return a prepared view, or {@code null} if handled directly
+	 * @throws Exception in case of errors
+	 * @see #showNewForm
+	 * @see #setBindOnNewForm
+	 */
+	@Override
+	protected ModelAndView handleInvalidSubmit(HttpServletRequest request, HttpServletResponse response) throws Exception {
+		
+		return showNewForm(request, response);
+	}
+	
+	/**
+	 * Apply wizard workflow: finish, cancel, page change.
+	 */
+	@Override
+	protected final ModelAndView processFormSubmission(HttpServletRequest request, HttpServletResponse response,
+	        Object command, BindException errors) throws Exception {
+		
+		int currentPage = getCurrentPage(request);
+		// Remove page session attribute, provide copy as request attribute.
+		String pageAttrName = getPageSessionAttributeName(request);
+		if (isSessionForm()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Removing page session attribute [" + pageAttrName + "]");
+			}
+			request.getSession().removeAttribute(pageAttrName);
+		}
+		request.setAttribute(pageAttrName, new Integer(currentPage));
+		
+		// cancel?
+		if (isCancelRequest(request)) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Cancelling wizard for form bean '" + getCommandName() + "'");
+			}
+			return processCancel(request, response, command, errors);
+		}
+		
+		// finish?
+		if (isFinishRequest(request)) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Finishing wizard for form bean '" + getCommandName() + "'");
+			}
+			return validatePagesAndFinish(request, response, command, errors, currentPage);
+		}
+		
+		// Normal submit: validate current page and show specified target page.
+		if (!suppressValidation(request, command, errors)) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Validating wizard page " + currentPage + " for form bean '" + getCommandName() + "'");
+			}
+			validatePage(command, errors, currentPage, false);
+		}
+		
+		// Give subclasses a change to perform custom post-procession
+		// of the current page and its command object.
+		postProcessPage(request, command, errors, currentPage);
+		
+		int targetPage = getTargetPage(request, command, errors, currentPage);
+		if (logger.isDebugEnabled()) {
+			logger.debug("Target page " + targetPage + " requested");
+		}
+		if (targetPage != currentPage) {
+			if (!errors.hasErrors() || (this.allowDirtyBack && targetPage < currentPage)
+			        || (this.allowDirtyForward && targetPage > currentPage)) {
+				// Allowed to go to target page.
+				return showPage(request, errors, targetPage);
+			}
+		}
+		
+		// Show current page again.
+		return showPage(request, errors, currentPage);
+	}
+	
+	/**
+	 * Return the current page number. Used by {@link #processFormSubmission}.
+	 * <p>The default implementation checks the page session attribute.
+	 * Subclasses can override this for customized page determination.
+	 * @param request current HTTP request
+	 * @return the current page number
+	 * @see #getPageSessionAttributeName()
+	 */
+	protected int getCurrentPage(HttpServletRequest request) {
+		// Check for overriding attribute in request.
+		String pageAttrName = getPageSessionAttributeName(request);
+		Integer pageAttr = (Integer) request.getAttribute(pageAttrName);
+		if (pageAttr != null) {
+			return pageAttr.intValue();
+		}
+		// Check for explicit request parameter.
+		String pageParam = request.getParameter(PARAM_PAGE);
+		if (pageParam != null) {
+			return Integer.parseInt(pageParam);
+		}
+		// Check for original attribute in session.
+		if (isSessionForm()) {
+			pageAttr = (Integer) request.getSession().getAttribute(pageAttrName);
+			if (pageAttr != null) {
+				return pageAttr.intValue();
+			}
+		}
+		throw new IllegalStateException("Page attribute [" + pageAttrName + "] neither found in session nor in request");
+	}
+	
+	/**
+	 * Determine whether the incoming request is a request to finish the
+	 * processing of the current form.
+	 * <p>By default, this method returns {@code true} if a parameter
+	 * matching the "_finish" key is present in the request, otherwise it
+	 * returns {@code false}. Subclasses may override this method
+	 * to provide custom logic to detect a finish request.
+	 * <p>The parameter is recognized both when sent as a plain parameter
+	 * ("_finish") or when triggered by an image button ("_finish.x").
+	 * @param request current HTTP request
+	 * @return whether the request indicates to finish form processing
+	 * @see #PARAM_FINISH
+	 */
+	protected boolean isFinishRequest(HttpServletRequest request) {
+		return WebUtils.hasSubmitParameter(request, PARAM_FINISH);
+	}
+	
+	/**
+	 * Determine whether the incoming request is a request to cancel the
+	 * processing of the current form.
+	 * <p>By default, this method returns {@code true} if a parameter
+	 * matching the "_cancel" key is present in the request, otherwise it
+	 * returns {@code false}. Subclasses may override this method
+	 * to provide custom logic to detect a cancel request.
+	 * <p>The parameter is recognized both when sent as a plain parameter
+	 * ("_cancel") or when triggered by an image button ("_cancel.x").
+	 * @return whether the request indicates to cancel form processing
+	 * @param request current HTTP request
+	 * @see #PARAM_CANCEL
+	 */
+	protected boolean isCancelRequest(HttpServletRequest request) {
+		return WebUtils.hasSubmitParameter(request, PARAM_CANCEL);
+	}
+	
+	/**
+	 * Return the target page specified in the request.
+	 * <p>The default implementation delegates to {@link #getTargetPage(HttpServletRequest, int)}.
+	 * Subclasses can override this for customized target page determination.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder
+	 * @param currentPage the current page, to be returned as fallback
+	 * if no target page specified
+	 * @return the page specified in the request, or current page if not found
+	 * @see #getTargetPage(HttpServletRequest, int)
+	 */
+	protected int getTargetPage(HttpServletRequest request, Object command, Errors errors, int currentPage) {
+		return getTargetPage(request, currentPage);
+	}
+	
+	/**
+	 * Return the target page specified in the request.
+	 * <p>The default implementation examines "_target" parameter (e.g. "_target1").
+	 * Subclasses can override this for customized target page determination.
+	 * @param request current HTTP request
+	 * @param currentPage the current page, to be returned as fallback
+	 * if no target page specified
+	 * @return the page specified in the request, or current page if not found
+	 * @see #PARAM_TARGET
+	 */
+	protected int getTargetPage(HttpServletRequest request, int currentPage) {
+		return WebUtils.getTargetPage(request, PARAM_TARGET, currentPage);
+	}
+	
+	/**
+	 * Validate all pages and process finish.
+	 * If there are page validation errors, show the corresponding view page.
+	 */
+	private ModelAndView validatePagesAndFinish(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors, int currentPage) throws Exception {
+		
+		// In case of binding errors -> show current page.
+		if (errors.hasErrors()) {
+			return showPage(request, errors, currentPage);
+		}
+		
+		if (!suppressValidation(request, command, errors)) {
+			// In case of remaining errors on a page -> show the page.
+			for (int page = 0; page < getPageCount(request, command); page++) {
+				validatePage(command, errors, page, true);
+				if (errors.hasErrors()) {
+					return showPage(request, errors, page);
+				}
+			}
+		}
+		
+		// No remaining errors -> proceed with finish.
+		return processFinish(request, response, command, errors);
+	}
+	
+	/**
+	 * Template method for custom validation logic for individual pages.
+	 * The default implementation calls {@link #validatePage(Object, Errors, int)}.
+	 * <p>Implementations will typically call fine-granular {@code validateXXX}
+	 * methods of this instance's Validator, combining them to validation of the
+	 * corresponding pages. The Validator's default {@code validate} method
+	 * will not be called by a wizard form controller!
+	 * @param command form object with the current wizard state
+	 * @param errors validation errors holder
+	 * @param page number of page to validate
+	 * @param finish whether this method is called during final revalidation on finish
+	 * (else, it is called for validating the current page)
+	 * @see #validatePage(Object, Errors, int)
+	 * @see org.springframework.validation.Validator#validate
+	 */
+	protected void validatePage(Object command, Errors errors, int page, boolean finish) {
+		validatePage(command, errors, page);
+	}
+	
+	/**
+	 * Template method for custom validation logic for individual pages.
+	 * The default implementation is empty.
+	 * <p>Implementations will typically call fine-granular validateXXX methods of this
+	 * instance's validator, combining them to validation of the corresponding pages.
+	 * The validator's default {@code validate} method will not be called by a
+	 * wizard form controller!
+	 * @param command form object with the current wizard state
+	 * @param errors validation errors holder
+	 * @param page number of page to validate
+	 * @see org.springframework.validation.Validator#validate
+	 */
+	protected void validatePage(Object command, Errors errors, int page) {
+	}
+	
+	/**
+	 * Post-process the given page after binding and validation, potentially
+	 * updating its command object. The passed-in request might contain special
+	 * parameters sent by the page.
+	 * <p>Only invoked when displaying another page or the same page again,
+	 * not when finishing or cancelling.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder
+	 * @param page number of page to post-process
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected void postProcessPage(HttpServletRequest request, Object command, Errors errors, int page) throws Exception {
+	}
+	
+	/**
+	 * Template method for processing the final action of this wizard.
+	 * <p>Call {@code errors.getModel()} to populate the ModelAndView model
+	 * with the command and the Errors instance, under the specified command name,
+	 * as expected by the "spring:bind" tag.
+	 * <p>You can call the {@link #showPage} method to return back to the wizard,
+	 * in case of last-minute validation errors having been found that you would
+	 * like to present to the user within the original wizard form.
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param command form object with the current wizard state
+	 * @param errors validation errors holder
+	 * @return the finish view
+	 * @throws Exception in case of invalid state or arguments
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 * @see #showPage(javax.servlet.http.HttpServletRequest, org.springframework.validation.BindException, int)
+	 */
+	protected abstract ModelAndView processFinish(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors) throws Exception;
+	
+	/**
+	 * Template method for processing the cancel action of this wizard.
+	 * <p>The default implementation throws a ServletException, saying that a cancel
+	 * operation is not supported by this controller. Thus, you do not need to
+	 * implement this template method if you do not support a cancel operation.
+	 * <p>Call {@code errors.getModel()} to populate the ModelAndView model
+	 * with the command and the Errors instance, under the specified command name,
+	 * as expected by the "spring:bind" tag.
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param command form object with the current wizard state
+	 * @param errors Errors instance containing errors
+	 * @return the cancellation view
+	 * @throws Exception in case of invalid state or arguments
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 */
+	protected ModelAndView processCancel(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors) throws Exception {
+		
+		throw new ServletException("Wizard form controller class [" + getClass().getName()
+		        + "] does not support a cancel operation");
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/servlet/mvc/BaseCommandController.java
+++ b/web/src/main/java/org/springframework/web/servlet/mvc/BaseCommandController.java
@@ -1,0 +1,586 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.PropertyEditorRegistrar;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingErrorProcessor;
+import org.springframework.validation.MessageCodesResolver;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+import org.springframework.web.bind.ServletRequestDataBinder;
+import org.springframework.web.bind.support.WebBindingInitializer;
+import org.springframework.web.context.request.ServletWebRequest;
+
+/**
+ * <p>Controller implementation which creates an object (the command object) on
+ * receipt of a request and attempts to populate this object with request parameters.</p>
+ *
+ * <p>This controller is the base for all controllers wishing to populate
+ * JavaBeans based on request parameters, validate the content of such
+ * JavaBeans using {@link org.springframework.validation.Validator Validators}
+ * and use custom editors (in the form of
+ * {@link java.beans.PropertyEditor PropertyEditors}) to transform
+ * objects into strings and vice versa, for example. Three notions are mentioned here:</p>
+ *
+ * <p><b>Command class:</b><br>
+ * An instance of the command class will be created for each request and populated
+ * with request parameters. A command class can basically be any Java class; the only
+ * requirement is a no-arg constructor. The command class should preferably be a
+ * JavaBean in order to be able to populate bean properties with request parameters.</p>
+ *
+ * <p><b>Populating using request parameters and PropertyEditors:</b><br>
+ * Upon receiving a request, any BaseCommandController will attempt to fill the
+ * command object using the request parameters. This is done using the typical
+ * and well-known JavaBeans property notation. When a request parameter named
+ * {@code 'firstName'} exists, the framework will attempt to call
+ * {@code setFirstName([value])} passing the value of the parameter. Nested properties
+ * are of course supported. For instance a parameter named {@code 'address.city'}
+ * will result in a {@code getAddress().setCity([value])} call on the
+ * command class.</p>
+ *
+ * <p>It's important to realise that you are not limited to String arguments in
+ * your JavaBeans. Using the PropertyEditor-notion as supplied by the
+ * java.beans package, you will be able to transform Strings to Objects and
+ * the other way around. For instance {@code setLocale(Locale loc)} is
+ * perfectly possible for a request parameter named {@code locale} having
+ * a value of {@code en}, as long as you register the appropriate
+ * PropertyEditor in the Controller (see {@link #initBinder initBinder()}
+ * for more information on that matter.</p>
+ *
+ * <p><b>Validators:</b>
+ * After the controller has successfully populated the command object with
+ * parameters from the request, it will use any configured validators to
+ * validate the object. Validation results will be put in a
+ * {@link org.springframework.validation.Errors Errors} object which can be
+ * used in a View to render any input problems.</p>
+ *
+ * <p><b><a name="workflow">Workflow
+ * (<a href="AbstractController.html#workflow">and that defined by superclass</a>):</b><br>
+ * Since this class is an abstract base class for more specific implementation,
+ * it does not override the handleRequestInternal() method and also has no
+ * actual workflow. Implementing classes like
+ * {@link AbstractFormController AbstractFormController},
+ * {@link AbstractCommandController AbstractcommandController},
+ * {@link SimpleFormController SimpleFormController} and
+ * {@link AbstractWizardFormController AbstractWizardFormController}
+ * provide actual functionality and workflow.
+ * More information on workflow performed by superclasses can be found
+ * <a href="AbstractController.html#workflow">here</a>.</p>
+ *
+ * <p><b><a name="config">Exposed configuration properties</a>
+ * (<a href="AbstractController.html#config">and those defined by superclass</a>):</b><br>
+ * <table border="1">
+ *  <tr>
+ *      <td><b>name</b></th>
+ *      <td><b>default</b></td>
+ *      <td><b>description</b></td>
+ *  </tr>
+ *  <tr>
+ *      <td>commandName</td>
+ *      <td>command</td>
+ *      <td>the name to use when binding the instantiated command class
+ *          to the request</td>
+ *  </tr>
+ *  <tr>
+ *      <td>commandClass</td>
+ *      <td><i>null</i></td>
+ *      <td>the class to use upon receiving a request and which to fill
+ *          using the request parameters. What object is used and whether
+ *          or not it should be created is defined by extending classes
+ *          and their configuration properties and methods.</td>
+ *  </tr>
+ *  <tr>
+ *      <td>validators</td>
+ *      <td><i>null</i></td>
+ *      <td>Array of Validator beans. The validator will be called at appropriate
+ *          places in the workflow of subclasses (have a look at those for more info)
+ *          to validate the command object.</td>
+ *  </tr>
+ *  <tr>
+ *      <td>validator</td>
+ *      <td><i>null</i></td>
+ *      <td>Short-form property for setting only one Validator bean (usually passed in
+ *          using a &lt;ref bean="beanId"/&gt; property.</td>
+ *  </tr>
+ *  <tr>
+ *      <td>validateOnBinding</td>
+ *      <td>true</td>
+ *      <td>Indicates whether or not to validate the command object after the
+ *          object has been populated with request parameters.</td>
+ *  </tr>
+ * </table>
+ * </p>
+ *
+ * @author Rod Johnson
+ * @author Juergen Hoeller
+ * @deprecated as of Spring 3.0, in favor of annotated controllers
+ */
+@Deprecated
+public abstract class BaseCommandController extends AbstractController {
+	
+	/** Default command name used for binding command objects: "command" */
+	public static final String DEFAULT_COMMAND_NAME = "command";
+	
+	private String commandName = DEFAULT_COMMAND_NAME;
+	
+	private Class commandClass;
+	
+	private Validator[] validators;
+	
+	private boolean validateOnBinding = true;
+	
+	private MessageCodesResolver messageCodesResolver;
+	
+	private BindingErrorProcessor bindingErrorProcessor;
+	
+	private PropertyEditorRegistrar[] propertyEditorRegistrars;
+	
+	private WebBindingInitializer webBindingInitializer;
+	
+	/**
+	 * Set the name of the command in the model.
+	 * The command object will be included in the model under this name.
+	 */
+	public final void setCommandName(String commandName) {
+		this.commandName = commandName;
+	}
+	
+	/**
+	 * Return the name of the command in the model.
+	 */
+	public final String getCommandName() {
+		return this.commandName;
+	}
+	
+	/**
+	 * Set the command class for this controller.
+	 * An instance of this class gets populated and validated on each request.
+	 */
+	public final void setCommandClass(Class commandClass) {
+		this.commandClass = commandClass;
+	}
+	
+	/**
+	 * Return the command class for this controller.
+	 */
+	public final Class getCommandClass() {
+		return this.commandClass;
+	}
+	
+	/**
+	 * Set the primary Validator for this controller. The Validator
+	 * must support the specified command class. If there are one
+	 * or more existing validators set already when this method is
+	 * called, only the specified validator will be kept. Use
+	 * {@link #setValidators(Validator[])} to set multiple validators.
+	 */
+	public final void setValidator(Validator validator) {
+		this.validators = new Validator[] { validator };
+	}
+	
+	/**
+	 * Return the primary Validator for this controller.
+	 */
+	public final Validator getValidator() {
+		return (this.validators != null && this.validators.length > 0 ? this.validators[0] : null);
+	}
+	
+	/**
+	 * Set the Validators for this controller.
+	 * The Validator must support the specified command class.
+	 */
+	public final void setValidators(Validator[] validators) {
+		this.validators = validators;
+	}
+	
+	/**
+	 * Return the Validators for this controller.
+	 */
+	public final Validator[] getValidators() {
+		return this.validators;
+	}
+	
+	/**
+	 * Set if the Validator should get applied when binding.
+	 */
+	public final void setValidateOnBinding(boolean validateOnBinding) {
+		this.validateOnBinding = validateOnBinding;
+	}
+	
+	/**
+	 * Return if the Validator should get applied when binding.
+	 */
+	public final boolean isValidateOnBinding() {
+		return this.validateOnBinding;
+	}
+	
+	/**
+	 * Set the strategy to use for resolving errors into message codes.
+	 * Applies the given strategy to all data binders used by this controller.
+	 * <p>Default is {@code null}, i.e. using the default strategy of
+	 * the data binder.
+	 * @see #createBinder
+	 * @see org.springframework.validation.DataBinder#setMessageCodesResolver
+	 */
+	public final void setMessageCodesResolver(MessageCodesResolver messageCodesResolver) {
+		this.messageCodesResolver = messageCodesResolver;
+	}
+	
+	/**
+	 * Return the strategy to use for resolving errors into message codes (if any).
+	 */
+	public final MessageCodesResolver getMessageCodesResolver() {
+		return this.messageCodesResolver;
+	}
+	
+	/**
+	 * Set the strategy to use for processing binding errors, that is,
+	 * required field errors and {@code PropertyAccessException}s.
+	 * <p>Default is {@code null}, that is, using the default strategy
+	 * of the data binder.
+	 * @see #createBinder
+	 * @see org.springframework.validation.DataBinder#setBindingErrorProcessor
+	 */
+	public final void setBindingErrorProcessor(BindingErrorProcessor bindingErrorProcessor) {
+		this.bindingErrorProcessor = bindingErrorProcessor;
+	}
+	
+	/**
+	 * Return the strategy to use for processing binding errors (if any).
+	 */
+	public final BindingErrorProcessor getBindingErrorProcessor() {
+		return this.bindingErrorProcessor;
+	}
+	
+	/**
+	 * Specify a single PropertyEditorRegistrar to be applied
+	 * to every DataBinder that this controller uses.
+	 * <p>Allows for factoring out the registration of PropertyEditors
+	 * to separate objects, as an alternative to {@link #initBinder}.
+	 * @see #initBinder
+	 */
+	public final void setPropertyEditorRegistrar(PropertyEditorRegistrar propertyEditorRegistrar) {
+		this.propertyEditorRegistrars = new PropertyEditorRegistrar[] { propertyEditorRegistrar };
+	}
+	
+	/**
+	 * Specify multiple PropertyEditorRegistrars to be applied
+	 * to every DataBinder that this controller uses.
+	 * <p>Allows for factoring out the registration of PropertyEditors
+	 * to separate objects, as an alternative to {@link #initBinder}.
+	 * @see #initBinder
+	 */
+	public final void setPropertyEditorRegistrars(PropertyEditorRegistrar[] propertyEditorRegistrars) {
+		this.propertyEditorRegistrars = propertyEditorRegistrars;
+	}
+	
+	/**
+	 * Return the PropertyEditorRegistrars (if any) to be applied
+	 * to every DataBinder that this controller uses.
+	 */
+	public final PropertyEditorRegistrar[] getPropertyEditorRegistrars() {
+		return this.propertyEditorRegistrars;
+	}
+	
+	/**
+	 * Specify a WebBindingInitializer which will apply pre-configured
+	 * configuration to every DataBinder that this controller uses.
+	 * <p>Allows for factoring out the entire binder configuration
+	 * to separate objects, as an alternative to {@link #initBinder}.
+	 */
+	public final void setWebBindingInitializer(WebBindingInitializer webBindingInitializer) {
+		this.webBindingInitializer = webBindingInitializer;
+	}
+	
+	/**
+	 * Return the WebBindingInitializer (if any) which will apply pre-configured
+	 * configuration to every DataBinder that this controller uses.
+	 */
+	public final WebBindingInitializer getWebBindingInitializer() {
+		return this.webBindingInitializer;
+	}
+	
+	@Override
+	protected void initApplicationContext() {
+		if (this.validators != null) {
+			for (int i = 0; i < this.validators.length; i++) {
+				if (this.commandClass != null && !this.validators[i].supports(this.commandClass))
+					throw new IllegalArgumentException("Validator [" + this.validators[i]
+					        + "] does not support command class [" + this.commandClass.getName() + "]");
+			}
+		}
+	}
+	
+	/**
+	 * Retrieve a command object for the given request.
+	 * <p>The default implementation calls {@link #createCommand}.
+	 * Subclasses can override this.
+	 * @param request current HTTP request
+	 * @return object command to bind onto
+	 * @throws Exception if the command object could not be obtained
+	 * @see #createCommand
+	 */
+	protected Object getCommand(HttpServletRequest request) throws Exception {
+		return createCommand();
+	}
+	
+	/**
+	 * Create a new command instance for the command class of this controller.
+	 * <p>This implementation uses {@code BeanUtils.instantiateClass},
+	 * so the command needs to have a no-arg constructor (supposed to be
+	 * public, but not required to).
+	 * @return the new command instance
+	 * @throws Exception if the command object could not be instantiated
+	 * @see org.springframework.beans.BeanUtils#instantiateClass(Class)
+	 */
+	protected final Object createCommand() throws Exception {
+		if (this.commandClass == null) {
+			throw new IllegalStateException("Cannot create command without commandClass being set - "
+			        + "either set commandClass or (in a form controller) override formBackingObject");
+		}
+		if (logger.isDebugEnabled()) {
+			logger.debug("Creating new command of class [" + this.commandClass.getName() + "]");
+		}
+		return BeanUtils.instantiateClass(this.commandClass);
+	}
+	
+	/**
+	 * Check if the given command object is a valid for this controller,
+	 * i.e. its command class.
+	 * @param command the command object to check
+	 * @return if the command object is valid for this controller
+	 */
+	protected final boolean checkCommand(Object command) {
+		return (this.commandClass == null || this.commandClass.isInstance(command));
+	}
+	
+	/**
+	 * Bind the parameters of the given request to the given command object.
+	 * @param request current HTTP request
+	 * @param command the command to bind onto
+	 * @return the ServletRequestDataBinder instance for additional custom validation
+	 * @throws Exception in case of invalid state or arguments
+	 */
+	protected final ServletRequestDataBinder bindAndValidate(HttpServletRequest request, Object command) throws Exception {
+		
+		ServletRequestDataBinder binder = createBinder(request, command);
+		BindException errors = new BindException(binder.getBindingResult());
+		if (!suppressBinding(request)) {
+			binder.bind(request);
+			onBind(request, command, errors);
+			if (this.validators != null && isValidateOnBinding() && !suppressValidation(request, command, errors)) {
+				for (int i = 0; i < this.validators.length; i++) {
+					ValidationUtils.invokeValidator(this.validators[i], command, errors);
+				}
+			}
+			onBindAndValidate(request, command, errors);
+		}
+		return binder;
+	}
+	
+	/**
+	 * Return whether to suppress binding for the given request.
+	 * <p>The default implementation always returns "false". Can be overridden
+	 * in subclasses to suppress validation, for example, if a special
+	 * request parameter is set.
+	 * @param request current HTTP request
+	 * @return whether to suppress binding for the given request
+	 * @see #suppressValidation
+	 */
+	protected boolean suppressBinding(HttpServletRequest request) {
+		return false;
+	}
+	
+	/**
+	 * Create a new binder instance for the given command and request.
+	 * <p>Called by {@link #bindAndValidate}. Can be overridden to plug in
+	 * custom ServletRequestDataBinder instances.
+	 * <p>The default implementation creates a standard ServletRequestDataBinder
+	 * and invokes {@link #prepareBinder} and {@link #initBinder}.
+	 * <p>Note that neither {@link #prepareBinder} nor {@link #initBinder} will
+	 * be invoked automatically if you override this method! Call those methods
+	 * at appropriate points of your overridden method.
+	 * @param request current HTTP request
+	 * @param command the command to bind onto
+	 * @return the new binder instance
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #bindAndValidate
+	 * @see #prepareBinder
+	 * @see #initBinder
+	 */
+	protected ServletRequestDataBinder createBinder(HttpServletRequest request, Object command) throws Exception {
+		
+		ServletRequestDataBinder binder = new ServletRequestDataBinder(command, getCommandName());
+		prepareBinder(binder);
+		initBinder(request, binder);
+		return binder;
+	}
+	
+	/**
+	 * Prepare the given binder, applying the specified MessageCodesResolver,
+	 * BindingErrorProcessor and PropertyEditorRegistrars (if any).
+	 * Called by {@link #createBinder}.
+	 * @param binder the new binder instance
+	 * @see #createBinder
+	 * @see #setMessageCodesResolver
+	 * @see #setBindingErrorProcessor
+	 */
+	protected final void prepareBinder(ServletRequestDataBinder binder) {
+		if (useDirectFieldAccess()) {
+			binder.initDirectFieldAccess();
+		}
+		if (this.messageCodesResolver != null) {
+			binder.setMessageCodesResolver(this.messageCodesResolver);
+		}
+		if (this.bindingErrorProcessor != null) {
+			binder.setBindingErrorProcessor(this.bindingErrorProcessor);
+		}
+		if (this.propertyEditorRegistrars != null) {
+			for (int i = 0; i < this.propertyEditorRegistrars.length; i++) {
+				this.propertyEditorRegistrars[i].registerCustomEditors(binder);
+			}
+		}
+	}
+	
+	/**
+	 * Determine whether to use direct field access instead of bean property access.
+	 * Applied by {@link #prepareBinder}.
+	 * <p>Default is "false". Can be overridden in subclasses.
+	 * @return whether to use direct field access ({@code true})
+	 * or bean property access ({@code false})
+	 * @see #prepareBinder
+	 * @see org.springframework.validation.DataBinder#initDirectFieldAccess()
+	 */
+	protected boolean useDirectFieldAccess() {
+		return false;
+	}
+	
+	/**
+	 * Initialize the given binder instance, for example with custom editors.
+	 * Called by {@link #createBinder}.
+	 * <p>This method allows you to register custom editors for certain fields of your
+	 * command class. For instance, you will be able to transform Date objects into a
+	 * String pattern and back, in order to allow your JavaBeans to have Date properties
+	 * and still be able to set and display them in an HTML interface.
+	 * <p>The default implementation is empty.
+	 * @param request current HTTP request
+	 * @param binder the new binder instance
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #createBinder
+	 * @see org.springframework.validation.DataBinder#registerCustomEditor
+	 * @see org.springframework.beans.propertyeditors.CustomDateEditor
+	 */
+	protected void initBinder(HttpServletRequest request, ServletRequestDataBinder binder) throws Exception {
+		if (this.webBindingInitializer != null) {
+			this.webBindingInitializer.initBinder(binder, new ServletWebRequest(request));
+		}
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding.
+	 * Called on each submit, after standard binding but before validation.
+	 * <p>The default implementation delegates to {@link #onBind(HttpServletRequest, Object)}.
+	 * @param request current HTTP request
+	 * @param command the command object to perform further binding on
+	 * @param errors validation errors holder, allowing for additional
+	 * custom registration of binding errors
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #bindAndValidate
+	 * @see #onBind(HttpServletRequest, Object)
+	 */
+	protected void onBind(HttpServletRequest request, Object command, BindException errors) throws Exception {
+		onBind(request, command);
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding.
+	 * <p>Called by the default implementation of the
+	 * {@link #onBind(HttpServletRequest, Object, BindException)} variant
+	 * with all parameters, after standard binding but before validation.
+	 * <p>The default implementation is empty.
+	 * @param request current HTTP request
+	 * @param command the command object to perform further binding on
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #onBind(HttpServletRequest, Object, BindException)
+	 */
+	protected void onBind(HttpServletRequest request, Object command) throws Exception {
+	}
+	
+	/**
+	 * Return whether to suppress validation for the given request.
+	 * <p>The default implementation delegates to {@link #suppressValidation(HttpServletRequest, Object)}.
+	 * @param request current HTTP request
+	 * @param command the command object to validate
+	 * @param errors validation errors holder, allowing for additional
+	 * custom registration of binding errors
+	 * @return whether to suppress validation for the given request
+	 */
+	protected boolean suppressValidation(HttpServletRequest request, Object command, BindException errors) {
+		return suppressValidation(request, command);
+	}
+	
+	/**
+	 * Return whether to suppress validation for the given request.
+	 * <p>Called by the default implementation of the
+	 * {@link #suppressValidation(HttpServletRequest, Object, BindException)} variant
+	 * with all parameters.
+	 * <p>The default implementation delegates to {@link #suppressValidation(HttpServletRequest)}.
+	 * @param request current HTTP request
+	 * @param command the command object to validate
+	 * @return whether to suppress validation for the given request
+	 */
+	protected boolean suppressValidation(HttpServletRequest request, Object command) {
+		return suppressValidation(request);
+	}
+	
+	/**
+	 * Return whether to suppress validation for the given request.
+	 * <p>Called by the default implementation of the
+	 * {@link #suppressValidation(HttpServletRequest, Object)} variant
+	 * with all parameters.
+	 * <p>The default implementation is empty.
+	 * @param request current HTTP request
+	 * @return whether to suppress validation for the given request
+	 * @deprecated as of Spring 2.0.4, in favor of the
+	 * {@link #suppressValidation(HttpServletRequest, Object)} variant
+	 */
+	@Deprecated
+	protected boolean suppressValidation(HttpServletRequest request) {
+		return false;
+	}
+	
+	/**
+	 * Callback for custom post-processing in terms of binding and validation.
+	 * Called on each submit, after standard binding and validation,
+	 * but before error evaluation.
+	 * <p>The default implementation is empty.
+	 * @param request current HTTP request
+	 * @param command the command object, still allowing for further binding
+	 * @param errors validation errors holder, allowing for additional
+	 * custom validation
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #bindAndValidate
+	 * @see org.springframework.validation.Errors
+	 */
+	protected void onBindAndValidate(HttpServletRequest request, Object command, BindException errors) throws Exception {
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/servlet/mvc/SimpleFormController.java
+++ b/web/src/main/java/org/springframework/web/servlet/mvc/SimpleFormController.java
@@ -1,0 +1,455 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.mvc;
+
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * <p>Concrete FormController implementation that provides configurable
+ * form and success views, and an onSubmit chain for convenient overriding.
+ * Automatically resubmits to the form view in case of validation errors,
+ * and renders the success view in case of a valid submission.</p>
+ *
+ * <p>The workflow of this Controller does not differ much from the one described
+ * in the {@link AbstractFormController AbstractFormController}. The difference
+ * is that you do not need to implement {@link #showForm showForm} and
+ * {@link #processFormSubmission processFormSubmission}: A form view and a
+ * success view can be configured declaratively.</p>
+ *
+ * <p><b><a name="workflow">Workflow
+ * (<a href="AbstractFormController.html#workflow">in addition to the superclass</a>):</b><br>
+ * <ol>
+ *  <li>Call to {@link #processFormSubmission processFormSubmission} which inspects
+ *      the {@link org.springframework.validation.Errors Errors} object to see if
+ *      any errors have occurred during binding and validation.</li>
+ *  <li>If errors occured, the controller will return the configured formView,
+ *      showing the form again (possibly rendering according error messages).</li>
+ *  <li>If {@link #isFormChangeRequest isFormChangeRequest} is overridden and returns
+ *      true for the given request, the controller will return the formView too.
+ *      In that case, the controller will also suppress validation. Before returning the formView,
+ *      the controller will invoke {@link #onFormChange}, giving sub-classes a chance
+ *      to make modification to the command object.
+ *      This is intended for requests that change the structure of the form,
+ *      which should not cause validation and show the form in any case.</li>
+ *  <li>If no errors occurred, the controller will call
+ *      {@link #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException) onSubmit}
+ *      using all parameters, which in case of the default implementation delegates to
+ *      {@link #onSubmit(Object, BindException) onSubmit} with just the command object.
+ *      The default implementation of the latter method will return the configured
+ *      {@code successView}. Consider implementing {@link #doSubmitAction} doSubmitAction
+ *      for simply performing a submit action and rendering the success view.</li>
+ *  </ol>
+ * </p>
+ *
+ * <p>The submit behavior can be customized by overriding one of the
+ * {@link #onSubmit onSubmit} methods. Submit actions can also perform
+ * custom validation if necessary (typically database-driven checks), calling
+ * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException) showForm}
+ * in case of validation errors to show the form view again.</p>
+ *
+ * <p><b><a name="config">Exposed configuration properties</a>
+ * (<a href="AbstractFormController.html#config">and those defined by superclass</a>):</b><br>
+ * <table border="1">
+ *  <tr>
+ *      <td><b>name</b></td>
+ *      <td><b>default</b></td>
+ *      <td><b>description</b></td>
+ *  </tr>
+ *  <tr>
+ *      <td>formView</td>
+ *      <td><i>null</i></td>
+ *      <td>Indicates what view to use when the user asks for a new form
+ *          or when validation errors have occurred on form submission.</td>
+ *  </tr>
+ *  <tr>
+ *      <td>successView</td>
+ *      <td><i>null</i></td>
+ *      <td>Indicates what view to use when successful form submissions have
+ *          occurred. Such a success view could e.g. display a submission summary.
+ *          More sophisticated actions can be implemented by overriding one of
+ *          the {@link #onSubmit(Object) onSubmit()} methods.</td>
+ *  </tr>
+ * <table>
+ * </p>
+ *
+ * @author Juergen Hoeller
+ * @author Rob Harrop
+ * @since 05.05.2003
+ * @deprecated as of Spring 3.0, in favor of annotated controllers
+ */
+@Deprecated
+public class SimpleFormController extends AbstractFormController {
+	
+	private String formView;
+	
+	private String successView;
+	
+	/**
+	 * Create a new SimpleFormController.
+	 * <p>Subclasses should set the following properties, either in the constructor
+	 * or via a BeanFactory: commandName, commandClass, sessionForm, formView,
+	 * successView. Note that commandClass doesn't need to be set when overriding
+	 * {@code formBackingObject}, as this determines the class anyway.
+	 * @see #setCommandClass
+	 * @see #setCommandName
+	 * @see #setSessionForm
+	 * @see #setFormView
+	 * @see #setSuccessView
+	 * @see #formBackingObject
+	 */
+	public SimpleFormController() {
+		// AbstractFormController sets default cache seconds to 0.
+		super();
+	}
+	
+	/**
+	 * Set the name of the view that should be used for form display.
+	 */
+	public final void setFormView(String formView) {
+		this.formView = formView;
+	}
+	
+	/**
+	 * Return the name of the view that should be used for form display.
+	 */
+	public final String getFormView() {
+		return this.formView;
+	}
+	
+	/**
+	 * Set the name of the view that should be shown on successful submit.
+	 */
+	public final void setSuccessView(String successView) {
+		this.successView = successView;
+	}
+	
+	/**
+	 * Return the name of the view that should be shown on successful submit.
+	 */
+	public final String getSuccessView() {
+		return this.successView;
+	}
+	
+	/**
+	 * This implementation shows the configured form view, delegating to the analogous
+	 * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException, Map)}
+	 * variant with a "controlModel" argument.
+	 * <p>Can be called within
+	 * {@link #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)}
+	 * implementations, to redirect back to the form in case of custom validation errors
+	 * (errors not determined by the validator).
+	 * <p>Can be overridden in subclasses to show a custom view, writing directly
+	 * to the response or preparing the response before rendering a view.
+	 * <p>If calling showForm with a custom control model in subclasses, it's preferable
+	 * to override the analogous showForm version with a controlModel argument
+	 * (which will handle both standard form showing and custom form showing then).
+	 * @see #setFormView
+	 * @see #showForm(HttpServletRequest, HttpServletResponse, BindException, Map)
+	 */
+	@Override
+	protected ModelAndView showForm(HttpServletRequest request, HttpServletResponse response, BindException errors)
+	        throws Exception {
+		
+		return showForm(request, response, errors, null);
+	}
+	
+	/**
+	 * This implementation shows the configured form view.
+	 * <p>Can be called within
+	 * {@link #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)}
+	 * implementations, to redirect back to the form in case of custom validation errors
+	 * (errors not determined by the validator).
+	 * <p>Can be overridden in subclasses to show a custom view, writing directly
+	 * to the response or preparing the response before rendering a view.
+	 * @param request current HTTP request
+	 * @param errors validation errors holder
+	 * @param controlModel model map containing controller-specific control data
+	 * (e.g. current page in wizard-style controllers or special error message)
+	 * @return the prepared form view
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #setFormView
+	 */
+	protected ModelAndView showForm(HttpServletRequest request, HttpServletResponse response, BindException errors,
+	        Map controlModel) throws Exception {
+		
+		return showForm(request, errors, getFormView(), controlModel);
+	}
+	
+	/**
+	 * Create a reference data map for the given request and command,
+	 * consisting of bean name/bean instance pairs as expected by ModelAndView.
+	 * <p>The default implementation delegates to {@link #referenceData(HttpServletRequest)}.
+	 * Subclasses can override this to set reference data used in the view.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder
+	 * @return a Map with reference data entries, or {@code null} if none
+	 * @throws Exception in case of invalid state or arguments
+	 * @see ModelAndView
+	 */
+	@Override
+	protected Map referenceData(HttpServletRequest request, Object command, Errors errors) throws Exception {
+		return referenceData(request);
+	}
+	
+	/**
+	 * Create a reference data map for the given request.
+	 * Called by the {@link #referenceData(HttpServletRequest, Object, Errors)}
+	 * variant with all parameters.
+	 * <p>The default implementation returns {@code null}.
+	 * Subclasses can override this to set reference data used in the view.
+	 * @param request current HTTP request
+	 * @return a Map with reference data entries, or {@code null} if none
+	 * @throws Exception in case of invalid state or arguments
+	 * @see #referenceData(HttpServletRequest, Object, Errors)
+	 * @see ModelAndView
+	 */
+	protected Map referenceData(HttpServletRequest request) throws Exception {
+		return null;
+	}
+	
+	/**
+	 * This implementation calls
+	 * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException)}
+	 * in case of errors, and delegates to the full
+	 * {@link #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)}'s
+	 * variant else.
+	 * <p>This can only be overridden to check for an action that should be executed
+	 * without respect to binding errors, like a cancel action. To just handle successful
+	 * submissions without binding errors, override one of the {@code onSubmit}
+	 * methods or {@link #doSubmitAction}.
+	 * @see #showForm(HttpServletRequest, HttpServletResponse, BindException)
+	 * @see #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)
+	 * @see #onSubmit(Object, BindException)
+	 * @see #onSubmit(Object)
+	 * @see #doSubmitAction(Object)
+	 */
+	@Override
+	protected ModelAndView processFormSubmission(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors) throws Exception {
+		
+		if (errors.hasErrors()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Data binding errors: " + errors.getErrorCount());
+			}
+			return showForm(request, response, errors);
+		} else if (isFormChangeRequest(request, command)) {
+			logger.debug("Detected form change request -> routing request to onFormChange");
+			onFormChange(request, response, command, errors);
+			return showForm(request, response, errors);
+		} else {
+			logger.debug("No errors -> processing submit");
+			return onSubmit(request, response, command, errors);
+		}
+	}
+	
+	/**
+	 * This implementation delegates to {@link #isFormChangeRequest(HttpServletRequest, Object)}:
+	 * A form change request changes the appearance of the form and should not get
+	 * validated but just show the new form.
+	 * @see #isFormChangeRequest
+	 */
+	@Override
+	protected boolean suppressValidation(HttpServletRequest request, Object command) {
+		return isFormChangeRequest(request, command);
+	}
+	
+	/**
+	 * Determine whether the given request is a form change request.
+	 * A form change request changes the appearance of the form
+	 * and should always show the new form, without validation.
+	 * <p>Gets called by {@link #suppressValidation} and {@link #processFormSubmission}.
+	 * Consequently, this single method determines to suppress validation
+	 * <i>and</i> to show the form view in any case.
+	 * <p>The default implementation delegates to
+	 * {@link #isFormChangeRequest(javax.servlet.http.HttpServletRequest)}.
+	 * @param request current HTTP request
+	 * @param command form object with request parameters bound onto it
+	 * @return whether the given request is a form change request
+	 * @see #suppressValidation
+	 * @see #processFormSubmission
+	 */
+	protected boolean isFormChangeRequest(HttpServletRequest request, Object command) {
+		return isFormChangeRequest(request);
+	}
+	
+	/**
+	 * Simpler {@code isFormChangeRequest} variant, called by the full
+	 * variant {@link #isFormChangeRequest(HttpServletRequest, Object)}.
+	 * <p>The default implementation returns {@code false}.
+	 * @param request current HTTP request
+	 * @return whether the given request is a form change request
+	 * @see #suppressValidation
+	 * @see #processFormSubmission
+	 */
+	protected boolean isFormChangeRequest(HttpServletRequest request) {
+		return false;
+	}
+	
+	/**
+	 * Called during form submission if
+	 * {@link #isFormChangeRequest(javax.servlet.http.HttpServletRequest)}
+	 * returns {@code true}. Allows subclasses to implement custom logic
+	 * to modify the command object to directly modify data in the form.
+	 * <p>The default implementation delegates to
+	 * {@link #onFormChange(HttpServletRequest, HttpServletResponse, Object, BindException)}.
+	 * @param request current servlet request
+	 * @param response current servlet response
+	 * @param command form object with request parameters bound onto it
+	 * @param errors validation errors holder, allowing for additional
+	 * custom validation
+	 * @throws Exception in case of errors
+	 * @see #isFormChangeRequest(HttpServletRequest)
+	 * @see #onFormChange(HttpServletRequest, HttpServletResponse, Object)
+	 */
+	protected void onFormChange(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors) throws Exception {
+		
+		onFormChange(request, response, command);
+	}
+	
+	/**
+	 * Simpler {@code onFormChange} variant, called by the full variant
+	 * {@link #onFormChange(HttpServletRequest, HttpServletResponse, Object, BindException)}.
+	 * <p>The default implementation is empty.
+	 * @param request current servlet request
+	 * @param response current servlet response
+	 * @param command form object with request parameters bound onto it
+	 * @throws Exception in case of errors
+	 * @see #onFormChange(HttpServletRequest, HttpServletResponse, Object, BindException)
+	 */
+	protected void onFormChange(HttpServletRequest request, HttpServletResponse response, Object command) throws Exception {
+	}
+	
+	/**
+	 * Submit callback with all parameters. Called in case of submit without errors
+	 * reported by the registered validator, or on every submit if no validator.
+	 * <p>The default implementation delegates to {@link #onSubmit(Object, BindException)}.
+	 * For simply performing a submit action and rendering the specified success
+	 * view, consider implementing {@link #doSubmitAction} rather than an
+	 * {@code onSubmit} variant.
+	 * <p>Subclasses can override this to provide custom submission handling like storing
+	 * the object to the database. Implementations can also perform custom validation and
+	 * call showForm to return to the form. Do <i>not</i> implement multiple onSubmit
+	 * methods: In that case, just this method will be called by the controller.
+	 * <p>Call {@code errors.getModel()} to populate the ModelAndView model
+	 * with the command and the Errors instance, under the specified command name,
+	 * as expected by the "spring:bind" tag.
+	 * @param request current servlet request
+	 * @param response current servlet response
+	 * @param command form object with request parameters bound onto it
+	 * @param errors Errors instance without errors (subclass can add errors if it wants to)
+	 * @return the prepared model and view, or {@code null}
+	 * @throws Exception in case of errors
+	 * @see #onSubmit(Object, BindException)
+	 * @see #doSubmitAction
+	 * @see #showForm
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 */
+	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object command,
+	        BindException errors) throws Exception {
+		
+		return onSubmit(command, errors);
+	}
+	
+	/**
+	 * Simpler {@code onSubmit} variant.
+	 * Called by the default implementation of the
+	 * {@link #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)}
+	 * variant with all parameters.
+	 * <p>The default implementation calls {@link #onSubmit(Object)}, using the
+	 * returned ModelAndView if actually implemented in a subclass. Else, the
+	 * default behavior will apply: rendering the success view with the command
+	 * and Errors instance as model.
+	 * <p>Subclasses can override this to provide custom submission handling that
+	 * does not need request and response.
+	 * <p>Call {@code errors.getModel()} to populate the ModelAndView model
+	 * with the command and the Errors instance, under the specified command name,
+	 * as expected by the "spring:bind" tag.
+	 * @param command form object with request parameters bound onto it
+	 * @param errors Errors instance without errors
+	 * @return the prepared model and view
+	 * @throws Exception in case of errors
+	 * @see #onSubmit(HttpServletRequest, HttpServletResponse, Object, BindException)
+	 * @see #onSubmit(Object)
+	 * @see #setSuccessView
+	 * @see org.springframework.validation.Errors
+	 * @see org.springframework.validation.BindException#getModel
+	 */
+	protected ModelAndView onSubmit(Object command, BindException errors) throws Exception {
+		ModelAndView mv = onSubmit(command);
+		if (mv != null) {
+			// simplest onSubmit variant implemented in custom subclass
+			return mv;
+		} else {
+			// default behavior: render success view
+			if (getSuccessView() == null) {
+				throw new ServletException("successView isn't set");
+			}
+			return new ModelAndView(getSuccessView(), errors.getModel());
+		}
+	}
+	
+	/**
+	 * Simplest {@code onSubmit} variant. Called by the default implementation
+	 * of the {@link #onSubmit(Object, BindException)} variant.
+	 * <p>This implementation calls {@link #doSubmitAction(Object)} and returns
+	 * {@code null} as ModelAndView, making the calling {@code onSubmit}
+	 * method perform its default rendering of the success view.
+	 * <p>Subclasses can override this to provide custom submission handling
+	 * that just depends on the command object. It's preferable to use either
+	 * {@link #onSubmit(Object, BindException)} or {@link #doSubmitAction(Object)},
+	 * though: Use the former when you want to build your own ModelAndView; use the
+	 * latter when you want to perform an action and forward to the successView.
+	 * @param command form object with request parameters bound onto it
+	 * @return the prepared model and view, or {@code null} for default
+	 * (that is, rendering the configured "successView")
+	 * @throws Exception in case of errors
+	 * @see #onSubmit(Object, BindException)
+	 * @see #doSubmitAction
+	 * @see #setSuccessView
+	 */
+	protected ModelAndView onSubmit(Object command) throws Exception {
+		doSubmitAction(command);
+		return null;
+	}
+	
+	/**
+	 * Template method for submit actions. Called by the default implementation
+	 * of the simplest {@link #onSubmit(Object)} variant.
+	 * <p><b>This is the preferred submit callback to implement if you want to
+	 * perform an action (like storing changes to the database) and then render
+	 * the success view with the command and Errors instance as model.</b>
+	 * You don't need to care about the success ModelAndView here.
+	 * @param command form object with request parameters bound onto it
+	 * @throws Exception in case of errors
+	 * @see #onSubmit(Object)
+	 * @see #setSuccessView
+	 */
+	protected void doSubmitAction(Object command) throws Exception {
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/servlet/view/json/MappingJacksonJsonView.java
+++ b/web/src/main/java/org/springframework/web/servlet/view/json/MappingJacksonJsonView.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2002-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.servlet.view.json;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.codehaus.jackson.JsonEncoding;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.view.AbstractView;
+
+/**
+ * Spring MVC {@link View} that renders JSON content by serializing the model for the current request
+ * using <a href="http://jackson.codehaus.org/">Jackson's</a> {@link ObjectMapper}.
+ *
+ * <p>By default, the entire contents of the model map (with the exception of framework-specific classes)
+ * will be encoded as JSON. If the model contains only one key, you can have it extracted encoded as JSON
+ * alone via  {@link #setExtractValueFromSingleKeyModel}.
+ *
+ * @author Jeremy Grelle
+ * @author Arjen Poutsma
+ * @author Rossen Stoyanchev
+ * @author Juergen Hoeller
+ * @since 3.0
+ * @see org.springframework.http.converter.json.MappingJacksonHttpMessageConverter
+ */
+public class MappingJacksonJsonView extends AbstractView {
+	
+	/**
+	 * Default content type: "application/json".
+	 * Overridable through {@link #setContentType}.
+	 */
+	public static final String DEFAULT_CONTENT_TYPE = "application/json";
+	
+	private ObjectMapper objectMapper = new ObjectMapper();
+	
+	private JsonEncoding encoding = JsonEncoding.UTF8;
+	
+	private String jsonPrefix;
+	
+	private Boolean prettyPrint;
+	
+	private Set<String> modelKeys;
+	
+	private boolean extractValueFromSingleKeyModel = false;
+	
+	private boolean disableCaching = true;
+	
+	private boolean updateContentLength = false;
+	
+	/**
+	 * Construct a new {@code MappingJacksonJsonView}, setting the content type to {@code application/json}.
+	 */
+	public MappingJacksonJsonView() {
+		setContentType(DEFAULT_CONTENT_TYPE);
+		setExposePathVariables(false);
+	}
+	
+	/**
+	 * Set the {@code ObjectMapper} for this view.
+	 * If not set, a default {@link ObjectMapper#ObjectMapper() ObjectMapper} will be used.
+	 * <p>Setting a custom-configured {@code ObjectMapper} is one way to take further control of
+	 * the JSON serialization process. The other option is to use Jackson's provided annotations
+	 * on the types to be serialized, in which case a custom-configured ObjectMapper is unnecessary.
+	 */
+	public void setObjectMapper(ObjectMapper objectMapper) {
+		Assert.notNull(objectMapper, "'objectMapper' must not be null");
+		this.objectMapper = objectMapper;
+		configurePrettyPrint();
+	}
+	
+	/**
+	 * Return the {@code ObjectMapper} for this view.
+	 */
+	public final ObjectMapper getObjectMapper() {
+		return this.objectMapper;
+	}
+	
+	/**
+	 * Set the {@code JsonEncoding} for this view.
+	 * By default, {@linkplain JsonEncoding#UTF8 UTF-8} is used.
+	 */
+	public void setEncoding(JsonEncoding encoding) {
+		Assert.notNull(encoding, "'encoding' must not be null");
+		this.encoding = encoding;
+	}
+	
+	/**
+	 * Return the {@code JsonEncoding} for this view.
+	 */
+	public final JsonEncoding getEncoding() {
+		return this.encoding;
+	}
+	
+	/**
+	 * Specify a custom prefix to use for this view's JSON output.
+	 * Default is none.
+	 * @see #setPrefixJson
+	 */
+	public void setJsonPrefix(String jsonPrefix) {
+		this.jsonPrefix = jsonPrefix;
+	}
+	
+	/**
+	 * Indicates whether the JSON output by this view should be prefixed with <tt>"{} && "</tt>.
+	 * Default is {@code false}.
+	 * <p>Prefixing the JSON string in this manner is used to help prevent JSON Hijacking.
+	 * The prefix renders the string syntactically invalid as a script so that it cannot be hijacked.
+	 * This prefix does not affect the evaluation of JSON, but if JSON validation is performed
+	 * on the string, the prefix would need to be ignored.
+	 * @see #setJsonPrefix
+	 */
+	public void setPrefixJson(boolean prefixJson) {
+		this.jsonPrefix = (prefixJson ? "{} && " : null);
+	}
+	
+	/**
+	 * Whether to use the default pretty printer when writing JSON.
+	 * This is a shortcut for setting up an {@code ObjectMapper} as follows:
+	 * <pre class="code">
+	 * ObjectMapper mapper = new ObjectMapper();
+	 * mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+	 * </pre>
+	 * <p>The default value is {@code false}.
+	 */
+	public void setPrettyPrint(boolean prettyPrint) {
+		this.prettyPrint = prettyPrint;
+		configurePrettyPrint();
+	}
+	
+	private void configurePrettyPrint() {
+		if (this.prettyPrint != null) {
+			this.objectMapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, this.prettyPrint);
+		}
+	}
+	
+	/**
+	 * Set the attribute in the model that should be rendered by this view.
+	 * When set, all other model attributes will be ignored.
+	 */
+	public void setModelKey(String modelKey) {
+		this.modelKeys = Collections.singleton(modelKey);
+	}
+	
+	/**
+	 * Set the attributes in the model that should be rendered by this view.
+	 * When set, all other model attributes will be ignored.
+	 */
+	public void setModelKeys(Set<String> modelKeys) {
+		this.modelKeys = modelKeys;
+	}
+	
+	/**
+	 * Return the attributes in the model that should be rendered by this view.
+	 */
+	public final Set<String> getModelKeys() {
+		return this.modelKeys;
+	}
+	
+	/**
+	 * Set the attributes in the model that should be rendered by this view.
+	 * When set, all other model attributes will be ignored.
+	 * @deprecated use {@link #setModelKeys(Set)} instead
+	 */
+	@Deprecated
+	public void setRenderedAttributes(Set<String> renderedAttributes) {
+		this.modelKeys = renderedAttributes;
+	}
+	
+	/**
+	 * Return the attributes in the model that should be rendered by this view.
+	 * @deprecated use {@link #getModelKeys()} instead
+	 */
+	@Deprecated
+	public final Set<String> getRenderedAttributes() {
+		return this.modelKeys;
+	}
+	
+	/**
+	 * Set whether to serialize models containing a single attribute as a map or whether to
+	 * extract the single value from the model and serialize it directly.
+	 * <p>The effect of setting this flag is similar to using {@code MappingJacksonHttpMessageConverter}
+	 * with an {@code @ResponseBody} request-handling method.
+	 * <p>Default is {@code false}.
+	 */
+	public void setExtractValueFromSingleKeyModel(boolean extractValueFromSingleKeyModel) {
+		this.extractValueFromSingleKeyModel = extractValueFromSingleKeyModel;
+	}
+	
+	/**
+	 * Disables caching of the generated JSON.
+	 * <p>Default is {@code true}, which will prevent the client from caching the generated JSON.
+	 */
+	public void setDisableCaching(boolean disableCaching) {
+		this.disableCaching = disableCaching;
+	}
+	
+	/**
+	 * Whether to update the 'Content-Length' header of the response. When set to
+	 * {@code true}, the response is buffered in order to determine the content
+	 * length and set the 'Content-Length' header of the response.
+	 * <p>The default setting is {@code false}.
+	 */
+	public void setUpdateContentLength(boolean updateContentLength) {
+		this.updateContentLength = updateContentLength;
+	}
+	
+	@Override
+	protected void prepareResponse(HttpServletRequest request, HttpServletResponse response) {
+		setResponseContentType(request, response);
+		response.setCharacterEncoding(this.encoding.getJavaName());
+		if (this.disableCaching) {
+			response.addHeader("Pragma", "no-cache");
+			response.addHeader("Cache-Control", "no-cache, no-store, max-age=0");
+			response.addDateHeader("Expires", 1L);
+		}
+	}
+	
+	@Override
+	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request,
+	        HttpServletResponse response) throws Exception {
+		
+		OutputStream stream = (this.updateContentLength ? createTemporaryOutputStream() : response.getOutputStream());
+		Object value = filterModel(model);
+		writeContent(stream, value, this.jsonPrefix);
+		if (this.updateContentLength) {
+			writeToResponse(response, (ByteArrayOutputStream) stream);
+		}
+	}
+	
+	/**
+	 * Filter out undesired attributes from the given model.
+	 * The return value can be either another {@link Map} or a single value object.
+	 * <p>The default implementation removes {@link BindingResult} instances and entries
+	 * not included in the {@link #setRenderedAttributes renderedAttributes} property.
+	 * @param model the model, as passed on to {@link #renderMergedOutputModel}
+	 * @return the value to be rendered
+	 */
+	protected Object filterModel(Map<String, Object> model) {
+		Map<String, Object> result = new HashMap<String, Object>(model.size());
+		Set<String> renderedAttributes = (!CollectionUtils.isEmpty(this.modelKeys) ? this.modelKeys : model.keySet());
+		for (Map.Entry<String, Object> entry : model.entrySet()) {
+			if (!(entry.getValue() instanceof BindingResult) && renderedAttributes.contains(entry.getKey())) {
+				result.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return (this.extractValueFromSingleKeyModel && result.size() == 1 ? result.values().iterator().next() : result);
+	}
+	
+	/**
+	 * Write the actual JSON content to the stream.
+	 * @param stream the output stream to use
+	 * @param value the value to be rendered, as returned from {@link #filterModel}
+	 * @param jsonPrefix the prefix for this view's JSON output
+	 * (as indicated through {@link #setJsonPrefix}/{@link #setPrefixJson})
+	 * @throws IOException if writing failed
+	 */
+	protected void writeContent(OutputStream stream, Object value, String jsonPrefix) throws IOException {
+		JsonGenerator generator = this.objectMapper.getJsonFactory().createJsonGenerator(stream, this.encoding);
+		
+		// A workaround for JsonGenerators not applying serialization features
+		// https://github.com/FasterXML/jackson-databind/issues/12
+		if (this.objectMapper.getSerializationConfig().isEnabled(SerializationConfig.Feature.INDENT_OUTPUT)) {
+			generator.useDefaultPrettyPrinter();
+		}
+		
+		if (jsonPrefix != null) {
+			generator.writeRaw(jsonPrefix);
+		}
+		this.objectMapper.writeValue(generator, value);
+	}
+	
+}

--- a/web/src/main/java/org/springframework/web/util/ExpressionEvaluationUtils.java
+++ b/web/src/main/java/org/springframework/web/util/ExpressionEvaluationUtils.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2002-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.util;
+
+import javax.servlet.ServletContext;
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.PageContext;
+import javax.servlet.jsp.el.ELException;
+
+import org.springframework.util.Assert;
+
+/**
+ * Convenience methods for accessing JSP 2.0's
+ * {@link javax.servlet.jsp.el.ExpressionEvaluator}.
+ *
+ * <p>The evaluation methods check if the value contains "${" before
+ * invoking the EL evaluator, treating the value as "normal" expression
+ * (i.e. a literal String value) else.
+ *
+ * <p><b>See {@link #isSpringJspExpressionSupportActive} for guidelines
+ * on when to use Spring's JSP expression support as opposed to the
+ * built-in expression support in JSP 2.0+ containers.</b>
+ *
+ * @author Juergen Hoeller
+ * @author Alef Arendsen
+ * @since 11.07.2003
+ * @see javax.servlet.jsp.el.ExpressionEvaluator#evaluate
+ * @deprecated as of Spring 3.2, in favor of the JSP 2.0+ native support
+ * for embedded expressions in JSP pages (also applying to tag attributes)
+ */
+@Deprecated
+public abstract class ExpressionEvaluationUtils {
+	
+	/**
+	 * Expression support parameter at the servlet context level
+	 * (i.e. a context-param in {@code web.xml}): "springJspExpressionSupport".
+	 */
+	public static final String EXPRESSION_SUPPORT_CONTEXT_PARAM = "springJspExpressionSupport";
+	
+	public static final String EXPRESSION_PREFIX = "${";
+	
+	public static final String EXPRESSION_SUFFIX = "}";
+	
+	/**
+	 * Check whether Spring's JSP expression support is actually active.
+	 * <p>Note that JSP 2.0+ containers come with expression support themselves:
+	 * However, it will only be active for web applications declaring Servlet 2.4
+	 * or higher in their {@code web.xml} deployment descriptor.
+	 * <p>If a {@code web.xml} context-param named "springJspExpressionSupport" is
+	 * found, its boolean value will be taken to decide whether this support is active.
+	 * If not found, the default is for expression support to be inactive on Servlet 3.0
+	 * containers with web applications declaring Servlet 2.4 or higher in their
+	 * {@code web.xml}. For backwards compatibility, Spring's expression support
+	 * will remain active for applications declaring Servlet 2.3 or earlier. However,
+	 * on Servlet 2.4/2.5 containers, we can't find out what the application has declared;
+	 * as of Spring 3.2, we won't activate Spring's expression support at all then since
+	 * it got deprecated and will be removed in the next iteration of the framework.
+	 * @param pageContext current JSP PageContext
+	 * @return {@code true} if active (ExpressionEvaluationUtils will actually evaluate expressions);
+	 * {@code false} if not active (ExpressionEvaluationUtils will return given values as-is,
+	 * relying on the JSP container pre-evaluating values before passing them to JSP tag attributes)
+	 */
+	public static boolean isSpringJspExpressionSupportActive(PageContext pageContext) {
+		ServletContext sc = pageContext.getServletContext();
+		String springJspExpressionSupport = sc.getInitParameter(EXPRESSION_SUPPORT_CONTEXT_PARAM);
+		if (springJspExpressionSupport != null) {
+			return Boolean.valueOf(springJspExpressionSupport);
+		}
+		/**
+		if (sc.getMajorVersion() >= 3) {
+			// We're on a Servlet 3.0+ container: Let's check what the application declares...
+			if (sc.getEffectiveMajorVersion() == 2 && sc.getEffectiveMinorVersion() < 4) {
+				// Application declares Servlet 2.3- in its web.xml: JSP 2.0 expressions not active.
+				// Activate our own expression support.
+				return true;
+			}
+		}
+		 */
+		return false;
+	}
+	
+	/**
+	 * Check if the given expression value is an EL expression.
+	 * @param value the expression to check
+	 * @return {@code true} if the expression is an EL expression,
+	 * {@code false} otherwise
+	 */
+	public static boolean isExpressionLanguage(String value) {
+		return (value != null && value.contains(EXPRESSION_PREFIX));
+	}
+	
+	/**
+	 * Evaluate the given expression (be it EL or a literal String value)
+	 * to an Object of a given type,
+	 * @param attrName name of the attribute (typically a JSP tag attribute)
+	 * @param attrValue value of the attribute
+	 * @param resultClass class that the result should have (String, Integer, Boolean)
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors, also in case of type mismatch
+	 * if the passed-in literal value is not an EL expression and not assignable to
+	 * the result class
+	 */
+	public static Object evaluate(String attrName, String attrValue, Class resultClass, PageContext pageContext)
+	        throws JspException {
+		
+		if (isSpringJspExpressionSupportActive(pageContext) && isExpressionLanguage(attrValue)) {
+			return doEvaluate(attrName, attrValue, resultClass, pageContext);
+		} else if (attrValue != null && resultClass != null && !resultClass.isInstance(attrValue)) {
+			throw new JspException("Attribute value \"" + attrValue + "\" is neither a JSP EL expression nor "
+			        + "assignable to result class [" + resultClass.getName() + "]");
+		} else {
+			return attrValue;
+		}
+	}
+	
+	/**
+	 * Evaluate the given expression (be it EL or a literal String value) to an Object.
+	 * @param attrName name of the attribute (typically a JSP tag attribute)
+	 * @param attrValue value of the attribute
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors
+	 */
+	public static Object evaluate(String attrName, String attrValue, PageContext pageContext) throws JspException {
+		
+		if (isSpringJspExpressionSupportActive(pageContext) && isExpressionLanguage(attrValue)) {
+			return doEvaluate(attrName, attrValue, Object.class, pageContext);
+		} else {
+			return attrValue;
+		}
+	}
+	
+	/**
+	 * Evaluate the given expression (be it EL or a literal String value) to a String.
+	 * @param attrName name of the attribute (typically a JSP tag attribute)
+	 * @param attrValue value of the attribute
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors
+	 */
+	public static String evaluateString(String attrName, String attrValue, PageContext pageContext) throws JspException {
+		
+		if (isSpringJspExpressionSupportActive(pageContext) && isExpressionLanguage(attrValue)) {
+			return (String) doEvaluate(attrName, attrValue, String.class, pageContext);
+		} else {
+			return attrValue;
+		}
+	}
+	
+	/**
+	 * Evaluate the given expression (be it EL or a literal String value) to an integer.
+	 * @param attrName name of the attribute (typically a JSP tag attribute)
+	 * @param attrValue value of the attribute
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors
+	 */
+	public static int evaluateInteger(String attrName, String attrValue, PageContext pageContext) throws JspException {
+		
+		if (isSpringJspExpressionSupportActive(pageContext) && isExpressionLanguage(attrValue)) {
+			return (Integer) doEvaluate(attrName, attrValue, Integer.class, pageContext);
+		} else {
+			return Integer.parseInt(attrValue);
+		}
+	}
+	
+	/**
+	 * Evaluate the given expression (be it EL or a literal String value) to a boolean.
+	 * @param attrName name of the attribute (typically a JSP tag attribute)
+	 * @param attrValue value of the attribute
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors
+	 */
+	public static boolean evaluateBoolean(String attrName, String attrValue, PageContext pageContext) throws JspException {
+		
+		if (isSpringJspExpressionSupportActive(pageContext) && isExpressionLanguage(attrValue)) {
+			return (Boolean) doEvaluate(attrName, attrValue, Boolean.class, pageContext);
+		} else {
+			return Boolean.valueOf(attrValue);
+		}
+	}
+	
+	/**
+	 * Actually evaluate the given expression (be it EL or a literal String value)
+	 * to an Object of a given type. Supports concatenated expressions,
+	 * for example: "${var1}text${var2}"
+	 * @param attrName name of the attribute
+	 * @param attrValue value of the attribute
+	 * @param resultClass class that the result should have
+	 * @param pageContext current JSP PageContext
+	 * @return the result of the evaluation
+	 * @throws JspException in case of parsing errors
+	 */
+	private static Object doEvaluate(String attrName, String attrValue, Class resultClass, PageContext pageContext)
+	        throws JspException {
+		
+		Assert.notNull(attrValue, "Attribute value must not be null");
+		Assert.notNull(resultClass, "Result class must not be null");
+		Assert.notNull(pageContext, "PageContext must not be null");
+		
+		try {
+			if (resultClass.isAssignableFrom(String.class)) {
+				StringBuilder resultValue = null;
+				int exprPrefixIndex;
+				int exprSuffixIndex = 0;
+				do {
+					exprPrefixIndex = attrValue.indexOf(EXPRESSION_PREFIX, exprSuffixIndex);
+					if (exprPrefixIndex != -1) {
+						int prevExprSuffixIndex = exprSuffixIndex;
+						exprSuffixIndex = attrValue.indexOf(EXPRESSION_SUFFIX, exprPrefixIndex + EXPRESSION_PREFIX.length());
+						String expr;
+						if (exprSuffixIndex != -1) {
+							exprSuffixIndex += EXPRESSION_SUFFIX.length();
+							expr = attrValue.substring(exprPrefixIndex, exprSuffixIndex);
+						} else {
+							expr = attrValue.substring(exprPrefixIndex);
+						}
+						if (expr.length() == attrValue.length()) {
+							// A single expression without static prefix or suffix ->
+							// parse it with the specified result class rather than String.
+							return evaluateExpression(attrValue, resultClass, pageContext);
+						} else {
+							// We actually need to concatenate partial expressions into a String.
+							if (resultValue == null) {
+								resultValue = new StringBuilder();
+							}
+							resultValue.append(attrValue.substring(prevExprSuffixIndex, exprPrefixIndex));
+							resultValue.append(evaluateExpression(expr, String.class, pageContext));
+						}
+					} else {
+						if (resultValue == null) {
+							resultValue = new StringBuilder();
+						}
+						resultValue.append(attrValue.substring(exprSuffixIndex));
+					}
+				} while (exprPrefixIndex != -1 && exprSuffixIndex != -1);
+				return resultValue.toString();
+			} else {
+				return evaluateExpression(attrValue, resultClass, pageContext);
+			}
+		}
+		catch (ELException ex) {
+			throw new JspException("Parsing of JSP EL expression failed for attribute '" + attrName + "'", ex);
+		}
+	}
+	
+	private static Object evaluateExpression(String exprValue, Class resultClass, PageContext pageContext)
+	        throws ELException {
+		
+		return pageContext.getExpressionEvaluator()
+		        .evaluate(exprValue, resultClass, pageContext.getVariableResolver(), null);
+	}
+	
+}

--- a/web/src/test/java/org/openmrs/web/controller/form/FieldTypeListControllerTest.java
+++ b/web/src/test/java/org/openmrs/web/controller/form/FieldTypeListControllerTest.java
@@ -25,7 +25,8 @@ import org.openmrs.web.test.WebTestHelper.Response;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.annotation.NotTransactional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
 
 public class FieldTypeListControllerTest extends BaseWebContextSensitiveTest {
@@ -39,7 +40,7 @@ public class FieldTypeListControllerTest extends BaseWebContextSensitiveTest {
 	 * @verifies display a user friendly error message
 	 */
 	@Test
-	@NotTransactional
+	@Transactional(propagation=Propagation.NOT_SUPPORTED)
 	public void onSubmit_shouldDisplayAUserFriendlyErrorMessage() throws Exception {
 		MockHttpServletRequest post = webTestHelper.newPOST("/admin/forms/fieldType.list");
 		

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,0 +1,3 @@
+openmrs.log
+
+activemq-default-data

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -2,7 +2,7 @@
    <parent>
       <groupId>org.openmrs</groupId>
       <artifactId>openmrs</artifactId>
-      <version>1.12.0-SNAPSHOT</version>
+      <version>1.12.0.SPRING-SNAPSHOT</version>
    </parent>
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.openmrs.web</groupId>

--- a/webapp/src/main/resources/log4j.xml
+++ b/webapp/src/main/resources/log4j.xml
@@ -16,6 +16,14 @@
 				value="%p - %C{1}.%M(%L) |%d{ISO8601}| %m%n" />
 		</layout>
 	</appender>	
+	
+	<appender name="DEBUGGING_FILE_APPENDER" class="org.apache.log4j.RollingFileAppender">
+      <param name="append" value="false"/>
+      <param name="file" value="openmrs.log"/>
+      <layout class="org.apache.log4j.PatternLayout">
+         <param name="ConversionPattern" value="%d{ABSOLUTE} %-5p [%c{1}] %m%n"/>
+      </layout>
+   </appender>
 
 	<logger name="org.apache">
 		<level value="WARN" />
@@ -60,6 +68,9 @@
 		<level value="WARN" />
 		<appender-ref ref="CONSOLE" />
 		<appender-ref ref="MEMORY_APPENDER" />
+		<!--
+		<appender-ref ref="DEBUGGING_FILE_APPENDER" />
+		-->
 	</root>
 
 </log4j:configuration>


### PR DESCRIPTION
Initial attempt of upgrading to Spring 4, with a minimal number of changes. Only the Spring and servlet jars have been updated. Spring 3 files that were removed in 4 have been added back under org.springframework package in core api as a first cut. I also re-versioned the maven projects to 1.12.0.SPRING-SNAPSHOT to make it easier to avoid build conflicts when building against both Spring 3 and Spring 4. Added a log4j file logger that is off by default, to make it easier to record errors on startup.

mvn clean package works and all tests pass. The classic UI works and many modules load cleanly, but there are still several runtime issues that need to be addressed before it will be possible to run all of the modules needed for the reference app.
