### PR TITLE
TRUNK-4603 Test fails under JVM 1.8

### DIFF
--- a/web/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormControllerTest.java
+++ b/web/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormControllerTest.java
@@ -151,6 +151,7 @@ public class SchedulerFormControllerTest extends BaseWebContextSensitiveTest {
 		assertTrue(mav.getModel().isEmpty());
 		
 		Assert.assertSame(oldTaskInstance, task.getTaskInstance());
+		deleteAllData();
 	}
 	
 	/**

--- a/web/src/test/java/org/openmrs/scheduler/web/controller/TaskHelperTest.java
+++ b/web/src/test/java/org/openmrs/scheduler/web/controller/TaskHelperTest.java
@@ -93,6 +93,7 @@ public class TaskHelperTest extends BaseWebContextSensitiveTest {
 		taskHelper.waitUntilTaskIsExecuting(task, MAX_WAIT_TIME_IN_MILLISECONDS);
 		
 		Assert.assertTrue(task.getTaskInstance().isExecuting());
+		deleteAllData();
 	}
 	
 	/**


### PR DESCRIPTION
Exceptions in TaskHelperTest and SchedullerFormControllerTest when run under JVM 1.8. 
Resolves: 
https://issues.openmrs.org/browse/TRUNK-4598
https://issues.openmrs.org/browse/TRUNK-4599
https://issues.openmrs.org/browse/TRUNK-4601
https://issues.openmrs.org/browse/TRUNK-4602
https://issues.openmrs.org/browse/TRUNK-4603 (here I have posted explanation)
https://issues.openmrs.org/browse/TRUNK-4604

Also, after merge this PR, we can resolve https://issues.openmrs.org/browse/TRUNK-3948 just by removing "@Ignore" annotation and it will works.
