### PR TITLE
TRUNK-4571: Get encounters by creation/modification date

### DIFF
--- a/api/src/main/java/org/openmrs/api/EncounterService.java
+++ b/api/src/main/java/org/openmrs/api/EncounterService.java
@@ -28,6 +28,7 @@ import org.openmrs.VisitType;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.db.EncounterDAO;
 import org.openmrs.api.handler.EncounterVisitHandler;
+import org.openmrs.parameter.EncounterSearchCriteria;
 import org.openmrs.util.PrivilegeConstants;
 
 /**
@@ -163,8 +164,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get encounters by provider
 	 * @should exclude voided encounters
 	 * @should include voided encounters
-	 * @deprecated replaced by
-	 *             {@link #getEncounters(Patient, Location, Date, Date, Collection, Collection, Collection, Collection, Collection, boolean)}
+	 * @deprecated use {@link #getEncounters(EncounterSearchCriteria)} instead
 	 */
 	@Deprecated
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
@@ -198,11 +198,25 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get encounters by visit
 	 * @should exclude voided encounters
 	 * @should include voided encounters
+	 * @deprecated use {@link #getEncounters(EncounterSearchCriteria)} instead
 	 */
+	@Deprecated
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
 	public List<Encounter> getEncounters(Patient who, Location loc, Date fromDate, Date toDate,
 	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
 	        Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided);
+	
+	/**
+	 * Get all encounters that match a variety of (nullable) criteria contained in the parameter object.
+	 * Each extra value for a parameter that is provided acts as an "and" and will reduce the number of results returned
+	 *
+	 * @param encounterSearchCriteria the object containing search parameters
+	 * @return a list of encounters ordered by increasing encounterDatetime
+	 * @since 1.12
+	 * @should get encounters by date changed
+	 */
+	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
+	public List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
 	
 	/**
 	 * Voiding a encounter essentially removes it from circulation

--- a/api/src/main/java/org/openmrs/api/db/EncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/EncounterDAO.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.api.db;
 
-import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -18,13 +17,11 @@ import org.openmrs.Cohort;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterRole;
 import org.openmrs.EncounterType;
-import org.openmrs.Form;
 import org.openmrs.Location;
 import org.openmrs.Patient;
-import org.openmrs.Provider;
 import org.openmrs.Visit;
-import org.openmrs.VisitType;
 import org.openmrs.api.EncounterService;
+import org.openmrs.parameter.EncounterSearchCriteria;
 
 /**
  * Encounter-related database functions
@@ -63,14 +60,9 @@ public interface EncounterDAO {
 	public List<Encounter> getEncountersByPatientId(Integer patientId) throws DAOException;
 	
 	/**
-	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.Patient,
-	 *      org.openmrs.Location, java.util.Date, java.util.Date, java.util.Collection,
-	 *      java.util.Collection, java.util.Collection, java.util.Collection, java.util.Collection,
-	 *      boolean)
+	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.parameter.EncounterSearchCriteria)
 	 */
-	public List<Encounter> getEncounters(Patient patient, Location location, Date fromDate, Date toDate,
-	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
-	        Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided);
+	public List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
 	
 	/**
 	 * Save an Encounter Type

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -45,6 +45,7 @@ import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.EncounterDAO;
+import org.openmrs.parameter.EncounterSearchCriteria;
 
 /**
  * Hibernate specific dao for the {@link EncounterService} All calls should be made on the
@@ -106,46 +107,54 @@ public class HibernateEncounterDAO implements EncounterDAO {
 	}
 	
 	/**
-	 * @see org.openmrs.api.db.EncounterDAO#getEncounters(Patient, Location, Date, Date, Collection, Collection, Collection, Collection, Collection, boolean)
+	 * @see org.openmrs.api.db.EncounterDAO#getEncounters(org.openmrs.parameter.EncounterSearchCriteria)
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public List<Encounter> getEncounters(Patient patient, Location location, Date fromDate, Date toDate,
-	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
-	        Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided) {
-		
+	public List<Encounter> getEncounters(EncounterSearchCriteria searchCriteria) {
 		Criteria crit = sessionFactory.getCurrentSession().createCriteria(Encounter.class);
 		
-		if (patient != null && patient.getPatientId() != null) {
-			crit.add(Restrictions.eq("patient", patient));
+		if (searchCriteria.getPatient() != null && searchCriteria.getPatient().getPatientId() != null) {
+			crit.add(Restrictions.eq("patient", searchCriteria.getPatient()));
 		}
-		if (location != null && location.getLocationId() != null) {
-			crit.add(Restrictions.eq("location", location));
+		if (searchCriteria.getLocation() != null && searchCriteria.getLocation().getLocationId() != null) {
+			crit.add(Restrictions.eq("location", searchCriteria.getLocation()));
 		}
-		if (fromDate != null) {
-			crit.add(Restrictions.ge("encounterDatetime", fromDate));
+		if (searchCriteria.getFromDate() != null) {
+			crit.add(Restrictions.ge("encounterDatetime", searchCriteria.getFromDate()));
 		}
-		if (toDate != null) {
-			crit.add(Restrictions.le("encounterDatetime", toDate));
+		if (searchCriteria.getToDate() != null) {
+			crit.add(Restrictions.le("encounterDatetime", searchCriteria.getToDate()));
 		}
-		if (enteredViaForms != null && enteredViaForms.size() > 0) {
-			crit.add(Restrictions.in("form", enteredViaForms));
+		if (searchCriteria.getDateChanged() != null) {
+			crit.add(
+					Restrictions.or(
+							Restrictions.and(
+									Restrictions.isNull("dateChanged"),
+									Restrictions.ge("dateCreated", searchCriteria.getDateChanged())
+							),
+							Restrictions.ge("dateChanged", searchCriteria.getDateChanged())
+					)
+			);
 		}
-		if (encounterTypes != null && encounterTypes.size() > 0) {
-			crit.add(Restrictions.in("encounterType", encounterTypes));
+		if (searchCriteria.getEnteredViaForms() != null && searchCriteria.getEnteredViaForms().size() > 0) {
+			crit.add(Restrictions.in("form", searchCriteria.getEnteredViaForms()));
 		}
-		if (providers != null && providers.size() > 0) {
+		if (searchCriteria.getEncounterTypes() != null && searchCriteria.getEncounterTypes().size() > 0) {
+			crit.add(Restrictions.in("encounterType", searchCriteria.getEncounterTypes()));
+		}
+		if (searchCriteria.getProviders() != null && searchCriteria.getProviders().size() > 0) {
 			crit.createAlias("encounterProviders", "ep");
-			crit.add(Restrictions.in("ep.provider", providers));
+			crit.add(Restrictions.in("ep.provider", searchCriteria.getProviders()));
 		}
-		if (visitTypes != null && visitTypes.size() > 0) {
+		if (searchCriteria.getVisitTypes() != null && searchCriteria.getVisitTypes().size() > 0) {
 			crit.createAlias("visit", "v");
-			crit.add(Restrictions.in("v.visitType", visitTypes));
+			crit.add(Restrictions.in("v.visitType", searchCriteria.getVisitTypes()));
 		}
-		if (visits != null && visits.size() > 0) {
-			crit.add(Restrictions.in("visit", visits));
+		if (searchCriteria.getVisits() != null && searchCriteria.getVisits().size() > 0) {
+			crit.add(Restrictions.in("visit", searchCriteria.getVisits()));
 		}
-		if (!includeVoided) {
+		if (!searchCriteria.getIncludeVoided()) {
 			crit.add(Restrictions.eq("voided", false));
 		}
 		crit.addOrder(Order.asc("encounterDatetime"));

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -43,6 +43,8 @@ import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.EncounterDAO;
 import org.openmrs.api.handler.EncounterVisitHandler;
+import org.openmrs.parameter.EncounterSearchCriteria;
+import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
 import org.openmrs.util.HandlerUtil;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
@@ -285,9 +287,16 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 	public List<Encounter> getEncounters(Patient who, Location loc, Date fromDate, Date toDate,
 	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<User> providers,
 	        boolean includeVoided) {
-		return Context.getEncounterService().filterEncountersByViewPermissions(
-		    dao.getEncounters(who, loc, fromDate, toDate, enteredViaForms, encounterTypes, usersToProviders(providers),
-		        null, null, includeVoided), null);
+		EncounterSearchCriteriaBuilder encounterSearchCriteriaBuilder = new EncounterSearchCriteriaBuilder()
+				.setPatient(who)
+				.setLocation(loc)
+				.setFromDate(fromDate)
+				.setToDate(toDate)
+				.setEnteredViaForms(enteredViaForms)
+				.setEncounterTypes(encounterTypes)
+				.setProviders(usersToProviders(providers))
+				.setIncludeVoided(includeVoided);
+		return getEncounters(encounterSearchCriteriaBuilder.createEncounterSearchCriteria());
 	}
 	
 	/**
@@ -312,15 +321,37 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.Patient,
 	 *      org.openmrs.Location, java.util.Date, java.util.Date, java.util.Collection,
 	 *      java.util.Collection, java.util.Collection, boolean)
+	 * @deprecated replaced by
+	 *             {@link #getEncounters(org.openmrs.parameter.EncounterSearchCriteria)}
 	 */
+	@Deprecated
 	@Override
 	@Transactional(readOnly = true)
 	public List<Encounter> getEncounters(Patient who, Location loc, Date fromDate, Date toDate,
 	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
 	        Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided) {
-		return Context.getEncounterService().filterEncountersByViewPermissions(
-		    dao.getEncounters(who, loc, fromDate, toDate, enteredViaForms, encounterTypes, providers, visitTypes, visits,
-		        includeVoided), null);
+		EncounterSearchCriteriaBuilder encounterSearchCriteriaBuilder = new EncounterSearchCriteriaBuilder()
+				.setPatient(who)
+				.setLocation(loc)
+				.setFromDate(fromDate)
+				.setToDate(toDate)
+				.setEnteredViaForms(enteredViaForms)
+				.setEncounterTypes(encounterTypes)
+				.setProviders(providers)
+				.setVisitTypes(visitTypes)
+				.setVisits(visits)
+				.setIncludeVoided(includeVoided);
+
+		return getEncounters(encounterSearchCriteriaBuilder.createEncounterSearchCriteria());
+	}
+	
+	/**
+	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.parameter.EncounterSearchCriteria)
+	 */
+	public List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria) {
+		// the second search parameter is null as it defaults to authenticated user from context
+		return Context.getEncounterService().filterEncountersByViewPermissions(dao.getEncounters(encounterSearchCriteria),
+		    null);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -58,6 +58,8 @@ import org.openmrs.api.UserService;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.PatientDAO;
+import org.openmrs.parameter.EncounterSearchCriteria;
+import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.person.PersonMergeLog;
@@ -872,7 +874,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		// change all encounters. This will cascade to obs and orders contained in those encounters
 		// TODO: this should be a copy, not a move
 		EncounterService es = Context.getEncounterService();
-		for (Encounter e : es.getEncounters(notPreferred, null, null, null, null, null, null, null, null, true)) {
+
+		EncounterSearchCriteria notPreferredPatientEncounterSearchCriteria = new EncounterSearchCriteriaBuilder()
+				.setIncludeVoided(true)
+				.setPatient(notPreferred)
+				.createEncounterSearchCriteria();
+		for (Encounter e : es.getEncounters(notPreferredPatientEncounterSearchCriteria)) {
 			e.setPatient(preferred);
 			log.debug("Merging encounter " + e.getEncounterId() + " to " + preferred.getPatientId());
 			Encounter persisted = es.saveEncounter(e);

--- a/api/src/main/java/org/openmrs/parameter/EncounterSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/parameter/EncounterSearchCriteria.java
@@ -1,0 +1,161 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.parameter;
+
+import java.util.Collection;
+import java.util.Date;
+
+import org.openmrs.EncounterType;
+import org.openmrs.Form;
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
+
+/**
+ * The search parameter object for encounters. A convenience interface for building
+ * instances is provided by {@link EncounterSearchCriteriaBuilder}.
+ *
+ * @since 1.12
+ * @see EncounterSearchCriteriaBuilder
+ */
+public class EncounterSearchCriteria {
+	
+	private Patient patient;
+	
+	private Location location;
+	
+	private Date fromDate;
+	
+	private Date toDate;
+	
+	private Date dateChanged;
+	
+	private Collection<Form> enteredViaForms;
+	
+	private Collection<EncounterType> encounterTypes;
+	
+	private Collection<Provider> providers;
+	
+	private Collection<VisitType> visitTypes;
+	
+	private Collection<Visit> visits;
+	
+	private boolean includeVoided;
+
+	/**
+	 * Instead of calling this constructor directly, it is recommended to use {@link EncounterSearchCriteriaBuilder}.
+	 * @param patient the patient the encounter is for
+	 * @param location the location this encounter took place
+	 * @param fromDate the minimum date (inclusive) the encounter took place
+	 * @param toDate the maximum date (exclusive) the encounter took place
+	 * @param dateChanged the minimum date the encounter was changed
+	 * @param enteredViaForms the form that entered this encounter must be in this collection
+	 * @param encounterTypes the type of the encounter must be in this collection
+	 * @param providers the provider of the encounter must be in this collection
+	 * @param visitTypes the visit types of the encounter must be in this collection
+	 * @param visits the visits of the encounter must be in this collection
+	 * @param includeVoided whether to include the voided encounters or not
+	 */
+	public EncounterSearchCriteria(Patient patient, Location location, Date fromDate, Date toDate, Date dateChanged,
+								   Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes,
+								   Collection<Provider> providers, Collection<VisitType> visitTypes,
+								   Collection<Visit> visits, boolean includeVoided) {
+		this.patient = patient;
+		this.location = location;
+		this.fromDate = fromDate;
+		this.toDate = toDate;
+		this.dateChanged = dateChanged;
+		this.enteredViaForms = enteredViaForms;
+		this.encounterTypes = encounterTypes;
+		this.providers = providers;
+		this.visitTypes = visitTypes;
+		this.visits = visits;
+		this.includeVoided = includeVoided;
+	}
+
+	/**
+	 * @return the patient the encounter is for
+	 */
+	public Patient getPatient() {
+		return patient;
+	}
+	
+	/**
+	 * @return the location this encounter took place
+	 */
+	public Location getLocation() {
+		return location;
+	}
+	
+	/**
+	 * @return the minimum date (inclusive) this encounter took place
+	 */
+	public Date getFromDate() {
+		return fromDate;
+	}
+
+	/**
+	 * @return the maximum date (exclusive) this encounter took place
+	 */
+	public Date getToDate() {
+		return toDate;
+	}
+
+	/**
+	 * @return the minimum date this encounter was changed
+	 */
+	public Date getDateChanged() {
+		return dateChanged;
+	}
+
+	/**
+	 * @return the form that entered this encounter must be in this collection
+	 */
+	public Collection<Form> getEnteredViaForms() {
+		return enteredViaForms;
+	}
+
+	/**
+	 * @return the type of encounter must be in this list
+	 */
+	public Collection<EncounterType> getEncounterTypes() {
+		return encounterTypes;
+	}
+
+	/**
+	 * @return the provider of this encounter must be in this list
+	 */
+	public Collection<Provider> getProviders() {
+		return providers;
+	}
+
+	/**
+	 * @return the visit types of this encounter must be in this list
+	 */
+	public Collection<VisitType> getVisitTypes() {
+		return visitTypes;
+	}
+
+	/**
+	 * @return the visits of this encounter must be in this list
+	 */
+	public Collection<Visit> getVisits() {
+		return visits;
+	}
+
+	/**
+	 * @return whether to include the voided encounters or not
+	 */
+	public boolean getIncludeVoided() {
+		return includeVoided;
+	}
+}

--- a/api/src/main/java/org/openmrs/parameter/EncounterSearchCriteriaBuilder.java
+++ b/api/src/main/java/org/openmrs/parameter/EncounterSearchCriteriaBuilder.java
@@ -1,0 +1,164 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.parameter;
+
+import java.util.Collection;
+import java.util.Date;
+
+import org.openmrs.EncounterType;
+import org.openmrs.Form;
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.Provider;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
+
+/**
+ * A convenience builder for {@link EncounterSearchCriteria}. Create a builder, set
+ * its properties to desired values and finally call {@link #createEncounterSearchCriteria()}
+ * to create the actual search criteria instance.
+ * @see EncounterSearchCriteria
+ */
+public class EncounterSearchCriteriaBuilder {
+    private Patient patient;
+
+    private Location location;
+
+    private Date fromDate;
+
+    private Date toDate;
+
+    private Date dateChanged;
+
+    private Collection<Form> enteredViaForms;
+
+    private Collection<EncounterType> encounterTypes;
+
+    private Collection<Provider> providers;
+
+    private Collection<VisitType> visitTypes;
+
+    private Collection<Visit> visits;
+
+    private boolean includeVoided;
+
+    /**
+     * @param patient the patient the encounter is for
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setPatient(Patient patient) {
+        this.patient = patient;
+        return this;
+    }
+
+    /**
+     * @param location the location the encounter took place
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setLocation(Location location) {
+        this.location = location;
+        return this;
+    }
+
+    /**
+     * @param fromDate the minimum date (inclusive) the encounter took place
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+        return this;
+    }
+
+    /**
+     * @param toDate the maximum date (exclusive) the encounter took place
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setToDate(Date toDate) {
+        this.toDate = toDate;
+        return this;
+    }
+
+    /**
+     * @param dateChanged the minimum date the encounter was changed
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setDateChanged(Date dateChanged) {
+        this.dateChanged = dateChanged;
+        return this;
+    }
+
+    /**
+     * @param enteredViaForms the form that entered the encounter must be in this collection.
+     *                           This search parameter is omitted if the set is null or empty.
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setEnteredViaForms(Collection<Form> enteredViaForms) {
+        this.enteredViaForms = enteredViaForms;
+        return this;
+    }
+
+    /**
+     * @param encounterTypes the type of the encounter must be in this collection.
+     *                           This search parameter is omitted if the set is null or empty.
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setEncounterTypes(Collection<EncounterType> encounterTypes) {
+        this.encounterTypes = encounterTypes;
+        return this;
+    }
+
+    /**
+     * @param providers the provider of the encounter must be in this collection.
+     *                           This search parameter is omitted if the set is null or empty.
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setProviders(Collection<Provider> providers) {
+        this.providers = providers;
+        return this;
+    }
+
+    /**
+     * @param visitTypes the visit types of the encounter must be in this collection.
+     *                           This search parameter is omitted if the set is null or empty.
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setVisitTypes(Collection<VisitType> visitTypes) {
+        this.visitTypes = visitTypes;
+        return this;
+    }
+
+    /**
+     * @param visits the visits of the encounter must be in this collection.
+     *                           This search parameter is omitted if the set is null or empty.
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setVisits(Collection<Visit> visits) {
+        this.visits = visits;
+        return this;
+    }
+
+    /**
+     * @param includeVoided whether to include the voided encounters or not
+     * @return this builder instance
+     */
+    public EncounterSearchCriteriaBuilder setIncludeVoided(boolean includeVoided) {
+        this.includeVoided = includeVoided;
+        return this;
+    }
+
+    /**
+     * Create an {@link EncounterSearchCriteria} with the properties of this builder instance.
+     * @return a new search criteria instance
+     */
+    public EncounterSearchCriteria createEncounterSearchCriteria() {
+        return new EncounterSearchCriteria(patient, location, fromDate, toDate, dateChanged, enteredViaForms,
+                encounterTypes, providers, visitTypes, visits, includeVoided);
+    }
+}

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -38,6 +38,8 @@ import org.openmrs.api.handler.EncounterVisitHandler;
 import org.openmrs.api.handler.ExistingOrNewVisitAssignmentHandler;
 import org.openmrs.api.handler.ExistingVisitAssignmentHandler;
 import org.openmrs.api.handler.NoVisitAssignmentHandler;
+import org.openmrs.parameter.EncounterSearchCriteria;
+import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
@@ -879,6 +881,21 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
+	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.parameter.EncounterSearchCriteria)
+	 */
+	@Test
+	@Verifies(value = "should get encounters by date changed", method = "getEncounters(EncounterSearchParameter)")
+	public void getEncounters_shouldGetEncountersByDateChanged() throws Exception {
+		EncounterService encounterService = Context.getEncounterService();
+		Assert.assertEquals(7, encounterService.getEncounters(
+				encounterSearchForVoidedWithDateChanged("2006-01-01")).size());
+		Assert.assertEquals(5, encounterService.getEncounters(
+				encounterSearchForVoidedWithDateChanged("2008-06-01")).size());
+		Assert.assertEquals(1, encounterService.getEncounters(
+				encounterSearchForVoidedWithDateChanged("2010-01-01")).size());
+	}
+
+	/**
 	 * @see EncounterService#getEncounters(Patient, Location, Date, Date, java.util.Collection, java.util.Collection, java.util.Collection, boolean)
 	 */
 	@Test
@@ -1564,7 +1581,7 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		assertNotNull("We should get back an encounter role", newSavedEncounterRole);
 		assertEquals(encounterRole, newSavedEncounterRole);
 		assertTrue("The created encounter role needs to equal the pojo encounter role", encounterRole
-		        .equals(newSavedEncounterRole));
+				.equals(newSavedEncounterRole));
 		
 	}
 	
@@ -2784,7 +2801,15 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		Visit visit = Context.getVisitService().getVisit(200);
 		Assert.assertTrue(visit.isVoided());
 	}
-	
+
+	private EncounterSearchCriteria encounterSearchForVoidedWithDateChanged(String dateChanged) throws Exception {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+		return new EncounterSearchCriteriaBuilder()
+				.setIncludeVoided(true)
+				.setDateChanged(sdf.parse(dateChanged))
+				.createEncounterSearchCriteria();
+	}
+
 	private Person newPerson(String name) {
 		Person person = new Person();
 		Set<PersonName> personNames = new TreeSet<PersonName>();

--- a/api/src/test/resources/org/openmrs/api/include/EncounterServiceTest-initialData.xml
+++ b/api/src/test/resources/org/openmrs/api/include/EncounterServiceTest-initialData.xml
@@ -78,13 +78,13 @@
   <orders order_id="1" order_type_id="2" order_number="1" urgency="ROUTINE" patient_id="3" encounter_id="1" date_activated="2012-08-19 00:00:00.0" concept_id="1" orderer="1" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="0d86e8b4-2f33-495e-aa22-6954785e4e9e" order_action="NEW" care_setting="1"/>
 
   <!-- an encounter with a mismatched order.patient_id -->
-  <encounter encounter_id="15" encounter_type="1" form_id="1" encounter_datetime="2001-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="0" uuid="7fffd6b9-0970-4967-88c7-0b7b50f12bc6"/>
+  <encounter encounter_id="15" encounter_type="1" form_id="1" encounter_datetime="2001-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2005-01-01 00:00:00.0" date_changed="2006-01-01 00:00:00.0" voided="0" uuid="7fffd6b9-0970-4967-88c7-0b7b50f12bc6"/>
   <encounter_provider encounter_provider_id="3" encounter_id="15" provider_id="1" encounter_role_id="2" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="8a030bef-4362-4a1c-9967-ac4a4b425b45" />
   <!-- a voided encounter with a mismatched order.patient_id -->
-  <encounter encounter_id="16" encounter_type="1" form_id="1" encounter_datetime="2007-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2007-01-01 00:00:00.0" voided="1" uuid="929809cc-8ef7-11e0-a7a1-91c116298e4b"/>
+  <encounter encounter_id="16" encounter_type="1" form_id="1" encounter_datetime="2007-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2009-01-01 00:00:00.0" date_changed="2010-01-01 00:00:00.0" voided="1" uuid="929809cc-8ef7-11e0-a7a1-91c116298e4b"/>
   <encounter_provider encounter_provider_id="4" encounter_id="16" provider_id="1" encounter_role_id="2" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="0d9b354c-e6fd-11e0-be7d-593b1cdbf439" />
   <!-- a voided encounter with a mismatched order.patient_id -->
-  <encounter encounter_id="16" encounter_type="1" form_id="1" encounter_datetime="2007-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2007-01-01 00:00:00.0" voided="1" void_reason="testing" uuid="929809cc-8ef7-11e0-a7a1-91c116298e4b"/>
+  <encounter encounter_id="16" encounter_type="1" form_id="1" encounter_datetime="2007-01-01 00:00:00.0" patient_id="3" location_id="1" visit_id="1" creator="1" date_created="2009-01-01 00:00:00.0" date_changed="2010-01-01 00:00:00.0" voided="1" void_reason="testing" uuid="929809cc-8ef7-11e0-a7a1-91c116298e4b"/>
   <encounter_provider encounter_provider_id="4" encounter_id="16" provider_id="1" encounter_role_id="2" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="0d9b354c-e6fd-11e0-be7d-593b1cdbf439" />
   <orders order_id="10" order_type_id="2" order_number="10" urgency="ROUTINE" patient_id="2" encounter_id="15" concept_id="1" orderer="1" creator="1" date_activated="2012-08-19 00:00:00.0" date_created="2006-03-11 15:57:35.0" voided="false" uuid="bf003896-2caf-42ef-8cfa-5ad29a11661f" order_action="NEW" care_setting="1"/>
 


### PR DESCRIPTION
Deprecate the old api method and add a new one that uses a parameter
object (EncounterSearchCriteria) instead of individual parameters.
Provide a convenience builder EncounterSearchCriteriaBuilder for
creating unmodifiable instances of the search criteria.