### PR TITLE
Fixing bug that two clicks were necessary to force  the year menu to …

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
@@ -33,7 +33,10 @@
 			<openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui.custom.min.js" />
             <openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui-timepicker-addon.js" />
 			<openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui-datepicker-i18n.js" />
-			<openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui-timepicker-i18n.js" />
+            <%-- THIS IS A PATCH TO FIX BUG IN JQUERY FOR DATEPICKER ON IE FOR MONTH YEAR DROPDOWN --%>
+            <%-- IT'S ALREADY FIXED IN NEW VERSION OF JQUEYR  TICKET #6198 --%>
+            <%-- PLEASE, REMOVE THIS INCLUDE AFTER JQUERY UPGRADE --%>
+			<openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui-timepicker-month-year-patch.js" />
 			<link href="<openmrs:contextPath/>/scripts/jquery-ui/css/<spring:theme code='jqueryui.theme.name' />/jquery-ui.custom.css" type="text/css" rel="stylesheet" />
 		</c:if>
 		<link rel="shortcut icon" type="image/ico" href="<openmrs:contextPath/><spring:theme code='favicon' />">

--- a/webapp/src/main/webapp/WEB-INF/view/scripts/jquery-ui/js/jquery-ui-timepicker-month-year-patch.js
+++ b/webapp/src/main/webapp/WEB-INF/view/scripts/jquery-ui/js/jquery-ui-timepicker-month-year-patch.js
@@ -1,0 +1,26 @@
+/*
+ * jQuery UI Datepicker Patch for IE for month year dropdown
+ *
+ * Depends:
+ *    jquery.ui.datepicker.js
+ *
+ *********************************************************************
+ *  NOTE: THIS FILE MUST BE DELETED AFTER JQUERY UPGRADE
+ *********************************************************************
+ * THIS IS A PATCH TO FIX BUG IN JQUERY FOR DATEPICKER ON IE FOR MONTH YEAR DROPDOWN
+ * IT'S ALREADY FIXED IN NEW VERSION OF JQUEYR  TICKET #6198
+ * PLEASE, REMOVE THIS INCLUDE AFTER JQUERY UPGRADE
+ */
+
+(function( $, undefined ) {
+    var dpuuid = new Date().getTime();
+    $.extend($.datepicker, {
+        __updateDatepicker: $.datepicker._updateDatepicker,
+        _updateDatepicker: function(inst) {
+            inst.dpDiv.find("select.ui-datepicker-year, select.ui-datepicker-month").removeAttr("onclick");
+            this.__updateDatepicker(inst);
+        }
+    });
+    window['DP_jQuery_' + dpuuid] = $;
+})(jQuery);
+


### PR DESCRIPTION
I decided to patch Jquery DatePicker. Created jquery-ui-timepicker-month-year-patch.js patch and included it in headerFull.js
Tested. Worked as expected on Google Chrome and IE.
