### PR TITLE
Pull request for TRUNK-4659: Patient.setIdentifiers accepts args it shouldn't

### DIFF
--- a/api/src/main/java/org/openmrs/BaseCustomizableData.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableData.java
@@ -40,7 +40,7 @@ public abstract class BaseCustomizableData<A extends Attribute> extends BaseOpen
 	 * @param attributes the attributes to set
 	 */
 	public void setAttributes(Set<A> attributes) {
-		this.attributes = attributes;
+		this.attributes = new LinkedHashSet<A>(attributes);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
@@ -40,7 +40,7 @@ public abstract class BaseCustomizableMetadata<A extends Attribute> extends Base
 	 * @param attributes the attributes to set
 	 */
 	public void setAttributes(Set<A> attributes) {
-		this.attributes = attributes;
+		this.attributes = new LinkedHashSet<A>(attributes);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -190,7 +190,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param answers The answers to set.
 	 */
 	public void setAnswers(Collection<ConceptAnswer> answers) {
-		this.answers = answers;
+		this.answers = new HashSet<ConceptAnswer>(answers);
 	}
 	
 	/**
@@ -1025,7 +1025,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param names The names to set.
 	 */
 	public void setNames(Collection<ConceptName> names) {
-		this.names = names;
+		this.names = new HashSet<ConceptName>(names);
 	}
 	
 	/**
@@ -1223,7 +1223,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param descriptions the collection of descriptions
 	 */
 	public void setDescriptions(Collection<ConceptDescription> descriptions) {
-		this.descriptions = descriptions;
+		this.descriptions = new HashSet<ConceptDescription>(descriptions);
 	}
 	
 	/**
@@ -1359,7 +1359,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param conceptSets The conceptSets to set.
 	 */
 	public void setConceptSets(Collection<ConceptSet> conceptSets) {
-		this.conceptSets = conceptSets;
+		this.conceptSets = new TreeSet<ConceptSet>(conceptSets);
 	}
 	
 	/**
@@ -1386,7 +1386,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @param conceptMappings the conceptMappings to set
 	 */
 	public void setConceptMappings(Collection<ConceptMap> conceptMappings) {
-		this.conceptMappings = conceptMappings;
+		this.conceptMappings = new HashSet<ConceptMap>(conceptMappings);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -273,7 +273,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @param tags the tags to set.
 	 */
 	public void setTags(Collection<ConceptNameTag> tags) {
-		this.tags = tags;
+		this.tags = new TreeSet<ConceptNameTag>(tags);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -273,7 +273,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @param tags the tags to set.
 	 */
 	public void setTags(Collection<ConceptNameTag> tags) {
-		this.tags = new TreeSet<ConceptNameTag>(tags);
+		this.tags = new HashSet<ConceptNameTag>(tags);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/ConceptReferenceTerm.java
+++ b/api/src/main/java/org/openmrs/ConceptReferenceTerm.java
@@ -133,7 +133,7 @@ public class ConceptReferenceTerm extends BaseOpenmrsMetadata implements java.io
 	 * @param conceptReferenceTermMaps the conceptReferenceTermMaps to set
 	 */
 	public void setConceptReferenceTermMaps(Set<ConceptReferenceTermMap> conceptReferenceTermMaps) {
-		this.conceptReferenceTermMaps = conceptReferenceTermMaps;
+		this.conceptReferenceTermMaps = new LinkedHashSet<ConceptReferenceTermMap>(conceptReferenceTermMaps);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Drug.java
+++ b/api/src/main/java/org/openmrs/Drug.java
@@ -205,7 +205,7 @@ public class Drug extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @since 1.10
 	 */
 	public void setIngredients(Collection<DrugIngredient> ingredients) {
-		this.ingredients = LinkedHashSet<DrugIngredient>(ingredients);
+		this.ingredients = new LinkedHashSet<DrugIngredient>(ingredients);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Drug.java
+++ b/api/src/main/java/org/openmrs/Drug.java
@@ -205,7 +205,7 @@ public class Drug extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @since 1.10
 	 */
 	public void setIngredients(Collection<DrugIngredient> ingredients) {
-		this.ingredients = ingredients;
+		this.ingredients = LinkedHashSet<DrugIngredient>(ingredients);
 	}
 	
 	/**
@@ -257,7 +257,7 @@ public class Drug extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @since 1.10
 	 */
 	public void setDrugReferenceMaps(Set<DrugReferenceMap> drugReferenceMaps) {
-		this.drugReferenceMaps = drugReferenceMaps;
+		this.drugReferenceMaps = new LinkedHashSet<DrugReferenceMap>(drugReferenceMaps);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -259,7 +259,7 @@ public class Encounter extends BaseOpenmrsData implements java.io.Serializable {
 	 * @param obs The obs to set.
 	 */
 	public void setObs(Set<Obs> obs) {
-		this.obs = obs;
+		this.obs = new HashSet<Obs>(obs);
 	}
 	
 	/**
@@ -350,7 +350,7 @@ public class Encounter extends BaseOpenmrsData implements java.io.Serializable {
 	 * @param orders The orders to set.
 	 */
 	public void setOrders(Set<Order> orders) {
-		this.orders = orders;
+		this.orders = new LinkedHashSet<Order>(orders);
 	}
 	
 	/**
@@ -426,7 +426,7 @@ public class Encounter extends BaseOpenmrsData implements java.io.Serializable {
 	 * @since 1.9.1
 	 */
 	public void setEncounterProviders(Set<EncounterProvider> encounterProviders) {
-		this.encounterProviders = encounterProviders;
+		this.encounterProviders = new LinkedHashSet<EncounterProvider>(encounterProviders);
 	}
 
     /**

--- a/api/src/main/java/org/openmrs/Field.java
+++ b/api/src/main/java/org/openmrs/Field.java
@@ -173,7 +173,7 @@ public class Field extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param fieldAnswers The fieldAnswers to set.
 	 */
 	public void setAnswers(Set<FieldAnswer> fieldAnswers) {
-		this.answers = new TreeSet<FieldAnswer>(fieldAnswers);
+		this.answers = new HashSet<FieldAnswer>(fieldAnswers);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Field.java
+++ b/api/src/main/java/org/openmrs/Field.java
@@ -173,7 +173,7 @@ public class Field extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param fieldAnswers The fieldAnswers to set.
 	 */
 	public void setAnswers(Set<FieldAnswer> fieldAnswers) {
-		this.answers = fieldAnswers;
+		this.answers = new TreeSet<FieldAnswer>(fieldAnswers);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Form.java
+++ b/api/src/main/java/org/openmrs/Form.java
@@ -173,7 +173,7 @@ public class Form extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param formFields The formFields to set.
 	 */
 	public void setFormFields(Set<FormField> formFields) {
-		this.formFields = formFields;
+		this.formFields = new HashSet<FormField>(formFields>;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Form.java
+++ b/api/src/main/java/org/openmrs/Form.java
@@ -173,7 +173,7 @@ public class Form extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param formFields The formFields to set.
 	 */
 	public void setFormFields(Set<FormField> formFields) {
-		this.formFields = new HashSet<FormField>(formFields>;
+		this.formFields = new HashSet<FormField>(formFields);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -374,7 +374,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @since 1.5
 	 */
 	public void setChildLocations(Set<Location> childLocations) {
-		this.childLocations = childLocations;
+		this.childLocations = new HashSet<Location>(childLocations);
 	}
 	
 	/**
@@ -463,7 +463,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @since 1.5
 	 */
 	public void setTags(Set<LocationTag> tags) {
-		this.tags = tags;
+		this.tags = new HashSet<LocationTag>()tags;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -463,7 +463,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @since 1.5
 	 */
 	public void setTags(Set<LocationTag> tags) {
-		this.tags = new HashSet<LocationTag>()tags;
+		this.tags = new HashSet<LocationTag>(tags);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/OrderType.java
+++ b/api/src/main/java/org/openmrs/OrderType.java
@@ -139,7 +139,7 @@ public class OrderType extends BaseOpenmrsMetadata implements java.io.Serializab
 	 * @param conceptClasses the collection containing the {@link org.openmrs.ConceptClass}es
 	 */
 	public void setConceptClasses(Collection<ConceptClass> conceptClasses) {
-		this.conceptClasses = conceptClasses;
+		this.conceptClasses = new LinkedHashSet<ConceptClass>(conceptClasses);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -125,7 +125,7 @@ public class Patient extends Person implements java.io.Serializable {
 	 * @see org.openmrs.PatientIdentifier
 	 */
 	public void setIdentifiers(Set<PatientIdentifier> identifiers) {
-		this.identifiers = identifiers;
+		this.identifiers = new TreeSet<PatientIdentifier>(identifiers);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/PatientProgram.java
+++ b/api/src/main/java/org/openmrs/PatientProgram.java
@@ -352,7 +352,7 @@ public class PatientProgram extends BaseOpenmrsData implements java.io.Serializa
 	}
 	
 	public void setStates(Set<PatientState> states) {
-		this.states = states;
+		this.states = new HashSet<PatientState>(states);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -332,7 +332,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonAddress
 	 */
 	public void setAddresses(Set<PersonAddress> addresses) {
-		this.addresses = addresses;
+		this.addresses = new TreeSet<PersonAddress>(addresses);
 	}
 	
 	/**
@@ -353,7 +353,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonName
 	 */
 	public void setNames(Set<PersonName> names) {
-		this.names = names;
+		this.names = new TreeSet<PersonName>(names);
 	}
 	
 	/**
@@ -391,7 +391,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonAttribute
 	 */
 	public void setAttributes(Set<PersonAttribute> attributes) {
-		this.attributes = attributes;
+		this.attributes = new TreeSet<PersonAttribute>(attributes);
 		attributeMap = null;
 		allAttributeMap = null;
 	}

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -42,7 +42,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	
 	protected Integer personId;
 	
-	private Set<PersonAddress> addresses = null;
+	private SortedSet<PersonAddress> addresses = null;
 	
 	private Set<PersonName> names = null;
 	

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -353,7 +353,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonName
 	 */
 	public void setNames(Set<PersonName> names) {
-		this.names = new TreeSet<PersonName>(names);
+		this.names = names;
 	}
 	
 	/**
@@ -391,7 +391,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonAttribute
 	 */
 	public void setAttributes(Set<PersonAttribute> attributes) {
-		this.attributes = new TreeSet<PersonAttribute>(attributes);
+		this.attributes = attributes;
 		attributeMap = null;
 		allAttributeMap = null;
 	}

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -332,8 +332,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonAddress
 	 */
 	public void setAddresses(Set<PersonAddress> addresses) {
-		this.getAddresses().clear();
-		this.addresses = new TreeSet<PersonAddress>(addresses);
+		this.addresses = addresses;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -42,7 +42,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	
 	protected Integer personId;
 	
-	private SortedSet<PersonAddress> addresses = null;
+	private Set<PersonAddress> addresses = null;
 	
 	private Set<PersonName> names = null;
 	
@@ -332,6 +332,7 @@ public class Person extends BaseOpenmrsData implements java.io.Serializable {
 	 * @see org.openmrs.PersonAddress
 	 */
 	public void setAddresses(Set<PersonAddress> addresses) {
+		this.getAddresses().clear();
 		this.addresses = new TreeSet<PersonAddress>(addresses);
 	}
 	

--- a/api/src/main/java/org/openmrs/ProgramWorkflow.java
+++ b/api/src/main/java/org/openmrs/ProgramWorkflow.java
@@ -254,7 +254,7 @@ public class ProgramWorkflow extends BaseOpenmrsMetadata implements java.io.Seri
 	}
 	
 	public void setStates(Set<ProgramWorkflowState> states) {
-		this.states = states;
+		this.states = new HashSet<ProgramWorkflowState>(states);
 	}
 	
 	public Concept getConcept() {

--- a/api/src/main/java/org/openmrs/Role.java
+++ b/api/src/main/java/org/openmrs/Role.java
@@ -69,7 +69,7 @@ public class Role extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param privileges The privileges to set.
 	 */
 	public void setPrivileges(Set<Privilege> privileges) {
-		this.privileges = privileges;
+		this.privileges = new HashSet<Privilege>(privileges);
 	}
 	
 	public String getName() {
@@ -173,7 +173,7 @@ public class Role extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param inheritedRoles The inheritedRoles to set.
 	 */
 	public void setInheritedRoles(Set<Role> inheritedRoles) {
-		this.inheritedRoles = inheritedRoles;
+		this.inheritedRoles = new HashSet<Role>(inheritedRoles);
 	}
 	
 	/**
@@ -264,7 +264,7 @@ public class Role extends BaseOpenmrsMetadata implements java.io.Serializable {
 	 * @param childRoles the immediate children to set
 	 */
 	public void setChildRoles(Set<Role> childRoles) {
-		this.childRoles = childRoles;
+		this.childRoles = new HashSet<Role>(childRoles);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/User.java
+++ b/api/src/main/java/org/openmrs/User.java
@@ -248,7 +248,7 @@ public class User extends BaseOpenmrsMetadata implements java.io.Serializable, A
 	 * @param roles The roles to set.
 	 */
 	public void setRoles(Set<Role> roles) {
-		this.roles = roles;
+		this.roles = new HashSet<Role>(roles);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/Visit.java
+++ b/api/src/main/java/org/openmrs/Visit.java
@@ -205,7 +205,7 @@ public class Visit extends BaseCustomizableData<VisitAttribute> implements Audit
 	 * @param encounters the encounters to set
 	 */
 	public void setEncounters(Set<Encounter> encounters) {
-		this.encounters = encounters;
+		this.encounters = new HashSet<Encounter>(encounters);
 	}
 	
 	/**


### PR DESCRIPTION
Look only at the commit titled: "setter methods have been modified. The arguments are copied, so they should be able to be converted to SortedSet."