### PR TITLE
Fix for TRUNK-3920

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -51,7 +51,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.Module;
-import org.openmrs.module.ModuleConstants;
 import org.openmrs.module.ModuleException;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleUtil;
@@ -417,28 +416,14 @@ public class WebModuleUtil {
 			if (log.isDebugEnabled()) {
 				log.debug("Copying message property file: " + localeEntry.getKey());
 			}
-			
+
 			Properties props = localeEntry.getValue();
-			
-			if (!"true".equalsIgnoreCase(props
-			        .getProperty(ModuleConstants.MESSAGE_PROPERTY_ALLOW_KEYS_OUTSIDE_OF_MODULE_NAMESPACE))) {
-				// set all properties to start with 'moduleName.' if not already
-				List<Object> keys = new Vector<Object>();
-				keys.addAll(props.keySet());
-				for (Object obj : keys) {
-					String key = (String) obj;
-					if (!key.startsWith(mod.getModuleId())) {
-						props.put(mod.getModuleId() + "." + key, props.get(key));
-						props.remove(key);
-					}
-				}
-			}
-			
+
 			String lang = "_" + localeEntry.getKey();
 			if (lang.equals("_en") || lang.equals("_")) {
 				lang = "";
 			}
-			
+
 			insertIntoModuleMessagePropertiesFile(realPath, props, lang);
 		}
 	}

--- a/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
+++ b/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
@@ -177,22 +177,21 @@ public class WebModuleUtilTest {
 		
 		ModuleFactory.getStartedModulesMap().clear();
 	}
-	
+
 	/**
 	 * @see WebModuleUtil#copyModuleMessagesIntoWebapp(org.openmrs.module.Module, String)
 	 * @verifies prefix messages with module id
 	 */
 	@Test
-	public void copyModuleMessagesIntoWebapp_shouldPrefixMessagesWithModuleId() throws Exception {
+	public void copyModuleMessagesIntoWebapp_shouldNotPrefixMessagesWithModuleId() throws Exception {
 		Module mod = buildModuleForMessageTest();
 		partialMockWebModuleUtilForMessagesTests();
 		WebModuleUtil.copyModuleMessagesIntoWebapp(mod, "unused/real/path");
-		
-		assertThat(propertiesWritten.getProperty("mymodule.title"), is("My Module"));
-		assertThat(propertiesWritten.getProperty("mymodule.withoutPrefix"), is("Without prefix"));
-		assertNull(propertiesWritten.getProperty("withoutPrefix"));
+
+		assertThat(propertiesWritten.getProperty("withoutPrefix"), is("Without prefix"));
+		assertNull(propertiesWritten.getProperty("mymodule.withoutPrefix"));
 	}
-	
+
 	/**
 	 * @see WebModuleUtil#copyModuleMessagesIntoWebapp(org.openmrs.module.Module, String)
 	 * @verifies not prefix messages with module id if override setting is specified
@@ -207,7 +206,6 @@ public class WebModuleUtilTest {
 		partialMockWebModuleUtilForMessagesTests();
 		WebModuleUtil.copyModuleMessagesIntoWebapp(mod, "unused/real/path");
 		
-		assertThat(propertiesWritten.getProperty("mymodule.title"), is("My Module"));
 		assertThat(propertiesWritten.getProperty("withoutPrefix"), is("Without prefix"));
 		assertNull(propertiesWritten.getProperty("mymodule.withoutPrefix"));
 	}
@@ -229,7 +227,6 @@ public class WebModuleUtilTest {
 	
 	private Module buildModuleForMessageTest() throws ParserConfigurationException {
 		Properties englishMessages = new Properties();
-		englishMessages.put("mymodule.title", "My Module");
 		englishMessages.put("withoutPrefix", "Without prefix");
 		
 		Module mod = new Module("My Module");


### PR DESCRIPTION
Stopped automatically preprending moduleId to the start of message properties