### PR TITLE
TRUNK-4639 "equals(Object obj)" should be overridden along with the "com...

### DIFF
--- a/api/src/main/java/org/openmrs/FormField.java
+++ b/api/src/main/java/org/openmrs/FormField.java
@@ -67,7 +67,7 @@ public class FormField extends BaseOpenmrsMetadata implements java.io.Serializab
 	 * @Depracated since 1.12. Use DefaultComparator instead.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
-	@SuppressWarnings("squid:3AS1210")
+	@SuppressWarnings("squid:S1210")
 	public int compareTo(FormField f) {
 		DefaultComparator ffDComparator = new DefaultComparator();
 		return ffDComparator.compare(this, f);

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -199,7 +199,7 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 	 * @Depracated since 1.12. Use DefaultComparator instead.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
-	@SuppressWarnings("squid:3AS1210")
+	@SuppressWarnings("squid:S1210")
 	public int compareTo(PatientIdentifier other) {
 		DefaultComparator piDefaultComparator = new DefaultComparator();
 		return piDefaultComparator.compare(this, other);

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -300,7 +300,7 @@ public class PersonAttribute extends BaseOpenmrsData implements java.io.Serializ
 	 * @Depracated since 1.12. Use DefaultComparator instead.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
-	@SuppressWarnings("squid:3AS1210")
+	@SuppressWarnings("squid:S1210")
 	public int compareTo(PersonAttribute other) {
 		DefaultComparator paDComparator = new DefaultComparator();
 		return paDComparator.compare(this, other);

--- a/api/src/main/java/org/openmrs/PersonAttributeType.java
+++ b/api/src/main/java/org/openmrs/PersonAttributeType.java
@@ -183,7 +183,7 @@ public class PersonAttributeType extends BaseOpenmrsMetadata implements java.io.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
 	@Override
-	@SuppressWarnings("squid:3AS1210")
+	@SuppressWarnings("squid:S1210")
 	public int compareTo(PersonAttributeType other) {
 		DefaultComparator patDefaultComparator = new DefaultComparator();
 		return patDefaultComparator.compare(this, other);

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -534,7 +534,7 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * @Depracated since 1.12. Use DefaultComparator instead.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
-	@SuppressWarnings("squid:3AS1210")
+	@SuppressWarnings("squid:S1210")
 	public int compareTo(PersonName other) {
 		DefaultComparator pnDefaultComparator = new DefaultComparator();
 		return pnDefaultComparator.compare(this, other);


### PR DESCRIPTION
...pareTo(T obj)" method"