### PR TITLE
TRUNK-4637 : delete temp jar files related to modules

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -1183,9 +1183,8 @@ public class ModuleUtil {
 		finally {
 			IOUtils.closeQuietly(tempOut);
 			IOUtils.closeQuietly(innerInputStream);
-			if (tempFile != null && !tempFile.delete()) {
-				log.warn("Could not delete temporary jarfile: " + tempFile);
-			}
+
+			// close inner jar file before attempting to delete temporary file
 			try {
 				if (innerJarFile != null) {
 					innerJarFile.close();
@@ -1193,6 +1192,11 @@ public class ModuleUtil {
 			}
 			catch (IOException e) {
 				log.warn("Unable to close inner jarfile: " + innerJarFile, e);
+			}
+
+			// delete temporary file
+			if (tempFile != null && !tempFile.delete()) {
+				log.warn("Could not delete temporary jarfile: " + tempFile);
 			}
 		}
 		return null;

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -108,7 +108,7 @@
              <version>8.1.16.v20140903</version>
              <configuration>
                <webApp>
-               	  <descriptor>${project.build.directory}/jetty/WEB-INF/web.xm</descriptor>
+               	  <descriptor>${project.build.directory}/jetty/WEB-INF/web.xml</descriptor>
                   <contextPath>/${webapp.name}</contextPath>
                   <!--enable reloading static resources -->
                   <overrideDescriptor>src/test/resources/override-web.xml</overrideDescriptor>


### PR DESCRIPTION
Hi Daniel,

I think that consistency in file naming is important, however I understand your concerns :) I will leave the "extensionless"  temporary file as is.

Jason
