### PR TITLE
TRUNK-4691 - Force isSet when concept has set members

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -163,6 +163,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 * @should leave preferred name preferred if set
 	 * @should set default preferred name to fully specified first
 	 * @should not set default preferred name to short or index terms
+         * @should force set flag if set members exist
 	 */
 	public Concept saveConcept(Concept concept) throws APIException {
 		ConceptMapType defaultConceptMapType = null;
@@ -280,6 +281,11 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		concept.setDateChanged(new Date());
 		concept.setChangedBy(Context.getAuthenticatedUser());
 		
+		// force isSet when concept has members
+		if (!concept.isSet() && (concept.getSetMembers().size() > 0)) {
+                    concept.setSet(true);
+		}
+
 		Concept conceptToReturn = dao.saveConcept(concept);
 		
 		return conceptToReturn;

--- a/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
@@ -220,4 +220,24 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		assertNotEquals(concept.getName().getName(), nameWithSpaces);
 		assertEquals(concept.getName().getName(), "jwm");
 	}
+        
+        /**
+	 * @see ConceptServiceImpl#saveConcept(Concept)
+	 * @verifies force set flag if set members exist
+	 */        
+        @Test
+	public void saveConcept_shouldForceSetFlagIfSetMembersExist() throws Exception {
+		//Given
+		Concept concept = new Concept();
+                concept.addName(new ConceptName("Concept", new Locale("en", "US")));
+                Concept conceptSetMember = new Concept();
+                conceptSetMember.addName(new ConceptName("Set Member", new Locale("en", "US")));
+                Context.getConceptService().saveConcept(conceptSetMember);
+                concept.addSetMember(conceptSetMember);
+                concept.setSet(false);
+		//When
+		Context.getConceptService().saveConcept(concept);
+		//Then
+                assertTrue(concept.getSet());
+	}
 }


### PR DESCRIPTION
Since my last pull request did not match the guidelines, I have now created a new one. 
This is for TRUNK-4691, ConceptService.saveConcept now forces isSet==true, if the concept has set members.