### PR TITLE
Fixing the missed update for mysql driver from 5.1.8 to 5.1.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.8</version>
+				<version>5.1.28</version>
 				<scope>runtime</scope>
 			</dependency>
             <dependency>


### PR DESCRIPTION
Updating the mysql-connector-java to use 5.1.28 version of jar.