### PR TITLE
Trunk 4522: JVM 1.8 test fails.

### DIFF
--- a/api/src/test/java/org/openmrs/util/HttpClientTest.java
+++ b/api/src/test/java/org/openmrs/util/HttpClientTest.java
@@ -56,7 +56,8 @@ public class HttpClientTest {
 		verify(connection).setRequestProperty("Content-Length", String.valueOf(16));
 		verify(connection).setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 		
-		assertThat(stream.toString(), is("&two=two&one=one"));
+		assertThat(stream.toString(), containsString("&one=one"));
+		assertThat(stream.toString(), containsString("&two=two"));
 		assertThat(response, containsString("response"));
 	}
 }


### PR DESCRIPTION
The problem is in HashMap parameters order.
HashMap<String, String> parameters = new HashMap<String, String>();
parameters.put("one", "one");
parameters.put("two", "two");
The assertion like : assertThat(stream.toString(), is("&two=two&one=one")).
Is not pretty good idea.
Can we use something like:
assertThat(stream.toString(), contains("&two=two");
assertThat(stream.toString(), contains("&one=one");
It would be more stable, as we can't predict parameters order in HashMap.