### PR TITLE
Adding tests for org.openmrs.util.Format in org.openmrs.util.FormatTe…

### DIFF
--- a/api/src/main/java/org/openmrs/util/Format.java
+++ b/api/src/main/java/org/openmrs/util/Format.java
@@ -62,8 +62,30 @@ public class Format {
 	public static String format(Date date, FORMAT_TYPE type) {
 		return format(date, Context.getLocale(), type);
 	}
-	
+
+	/**
+	 * This method formats a date object according to a particular locale and returns the date as a string.
+	 * The string can contain only the date (month, day and year), only the time (hours, minutes, seconds) or as a
+	 * timestamp (both date and time).
+	 *
+	 * @param date input date to format as a string
+	 * @param locale input locale to determine how to format the date
+	 * @param type input type to determine how much information from the date is returned
+	 * @return empty string if one of the parameters is null. Otherwise a string object for the date such that it is
+	 * formatted according to locale and the amount of information it contains is determined by type.
+	 * @should not fail when only date is null
+	 * @should not fail when only locale is null
+	 * @should not fail when only type is null
+	 * @should not fail when date and locale is null
+	 * @should not fail when date and type is null
+	 * @should not fail when locale and type is null
+	 * @should not fail when all parameters are null
+	 * @should not fail when none of the parameters are null
+	 */
 	public static String format(Date date, Locale locale, FORMAT_TYPE type) {
+		if (date == null || locale == null || type == null) {
+			return "";
+		}
 		log.debug("Formatting date: " + date + " with locale " + locale);
 		
 		DateFormat dateFormat = null;
@@ -75,7 +97,7 @@ public class Format {
 		} else {
 			dateFormat = DateFormat.getDateInstance(DateFormat.SHORT, locale);
 		}
-		return date == null ? "" : dateFormat.format(date);
+		return dateFormat.format(date);
 	}
 	
 	public static String format(Throwable t) {

--- a/api/src/test/java/org/openmrs/util/FormatTest.java
+++ b/api/src/test/java/org/openmrs/util/FormatTest.java
@@ -1,0 +1,91 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.Locale;
+
+public class FormatTest {
+
+    /**
+     * @verifies that all arguments can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenAllParametersAreNull() {
+        Assert.assertEquals("",Format.format(null, null, null));
+    }
+
+    /**
+     * @verifies that the date and locale arguments can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenDateAndLocaleIsNull() {
+        Assert.assertEquals("", Format.format(null, null, Format.FORMAT_TYPE.DATE));
+    }
+
+    /**
+     * @verifies that the type and locale arguments can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenLocaleAndTypeIsNull() {
+        Assert.assertEquals("", Format.format(new Date(1460323142), null, null));
+    }
+
+    /**
+     * @verifies that the locale argument can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenOnlyLocaleIsNull() {
+        Assert.assertEquals("", Format.format(new Date(1460323142), null, Format.FORMAT_TYPE.DATE));
+    }
+
+    /**
+     * @verifies that the date and type arguments can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenDateAndTypeIsNull() {
+        Assert.assertEquals("", Format.format(null, Locale.US, null));
+    }
+
+    /**
+     * @verifies that the date argument can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenOnlyDateIsNull() {
+        Assert.assertEquals("", Format.format(null, Locale.US, Format.FORMAT_TYPE.DATE));
+    }
+
+    /**
+     * @verifies that the type argument can be null
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenOnlyTypeIsNull() {
+        Assert.assertEquals("", Format.format(new Date(1460323539000L), Locale.US, null));
+    }
+
+    /**
+     * @verifies that with non-null arguments, the method returns the correct date
+     * @see Format#format(Date, Locale, Format.FORMAT_TYPE)
+     */
+    @Test
+    public void format_shouldNotFailWhenNoneOfTheParametersAreNull() {
+        Assert.assertEquals("4/10/16", Format.format(new Date(1460323539000L), Locale.US, Format.FORMAT_TYPE.DATE));
+    }
+}


### PR DESCRIPTION
…st. The added tests calls org.openmrs.util.Format.format with nulls and valid arguments. The following tests fail because it is expecting org.openmrs.util.Format.format to return null. format_shouldAllowAllNullParameters, format_shouldAllowLocaleTypeNullParameters, format_shouldAllowLocaleNullParameters, and format_shouldAllowDateLocaleNullParameters gets a NullPointerException instead and format_shouldReturnDateWithNullType and format_shouldAllowDateNullParameters receives an empty string as the return.

A bug report related to this pull request can be found on: 
https://issues.openmrs.org/browse/TRUNK-4849