### PR TITLE
TRUNK-4798: Resolving error in HibernateContextDAO.authenticate

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -176,7 +176,7 @@ public class HibernateContextDAO implements ContextDAO {
 				
 				try {
 					allowedFailedLoginCount = Integer.valueOf(Context.getAdministrationService().getGlobalProperty(
-					    OpenmrsConstants.GP_ALLOWED_FAILED_LOGINS_BEFORE_LOCKOUT).trim());
+					    OpenmrsConstants.GP_ALLOWED_FAILED_LOGINS_BEFORE_LOCKOUT, String.valueOf(allowedFailedLoginCount)).trim());
 				}
 				catch (Exception ex) {
 					log.error("Unable to convert the global property "


### PR DESCRIPTION
This set default value in case that GP_ALLOWED_FAILED_LOGINS_BEFORE_LOCKOUT is null which caused the error.