### PR TITLE
- Fixed TRUNK-4778

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
@@ -14,6 +14,7 @@
 package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
+import java.text.DecimalFormat;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,7 +46,10 @@ public class LocationEditor extends PropertyEditorSupport {
 		LocationService ls = Context.getLocationService();
 		if (StringUtils.hasText(text)) {
 			try {
-				setValue(ls.getLocation(Integer.valueOf(text)));
+				DecimalFormat df = new DecimalFormat();
+				df.setGroupingUsed(false);
+				Integer id = df.parse(text).intValue();
+				setValue(ls.getLocation(id));
 			}
 			catch (Exception ex) {
 				Location location = ls.getLocationByUuid(text);

--- a/api/src/test/java/org/openmrs/propertyeditor/LocationEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/LocationEditorTest.java
@@ -19,6 +19,17 @@ public class LocationEditorTest extends BaseContextSensitiveTest {
 	
 	/**
 	 * @see LocationEditor#setAsText(String)
+	 * @verifies set using id
+	 */
+	@Test
+	public void setAsText_shouldSetUsingIdWithGrouping() throws Exception {
+		LocationEditor editor = new LocationEditor();
+		editor.setAsText("1,0");
+		Assert.assertNotNull(editor.getValue());
+	}
+	
+	/**
+	 * @see LocationEditor#setAsText(String)
 	 * @verifies set using uuid
 	 */
 	@Test


### PR DESCRIPTION
-  The location Id, when greated than 1000 was beingreceived as grouped Id, like 1,000 causing NumberFormatException. Fixed by handling the Id in string using DecimalFormat with grouping flag
disabled.
- Added test case to reproduce bug reported in TRUNK-4778