### PR TITLE
TRUNK-3382 make provider name to be resolved from linked person only

### DIFF
--- a/api/src/main/java/org/openmrs/Provider.java
+++ b/api/src/main/java/org/openmrs/Provider.java
@@ -12,6 +12,7 @@ package org.openmrs;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.APIException;
 
 /**
  * Represents a person who may provide care to a patient during an encounter
@@ -67,15 +68,9 @@ public class Provider extends BaseCustomizableMetadata<ProviderAttribute> {
 	
 	/**
 	 * @param person the person to set
-	 * @should blank out name if set to non null person
 	 */
 	public void setPerson(Person person) {
 		this.person = person;
-		
-		//blank out name so that there isn't double data sitting in the provider table.
-		if (person != null) {
-			setName(null);
-		}
 	}
 	
 	/**
@@ -110,27 +105,26 @@ public class Provider extends BaseCustomizableMetadata<ProviderAttribute> {
 	
 	/**
 	 * @see org.openmrs.BaseOpenmrsMetadata#getName()
-	 * @should return person full name if person is not null
+	 * @should return person full name if person is not null or null otherwise
 	 */
+	
 	@Override
 	public String getName() {
 		if (getPerson() != null && getPerson().getPersonName() != null) {
 			return getPerson().getPersonName().getFullName();
 		} else {
-			return super.getName();
+			log.warn("Provider object must be associated with a Person");
+			return null;
 		}
 	}
 	
 	/**
 	 * @see org.openmrs.BaseOpenmrsMetadata#setName(java.lang.String)
+	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public void setName(String name) {
-		super.setName(name);
-		
-		//Trace message if we are setting a name when already attached to a person.
-		if (getPerson() != null && !StringUtils.isBlank(super.getName())) {
-			log.trace("Setting name for a provider who is already attached to a person");
-		}
+		throw new APIException("Method deprecated. MUST not be used.");
 	}
 }

--- a/api/src/test/java/org/openmrs/ProviderTest.java
+++ b/api/src/test/java/org/openmrs/ProviderTest.java
@@ -21,35 +21,15 @@ import org.openmrs.test.Verifies;
 public class ProviderTest {
 	
 	/**
-	 * @see {@link Provider#setPerson(Person)}
-	 */
-	@Test
-	@Verifies(value = "should blank out name if set to non null person", method = "setPerson(Person)")
-	public void setPerson_shouldBlankOutNameIfSetToNonNullPerson() throws Exception {
-		final String providerName = "Provider Name";
-		final String nameField = "name";
-		
-		Provider provider = new Provider();
-		provider.setName(providerName);
-		Assert.assertEquals(providerName, FieldUtils.readField(provider, nameField, true));
-		
-		Person person = new Person(1);
-		person.addName(new PersonName("givenName", "middleName", "familyName"));
-		provider.setPerson(person);
-		Assert.assertNull(FieldUtils.readField(provider, nameField, true));
-	}
-	
-	/**
 	 * @see {@link Provider#getName()}
 	 */
 	@Test
-	@Verifies(value = "return person full name if person is not null", method = "getName()")
+	@Verifies(value = "return person full name if person is not null or null otherwise", method = "getName()")
 	public void getName_shouldReturnPersonFullNameIfPersonIsNotNull() throws Exception {
 		final String providerName = "Provider Name";
 		
 		Provider provider = new Provider();
-		provider.setName(providerName);
-		Assert.assertEquals(providerName, provider.getName());
+		Assert.assertNull(providerName, provider.getName());
 		
 		Person person = new Person(1);
 		person.addName(new PersonName("givenName", "middleName", "familyName"));
@@ -63,10 +43,8 @@ public class ProviderTest {
 	@Test
 	@Verifies(value = "return person all names of person with specific format", method = "toString()")
 	public void toString_shouldReturnPersonAllNamesWithSpecificFormat() throws Exception {
-		final String providerName = "Provider Name";
 		
 		Provider provider = new Provider();
-		provider.setName(providerName);
 		provider.setProviderId(1);
 		
 		Person person = new Person(1);

--- a/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
@@ -119,7 +119,6 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void getProvider_shouldGetProviderGivenID() throws Exception {
 		Provider provider = service.getProvider(1);
-		assertEquals("RobertClive", provider.getName());
 		assertEquals("a2c3868a-6b90-11e0-93c3-18a905e044dc", provider.getUuid());
 	}
 	
@@ -130,7 +129,6 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void getProviderAttribute_shouldGetProviderAttributeGivenID() throws Exception {
 		ProviderAttribute providerAttribute = service.getProviderAttribute(1);
-		assertEquals("RobertClive", providerAttribute.getProvider().getName());
 		assertEquals("a2c3868a-6b90-11e0-93c3-18a905e044dc", providerAttribute.getProvider().getUuid());
 	}
 	
@@ -142,7 +140,6 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void getProviderAttributeByUuid_shouldGetProviderAttributeGivenUuid() throws Exception {
 		ProviderAttribute providerAttribute = service.getProviderAttributeByUuid("3a2bdb18-6faa-11e0-8414-001e378eb67e");
-		assertEquals("RobertClive", providerAttribute.getProvider().getName());
 		assertEquals("a2c3868a-6b90-11e0-93c3-18a905e044dc", providerAttribute.getProvider().getUuid());
 	}
 	
@@ -175,8 +172,7 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void getProviderByUuid_shouldGetProviderGivenUuid() throws Exception {
 		Provider provider = service.getProviderByUuid("a2c3868a-6b90-11e0-93c3-18a905e044dc");
-		Assert.assertNotNull(provider);
-		assertEquals("RobertClive", provider.getName());
+		assertNotNull(provider);
 	}
 	
 	/**


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-3382

getAllPrivileges_shouldReturnAllPrivilegesInTheSystem(org.openmrs.api.UserServiceTest) is failing. But it has no dependency on my changes and looks to be failing clean trunk too.