### PR TITLE
Redirecting Authenticated User to home if user tries to access 'login.htm' page [TRUNK-4817]

### DIFF
--- a/web/src/main/java/org/openmrs/web/controller/LoginController.java
+++ b/web/src/main/java/org/openmrs/web/controller/LoginController.java
@@ -44,8 +44,10 @@ public class LoginController {
 			webRequest.removeAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, WebRequest.SCOPE_SESSION);
 		}
 		
-		//If there is a currently logged in user and they failed a privilege check, else go to login in page
-		if (Context.getAuthenticatedUser() != null && failedPrivilegeCheck) {
+		//If the user is logged in and there are no privilege problems, he should be redirected to home
+		if (Context.getAuthenticatedUser() != null && !failedPrivilegeCheck) {
+			return "redirect:/index.htm";
+		} else if (Context.getAuthenticatedUser() != null && failedPrivilegeCheck) { //If there is a currently logged in user and they failed a privilege check, else go to login in page
 			model.addAttribute("foundMissingPrivileges", true);
 			webRequest.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "error.insufficientPrivileges",
 			    WebRequest.SCOPE_SESSION);


### PR DESCRIPTION
Issue: [[TRUNK-4817] Backport LUI-60 where user is redirected to home page if he/she tries to access login page while logged in.](https://issues.openmrs.org/browse/TRUNK-4817)<br>

If the User is Authenticated, then he should be redirected to his/her OpenMRS home page and should not be allowed the access the login page