### PR TITLE
OrderSet-Story Extra Changes

### DIFF
--- a/api/src/main/java/org/openmrs/OrderSet.java
+++ b/api/src/main/java/org/openmrs/OrderSet.java
@@ -95,9 +95,7 @@ public class OrderSet extends BaseOpenmrsMetadata implements Serializable {
 	 * @param orderSetMembers the orderSetMembers to set
 	 */
 	public void setOrderSetMembers(List<OrderSetMember> orderSetMembers) {
-		for (OrderSetMember orderSetMember : orderSetMembers) {
-			addOrderSetMember(orderSetMember);
-		}
+		this.orderSetMembers = orderSetMembers;
 	}
 	
 	/**
@@ -143,6 +141,42 @@ public class OrderSet extends BaseOpenmrsMetadata implements Serializable {
 	
 	public void setId(Integer id) {
 		setOrderSetId(id);
+	}
+
+	/**
+	 * Fetches the list of orderSetMembers that are not retired
+	 *
+	 * @return the orderSetMembers that are not retired
+	 */
+	public List<OrderSetMember> getUnRetiredOrderSetMembers() {
+		List<OrderSetMember> osm = new ArrayList<OrderSetMember>();
+		for (OrderSetMember orderSetMember : getOrderSetMembers()) {
+			if (!orderSetMember.isRetired()) {
+				osm.add(orderSetMember);
+			}
+		}
+		return osm;
+	}
+
+	/**
+	 * Removes and orderSetMember from a list of existing orderSetMembers
+	 *
+	 * @param orderSetMember that is to be removed
+	 */
+	public void removeOrderSetMember(OrderSetMember orderSetMember) {
+		if (getOrderSetMembers().contains(orderSetMember)) {
+			getOrderSetMembers().remove(orderSetMember);
+			orderSetMember.setOrderSet(null);
+		}
+	}
+
+	/**
+	 * Retires an orderSetMember
+	 *
+	 * @param orderSetMember to be retired
+	 */
+	public void retireOrderSetMember(OrderSetMember orderSetMember) {
+		orderSetMember.setRetired(true);
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/api/OrderSetService.java
+++ b/api/src/main/java/org/openmrs/api/OrderSetService.java
@@ -10,6 +10,7 @@
 package org.openmrs.api;
 
 import org.openmrs.OrderSet;
+import org.openmrs.OrderSetMember;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.db.OrderSetDAO;
 import org.openmrs.util.PrivilegeConstants;
@@ -94,4 +95,16 @@ public interface OrderSetService extends OpenmrsService {
 	@Authorized( { PrivilegeConstants.MANAGE_ORDER_SETS })
 	OrderSet unretireOrderSet(OrderSet orderSet) throws APIException;
 	
+
+	/**
+	 * Get OrderSetMember by uuid
+	 *
+	 * @param uuid
+	 * @return
+	 * @should find object given valid uuid
+	 * @should return null if no object found with given uuid
+	 */
+	@Authorized(PrivilegeConstants.GET_ORDER_SETS)
+	OrderSetMember getOrderSetMemberByUuid(String uuid);
+
 }

--- a/api/src/main/java/org/openmrs/api/db/OrderSetDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/OrderSetDAO.java
@@ -10,6 +10,7 @@
 package org.openmrs.api.db;
 
 import org.openmrs.OrderSet;
+import org.openmrs.OrderSetMember;
 
 import java.util.List;
 
@@ -43,4 +44,9 @@ public interface OrderSetDAO {
 	 */
 	OrderSet getOrderSetByUniqueUuid(String orderSetUuid) throws DAOException;
 	
+
+	/**
+	 * @see org.openmrs.api.OrderSetService#getOrderSetMemberByUuid(String)
+	 */
+	OrderSetMember getOrderSetMemberByUuid(String uuid) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderSetDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderSetDAO.java
@@ -15,7 +15,9 @@ import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.classic.Session;
 import org.hibernate.criterion.Restrictions;
+import org.openmrs.ConceptDescription;
 import org.openmrs.OrderSet;
+import org.openmrs.OrderSetMember;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.OrderSetDAO;
 
@@ -94,4 +96,14 @@ public class HibernateOrderSetDAO implements OrderSetDAO {
 		    "uuid", orderSetUuid).uniqueResult();
 	}
 	
+
+	/**
+	 * @see org.openmrs.api.db.OrderSetDAO#getOrderSetMemberByUuid(String)
+	 */
+	@Override
+	public OrderSetMember getOrderSetMemberByUuid(String uuid) throws DAOException {
+		return (OrderSetMember) sessionFactory.getCurrentSession().createQuery("from OrderSetMember osm where osm.uuid = :uuid").setString(
+				"uuid", uuid).uniqueResult();
+	}
+
 }

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSet.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSet.hbm.xml
@@ -35,7 +35,7 @@
             </type>
         </property>
 
-        <list name="orderSetMembers"  lazy="true" cascade="all-delete-orphan" access="field">
+        <list name="orderSetMembers" lazy="true" cascade="save-update" inverse="false">
             <key column="order_set_id" not-null="true"/>
             <list-index column="sequence_number"/>
             <one-to-many class="OrderSetMember" />

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSetMember.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSetMember.hbm.xml
@@ -28,6 +28,11 @@
         <many-to-one name="orderType" class="OrderType" not-null="true">
             <column name="order_type"/>
         </many-to-one>
+
+        <many-to-one name="orderSet" class="OrderSet" insert="false" update="false">
+            <column name="order_set_id"/>
+        </many-to-one>
+
         <property name="orderTemplate" type="java.lang.String"
                   column="order_template"/>
         <property name="orderTemplateType" type="java.lang.String"


### PR DESCRIPTION
Added helper methods to OrderSet model.
	a. removing an orderSetMember from an orderSet
        b. retiring an orderSetMember in an orderSet
	c. fetching unretired orderSetMembers
Added a method to fetch orderSetMembers by Uuid.
Retiring an orderSet retires the orderSetMembers as well.
Added bi-directional mapping between orderSet and orderSetMember.