### PR TITLE
TRUNK-4093 FIX- return null if uuid AND id is null

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -1125,12 +1125,14 @@ public class ORUR01Handler implements Application {
 	 *
 	 * @param msh
 	 * @return
+	 * @should pass if return value is null when uuid and id is null
+	 * @should pass if return value is not null when uuid or id is not null
 	 * @throws HL7Exception
 	 */
-	private Form getForm(MSH msh) throws HL7Exception {
+	public Form getForm(MSH msh) throws HL7Exception {
 		String uuid = null;
 		String id = null;
-		
+
 		for (EI identifier : msh.getMessageProfileIdentifier()) {
 			if (identifier != null && identifier.getNamespaceID() != null) {
 				String identifierType = identifier.getNamespaceID().getValue();
@@ -1143,28 +1145,34 @@ public class ORUR01Handler implements Application {
 				}
 			}
 		}
-		
+
 		Form form = null;
-		
+
+		if (uuid == null && id == null) {
+			return form;
+		}
+
 		// prefer uuid over id
 		if (uuid != null) {
 			form = Context.getFormService().getFormByUuid(uuid);
 		}
-		
+
 		// if uuid did not work ...
-		if (form == null) {
+		if (id != null) {
+
 			try {
 				Integer formId = Integer.parseInt(id);
 				form = Context.getFormService().getForm(formId);
-			}
-			catch (NumberFormatException e) {
+			} catch (NumberFormatException e) {
 				throw new HL7Exception(Context.getMessageSourceService().getMessage("ORUR01.error.parseFormId"), e);
 			}
+
 		}
-		
+
 		return form;
+
 	}
-	
+
 	private EncounterType getEncounterType(MSH msh, Form form) {
 		if (form != null) {
 			return form.getEncounterType();

--- a/api/src/test/java/org/openmrs/hl7/handler/ORUR01HandlerTest.java
+++ b/api/src/test/java/org/openmrs/hl7/handler/ORUR01HandlerTest.java
@@ -17,6 +17,7 @@ import ca.uhn.hl7v2.model.v25.message.ORU_R01;
 import ca.uhn.hl7v2.model.v25.segment.NK1;
 import ca.uhn.hl7v2.model.v25.segment.OBR;
 import ca.uhn.hl7v2.model.v25.segment.OBX;
+import ca.uhn.hl7v2.model.v26.segment.MSH;
 import ca.uhn.hl7v2.parser.GenericParser;
 import org.junit.Assert;
 import org.junit.Before;
@@ -1267,4 +1268,54 @@ public class ORUR01HandlerTest extends BaseContextSensitiveTest {
 			return false;
 		}
 	}
+
+
+
+	/**
+	 * @see ORUR01Handler#getForm(MSH)
+	 * @verifies pass if return value is null when uuid and id is null
+	 */
+	@Test
+	public void getForm_shouldPassIfReturnValueIsNullWhenUuidAndIdIsNull() throws Exception {
+		String hl7String = "MSH|^~\\&|FORMENTRY|AMRS.ELD|HL7LISTENER|AMRS.ELD|20090728170332||ORU^R01|gu99yBh4loLX2mh9cHaV|P|2.5|1||||||||\r"
+		        + "PID|||3^^^^||Beren^John^Bondo||\r"
+		        + "NK1|1|Jones^Jane^Lee^^RN|3A^Parent^99REL||||||||||||F|19751016|||||||||||||||||2^^^L^PI\r"
+		        + "PV1||O|1^Unknown||||1^Super User (admin)|||||||||||||||||||||||||||||||||||||20090714|||||||V\r"
+		        + "ORC|RE||||||||20090728165937|1^Super User\r"
+		        + "OBR|1|||1238^MEDICAL RECORD OBSERVATIONS^99DCT\r"
+		        + "OBX|2|NM|5497^CD4 COUNT^99DCT||123|||||||||20090714\r"
+		        + "OBR|3|||23^FOOD CONSTRUCT^99DCT\r"
+		        + "OBX|1|CWE|21^FOOD ASSISTANCE FOR ENTIRE FAMILY^99DCT||22^UNKNOWN^99DCT^2471^UNKNOWN^99NAM|||||||||20090714";
+		
+		ORUR01Handler oruHandler = new ORUR01Handler();
+		Message hl7message = parser.parse(hl7String);
+		ORU_R01 oru = (ORU_R01) hl7message;
+		ca.uhn.hl7v2.model.v25.segment.MSH msh = oru.getMSH();
+		Form form = oruHandler.getForm(msh);
+		Assert.assertNull(form);
+	}
+
+	/**
+	 * @see ORUR01Handler#getForm(MSH)
+	 * @verifies pass if return value is not null when uuid or id is not null
+	 */
+	@Test
+	public void getForm_shouldPassIfReturnValueIsNotNullWhenUuidOrIdIsNotNull() throws Exception {
+		String hl7String = "MSH|^~\\&|FORMENTRY|AMRS.ELD|HL7LISTENER|AMRS.ELD|20090728170332||ORU^R01|gu99yBh4loLX2mh9cHaV|P|2.5|1||||||||16^AMRS.ELD.FORMID\r"
+		        + "PID|||3^^^^||Beren^John^Bondo||\r"
+		        + "NK1|1|Jones^Jane^Lee^^RN|3A^Parent^99REL||||||||||||F|19751016|||||||||||||||||2^^^L^PI\r"
+		        + "PV1||O|1^Unknown||||1^Super User (admin)|||||||||||||||||||||||||||||||||||||20090714|||||||V\r"
+		        + "ORC|RE||||||||20090728165937|1^Super User\r"
+		        + "OBR|1|||1238^MEDICAL RECORD OBSERVATIONS^99DCT\r"
+		        + "OBX|2|NM|5497^CD4 COUNT^99DCT||123|||||||||20090714\r"
+		        + "OBR|3|||23^FOOD CONSTRUCT^99DCT\r"
+		        + "OBX|1|CWE|21^FOOD ASSISTANCE FOR ENTIRE FAMILY^99DCT||22^UNKNOWN^99DCT^2471^UNKNOWN^99NAM|||||||||20090714";
+		
+		ORUR01Handler oruHandler = new ORUR01Handler();
+		Message hl7message = parser.parse(hl7String);
+		ORU_R01 oru = (ORU_R01) hl7message;
+		ca.uhn.hl7v2.model.v25.segment.MSH msh = oru.getMSH();
+		Form form = oruHandler.getForm(msh);
+		Assert.assertNotNull(form);	
+		}
 }


### PR DESCRIPTION
In the description of the ticket, it was explicitly mention that return value of form should be null if uuid OR id is null.
While fixing the bug i realised that this will not solve the issue, since if either of uuid or id is present we get the form using that value (we prefer form id if uuid is not found or prefer form uuid over id if both are present), thus if either of the value is present the return value should not be null.
Incase both uuid and id is null then, the return value of should be null. 