### PR TITLE
TRUNK-4854: error in uni test of WebModuleUtilTest

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -109,6 +109,7 @@ public class WebModuleUtil {
 	 * @param servletContext the current ServletContext
 	 * @param delayContextRefresh true/false whether or not to do the context refresh
 	 * @return boolean whether or not the spring context need to be refreshed
+	 * @should not throw ModuleException when serveletContext returns a directory name with whitespaces
 	 */
 	public static boolean startModule(Module mod, ServletContext servletContext, boolean delayContextRefresh) {
 		

--- a/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
+++ b/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
@@ -128,6 +128,24 @@ public class WebModuleUtilTest {
 		
 		ModuleFactory.getStartedModulesMap().clear();
 	}
+
+	@Test(expected = ModuleException.class)
+	public void startModule_shouldnotThrowModuleExceptionWhenSpacesInDirectonryName() throws Exception {
+		// create dummy module and start it
+		Module mod = buildModuleForMessageTest();
+		ModuleFactory.getStartedModulesMap().put(mod.getModuleId(), mod);
+		
+		ServletContext servletContext = mock(ServletContext.class);
+		String realPath = servletContext.getRealPath("");
+		if (realPath == null)
+			realPath = System.getProperty("user.dir");
+		when(servletContext.getRealPath("")).thenReturn(realPath + "/WEB-INF Test");
+		
+		
+		WebModuleUtil.startModule(mod, servletContext, true);
+		
+		ModuleFactory.getStartedModulesMap().clear();
+	}
 	
 	/**
 	 * @see WebModuleUtil#startModule(Module, ServletContext, boolean)


### PR DESCRIPTION
class: openmrs-core\web\src\test\java\org\openmrs\web\WebModuleUtilTest
the unit test:  startModule_shouldCreateDwrModulesXmlIfNotExists
attempts to test the startModule method in WebModuleUtil.java
 
public static boolean startModule(Module mod, ServletContext servletContext, boolean delayContextRefresh)

however this unit test will not always pass all the time.
In the case where variable realPath(a directory) in startModule contains whitespace(meaning that some clients directory name contains a space), for example dir/subdir/subdir 1/, the unit test will throw a ModuleException class. This is because in startModule the FileNotFoundException is thrown and it is caught at line 276 in WebModuleUtil.java