### PR TITLE
Added mapping to standard test dataset to demonstrate …

### DIFF
--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -2056,7 +2056,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should return all the concept reference terms if includeRetired is set to true", method = "getConceptReferenceTerms(null)")
 	public void getConceptReferenceTerms_shouldReturnAllTheConceptReferenceTermsIfIncludeRetiredIsSetToTrue()
 	        throws Exception {
-		Assert.assertEquals(11, Context.getConceptService().getConceptReferenceTerms(true).size());
+		Assert.assertEquals(12, Context.getConceptService().getConceptReferenceTerms(true).size());
 	}
 	
 	/**
@@ -2066,7 +2066,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should return only un retired concept reference terms if includeRetired is set to false", method = "getConceptReferenceTerms(null)")
 	public void getConceptReferenceTerms_shouldReturnOnlyUnRetiredConceptReferenceTermsIfIncludeRetiredIsSetToFalse()
 	        throws Exception {
-		Assert.assertEquals(10, Context.getConceptService().getConceptReferenceTerms(false).size());
+		Assert.assertEquals(11, Context.getConceptService().getConceptReferenceTerms(false).size());
 	}
 	
 	/**
@@ -2209,7 +2209,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Test
 	@Verifies(value = "should return all concept reference terms in the database", method = "getAllConceptReferenceTerms()")
 	public void getAllConceptReferenceTerms_shouldReturnAllConceptReferenceTermsInTheDatabase() throws Exception {
-		Assert.assertEquals(11, Context.getConceptService().getAllConceptReferenceTerms().size());
+		Assert.assertEquals(12, Context.getConceptService().getAllConceptReferenceTerms().size());
 	}
 	
 	/**
@@ -2309,7 +2309,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Test
 	@Verifies(value = "should include retired terms if includeRetired is set to true", method = "getCountOfConceptReferenceTerms(String,ConceptSource,null)")
 	public void getCountOfConceptReferenceTerms_shouldIncludeRetiredTermsIfIncludeRetiredIsSetToTrue() throws Exception {
-		Assert.assertEquals(11, conceptService.getCountOfConceptReferenceTerms("", null, true).intValue());
+		Assert.assertEquals(12, conceptService.getCountOfConceptReferenceTerms("", null, true).intValue());
 	}
 	
 	/**
@@ -2318,7 +2318,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Test
 	@Verifies(value = "should not include retired terms if includeRetired is set to false", method = "getCountOfConceptReferenceTerms(String,ConceptSource,null)")
 	public void getCountOfConceptReferenceTerms_shouldNotIncludeRetiredTermsIfIncludeRetiredIsSetToFalse() throws Exception {
-		Assert.assertEquals(10, conceptService.getCountOfConceptReferenceTerms("", null, false).intValue());
+		Assert.assertEquals(11, conceptService.getCountOfConceptReferenceTerms("", null, false).intValue());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -45,12 +45,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
+import org.springframework.validation.FieldError;
 
 /**
  * Tests methods on the {@link DrugOrderValidator} class.
  */
 public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
-	
+
 	@Autowired
 	@Qualifier("adminService")
 	AdministrationService adminService;
@@ -655,8 +656,13 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		order.setDurationUnits(cs.getConcept(28));
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
-		assertEquals("DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode", errors.getFieldError("durationUnits")
-		        .getCode());
+
+		FieldError fieldError = errors.getFieldError("durationUnits");
+		if (fieldError != null) {
+			assertEquals("DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode", fieldError.getCode());
+		} else {
+			Assert.fail("duration unit _is_ mapped to SNOMED Ct duration code");
+		}
 	}
 
 	/**
@@ -707,30 +713,30 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
         order.setConcept(Context.getConceptService().getConcept(88));
         order.setOrderer(Context.getProviderService().getProvider(1));
         order.setDosingType(FreeTextDosingInstructions.class);
-        order.setInstructions("Instructions");
+		order.setInstructions("Instructions");
         order.setDosingInstructions("Test Instruction");
         order.setPatient(patient);
         encounter.setPatient(patient);
         order.setEncounter(encounter);
-        Calendar cal = Calendar.getInstance();
+		Calendar cal = Calendar.getInstance();
         cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
-        order.setDateActivated(cal.getTime());
-        order.setAutoExpireDate(new Date());
-        order.setOrderType(Context.getOrderService().getOrderTypeByName("Drug order"));
-        order.setDrug(Context.getConceptService().getDrug(3));
-        order.setCareSetting(Context.getOrderService().getCareSetting(1));
+		order.setDateActivated(cal.getTime());
+		order.setAutoExpireDate(new Date());
+		order.setOrderType(Context.getOrderService().getOrderTypeByName("Drug order"));
+		order.setDrug(Context.getConceptService().getDrug(3));
+		order.setCareSetting(Context.getOrderService().getCareSetting(1));
         order.setQuantity(2.00);
-        order.setQuantityUnits(Context.getConceptService().getConcept(51));
+		order.setQuantityUnits(Context.getConceptService().getConcept(51));
         order.setNumRefills(10);
 
         order
-                .setAsNeededCondition("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
-        order
-                .setBrandName("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
+				.setAsNeededCondition("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
+		order
+				.setBrandName("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
 
         Errors errors = new BindException(order, "order");
         new DrugOrderValidator().validate(order, errors);
-        Assert.assertTrue(errors.hasFieldErrors("asNeededCondition"));
+		Assert.assertTrue(errors.hasFieldErrors("asNeededCondition"));
         Assert.assertTrue(errors.hasFieldErrors("brandName"));
     }
 

--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -117,6 +117,7 @@
   <concept_reference_term concept_reference_term_id="9" concept_source_id="1" code="127cd4689" name="cd4died term2" description="died" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-127689_3"/>
   <concept_reference_term concept_reference_term_id="10" concept_source_id="1" code="454545" name="no term name3" description="" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-454545"/>
   <concept_reference_term concept_reference_term_id="11" concept_source_id="1" code="retired code" name="retired name" description="test duplicate term that is retired" retired="1" retired_by="1" retire_reason="test reason" date_retired="2004-08-12 12:00:00" creator="1" date_created="2004-08-12 00:00:00.0" uuid="SSTRM-retired code"/>
+  <concept_reference_term concept_reference_term_id="12" concept_source_id="2" code="258703001" name="day" description="Non-SI unit of time" retired="0" creator="1" date_created="2002-01-31 00:00:00.0" uuid="SNOMED CT-258703001"/>
   <concept_map_type concept_map_type_id="1" name="is a" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="1ce7a784-7d8f-11e1-909d-c80aa9edcf4e"/>
   <concept_map_type concept_map_type_id="2" name="same-as" description="Indicates similarity" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="35543629-7d8c-11e1-909d-c80aa9edcf4e"/>
   <concept_map_type concept_map_type_id="3" name="broader-than" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="4b9d9421-7d8c-11e1-909d-c80aa9edcf4e"/>
@@ -135,6 +136,11 @@
   <concept_reference_map concept_map_id="8" concept_id="24" concept_reference_term_id="8" concept_map_type_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="ac10cce0-49d8-11e0-8fed-18a905e044dc"/>
   <concept_reference_map concept_map_id="9" concept_id="16" concept_reference_term_id="9" concept_map_type_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="b61bc708-49d8-11e0-8fed-18a905e044dc"/>
   <concept_reference_map concept_map_id="10" concept_id="24" concept_reference_term_id="10" concept_map_type_id="6" creator="1" date_created="2004-08-12 00:00:00.0" uuid="beafba1e-49d8-11e0-8fed-18a905e044dc"/>
+
+  <!-- https://issues.openmrs.org/browse/TRUNK-4575, uncomment to demonstrate that this mapping breaks org.openmrs.validator.DrugOrderValidatorTest
+  <concept_reference_map concept_map_id="11" concept_id="28" concept_reference_term_id="12" concept_map_type_id="2" creator="1" date_created="2015-11-08 00:00:00.0" uuid="A8E1C22C-CB3B-4E77-AD2E-EA68F65397A3"/>
+  -->
+
   <concept_reference_term_map concept_reference_term_map_id="1" term_a_id="1" term_b_id="2" a_is_to_b_id="4" creator="1" date_created="2004-08-12 00:00:00.0" uuid="dff198e4-562d-11e0-b169-18a905e044dc"/>
   <concept_reference_term_map concept_reference_term_map_id="2" term_a_id="1" term_b_id="4" a_is_to_b_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="f7edaa46-562d-11e0-b169-18a905e044dc"/>
   <concept_reference_term_map concept_reference_term_map_id="3" term_a_id="2" term_b_id="4" a_is_to_b_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="756c5a64-d36d-11e0-a71a-00248140a5eb"/>


### PR DESCRIPTION
… that this breaks an existing test. The mapping is commented and needs to be uncommented to see the test fail. 

Step 1: Uncomment line 141 in standardTestDataSet.xml
Step 2: Run org.openmrs.validator.DrugOrderValidatorTest#validate_shouldFailIfDurationUnitsHasNoMappingToSNOMEDCTSource(). 

The purpose of this test is to ensure that missing mappings are handled correctly. The tests expects an error that no longer occurs after the mapping has been added to the test data set.
