### PR TITLE
[TRUNK-4818] : Changed `presentationLocale` to LinkedHashSet to Preserve Insertion Order of Locales

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -522,7 +522,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	@Transactional(readOnly = true)
 	public Set<Locale> getPresentationLocales() {
 		if (presentationLocales == null) {
-			presentationLocales = new HashSet<Locale>();
+			presentationLocales = new LinkedHashSet<Locale>();
 			Collection<Locale> messageLocales = Context.getMessageSourceService().getLocales();
 			List<Locale> allowedLocales = getAllowedLocales();
 			


### PR DESCRIPTION
**Issue**:[TRUNK-4818](https://issues.openmrs.org/browse/TRUNK-4818): 
In AdministrationServiceImpl.getPresentationLocales() the set we return is a HashSet, but this causes us to lose the ordering of locales (that ultimately comes from an admin-configured global property)

Instead we should use a LinkedHashSet, in order to preserve the order of locales we get from getAllowedLocales() (and ultimately the admin configured via a global property).<br>
**Fix**: Changed `presentationLocales` from `HashSet` to `LinkedHashSet` to preserve insertion order as discussed in ticket. Also added a Unit Test