### PR TITLE
TRUNK-4522: Fix HttpClientTest test on JVM 1.8.

### DIFF
--- a/api/src/test/java/org/openmrs/util/HttpClientTest.java
+++ b/api/src/test/java/org/openmrs/util/HttpClientTest.java
@@ -56,7 +56,7 @@ public class HttpClientTest {
 		verify(connection).setRequestProperty("Content-Length", String.valueOf(16));
 		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 		
-		assertThat(stream.toString(), is("&two=two&one=one"));
+		assertThat(stream.toString(), is("&one=one&two=two"));
 		assertThat(response, containsString("response"));
 	}
 }


### PR DESCRIPTION
Fix test post_shouldPostUrlParametersAndGetResponse(org.openmrs.util.HttpClientTest)