### PR TITLE
Added tests to org.openmrs.web.WebUtilTest. The tests are for org.ope…

### DIFF
--- a/web/src/main/java/org/openmrs/web/WebUtil.java
+++ b/web/src/main/java/org/openmrs/web/WebUtil.java
@@ -290,13 +290,14 @@ public class WebUtil implements GlobalPropertyListener {
 	 * @should not accept invalid locales
 	 * @should not fail with empty strings
 	 * @should not fail with whitespace only
+	 * @should not fail with "_" character only
 	 */
 	public static Locale normalizeLocale(String localeString) {
 		if (localeString == null) {
 			return null;
 		}
 		localeString = localeString.trim();
-		if (localeString.isEmpty()) {
+		if (localeString.isEmpty() || localeString.equals("_")) {
 			return null;
 		}
 		int len = localeString.length();

--- a/web/src/test/java/org/openmrs/web/WebUtilTest.java
+++ b/web/src/test/java/org/openmrs/web/WebUtilTest.java
@@ -20,7 +20,7 @@ import org.openmrs.BaseOpenmrsObject;
  * Tests methods on the {@link WebUtil} class.
  */
 public class WebUtilTest {
-	
+
 	/**
 	 * @see org.openmrs.web.WebUtil#getContextPath()
 	 * @verifies should return empty string if webappname is null
@@ -96,7 +96,45 @@ public class WebUtilTest {
 	public void normalizeLocale_shouldNotFailWithWhitespaceOnly() throws Exception {
 		Assert.assertNull(WebUtil.normalizeLocale("      "));
 	}
-	
+
+	/**
+	 * @see WebUtil#normalizeLocale(String)
+	 * @verifies does not fail with "\t"
+	 */
+	@Test
+	public void normalizeLocale_shouldNotFailWithTab() throws Exception {
+		String s = new String(new byte[]{0x9}, "ASCII");
+		Assert.assertNull(WebUtil.normalizeLocale(s));
+	}
+
+	/**
+	 * @see WebUtil#normalizeLocale(String)
+	 * @verifies does not fail with "Ši"
+	 */
+	@Test
+	public void normalizeLocale_shouldNotFailWithUnicode() {
+		Assert.assertNull(WebUtil.normalizeLocale("Ši"));
+	}
+
+	/**
+	 * @see WebUtil#normalizeLocale(String)
+	 * @verifies does not fail with "s"
+	 */
+	@Test
+	public void normalizeLocale_shouldNotFailWithSingleChar() {
+		Assert.assertNull(WebUtil.normalizeLocale("s"));
+	}
+
+	/**
+	 * @see WebUtil#normalizeLocale(String)
+	 * @verifies does not fail with "_"
+	 */
+	@Test
+	public void normalizeLocale_shouldNotFailWithUnderline() throws Exception {
+		String s = new String(new byte[]{0x5f}, "ASCII");
+		Assert.assertNull(WebUtil.normalizeLocale(s));
+	}
+
 	/**
 	 * @see WebUtil#sanitizeLocales(String)
 	 * @verifies skip over invalid locales


### PR DESCRIPTION
…nmrs.web.WebUtil.normalizeLocale to validate the arguments accepted by this method. The test normalizeLocale_shouldNotFailWithUnderline fails when testing the normalizeLocale method with the argument "_". However according to the comments of normalizeLocale, "_" is a valid argument.

A bug report related to this commit has been reported here:
https://issues.openmrs.org/browse/TRUNK-4848