### PR TITLE
TRUNK-2205: Jackson JSON cannot handle BaseOpenmrsObject

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -9,11 +9,13 @@
  */
 package org.openmrs;
 
+import java.util.Date;
+
 import javax.persistence.Column;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 
-import java.util.Date;
+import org.codehaus.jackson.annotate.JsonIgnore;
 
 /**
  * In OpenMRS, we distinguish between data and metadata within our data model. Data (as opposed to
@@ -121,10 +123,14 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	}
 	
 	/**
+	 * @deprecated as of 2.0, use {@link #getVoided()}
+	 * 
 	 * @see org.openmrs.Voidable#isVoided()
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isVoided() {
-		return voided;
+		return getVoided();
 	}
 	
 	/**
@@ -135,7 +141,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.Voidable#isVoided()
 	 */
 	public Boolean getVoided() {
-		return isVoided();
+		return voided;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
@@ -11,11 +11,12 @@ package org.openmrs;
 
 import java.util.Date;
 
-import org.hibernate.search.annotations.Field;
-
 import javax.persistence.Column;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.hibernate.search.annotations.Field;
 
 /**
  * In OpenMRS, we distinguish between data and metadata within our data model. Metadata represent
@@ -160,10 +161,14 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	}
 	
 	/**
+	 * @deprecated as of 2.0, use {@link #getRetired()}
+	 * 
 	 * @see org.openmrs.Retireable#isRetired()
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isRetired() {
-		return retired;
+		return getRetired();
 	}
 	
 	/**
@@ -174,7 +179,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @see org.openmrs.Retireable#isRetired()
 	 */
 	public Boolean getRetired() {
-		return isRetired();
+		return retired;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -26,6 +26,7 @@ import java.util.Vector;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.ContainedIn;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
@@ -259,9 +260,13 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	
 	/**
 	 * whether or not this concept is a set
+	 * 
+	 * @deprecated as of 2.0, use {@link #getSet()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isSet() {
-		return set;
+		return getSet();
 	}
 	
 	/**
@@ -272,7 +277,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	}
 	
 	public Boolean getSet() {
-		return isSet();
+		return set;
 	}
 	
 	/**
@@ -1252,9 +1257,13 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	
 	/**
 	 * @return Returns the retired.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getRetired()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isRetired() {
-		return retired;
+		return getRetired();
 	}
 	
 	/**
@@ -1265,7 +1274,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @see org.openmrs.Retireable#isRetired()
 	 */
 	public Boolean getRetired() {
-		return isRetired();
+		return retired;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptMapType.java
+++ b/api/src/main/java/org/openmrs/ConceptMapType.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * ConceptMapType are used to define relationships between concepts and concept reference terms e.g
  * IS_A or SAME_AS, BROADER_THAN
@@ -91,8 +93,12 @@ public class ConceptMapType extends BaseOpenmrsMetadata implements java.io.Seria
 	 * Returns true if this concept map type is hidden otherwise false
 	 *
 	 * @return true if this concept map type is hidden otherwise false
+	 *
+	 * @deprecated as of 2.0, use {@link #getIsHidden()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public boolean isHidden() {
-		return isHidden;
+		return getIsHidden();
 	}
 }

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.standard.StandardFilterFactory;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.AnalyzerDef;
@@ -173,9 +174,13 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * Returns whether the ConceptName has been voided.
 	 *
 	 * @return true if the ConceptName has been voided, false otherwise.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getVoided()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isVoided() {
-		return voided;
+		return getVoided();
 	}
 	
 	/**
@@ -184,7 +189,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @return true if the ConceptName has been voided, false otherwise.
 	 */
 	public Boolean getVoided() {
-		return isVoided();
+		return voided;
 	}
 	
 	/**
@@ -289,9 +294,13 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * Getter for localePreferred
 	 *
 	 * @return localPreferred
+	 * 
+	 * @deprecated as of 2.0, use {@link #getLocalePreferred()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isLocalePreferred() {
-		return localePreferred;
+		return getLocalePreferred();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptNameTag.java
+++ b/api/src/main/java/org/openmrs/ConceptNameTag.java
@@ -11,6 +11,8 @@ package org.openmrs;
 
 import java.util.Date;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * ConceptNameTag is a textual tag which can be applied to a ConceptName.
  */
@@ -126,9 +128,13 @@ public class ConceptNameTag extends BaseOpenmrsObject implements Auditable, Void
 	 * Returns whether the ConceptName has been voided.
 	 * 
 	 * @return true if the ConceptName has been voided, false otherwise.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getVoided()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isVoided() {
-		return voided;
+		return getVoided();
 	}
 	
 	/**
@@ -137,7 +143,7 @@ public class ConceptNameTag extends BaseOpenmrsObject implements Auditable, Void
 	 * @return true if the ConceptName has been voided, false otherwise.
 	 */
 	public Boolean getVoided() {
-		return isVoided();
+		return voided;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptNumeric.java
+++ b/api/src/main/java/org/openmrs/ConceptNumeric.java
@@ -12,6 +12,7 @@ package org.openmrs;
 import java.util.HashSet;
 import java.util.TreeSet;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.Indexed;
 
 /**
@@ -210,14 +211,19 @@ public class ConceptNumeric extends Concept implements java.io.Serializable {
 	}
 	
 	public Boolean getAllowDecimal() {
-		return isAllowDecimal();
+		return allowDecimal == null ? false : allowDecimal;
 	}
 	
 	public void setAllowDecimal(Boolean allowDecimal) {
 		this.allowDecimal = allowDecimal;
 	}
 	
+	/**
+	 * @deprecated as of 2.0, use {@link #getAllowDecimal()}
+	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isAllowDecimal() {
-		return allowDecimal == null ? false : allowDecimal;
+		return getAllowDecimal();
 	}
 }

--- a/api/src/main/java/org/openmrs/Drug.java
+++ b/api/src/main/java/org/openmrs/Drug.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
@@ -106,13 +107,17 @@ public class Drug extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * Gets whether or not this is a combination drug
 	 *
 	 * @return Boolean
+	 * 
+	 * @deprecated as of 2.0, use {@link #getCombination()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isCombination() {
-		return this.combination;
+		return getCombination();
 	}
 	
 	public Boolean getCombination() {
-		return isCombination();
+		return combination;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Field.java
+++ b/api/src/main/java/org/openmrs/Field.java
@@ -12,6 +12,8 @@ package org.openmrs;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * Field
  *
@@ -137,15 +139,20 @@ public class Field extends BaseOpenmrsMetadata implements java.io.Serializable {
 		this.defaultValue = defaultValue;
 	}
 	
+	/**
+	 * @deprecated as of 2.0, use {@link #getSelectMultiple()}
+	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isSelectMultiple() {
-		return selectMultiple;
+		return getSelectMultiple();
 	}
 	
 	/**
 	 * @return Returns the selectMultiple.
 	 */
 	public Boolean getSelectMultiple() {
-		return isSelectMultiple();
+		return selectMultiple;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/FieldAnswer.java
+++ b/api/src/main/java/org/openmrs/FieldAnswer.java
@@ -11,6 +11,8 @@ package org.openmrs;
 
 import java.util.Date;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * FieldAnswer
  * 
@@ -40,8 +42,19 @@ public class FieldAnswer extends BaseOpenmrsObject implements java.io.Serializab
 	
 	/**
 	 * @return boolean whether or not this fieldAnswer has been modified
+	 *
+	 * @deprecated as of 2.0, use {@link #getDirty()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public boolean isDirty() {
+		return getDirty();
+	}
+	
+	/**
+	 * @return boolean whether or not this fieldAnswer has been modified
+	 */
+	public boolean getDirty() {
 		return dirty;
 	}
 	

--- a/api/src/main/java/org/openmrs/FormField.java
+++ b/api/src/main/java/org/openmrs/FormField.java
@@ -11,6 +11,8 @@ package org.openmrs;
 
 import java.util.Comparator;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * The FormField object relates/orders the <code>fields</code> on a <code>form</code> A form can
  * have many 0 to n fields associated with it in a hierarchical manor. This FormField object governs
@@ -188,16 +190,20 @@ public class FormField extends BaseOpenmrsMetadata implements java.io.Serializab
 	
 	/**
 	 * @return Returns the required status.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getRequired()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isRequired() {
-		return required == null ? false : required;
+		return getRequired();
 	}
 	
 	/**
 	 * @return same as isRequired()
 	 */
 	public Boolean getRequired() {
-		return isRequired();
+		return required == null ? false : required;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/FormResource.java
+++ b/api/src/main/java/org/openmrs/FormResource.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.customdatatype.CustomDatatypeUtil;
 import org.openmrs.customdatatype.CustomValueDescriptor;
 import org.openmrs.customdatatype.InvalidCustomValueException;
@@ -248,10 +249,17 @@ public class FormResource extends BaseOpenmrsObject implements CustomValueDescri
 	
 	/**
 	 * @see org.openmrs.customdatatype.SingleCustomValue#isDirty()
+	 *
+	 * @deprecated as of 2.0, use {@link #getDirty()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	@Override
 	public boolean isDirty() {
-		return dirty;
+		return getDirty();
 	}
 	
+	public boolean getDirty() {
+		return dirty;
+	}
 }

--- a/api/src/main/java/org/openmrs/GlobalProperty.java
+++ b/api/src/main/java/org/openmrs/GlobalProperty.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.CustomDatatypeUtil;
 import org.openmrs.customdatatype.CustomValueDescriptor;
@@ -285,10 +286,17 @@ public class GlobalProperty extends BaseOpenmrsObject implements CustomValueDesc
 	
 	/**
 	 * @see org.openmrs.customdatatype.SingleCustomValue#isDirty()
+	 *
+	 * @deprecated as of 2.0, use {@link #getDirty()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	@Override
 	public boolean isDirty() {
-		return dirty;
+		return getDirty();
 	}
 	
+	public boolean getDirty() {
+		return dirty;
+	}
 }

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -15,6 +15,7 @@ import java.util.Comparator;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
 
 /**
@@ -177,7 +178,7 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 	 * @return Returns the preferred.
 	 */
 	public Boolean getPreferred() {
-		return isPreferred();
+		return preferred;
 	}
 	
 	/**
@@ -189,9 +190,13 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 	
 	/**
 	 * @return the preferred status
+	 * 
+	 * @deprecated as of 2.0, use {@link #getPreferred()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isPreferred() {
-		return preferred;
+		return getPreferred();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -22,6 +22,7 @@ import java.util.Vector;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.StringUtils;
 
@@ -195,16 +196,20 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	
 	/**
 	 * @return true if person's birthdate is estimated
+	 * 
+	 * @deprecated as of 2.0, use {@link #getBirthdateEstimated()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isBirthdateEstimated() {
 		// if (this.birthdateEstimated == null) {
 		// return new Boolean(false);
 		// }
-		return this.birthdateEstimated;
+		return getBirthdateEstimated();
 	}
 	
 	public Boolean getBirthdateEstimated() {
-		return isBirthdateEstimated();
+		return birthdateEstimated;
 	}
 	
 	/**
@@ -258,16 +263,20 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 
 	/**
 	 * @return Returns the death status.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getDead()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isDead() {
-		return dead;
+		return getDead();
 	}
 	
 	/**
 	 * @return Returns the death status.
 	 */
 	public Boolean getDead() {
-		return isDead();
+		return dead;
 	}
 	
 	/**
@@ -958,11 +967,16 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	}
 	
 	public Boolean getPersonVoided() {
-		return isPersonVoided();
+		return personVoided;
 	}
 	
+	/**
+	 * @deprecated as of 2.0, use {@link #getPersonVoided()}
+	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isPersonVoided() {
-		return personVoided;
+		return getPersonVoided();
 	}
 	
 	public User getPersonVoidedBy() {
@@ -985,11 +999,18 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	
 	/**
 	 * @return true/false whether this person is a patient or not
+	 *
+	 * @deprecated as of 2.0, use {@link #getIsPatient()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public boolean isPatient() {
-		return isPatient;
+		return getIsPatient();
 	}
 	
+	public boolean getIsPatient() {
+		return isPatient;
+	}
 	/**
 	 * This should only be set by the database layer by looking at whether a row exists in the
 	 * patient table

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -18,6 +18,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
 
 /**
@@ -218,16 +219,17 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	
 	/**
 	 * @return Returns the preferred.
+	 * 
+	 * @deprecated as of 2.0, use {@link #getPreferred()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isPreferred() {
-		if (preferred == null) {
-			return new Boolean(false);
-		}
-		return preferred;
+		return getPreferred();
 	}
 	
 	public Boolean getPreferred() {
-		return isPreferred();
+		return preferred == null ? Boolean.FALSE : preferred;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/PersonAttributeType.java
+++ b/api/src/main/java/org/openmrs/PersonAttributeType.java
@@ -11,6 +11,7 @@ package org.openmrs;
 
 import java.util.Comparator;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
 
 /**
@@ -101,7 +102,11 @@ public class PersonAttributeType extends BaseOpenmrsMetadata implements java.io.
 	
 	/**
 	 * @return the searchable status
+	 * 
+	 * @deprecated as of 2.0, use {@link #getSearchable()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isSearchable() {
 		return getSearchable();
 	}

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.util.StringUtils;
@@ -320,16 +321,20 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	
 	/**
 	 * @return Returns the preferred.
+	 *
+	 * @deprecated as of 2.0, use {@link #getPreferred()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isPreferred() {
+		return getPreferred();
+	}
+	
+	public Boolean getPreferred() {
 		if (preferred == null) {
 			return Boolean.FALSE;
 		}
 		return preferred;
-	}
-	
-	public Boolean getPreferred() {
-		return isPreferred();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/RelationshipType.java
+++ b/api/src/main/java/org/openmrs/RelationshipType.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * Defines a type of relationship between two people in the database. <br>
  * <br>
@@ -117,8 +119,16 @@ public class RelationshipType extends BaseOpenmrsMetadata implements java.io.Ser
 	 * adding/editing a person's relationships
 	 * 
 	 * @return the preferred status
+	 * 
+	 * @deprecated as of 2.0, use {@link #getPrefered()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isPreferred() {
+		return getPreferred();
+	}
+	
+	public Boolean getPreferred() {
 		return preferred;
 	}
 	

--- a/api/src/main/java/org/openmrs/Retireable.java
+++ b/api/src/main/java/org/openmrs/Retireable.java
@@ -11,6 +11,8 @@ package org.openmrs;
 
 import java.util.Date;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * In OpenMRS, data are rarely fully deleted (purged) from the system; rather, they are either
  * voided or retired. When existing data remain valid but should no longer be used for new entries,
@@ -28,8 +30,14 @@ public interface Retireable extends OpenmrsObject {
 	
 	/**
 	 * @return Boolean - whether of not this object is retired
+	 *
+	 * @deprecated as of 2.0, use {@link #getRetired()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isRetired();
+	
+	public Boolean getRetired();
 	
 	/**
 	 * @param retired - whether of not this object is retired

--- a/api/src/main/java/org/openmrs/Voidable.java
+++ b/api/src/main/java/org/openmrs/Voidable.java
@@ -11,6 +11,8 @@ package org.openmrs;
 
 import java.util.Date;
 
+import org.codehaus.jackson.annotate.JsonIgnore;
+
 /**
  * In OpenMRS, data are rarely fully deleted (purged) from the system; rather, they are either
  * voided or retired. When data can be removed (effectively deleted from the user's perspective),
@@ -28,8 +30,14 @@ public interface Voidable extends OpenmrsObject {
 	
 	/**
 	 * @return Boolean - whether of not this object is voided
+	 *
+	 * @deprecated as of 2.0, use {@link #getVoided()}
 	 */
+	@Deprecated
+	@JsonIgnore
 	public Boolean isVoided();
+	
+	public Boolean getVoided();
 	
 	/**
 	 * @param voided - whether of not this object is voided


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-2205

After deprecating all isXyz() having corresponding getXyz() methods, i realized that there were now calls to the deprecated isXyz() inside the code, even getXyz() only calls isXyz() internally. I will create a jira ticket to remove calls to the deprecated isXyz() methods.