### PR TITLE
TRUNK-4660 "Administration page does not display"

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -103,10 +103,10 @@
             </configuration>
          </plugin>
          <plugin>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>maven-jetty-plugin</artifactId>
-            <version>6.1.10</version>
-            <configuration>
+             <groupId>org.mortbay.jetty</groupId>
+             <artifactId>jetty-maven-plugin</artifactId>
+             <version>8.1.16.v20140903</version>
+             <configuration>
                <webXml>${project.build.directory}/jetty/WEB-INF/web.xml</webXml>
                <webAppConfig>
                   <contextPath>/${webapp.name}</contextPath>
@@ -155,10 +155,10 @@
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.mortbay.jetty</groupId>
-                  <artifactId>maven-jetty-plugin</artifactId>
-                  <version>6.1.10</version>
-                  <configuration>
+                   <groupId>org.mortbay.jetty</groupId>
+                   <artifactId>jetty-maven-plugin</artifactId>
+                   <version>8.1.16.v20140903</version>
+                   <configuration>
                      <webXml>${project.build.directory}/jetty/WEB-INF/web.xml</webXml>
                      <webAppConfig>
                         <contextPath>/${webapp.name}</contextPath>


### PR DESCRIPTION
@rkorytkowski https://issues.openmrs.org/browse/TRUNK-4660

update to jetty 8.0.0 solves the problem