### PR TITLE
TRUNK-4604: Upgrading surefire plugin to make sure Bamboo will pick failures.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.5</version>
+					<version>2.18.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Looks like some tests are failing, but something on Bamboo agents are not picking them up. 
https://talk.openmrs.org/t/openmrs-core-build-failure-noticed-on-2015-05-28/2007/16

The affected build is:
https://ci.openmrs.org/browse/TRUNK-MASTER-JOB1-931/log

I can reproduce the failures locally (oracle jdk 8), any version of maven 3.2 (3.2.3 and 3.2.5), on my vagrant box (openjdk 8). TravisCI has the failure as well. With this change, I intend to have a consistent behaviour. 


This new version of surefire shows the error messages a little bit more clear as well. 
```
Results :

Tests in error: 
  EncounterServiceTest.saveEncounter_shouldNotOverwriteObsAndOrdersCreatorOrDateCreated:562 » PessimisticLock
  EncounterServiceTest.saveEncounter_shouldSetDateStoppedOnTheOriginalAfterAddingReviseOrder:283 » PessimisticLock
  EncounterServiceTest.transferEncounter_shouldTransferAnEncounterWithOrdersAndObservationsToGivenPatient:2701 » PessimisticLock
  ModuleActivatorTest>BaseModuleActivatorTest.beforeEachTest:36 » NullPointer

Tests run: 3060, Failures: 0, Errors: 4, Skipped: 28
```

It might be important to cherry pick this commit to another branches, not sure if they suffer of the same problem. 