### PR TITLE
TRUNK-2280: Refactor maximum length checking in the view layer

### DIFF
--- a/api/src/main/java/org/openmrs/validator/EncounterTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterTypeValidator.java
@@ -68,7 +68,7 @@ public class EncounterTypeValidator implements Validator {
 					    "Specified Encounter Type name already exists, please specify another ");
 				}
 			}
-			ValidateUtil.validateFieldLengths(errors, obj.getClass(), "name", "retireReason");
+			ValidateUtil.validateFieldLengths(errors, obj.getClass(), "name", "description", "retireReason");
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/validator/EncounterTypeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/EncounterTypeValidatorTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.validator;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.EncounterType;
@@ -129,6 +130,7 @@ public class EncounterTypeValidatorTest extends BaseContextSensitiveTest {
 	public void validate_shouldPassValidationIfFieldLengthsAreCorrect() throws Exception {
 		EncounterType type = new EncounterType();
 		type.setName("name");
+		type.setDescription("some descriptin not exceeding the limit");
 		type.setRetireReason("retireReason");
 		
 		Errors errors = new BindException(type, "type");
@@ -144,15 +146,15 @@ public class EncounterTypeValidatorTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should fail validation if field lengths are not correct", method = "validate(Object,Errors)")
 	public void validate_shouldFailValidationIfFieldLengthsAreNotCorrect() throws Exception {
 		EncounterType type = new EncounterType();
-		type
-		        .setName("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
-		type
-		        .setRetireReason("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
+		type.setName(StringUtils.repeat("longer than 50 chars", 6));
+		type.setDescription(StringUtils.repeat("longer than 1024 chars", 120));
+		type.setRetireReason(StringUtils.repeat("longer than 255 chars", 27));
 		
 		Errors errors = new BindException(type, "type");
 		new EncounterTypeValidator().validate(type, errors);
 		
 		Assert.assertTrue(errors.hasFieldErrors("name"));
+		Assert.assertTrue(errors.hasFieldErrors("description"));
 		Assert.assertTrue(errors.hasFieldErrors("retireReason"));
 	}
 }

--- a/webapp/src/main/webapp/WEB-INF/messages.properties
+++ b/webapp/src/main/webapp/WEB-INF/messages.properties
@@ -259,6 +259,7 @@ general.alertSent=Alert Sent
 general.noresult=No Results
 general.passwordLength=Password should be {0} characters long
 general.shouldHave=and should have
+general.charactersLeft=You only have {0} character(s) remaining
 
 ##### SEARCH WIDGET MESSAGES ######
 searchWidget.sInfoLabel=Showing {0} to {1} of {2} entries

--- a/webapp/src/main/webapp/WEB-INF/messages_de.properties
+++ b/webapp/src/main/webapp/WEB-INF/messages_de.properties
@@ -259,6 +259,7 @@ general.alertSent=Alarm gesendet
 general.noresult=Keine Ergebnisse
 general.passwordLength=Kennwort sollte {0} Zeichen lang sein
 general.shouldHave=und sollte haben
+general.charactersLeft=Noch {0} Zeichen verbleibend
 
 ##### SEARCH WIDGET MESSAGES ######
 searchWidget.sInfoLabel=Zeige {0} bis {1} von {2} Einträge

--- a/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerFull.jsp
@@ -76,6 +76,9 @@
 			};
 			dwr.engine.setErrorHandler(handler);
 			dwr.engine.setWarningHandler(handler);
+			
+			/* initialize common form validation */
+			jQuery(document).ready(initializeForceMaxLength);
 		</script>
 
 		<openmrs:extensionPoint pointId="org.openmrs.headerFullIncludeExt" type="html" requiredClass="org.openmrs.module.web.extension.HeaderIncludeExt">

--- a/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
+++ b/webapp/src/main/webapp/WEB-INF/template/headerMinimal.jsp
@@ -75,6 +75,9 @@
 			};
 			dwr.engine.setErrorHandler(handler);
 			dwr.engine.setWarningHandler(handler);
+			
+			/* initialize common form validation */
+			jQuery(document).ready(initializeForceMaxLength);
 		</script>
 
 		<openmrs:extensionPoint pointId="org.openmrs.headerMinimalIncludeExt" type="html" requiredClass="org.openmrs.module.web.extension.HeaderIncludeExt">

--- a/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterRoleForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterRoleForm.jsp
@@ -18,14 +18,6 @@
 
 </script>
 
-<script type="text/javascript">
-    function forceMaxLength(object, maxLength) {
-        if (object.value.length >= maxLength) {
-            object.value = object.value.substring(0, maxLength);
-        }
-    }
-</script>
-
 <h2><openmrs:message code="EncounterRole.title"/></h2>
 
 <openmrs:extensionPoint pointId="org.openmrs.admin.encounters.encounterRoleForm.belowTitle" type="html" parameters="encounterRoleId=${encounterRole.encounterRoleId}"/>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
@@ -32,7 +32,7 @@
 		<td>
 			<spring:bind path="encounterType.name">
 				<input type="text" name="name" value="${status.value}" size="35" />
-				<c:if test="${status.errorMessage != ''}"><c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if></c:if>
+				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>
 	</tr>
@@ -41,7 +41,7 @@
 		<td valign="top">
 			<spring:bind path="encounterType.description">
 				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
-				<c:if test="${status.errorMessage != ''}"><c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if></c:if>
+				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>
 	</tr>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
@@ -40,7 +40,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="encounterType.description">
-				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/encounters/encounterTypeForm.jsp
@@ -40,7 +40,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="encounterType.description">
-				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" data-maxlength="1024">${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/locations/locationAttributeType.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/locations/locationAttributeType.jsp
@@ -63,7 +63,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="attributeType.description">
-				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" data-maxlength="1024">${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/locations/locationAttributeType.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/locations/locationAttributeType.jsp
@@ -13,12 +13,6 @@
 			return false;
 		}
 	}
-
-	function forceMaxLength(object, maxLength) {
-		if ( object.value.length >= maxLength) {
-			object.value = object.value.substring(0, maxLength); 
-		}
-	}
 	
 	$j(function() {
 		$j('select[name="datatypeClassname"]').change(function() {
@@ -69,7 +63,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="attributeType.description">
-				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/provider/providerAttributeTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/provider/providerAttributeTypeForm.jsp
@@ -55,7 +55,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="providerAttributeType.description">
-				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" data-maxlength="1024">${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/provider/providerAttributeTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/provider/providerAttributeTypeForm.jsp
@@ -15,12 +15,6 @@
 		}
 	}
 
-	function forceMaxLength(object, maxLength) {
-		if (object.value.length >= maxLength) {
-			object.value = object.value.substring(0, maxLength); 
-		}
-	}
-	
 	$j(function() {
 		$j('select[name="datatypeClassname"]').change(function() {
 			$j('#datatypeDescription').load(openmrsContextPath + '/q/message.form', { key: $j(this).val() + '.description' });
@@ -61,7 +55,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="providerAttributeType.description">
-				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
@@ -54,7 +54,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="visitAttributeType.description">
-				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" data-maxlength="1024">${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitAttributeTypeForm.jsp
@@ -14,12 +14,6 @@
 		}
 	}
 	
-   function forceMaxLength(object, maxLength) {
-      if( object.value.length >= maxLength) {
-         object.value = object.value.substring(0, maxLength); 
-      }
-   }
-   
    $j(function() {
 	  $j('select[name="datatypeClassname"]').change(function() {
 		 $j('#datatypeDescription').load(openmrsContextPath + '/q/message.form', { key: $j(this).val() + '.description' });
@@ -60,7 +54,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="visitAttributeType.description">
-				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitTypeForm.jsp
@@ -41,7 +41,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="visitType.description">
-				<textarea name="description" rows="3" cols="40" onkeypress="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitTypeForm.jsp
+++ b/webapp/src/main/webapp/WEB-INF/view/admin/visits/visitTypeForm.jsp
@@ -41,7 +41,7 @@
 		<td valign="top"><openmrs:message code="general.description"/></td>
 		<td valign="top">
 			<spring:bind path="visitType.description">
-				<textarea name="description" rows="3" cols="40" oninput="return forceMaxLength(this, 1024);" >${status.value}</textarea>
+				<textarea name="description" rows="3" cols="40" data-maxlength="1024">${status.value}</textarea>
 				<c:if test="${status.errorMessage != ''}"><span class="error">${status.errorMessage}</span></c:if>
 			</spring:bind>
 		</td>

--- a/webapp/src/main/webapp/WEB-INF/view/scripts/openmrsmessages.js.withjstl
+++ b/webapp/src/main/webapp/WEB-INF/view/scripts/openmrsmessages.js.withjstl
@@ -48,6 +48,7 @@ omsgs.tabLabelPrefix="<openmrs:message code="Patient.merge.tabLabelPrefix" javaS
 omsgs.conceptSource="<openmrs:message javaScriptEscape="true" code="ConceptReferenceTerm.source"/>";
 omsgs.conceptReferenceTermCode="<openmrs:message javaScriptEscape="true" code="ConceptReferenceTerm.code"/>";
 omsgs.referencTermSearchPlaceholder="<openmrs:message javaScriptEscape="true" code="ConceptReferenceTerm.searchBox.placeholder"/>";
+omsgs.charactersLeft="<openmrs:message javaScriptEscape="true" code="general.charactersLeft"/>";
 
 omsgs.genderArray=new Array();
 <openmrs:forEachRecord name='gender'>

--- a/webapp/src/main/webapp/openmrs.js
+++ b/webapp/src/main/webapp/openmrs.js
@@ -628,7 +628,8 @@ function hideError(errorName) {
  */
 function forceMaxLength(object, maxLength) {
     if( object.value.length >= maxLength) {
-       object.value = object.value.substring(0, maxLength); 
+       object.value = object.value.substring(0, maxLength);
+       return false;
     }
 }
 

--- a/webapp/src/main/webapp/openmrs.js
+++ b/webapp/src/main/webapp/openmrs.js
@@ -621,16 +621,64 @@ function hideError(errorName) {
 }
 
 /**
+ * Initialize all textareas, that have a data-maxlength attribute configuring the maximal
+ * character count for the input. Add listener to validate user input and execute initial
+ * validation for those objects.
+ */
+function initializeForceMaxLength() {
+	jQuery("textarea[data-maxlength]").each(function(i, element) {
+		var updateForceMaxLength = function() {
+			return forceMaxLength(element, jQuery(element).data("maxlength"));
+		};
+		//on input: to get backspace events
+		//on keypress/on paste: to prevent insertion in the middle that will delete content at the end
+		jQuery(element).on("input keypress paste", updateForceMaxLength);
+		updateForceMaxLength(); // initialize once
+	});
+}
+
+/**
  * Forces the length of a field to be a maximum length
  * See view/admin/encounters/encounterTypeForm.jsp for usage example
  * @param object(Required) to be limited.
  * @param maxLength(Required) the length of the limit.
  */
 function forceMaxLength(object, maxLength) {
-    if( object.value.length >= maxLength) {
-       object.value = object.value.substring(0, maxLength);
-       return false;
-    }
+	if (object.value.length >= maxLength) {
+		object.value = object.value.substring(0, maxLength);
+		updateCharactersLeft(object, maxLength, object.value.length);
+		return false;
+	}
+	else{
+		updateCharactersLeft(object, maxLength, object.value.length);
+		return true;
+	}
+}
+
+/**
+ * Update the "characters left" hint for an input field / textarea.
+ * If the hint does not yet exist, it is created. The text is i18n
+ * standardized. The hint is only shown, if half of the allowed/maximal
+ * character count is exceeded.
+ *
+ * @param object the input/textarea input field, that will get a sibling
+ *        element containing the hint
+ * @param maxLength the maximal tolerated character count
+ * @param currentLength the current character count of the objects value
+ */
+function updateCharactersLeft(object, maxLength, currentLength){
+	if (!object.hint) {
+		object.hint = jQuery("<div class=\"tooltip\"></div>").hide();
+		object.hint.insertAfter(jQuery(object));
+	}
+	if (object.value.length >= maxLength * 0.3) {
+		var charactersLeft = maxLength - currentLength;
+		var hintText = omsgs.charactersLeft.replace('{0}', Math.max(charactersLeft, 0));
+		object.hint.text(hintText).show();
+	}
+	else {
+		object.hint.hide();
+	}
 }
 
 /**


### PR DESCRIPTION
We changed the character length limitations on certain textareas (five places had length restrictions in place).
* user input will be rejected when typing although the limit is reached
* if somehow the user provides longer text than allowed, the validator opens the input mask again with error displayed
* while typing into the textarea you get a hint right below the textarea how many characters are left (starting with 30% of the maximal length)
* typing, cut and paste events are covered as well
* english and german i18n message inserted (the others need to be adapted, how do you handle this? create new tickets?)