### PR TITLE
TRUNK-4752: User password should be validated before changing it

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -350,6 +350,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	 */
 	@Deprecated
 	public void changePassword(User u, String pw) throws APIException {
+		OpenmrsUtil.validatePassword(u.getUsername(), pw, u.getSystemId());
 		dao.changePassword(u, pw);
 	}
 	
@@ -357,7 +358,9 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	 * @see org.openmrs.api.UserService#changePassword(java.lang.String, java.lang.String)
 	 */
 	public void changePassword(String pw, String pw2) throws APIException {
-		dao.changePassword(pw, pw2);
+		User user = Context.getAuthenticatedUser();
+		
+		changePassword(user, pw, pw2);
 	}
 	
 	/**
@@ -734,6 +737,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 		} else if (!dao.getLoginCredential(user).checkPassword(oldPassword)) {
 			throw new APIException("old.password.not.correct", (Object[]) null);
 		}
+	
 		OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
 		dao.changePassword(user, newPassword);
 	}

--- a/api/src/test/java/org/openmrs/api/impl/UserServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/UserServiceImplTest.java
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.impl;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openmrs.User;
+import org.openmrs.api.InvalidCharactersPasswordException;
+import org.openmrs.api.ShortPasswordException;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseContextSensitiveTest;
+
+public class UserServiceImplTest extends BaseContextSensitiveTest {
+
+	UserService userService;
+	User user;
+	
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+	
+	@Before
+	public void before() {
+		userService = Context.getUserService();
+		user = Context.getAuthenticatedUser();
+	}
+	
+	@Test
+	public void changePassword_shouldThrowShortPasswordExceptionWithShortPassword() throws Exception {
+		thrown.expect(ShortPasswordException.class);
+		thrown.expectMessage("error.password.length");
+
+		userService.changePassword("test", "");
+	}
+
+	@Test
+	public void changePassword_shouldThrowInvalidCharactersPasswordExceptionWithAllDigitPassword() throws Exception {
+		thrown.expect(InvalidCharactersPasswordException.class);
+		thrown.expectMessage("error.password.requireMixedCase");
+		userService.changePassword(user, "12341111111111111111111111");
+	}
+	
+}


### PR DESCRIPTION
Added password validation using OpenmrsUtil.validatePassword() to UserServiceImpl changePassword, methods and also created test cases for every change i made

https://issues.openmrs.org/browse/TRUNK-4752