### PR TITLE
TRUNK-4851 fix error in unit test

### DIFF
--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -1021,19 +1021,17 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	 * @see PatientService#checkPatientIdentifiers(Patient)
 	 */
 	@Test(expected = DuplicateIdentifierException.class)
-	@Ignore
-	// TODO fix: DuplicateIdentifierException not being thrown
 	@Verifies(value = "should throw error when patient has identical identifiers", method = "checkPatientIdentifiers(Patient)")
 	public void checkPatientIdentifiers_shouldThrowErrorWhenPatientHasIdenticalIdentifiers() throws Exception {
 		
 		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
 		
 		Patient patient = new Patient();
-		
 		// Identifier #1
+		
 		PatientIdentifier patientIdentifier1 = new PatientIdentifier();
 		patientIdentifier1.setIdentifier("123456789");
-		patientIdentifier1.setDateCreated(new Date());
+		patientIdentifier1.setLocation( new Location(2) );
 		patientIdentifier1.setIdentifierType(patientIdentifierType);
 		patient.addIdentifier(patientIdentifier1);
 		
@@ -1041,11 +1039,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		PatientIdentifier patientIdentifier2 = new PatientIdentifier();
 		patientIdentifier2.setIdentifier("123456789");
 		patientIdentifier2.setIdentifierType(patientIdentifierType);
-		patientIdentifier2.setDateCreated(new Date());
+		patientIdentifier2.setLocation( new Location(2) );
 		patient.addIdentifier(patientIdentifier2);
-		
-		// Should throw blank identifier exception
-		Context.getPatientService().checkPatientIdentifiers(patient);
+		patientService.checkPatientIdentifiers(patient);
 		
 	}
 	


### PR DESCRIPTION
class: openmrs-core/api/src/test/java/org/openmrs/api/PatientServiceTest.java
unit test: checkPatientIdentifiers_shouldThrowErrorWhenPatientHasIdenticalIdentifiers

Developers expect a DuplicateIdentifierException to be thrown during testing, but this not the case. The reason for this is because a PatientIdentifierException is thrown before a DuplicateIdentifierException can be raise. To fix this, the "location" field of the PatientIdentifier field must be initialized.