### PR TITLE
Trunk 4454

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/view/portlets/patientEncounters.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/portlets/patientEncounters.jsp
@@ -59,7 +59,7 @@
             	null
         	],
 			"oLanguage": {
-					"sLengthMenu": 'Show <select><option value="20">20</option><option value="50">50</option><option value="100">100</option></select> entries',
+					/*"sLengthMenu": 'Show <select><option value="20">20</option><option value="50">50</option><option value="100">100</option></select> entries',*/
 					"sZeroRecords": '<openmrs:message code="Encounter.no.previous"/>'
 			}
 		} );

--- a/webapp/src/main/webapp/openmrs.css
+++ b/webapp/src/main/webapp/openmrs.css
@@ -1389,7 +1389,7 @@ span.otherHit{
 	text-align: right;
 }
 div#openmrsSearchTable_length{
-	text-align: left; float: left; padding-top: 5px;
+	text-align: left; float: left; padding-top: 5px; isibility: hidden;
 }
 tr.headerRow{
 	background-color: #CCCCCC;

--- a/webapp/src/main/webapp/openmrs.css
+++ b/webapp/src/main/webapp/openmrs.css
@@ -1389,7 +1389,7 @@ span.otherHit{
 	text-align: right;
 }
 div#openmrsSearchTable_length{
-	text-align: left; float: left; padding-top: 5px; isibility: hidden;
+	text-align: left; float: left; padding-top: 5px; visibility: hidden;
 }
 tr.headerRow{
 	background-color: #CCCCCC;


### PR DESCRIPTION
Ticket: TRUNK-4454
Hide 'Show N entries' on the patient dashboard under encounters since this is now configurable or let the configured number show there or when hide this when the configured number to display doesn't exceed or equal to 100
Also go through all pages where 'Show N entries' is displayed and do the same, for-example when a user searches for a patient at http://uat01.openmrs.org:8080/openmrs/admin/patients/index.htm and no or less patients are returned, hide this element. Link: https://issues.openmrs.org/browse/TRUNK-4454