### PR TITLE
TRUNK-4463 trim concept ids after being tokenised

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/view/portlets/customMostRecentObs.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/portlets/customMostRecentObs.jsp
@@ -15,49 +15,50 @@
 	<openmrs:htmlInclude file="/dwr/util.js" />
 
 	<table>
-	<c:forTokens var="conceptIds" items="${model.conceptIds}" delims="," >
+	<c:forTokens var="rawConceptId" items="${model.conceptIds}" delims="," >
+		<c:set var="conceptId" value="${fn:trim(rawConceptId)}"/>
 		<tr>
-			<td><openmrs_tag:concept conceptId="${conceptIds}"/>:</td>
+			<td><openmrs_tag:concept conceptId="${conceptId}"/>:</td>
 			<td>
 				<b>
-				<openmrs_tag:mostRecentObs concept="${conceptIds}" observations="${model.patientObs}" locale="${model.locale}" labelIfNone="general.none" showDate="true" showEditLink="true"/>
+				<openmrs_tag:mostRecentObs concept="${conceptId}" observations="${model.patientObs}" locale="${model.locale}" labelIfNone="general.none" showDate="true" showEditLink="true"/>
 				</b>
 			</td>
 			<c:if test="${allowNew}">
 				<td>
-					<c:set var="thisConcept" value="${model.conceptMapByStringIds[conceptIds]}"/>
-					<a href="javascript:showHideDiv('newCustomObs_${conceptIds}')">
+					<c:set var="thisConcept" value="${model.conceptMapByStringIds[conceptId]}"/>
+					<a href="javascript:showHideDiv('newCustomObs_${conceptId}')">
 						<openmrs:message code="general.new"/>
 					</a>
 				</td>
-				<td class="dashedAndHighlighted" id="newCustomObs_${conceptIds}" style="display:none">
+				<td class="dashedAndHighlighted" id="newCustomObs_${conceptId}" style="display:none">
 				
-				<openmrs:format conceptId="${conceptIds}"/>
+				<openmrs:format conceptId="${conceptId}"/>
 				<c:choose>
 					<c:when test="${thisConcept.datatype.hl7Abbreviation == 'DT'}">		
-				 		<input type="text" size="10" value="" onfocus="showCalendar(this)" id="value_${conceptIds}_id" />
+				 		<input type="text" size="10" value="" onfocus="showCalendar(this)" id="value_${conceptId}_id" />
 					</c:when>
 					<c:when test="${thisConcept.datatype.hl7Abbreviation == 'CWE'}">
-						<openmrs:fieldGen type="org.openmrs.Concept" formFieldName="value_${conceptIds}" val="" parameters="noBind=true|showAnswers=${conceptIds}" />
+						<openmrs:fieldGen type="org.openmrs.Concept" formFieldName="value_${conceptId}" val="" parameters="noBind=true|showAnswers=${conceptId}" />
 					</c:when>
 					<c:when test="${thisConcept.datatype.hl7Abbreviation == 'BIT'}">
 					<script>
 						$j(function() {
 							var booleanConcepts = ["Yes", "No", "False", "True", "0", "1"];
-							$j( "#value_${conceptIds}_id" ).autocomplete({ source: booleanConcepts });
+							$j( "#value_${conceptId}_id" ).autocomplete({ source: booleanConcepts });
 						});
 					</script>
-					<input type="text" id="value_${conceptIds}_id"/>
+					<input type="text" id="value_${conceptId}_id"/>
 					</c:when>
 					<c:otherwise>
-						<input type="text" id="value_${conceptIds}_id"/>
+						<input type="text" id="value_${conceptId}_id"/>
 					</c:otherwise>
 				</c:choose>	
 				
 					<openmrs:message code="general.onDate"/>
-					<openmrs:fieldGen type="java.util.Date" formFieldName="date_${conceptIds}" val="" parameters="noBind=true" />
-					<input type="button" value="<openmrs:message code="general.save"/>" onClick="handleAddCustomObs(${conceptIds})"/>
-					<input type="button" value="<openmrs:message code="general.cancel"/>" onClick="showHideDiv('newCustomObs_${conceptIds}')"/>
+					<openmrs:fieldGen type="java.util.Date" formFieldName="date_${conceptId}" val="" parameters="noBind=true" />
+					<input type="button" value="<openmrs:message code="general.save"/>" onClick="handleAddCustomObs(${conceptId})"/>
+					<input type="button" value="<openmrs:message code="general.cancel"/>" onClick="showHideDiv('newCustomObs_${conceptId}')"/>
 				</td>
 			</c:if>
 		</tr>


### PR DESCRIPTION
trims comma-separated values (from dashboard.overview.showConcepts GP) before using them, to also allow whitespaces before and after commas (for this specific GP)