### PR TITLE
TRUNK-4751 - Change openmrs-core master version to 2.0.0-SNAPSHOT 

### DIFF
--- a/release-test/pom.xml
+++ b/release-test/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.openmrs</groupId>
 		<artifactId>openmrs</artifactId>
-		<version>1.12.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>openmrs-release-test</artifactId>


### PR DESCRIPTION
updated release-test/pom.xml as discussed here : https://issues.openmrs.org/browse/TRUNK-4751