### PR TITLE
TRUNK-4729: Add changedBy and dateChanged attributes to EncounterType.

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -8710,4 +8710,29 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="201506192000-TRUNK-4729" author="thomasvandoren">
+		<preConditions onFail="MARK_RAN">
+			<not><columnExists tableName="encounter_type" columnName="changed_by" /></not>
+		</preConditions>
+		<comment>Add changed_by column to encounter_type table</comment>
+
+		<addColumn tableName="encounter_type">
+			<column name="changed_by" type="int" />
+		</addColumn>
+		<addForeignKeyConstraint constraintName="encounter_type_changed_by"
+			baseTableName="encounter_type" baseColumnNames="changed_by"
+			referencedTableName="users" referencedColumnNames="user_id" />
+	</changeSet>
+
+	<changeSet id="201506192001-TRUNK-4729" author="thomasvandoren">
+		<preConditions onFail="MARK_RAN">
+			<not><columnExists tableName="encounter_type" columnName="date_changed" /></not>
+		</preConditions>
+		<comment>Add date_changed column to encounter_type table</comment>
+
+		<addColumn tableName="encounter_type">
+			<column name="date_changed" type="datetime" />
+		</addColumn>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/EncounterType.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/EncounterType.hbm.xml
@@ -43,6 +43,10 @@
 			column="retire_reason" length="255" />
 		<property name="retired" type="boolean"
 			length="1" not-null="true" />
+		<many-to-one name="changedBy" class="User"
+			column="changed_by" />
+		<property name="dateChanged" type="java.util.Date"
+			column="date_changed" not-null="false" length="19" />
 
 	</class>
 </hibernate-mapping>

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -1006,6 +1006,36 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
+	 * @see {@link EncounterService#saveEncounterType(EncounterType)}
+	 */
+	@Test
+	@Verifies(value = "should set audit info if any item in EncounterType is Edited", method = "saveEncounterType(EncounterType)")
+	public void saveEncounterType_shouldSetAuditInfoIfAnyItemInEncounterTypeIsEdited() throws Exception {
+		EncounterService es = Context.getEncounterService();
+
+		// Create encounter type, ensure creator/dateCreated are set, and changedBy and dateChanged are not setDateCreated.
+		EncounterType encounterType = es.saveEncounterType(new EncounterType("testing", "desc"));
+		User creator = encounterType.getCreator();
+		Date dateCreated = encounterType.getDateCreated();
+
+		assertNotNull("creator should be set after saving", creator);
+		assertNotNull("date creates should be set after saving", dateCreated);
+		assertNull("changed by should not be set after creation", encounterType.getChangedBy());
+		assertNull("date changed should not be set after creation", encounterType.getDateChanged());
+
+		// Edit encounter type.
+		encounterType.setDescription("This has been a test!");
+		EncounterType editedEt = es.saveEncounterType(encounterType);
+		Context.flushSession();
+
+		// Ensure creator/dateCreated remain unchanged, and changedBy and dateChanged are set.
+		assertTrue("creator should not change during edit", creator.equals(editedEt.getCreator()));
+		assertTrue("date created should not changed during edit", dateCreated.equals(editedEt.getDateCreated()));
+		assertNotNull("changed by should be set after edit", editedEt.getChangedBy());
+		assertNotNull("date changed should be set after edit", editedEt.getDateChanged());
+	}
+
+	/**
 	 * @see {@link EncounterService#getEncounterType(String)}
 	 */
 	@Test


### PR DESCRIPTION
Add changed_by and date_changed columns to encounter_type table. Includes the
hibernate mapping file changes and liquibase changesets.

To verify, I 1) ran `mvn test` on my mac, and 2) ran the webapp in Jetty and confirmed
the columns were created and that changing an encounter type updated them.

This is my first patch on OpenMRS; please let me know if there are other behaviors
that unittests could exercise or if there is additional verification I need to run.

https://issues.openmrs.org/browse/TRUNK-4729