### PR TITLE
Override "equals(Object obj)" to comply with the contract of the "compareTo(T o)" method.

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptDatatype.java
+++ b/api/src/main/java/org/openmrs/ConceptDatatype.java
@@ -10,7 +10,6 @@
 package org.openmrs;
 
 import org.hibernate.search.annotations.DocumentId;
-import org.hibernate.search.annotations.Indexed;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Root;
 

--- a/api/src/main/java/org/openmrs/FormField.java
+++ b/api/src/main/java/org/openmrs/FormField.java
@@ -250,9 +250,72 @@ public class FormField extends BaseOpenmrsMetadata implements java.io.Serializab
 	}
 	
 	public int compareTo(FormField other) {
-		DefaultComparator pnDefaultComparator = new DefaultComparator();
-		return pnDefaultComparator.compare(this, other);
+	if (this.getSortWeight() != null || other.getSortWeight() != null) {
+		if (this.getSortWeight() == null) {
+			return -1;
+		}
+		if (other.getSortWeight() == null) {
+			return 1;
+		}
+		int c = this.getSortWeight().compareTo(other.getSortWeight());
+		if (c != 0) {
+			return c;
+		}
 	}
+	if (this.getPageNumber() != null || other.getPageNumber() != null) {
+		if (this.getPageNumber() == null) {
+			return -1;
+		}
+		if (other.getPageNumber() == null) {
+			return 1;
+		}
+		int c = this.getPageNumber().compareTo(other.getPageNumber());
+		if (c != 0) {
+			return c;
+		}
+	}
+	if (this.getFieldNumber() != null || other.getFieldNumber() != null) {
+		if (this.getFieldNumber() == null) {
+			return -1;
+		}
+		if (other.getFieldNumber() == null) {
+			return 1;
+		}
+		int c = this.getFieldNumber().compareTo(other.getFieldNumber());
+		if (c != 0) {	
+			return c;
+		}
+	}
+	if (this.getFieldPart() != null || other.getFieldPart() != null) {
+		if (this.getFieldPart() == null) {
+			return -1;
+		}
+		if (other.getFieldPart() == null) {
+			return 1;
+		}
+		int c = this.getFieldPart().compareTo(other.getFieldPart());
+		if (c != 0) {
+			return c;
+		}
+	}
+	if (this.getField() != null && other.getField() != null) {
+		int c = this.getField().getName().compareTo(other.getField().getName());
+		if (c != 0) {
+			return c;
+		}
+	}
+	if (this.getFormFieldId() == null && other.getFormFieldId() != null) {
+		return -1;
+	}
+	if (this.getFormFieldId() != null && other.getFormFieldId() == null) {
+		return 1;
+	}
+	if (this.getFormFieldId() == null && other.getFormFieldId() == null) {
+		return 1;
+	}
+			
+	return this.getFormFieldId().compareTo(other.getFormFieldId());
+ 	}
 	
 	/**
 	 Provides a default comparator.

--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
-import org.openmrs.api.APIException;
 
 /**
  * Defines a Patient in the system. A patient is simply an extension of a person and all that that

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -300,8 +300,24 @@ public class PersonAttribute extends BaseOpenmrsData implements java.io.Serializ
 	 * Note: this comparator imposes orderings that are inconsistent with equals
 	 */
 	public int compareTo(PersonAttribute other) {
-		DefaultComparator paDComparator = new DefaultComparator();
-		return paDComparator.compare(this, other);
+	int retValue;
+	if ((retValue = OpenmrsUtil.compareWithNullAsGreatest(this.getAttributeType(), other.getAttributeType())) != 0) {
+		return retValue;
+	}
+
+	if ((retValue = this.isVoided().compareTo(other.isVoided())) != 0) {
+		return retValue;
+	}
+			
+	if ((retValue = OpenmrsUtil.compareWithNullAsLatest(this.getDateCreated(), other.getDateCreated())) != 0) {
+		return retValue;
+	}
+			
+	if ((retValue = OpenmrsUtil.compareWithNullAsGreatest(this.getValue(), other.getValue())) != 0) {
+		return retValue;
+	}
+			
+	return OpenmrsUtil.compareWithNullAsGreatest(this.getPersonAttributeId(), other.getPersonAttributeId());
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -525,10 +525,6 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	}
 	
 	/**
-	 * TODO: the behavior of this method needs to be controlled by some sort of global property
-	 * because an implementation can define how they want their names to look (which fields to
-	 * show/hide)
-	 * 
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 * @should return negative if other name is voided
 	 * @should return negative if this name is preferred
@@ -542,8 +538,40 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
 	public int compareTo(PersonName other) {
-		DefaultComparator pnDefaultComparator = new DefaultComparator();
-		return pnDefaultComparator.compare(this, other);
+		int ret = this.isVoided().compareTo(other.isVoided());
+		if (ret == 0) {
+			ret = other.isPreferred().compareTo(this.isPreferred());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getFamilyName(), other.getFamilyName());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getFamilyName2(), other.getFamilyName2());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getGivenName(), other.getGivenName());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getMiddleName(), other.getMiddleName());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getFamilyNamePrefix(), other.getFamilyNamePrefix());
+		}
+		if (ret == 0) {
+			ret = OpenmrsUtil.compareWithNullAsGreatest(this.getFamilyNameSuffix(), other.getFamilyNameSuffix());
+		}
+		if (ret == 0 && this.getDateCreated() != null) {
+			ret = OpenmrsUtil.compareWithNullAsLatest(this.getDateCreated(), other.getDateCreated());
+		}
+			
+		// if we've gotten this far, just check all name values. If they are
+		// equal, leave the objects at 0. If not, arbitrarily pick retValue=1
+		// and return that (they are not equal).
+		if (ret == 0 && !this.equalsContent(other)) {
+			ret = 1;
+		}
+			
+		return ret;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
@@ -34,7 +34,6 @@ import org.openmrs.util.OpenmrsConstants;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.orm.hibernate3.LocalSessionFactoryBean;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -10,7 +10,6 @@
 package org.openmrs.api.db.hibernate;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -38,9 +37,7 @@ import org.openmrs.Form;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifierType;
-import org.openmrs.Provider;
 import org.openmrs.Visit;
-import org.openmrs.VisitType;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateNoteDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateNoteDAO.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.api.db.hibernate;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.logging.Log;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -39,7 +39,6 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.PatientDAO;
 
-import org.openmrs.api.APIException;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;
 

--- a/api/src/main/java/org/openmrs/notification/AlertService.java
+++ b/api/src/main/java/org/openmrs/notification/AlertService.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.notification;
 
-import java.util.Collection;
 import java.util.List;
 
 import org.openmrs.User;

--- a/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.scheduler;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;

--- a/api/src/main/java/org/openmrs/scheduler/TaskDefinition.java
+++ b/api/src/main/java/org/openmrs/scheduler/TaskDefinition.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.BaseOpenmrsMetadata;
-import org.openmrs.User;
 
 /**
  * Represents the metadata for a task that can be scheduled.

--- a/api/src/main/java/org/openmrs/util/Format.java
+++ b/api/src/main/java/org/openmrs/util/Format.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.util;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.Date;

--- a/api/src/main/java/org/openmrs/util/Reflect.java
+++ b/api/src/main/java/org/openmrs/util/Reflect.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.azeckoski.reflectutils.ClassData;
 import org.azeckoski.reflectutils.ClassDataCacher;
 import org.azeckoski.reflectutils.ClassFields;
 import org.azeckoski.reflectutils.exceptions.FieldnameNotFoundException;

--- a/api/src/main/java/org/openmrs/util/databasechange/MigrateAllergiesChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MigrateAllergiesChangeSet.java
@@ -23,7 +23,6 @@ import liquibase.exception.ValidationErrors;
 import liquibase.resource.ResourceAccessor;
 
 import org.openmrs.Concept;
-import org.openmrs.Allergy;
 import org.openmrs.AllergySeverity;
 import org.openmrs.api.context.Context;
 

--- a/api/src/main/java/org/openmrs/validator/UserValidator.java
+++ b/api/src/main/java/org/openmrs/validator/UserValidator.java
@@ -25,7 +25,6 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
-import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
 
 /**

--- a/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.web.filter.startuperror;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.logging.Log;


### PR DESCRIPTION
There were no references to equals in classes as inferred here: https://ci.openmrs.org/sonar/drilldown/issues/1865?&rule=squid%3AS1210&rule_sev=CRITICAL