### PR TITLE
TRUNK-4858 startModule method should not throw ModuleExeception

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -109,6 +109,7 @@ public class WebModuleUtil {
 	 * @param servletContext the current ServletContext
 	 * @param delayContextRefresh true/false whether or not to do the context refresh
 	 * @return boolean whether or not the spring context need to be refreshed
+	 * @should not throw ModuleException when realPath contains whitespace
 	 */
 	public static boolean startModule(Module mod, ServletContext servletContext, boolean delayContextRefresh) {
 		

--- a/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
+++ b/web/src/test/java/org/openmrs/module/web/WebModuleUtilTest.java
@@ -256,5 +256,22 @@ public class WebModuleUtilTest {
 		
 		WebModuleUtil.setDispatcherServlet(dispatcherServlet);
 	}
+	/*
+	startModule should be fixed. ModuleException should not be thrown
+	*/
+	@Test(expected = ModuleException.class)
+	public void startModule_shouldnotThrowModuleExceptionWhenRealPathContainsWhitespace() throws Exception {
+		// create dummy module and start it
+		Module mod = buildModuleForMessageTest();
+		ModuleFactory.getStartedModulesMap().put(mod.getModuleId(), mod);
+		
+		ServletContext servletContext = mock(ServletContext.class);
+		String realPath = System.getProperty("user.dir");
+		
+		when(servletContext.getRealPath("")).thenReturn(realPath + "/WEB-INF Test");
+		
+		WebModuleUtil.startModule(mod, servletContext, true);
+		ModuleFactory.getStartedModulesMap().clear();
+	}
 	
 }


### PR DESCRIPTION
Class: web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
method: startModule(Module mod, ServletContext servletContext, boolean delayContextRefresh)
When String realPath = getrealPath(servletContext) return a directory name containing spaces, startModule method should not throw ModuleException
when a directory name contains a whitespace line 251 (inputStream = new FileInputStream(f) throws FileNotFoundException then a ModuleException is thrown.
startModule should not fail simply because there is a whitespace in the directory name.
see pull request with unit test that causes failure: