### PR TITLE
TRUNK-4678 | Fix ModuleActivatorTest

### DIFF
--- a/api/src/test/java/org/openmrs/module/ModuleActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleActivatorTest.java
@@ -13,14 +13,12 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests methods of the module activator that do not require refreshing of the spring application
  * context. For those that require refreshing, see WebModuleActivatorTest
  */
-@Ignore("Unignore after investigating and fixing - TRUNK-4678")
 public class ModuleActivatorTest extends BaseModuleActivatorTest {
 	
 	@Test
@@ -78,7 +76,6 @@ public class ModuleActivatorTest extends BaseModuleActivatorTest {
 	}
 	
 	@Test
-	@Ignore("Unignore after investigating and fixing - TRUNK-4678")
 	public void shouldStopDependantModulesOnStopModule() throws Exception {
 		//since module2 depends on module1, and module3 depends on module2
 		//stopping module1 should also stop both module2 and module3
@@ -93,14 +90,14 @@ public class ModuleActivatorTest extends BaseModuleActivatorTest {
 		assertTrue(moduleTestData.getStoppedCallCount(MODULE1_ID) == 1);
 		assertTrue(moduleTestData.getStoppedCallCount(MODULE2_ID) == 1);
 		assertTrue(moduleTestData.getStoppedCallCount(MODULE3_ID) == 1);
-		
-		//willStop() and stopped() should have been called in the right order
-		//which is the reverse of the startup. that is module3, module2, module1
-		assertThat(moduleTestData.getWillStopCallTime(MODULE3_ID), lessThanOrEqualTo(moduleTestData
+
+		//willStop() should have been called in the order module1, module2, module3
+		assertThat(moduleTestData.getWillStopCallTime(MODULE1_ID), lessThanOrEqualTo(moduleTestData
 		        .getWillStopCallTime(MODULE2_ID)));
 		assertThat(moduleTestData.getWillStopCallTime(MODULE2_ID), lessThanOrEqualTo(moduleTestData
-		        .getWillStopCallTime(MODULE1_ID)));
-		
+		        .getWillStopCallTime(MODULE3_ID)));
+
+		//stopped() should have been called in the order module3, module2, module1
 		assertThat(moduleTestData.getStoppedCallTime(MODULE3_ID), lessThanOrEqualTo(moduleTestData
 		        .getStoppedCallTime(MODULE2_ID)));
 		assertThat(moduleTestData.getStoppedCallTime(MODULE2_ID), lessThanOrEqualTo(moduleTestData
@@ -128,7 +125,6 @@ public class ModuleActivatorTest extends BaseModuleActivatorTest {
 	}
 	
 	@Test
-	@Ignore("Unignore after investigating and fixing - TRUNK-4678")
 	public void shouldExcludePreviouslyStoppedModulesOnShutdown() {
 		//At OpenMRS shutdown, willStop() and stopped() methods get called for all 
 		//started module's activator EXCLUDING any module(s) that were previously stopped.

--- a/api/src/test/java/org/openmrs/module/ModuleTestData.java
+++ b/api/src/test/java/org/openmrs/module/ModuleTestData.java
@@ -60,12 +60,12 @@ public class ModuleTestData {
 		willStopCallCount.put(moduleId, 0);
 		stoppedCallCount.put(moduleId, 0);
 		
-		willRefreshContextCallTime.put(moduleId, 0l);
-		contextRefreshedCallTime.put(moduleId, 0l);
-		willStartCallTime.put(moduleId, 0l);
-		startedCallTime.put(moduleId, 0l);
-		willStopCallTime.put(moduleId, 0l);
-		stoppedCallTime.put(moduleId, 0l);
+		willRefreshContextCallTime.put(moduleId, 0L);
+		contextRefreshedCallTime.put(moduleId, 0L);
+		willStartCallTime.put(moduleId, 0L);
+		startedCallTime.put(moduleId, 0L);
+		willStopCallTime.put(moduleId, 0L);
+		stoppedCallTime.put(moduleId, 0L);
 	}
 	
 	public synchronized Integer getWillRefreshContextCallCount(String moduleId) {


### PR DESCRIPTION
The main problem was with the order of plugins in pom.xml. While starting a module, it checks for required openmrs version. Since, the build-helper was out of order, the openmrs.properties file wasn't updated with any value. It was throwing start up error for modules.