### PR TITLE
TODO: hard coded to the first row of the users search result

### DIFF
--- a/release-test/src/main/java/org/openmrs/steps/EditUserPasswordSteps.java
+++ b/release-test/src/main/java/org/openmrs/steps/EditUserPasswordSteps.java
@@ -53,13 +53,12 @@ public class EditUserPasswordSteps extends Steps {
 		clickOn(button().with(attribute("name", equalTo("action"))));
 	}
 
-	@When("I chose to edit the user")
+	@When("I choose to edit the user")
 	public void editUser() {
-		//TODO currently the user to edit is hard coded to the first row of the users search result. Need to change this.
 		WebElement openmrsSearchTable = driver.findElement(By.className("openmrsSearchTable"));
 		List<WebElement> trList = openmrsSearchTable.findElements(By.tagName("tr"));
-		if (trList.size() > 0) {
-			trList.get(1).findElement(By.tagName("td")).findElement(By.tagName("a")).click();
+		for (int i=0; i < trList.size(); i++) {
+			trList.get(i).findElement(By.tagName("td")).findElement(By.tagName("a")).click();
 		}
 	}
 


### PR DESCRIPTION
I hope this what the author of the TODO meant to do.

Running time of the tests on this code didn't change significantly
also.

Ticket: TRUNK-4641

*I'm aware of the ticket life cycle, but I decided to leave the pull
request here to get this of mind for now.