### PR TITLE
Fix three critical issues on OpenMRS sonarqube

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -193,8 +193,8 @@ public class ModuleFactory {
 		
 		//inform modules, that they can't start before other modules
 		Map<String, Module> loadedModulesMap = getLoadedModulesMapPackage();
-		for (String key : loadedModules.keySet()) {
-			Module m = loadedModules.get(key);
+		for (Entry<String, Module> entry : loadedModules.entrySet()) {
+			Module m = entry.getValue();
 			Map<String, String> startBeforeModules = m.getStartBeforeModulesMap();
 			if (startBeforeModules.size() > 0) {
 				for (String s : startBeforeModules.keySet()) {
@@ -469,8 +469,8 @@ public class ModuleFactory {
 		}
 		
 		Map<String, Module> map = new WeakHashMap<String, Module>();
-		for (String key : loadedModules.keySet()) {
-			map.put(loadedModules.get(key).getPackageName(), loadedModules.get(key));
+		for (Entry<String, Module> entry : loadedModules.entrySet()) {
+			map.put(entry.getValue().getPackageName(), entry.getValue());
 		}
 		return map;
 	}
@@ -1169,10 +1169,6 @@ public class ModuleFactory {
 						String extId = ext.getExtensionId();
 						try {
 							List<Extension> tmpExtensions = getExtensions(extId);
-							if (tmpExtensions == null) {
-								tmpExtensions = new Vector<Extension>();
-							}
-							
 							tmpExtensions.remove(ext);
 							getExtensionMap().put(extId, tmpExtensions);
 						}

--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -413,7 +413,7 @@ public class DatabaseUpdater {
 		
 		// hack for mysql to make sure innodb tables are created
 		if (url.contains("mysql") && !url.contains("InnoDB")) {
-			url = url + "&sessionVariables=storage_engine=InnoDB";
+			url = url + "&sessionVariables=default_storage_engine=InnoDB";
 		}
 		
 		Class.forName(driver);

--- a/api/src/main/java/org/openmrs/util/HandlerUtil.java
+++ b/api/src/main/java/org/openmrs/util/HandlerUtil.java
@@ -169,6 +169,8 @@ public class HandlerUtil implements ApplicationListener<ContextRefreshedEvent> {
 	 * @should return the preferred handler for the passed handlerType and type
 	 * @should throw a APIException if no handler is found
 	 * @should throw a APIException if multiple preferred handlers are found
+	 * @should should return patient validator for patient
+	 * @should should return person validator for person
 	 */
 	public static <H, T> H getPreferredHandler(Class<H> handlerType, Class<T> type) {
 		

--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -23,7 +23,7 @@ import org.springframework.validation.ValidationUtils;
 /**
  * This class validates a Patient object.
  */
-@Handler(supports = { Patient.class }, order = 50)
+@Handler(supports = { Patient.class }, order = 25)
 public class PatientValidator extends PersonValidator {
 	
 	private static Log log = LogFactory.getLog(PersonNameValidator.class);

--- a/api/src/test/java/org/openmrs/util/HandlerUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/HandlerUtilTest.java
@@ -9,25 +9,37 @@
  */
 package org.openmrs.util;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.util.List;
+import java.util.regex.Matcher;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openmrs.DrugOrder;
 import org.openmrs.Order;
 import org.openmrs.Patient;
+import org.openmrs.Person;
 import org.openmrs.api.APIException;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.validator.DrugOrderValidator;
 import org.openmrs.validator.OrderValidator;
 import org.openmrs.validator.PatientValidator;
+import org.openmrs.validator.PersonValidator;
 import org.springframework.validation.Validator;
 
 /**
  * Tests the methods in {@link HandlerUtil}
  */
 public class HandlerUtilTest extends BaseContextSensitiveTest {
+	
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 	
 	/**
 	 * @see HandlerUtil#getHandlerForType(Class, Class)
@@ -41,7 +53,7 @@ public class HandlerUtilTest extends BaseContextSensitiveTest {
 		l = HandlerUtil.getHandlersForType(Validator.class, DrugOrder.class);
 		Assert.assertEquals(2, l.size());
 	}
-	
+
 	/**
 	 * @see HandlerUtil#getHandlerForType(Class, Class)
 	 */
@@ -66,9 +78,28 @@ public class HandlerUtilTest extends BaseContextSensitiveTest {
 	/**
 	 * @see HandlerUtil#getPreferredHandler(Class, Class)
 	 */
-	@Test(expected = APIException.class)
+	@Test
 	@Verifies(value = "should throw a APIException if no handler is found", method = "getPreferredHandler(Class, Class)")
 	public void getPreferredHandler_shouldThrowAAPIExceptionExceptionIfNoHandlerIsFound() throws Exception {
-		HandlerUtil.getPreferredHandler(Validator.class, Patient.class);
+		thrown.expect(APIException.class);
+		thrown.expectMessage("handler.type.not.found");
+		
+		HandlerUtil.getPreferredHandler(Validator.class, Integer.class);
+	}
+	
+	@Test
+	@Verifies(value = "should return patient validator for patient", method = "getPreferredHandler(Class, Class)")
+	public void getPreferredHandler_shouldReturnPatientValidatorForPatient() throws Exception {
+		Validator handler = HandlerUtil.getPreferredHandler(Validator.class, Patient.class);
+		
+		assertThat(handler, is(instanceOf(PatientValidator.class)));
+	}
+	
+	@Test
+	@Verifies(value = "should return person validator for person", method = "getPreferredHandler(Class, Class)")
+	public void getPreferredHandler_shouldReturnPersonValidatorForPerson() throws Exception {
+		Validator handler = HandlerUtil.getPreferredHandler(Validator.class, Person.class);
+		
+		assertThat(handler, is(instanceOf(PersonValidator.class)));
 	}
 }

--- a/release-test/src/main/java/org/openmrs/TestUtils.java
+++ b/release-test/src/main/java/org/openmrs/TestUtils.java
@@ -13,7 +13,7 @@ public class TestUtils {
     public static String prepareJdbcConnectionUrl(String port, String databaseName) {
         return "jdbc:mysql://localhost:" + port + "/"+databaseName+"?"
                 + "autoReconnect=true"
-                + "&sessionVariables=storage_engine=InnoDB"
+                + "&sessionVariables=default_storage_engine=InnoDB"
                 + "&useUnicode=true&characterEncoding=UTF-8"
                 + "&server.basedir=target/database&server.datadir=target/database/data"
                 + "&server.collation-server=utf8_general_ci&server.character-set-server=utf8";

--- a/release-test/src/main/java/org/openmrs/steps/InstallationWizardSteps.java
+++ b/release-test/src/main/java/org/openmrs/steps/InstallationWizardSteps.java
@@ -75,7 +75,7 @@ public class InstallationWizardSteps extends Steps {
     	String port = System.getProperty(portProp, "3336");
 
         type("jdbc:mysql://localhost:" + port + "/@DBNAME@?"
-                + "autoReconnect=true&sessionVariables=storage_engine=InnoDB"
+                + "autoReconnect=true&sessionVariables=default_storage_engine=InnoDB"
                 + "&useUnicode=true&characterEncoding=UTF-8&server.initialize-user=true"
                 + "&createDatabaseIfNotExist=true&server.basedir=target/database&server.datadir=target/database/data"
                 + "&server.collation-server=utf8_general_ci&server.character-set-server=utf8",

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
@@ -100,7 +100,7 @@ public class InitializationWizardModel {
 	/**
 	 * Filled out by user on the databasesetup.vm page Looks like:
 	 */
-	public String databaseConnection = "jdbc:mysql://localhost:3306/@DBNAME@?autoReconnect=true&sessionVariables=storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8";
+	public String databaseConnection = "jdbc:mysql://localhost:3306/@DBNAME@?autoReconnect=true&sessionVariables=default_storage_engine=InnoDB&useUnicode=true&characterEncoding=UTF-8";
 	
 	/**
 	 * Optional Database Driver string filled in on databasesetup.vm

--- a/webapp/src/main/webapp/index.htm
+++ b/webapp/src/main/webapp/index.htm
@@ -38,7 +38,11 @@
         	<td width="100px"><div class="logo"></div></td>
         	<td>
             	<div class="bar-round">
-        			<div class="bar">OpenMRS Platform ${project.version}.${revisionNumber} Running!</div>
+        			<div class="bar">
+        				<h3>OpenMRS Platform ${project.version}.${revisionNumber} Running! </h3>
+        				<p>If you are seeing this page, it means that the OpenMRS Platform is running successfully, but no user interface module is installed. To learn about the available user interfaces, see [<a href="https://wiki.openmrs.org/display/docs/Administering+Modules">https://wiki.openmrs.org/display/docs/Administering+Module/</a>]</p>
+        				<p>If you are a developer, you can access the REST API. [<a href="https://wiki.openmrs.org/display/docs/REST+Module">https://wiki.openmrs.org/display/docs/REST+Module</a>]</p>
+        			</div>
         		</div>
             </td>
         </tr>


### PR DESCRIPTION
Selected critical issues
org.openmrs.module.ModuleFactory.loadModules(List) makes inefficient use of keySet iterator instead of entrySet iterator.
org.openmrs.module.ModuleFactory.getLoadedModulesMapPackage() makes inefficient use of keySet iterator instead of entrySet iterator.
Redundant nullcheck of tmpExtensions, which is known to be not-null. org.openmrs.module.ModuleFactory.stopModule(Module, boolean, boolean)