### PR TITLE
TRUNK-4626: Allows disabling of validation of OpenMRS objects via a global property.

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -77,6 +77,7 @@ import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.validator.ValidateUtil;
 import org.springframework.aop.Advisor;
 
 /**
@@ -1095,6 +1096,11 @@ public class Context {
 			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES);
 			Context.removeProxyPrivilege(PrivilegeConstants.VIEW_GLOBAL_PROPERTIES);
 		}
+
+		// setting default validation rule
+		AdministrationService as = Context.getAdministrationService();
+		Boolean disableValidation = Boolean.valueOf(as.getGlobalProperty(OpenmrsConstants.GP_DISABLE_VALIDATION, "false"));
+		ValidateUtil.setDisableValidation(disableValidation);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -1167,7 +1167,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 		if (object == null) {
 			throw new APIException("error.null", (Object[]) null);
 		}
-		
+
 		dao.validate(object, errors);
 	}
 	

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -1099,6 +1099,11 @@ public final class OpenmrsConstants {
 	 * @since 1.11
 	 */
 	public static final Integer SEARCH_INDEX_VERSION = 3;
+
+	/**
+	 * @since 1.12
+	 */
+	public static final String GP_DISABLE_VALIDATION = "validation.disable";
 	
 	/**
 	 * At OpenMRS startup these global properties/default values/descriptions are inserted into the
@@ -1554,7 +1559,10 @@ public final class OpenmrsConstants {
 		                GLOBAL_PROPERTY_PERSON_ATTRIBUTE_SEARCH_MATCH_MODE,
 		                GLOBAL_PROPERTY_PERSON_ATTRIBUTE_SEARCH_MATCH_EXACT,
 		                "Specifies how person attributes are matched while searching person. Valid values are 'ANYWHERE' or 'EXACT'. Defaults to exact if missing or invalid value is present."));
-		
+
+		props.add(new GlobalProperty(GP_DISABLE_VALIDATION, "false",
+				"Disables validation of OpenMRS Objects. Only takes affect on next restart. Warning: only do this is you know what you are doing!"));
+
 		for (GlobalProperty gp : ModuleFactory.getGlobalProperties()) {
 			props.add(gp);
 		}

--- a/api/src/main/java/org/openmrs/validator/ValidateUtil.java
+++ b/api/src/main/java/org/openmrs/validator/ValidateUtil.java
@@ -40,6 +40,11 @@ import org.springframework.validation.Validator;
  * @since 1.5
  */
 public class ValidateUtil {
+
+	/**
+	 * This is set in {@link Context#checkCoreDataset()} class
+	 */
+	private static Boolean disableValidation = false;
 	
 	/**
 	 * @deprecated in favor of using HandlerUtil to reflexively get validators
@@ -57,8 +62,13 @@ public class ValidateUtil {
 	 * @param obj the object to validate
 	 * @throws ValidationException thrown if a binding exception occurs
 	 * @should throw APIException if errors occur during validation
+	 * @should return immediately if validation is disabled
 	 */
 	public static void validate(Object obj) throws ValidationException {
+		if (disableValidation) {
+			return;
+		}
+
 		Errors errors = new BindException(obj, "");
 		
 		Context.getAdministrationService().validate(obj, errors);
@@ -88,8 +98,13 @@ public class ValidateUtil {
 	 * @param errors the validation errors found
 	 * @since 1.9
 	 * @should populate errors if object invalid
+	 * @should return immediately if validation is disabled and have no errors
 	 */
 	public static void validate(Object obj, Errors errors) {
+		if (disableValidation) {
+			return;
+		}
+
 		Context.getAdministrationService().validate(obj, errors);
 	}
 	
@@ -102,9 +117,13 @@ public class ValidateUtil {
 	 * @should pass validation if regEx field length is not too long
 	 * @should fail validation if regEx field length is too long
 	 * @should fail validation if name field length is too long
+	 * @should return immediately if validation is disabled and have no errors
 	 */
-	
 	public static void validateFieldLengths(Errors errors, Class aClass, String... fields) {
+		if (disableValidation) {
+			return;
+		}
+
 		Assert.notNull(errors, "Errors object must not be null");
 		for (String field : fields) {
 			Object value = errors.getFieldValue(field);
@@ -119,4 +138,13 @@ public class ValidateUtil {
 			}
 		}
 	}
+
+	public static Boolean getDisableValidation() {
+		return disableValidation;
+	}
+
+	public static void setDisableValidation(Boolean disableValidation) {
+		ValidateUtil.disableValidation = disableValidation;
+	}
+
 }

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -464,7 +464,7 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should return all global properties in the database", method = "getAllGlobalProperties()")
 	public void getAllGlobalProperties_shouldReturnAllGlobalPropertiesInTheDatabase() throws Exception {
 		executeDataSet(ADMIN_INITIAL_DATA_XML);
-		Assert.assertEquals(19, Context.getAdministrationService().getAllGlobalProperties().size());
+		Assert.assertEquals(20, Context.getAdministrationService().getAllGlobalProperties().size());
 	}
 	
 	/**
@@ -536,9 +536,9 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		executeDataSet(ADMIN_INITIAL_DATA_XML);
 		AdministrationService as = Context.getAdministrationService();
 		
-		Assert.assertEquals(19, as.getAllGlobalProperties().size());
+		Assert.assertEquals(20, as.getAllGlobalProperties().size());
 		as.purgeGlobalProperty(as.getGlobalPropertyObject("a_valid_gp_key"));
-		Assert.assertEquals(18, as.getAllGlobalProperties().size());
+		Assert.assertEquals(19, as.getAllGlobalProperties().size());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/validator/ValidateUtilTest.java
+++ b/api/src/test/java/org/openmrs/validator/ValidateUtilTest.java
@@ -11,6 +11,7 @@ package org.openmrs.validator;
 
 import org.junit.Test;
 import org.openmrs.Location;
+import org.openmrs.Patient;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.api.ValidationException;
 import org.openmrs.test.BaseContextSensitiveTest;
@@ -21,6 +22,7 @@ import org.springframework.validation.Errors;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests methods on the {@link ValidateUtil} class.
@@ -51,6 +53,26 @@ public class ValidateUtilTest extends BaseContextSensitiveTest {
 		}
 		
 	}
+
+	/**
+	 * @see {@link ValidateUtil#validate(Object)}
+	 */
+	@Test
+	@Verifies(value = "should return immediately if validation is disabled", method = "validate(Object)")
+	public void validate_shouldReturnImmediatelyIfValidationIsDisabled() {
+		Boolean prevVal = ValidateUtil.getDisableValidation();
+		ValidateUtil.setDisableValidation(true);
+
+		try {
+			ValidateUtil.validate(new Patient());
+		} catch (Exception e) {
+			ValidateUtil.setDisableValidation(prevVal);
+			e.printStackTrace();
+			fail("An unexpected exception occurred");
+		}
+
+		ValidateUtil.setDisableValidation(prevVal);
+	}
 	
 	/**
 	 * @see {@link ValidateUtil#validateFieldLengths(org.springframework.validation.Errors, Class, String...)}
@@ -79,6 +101,25 @@ public class ValidateUtilTest extends BaseContextSensitiveTest {
 		ValidateUtil.validateFieldLengths(errors, PatientIdentifierType.class, "name");
 		assertFalse(errors.hasFieldErrors("name"));
 	}
+
+	/**
+	 * @see {@link ValidateUtil#validateFieldLengths(org.springframework.validation.Errors, Class, String...)}
+	 */
+	@Test
+	@Verifies(value = "should return immediately if validation is disabled and have no errors", method = "validateFieldLengths(org.springframework.validation.Errors, Class, String...)")
+	public void validateFieldLength_shouldReturnImmediatelyIfValidationIsDisabledAndHaveNoErrors() {
+		Boolean prevVal = ValidateUtil.getDisableValidation();
+		ValidateUtil.setDisableValidation(true);
+
+		PatientIdentifierType patientIdentifierType = new PatientIdentifierType();
+		patientIdentifierType.setName("asdfghjkl asdfghjkl asdfghjkl asdfghjkl asdfghjkl +1");
+
+		BindException errors = new BindException(patientIdentifierType, "patientIdentifierType");
+		ValidateUtil.validateFieldLengths(errors, PatientIdentifierType.class, "name");
+		assertFalse(errors.hasFieldErrors("name"));
+
+		ValidateUtil.setDisableValidation(prevVal);
+	}
 	
 	/**
 	 * @see ValidateUtil#validate(Object,Errors)
@@ -91,5 +132,28 @@ public class ValidateUtilTest extends BaseContextSensitiveTest {
 		ValidateUtil.validate(loc, errors);
 		
 		assertTrue(errors.hasErrors());
+	}
+
+	/**
+	 * @see ValidateUtil#validate(Object,Errors)
+	 */
+	@Test
+	@Verifies(value = "should return immediately if validation is disabled and have no errors", method = "validate(Object,Errors)")
+	public void validate_shouldReturnImmediatelyIfValidationIsDisabledAndHaveNoErrors() {
+		Boolean prevVal = ValidateUtil.getDisableValidation();
+		ValidateUtil.setDisableValidation(true);
+
+		try {
+			Patient patient = new Patient();
+			Errors errors = new BindException(patient, "patient");
+			ValidateUtil.validate(patient, errors);
+			assertFalse(errors.hasErrors());
+		} catch (Exception e) {
+			ValidateUtil.setDisableValidation(prevVal);
+			e.printStackTrace();
+			fail("An unexpected exception occurred");
+		}
+
+		ValidateUtil.setDisableValidation(prevVal);
 	}
 }

--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -398,6 +398,7 @@
   <global_property property="order.durationUnitsConceptUuid" property_value="54d29840-d9e6-11e3-9c1a-0800200c9a66" uuid="3e26c300-d9e6-11e3-9c1a-0800200c9a66"/>
   <global_property property="order.testSpecimenSourcesConceptUuid" property_value="5e02d1a0-7869-11e4-981f-0800200c9a73" uuid="56466f40-d9c5-11e3-9c1a-0800200c9a66"/>
   <global_property property="order.drugRoutesConceptUuid" property_value="6e02d1a0-7869-11e4-981f-0800200c9a89" uuid="67466f40-d9c5-22e3-9c1a-0800200c9a66"/>
+  <global_property property="validation.disable" property_value="false" uuid="4a5e5566-b559-4026-bd73-7254e91a7268"/>
   <concept_stop_word concept_stop_word_id="1" word="A" locale="en" uuid="75af8c00-3ab2-4c1d-8a8d-3c0e5c2972eb"/>
   <concept_stop_word concept_stop_word_id="2" word="AN" locale="en" uuid="75af8c00-3ab2-4c1d-8a8d-3c0e5c2972ec"/>
   <concept_stop_word concept_stop_word_id="3" word="BUT" locale="en_GB" uuid="75af8c00-3ab2-4c1d-8a8d-3c0e5c2972ed"/>


### PR DESCRIPTION
Hey @dkayiwa I've opened another PR for the disable validation issue. I changed how this is done so that it doesn't interfere with other OpenMRS unit test. I've also added some unit tests of my own.

See https://issues.openmrs.org/browse/TRUNK-4626