### PR TITLE
Added more tests to ModuleTest.java and moved the Module.getExtensions() tests

### DIFF
--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -718,6 +718,10 @@ public final class Module {
 		return ModuleFactory.isModuleStarted(this);
 	}
 	
+	/**
+	 * @param e string to set as startup error message
+	 * @should throw exception when message is null
+	 */
 	public void setStartupErrorMessage(String e) {
 		if (e == null) {
 			throw new ModuleException("Startup error message cannot be null", this.getModuleId());
@@ -733,6 +737,10 @@ public final class Module {
 	 * @param exceptionMessage optional. the default message to show on the first line of the error
 	 *            message
 	 * @param t throwable stacktrace to include in the error message
+	 *
+	 * @should throw exception when throwable is null
+	 * @should set StartupErrorMessage when exceptionMessage is null
+	 * @should append throwable's message to exceptionMessage
 	 */
 	public void setStartupErrorMessage(String exceptionMessage, Throwable t) {
 		if (t == null) {
@@ -773,7 +781,10 @@ public final class Module {
 		
 		return moduleId;
 	}
-	
+
+	/*
+	 * @should dispose all classInstances, not AdvicePoints
+	 */	
 	public void disposeAdvicePointsClassInstance() {
 		if (advicePoints == null) {
 			return;

--- a/api/src/test/java/org/openmrs/module/ModuleExtensionsTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleExtensionsTest.java
@@ -1,0 +1,123 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.mockito.Mockito.never;
+
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+
+/**
+ * Tests Module Methods
+ */
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Module.class)
+public class ModuleExtensionsTest {
+
+	private Module mockModule;
+
+	@Before
+	public void before() throws Exception {
+		mockModule = spy(new Module("mockmodule"));
+	}
+
+	/*
+	 * @verifies not expand extensionNames if extensionNames is null
+	 * @see Module#getExtensions()
+	 */
+	@Test
+	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionNamesIsNull() throws Exception {
+		ArrayList<Extension> extensions = new ArrayList<Extension>();
+
+		Extension mockExtension = new MockExtension();
+		extensions.add(mockExtension);
+
+		mockModule.setExtensions(extensions);
+		mockModule.setExtensionNames(null);
+		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
+
+		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+	}
+
+	/*
+         * @verifies not expand extensionNames if extensionNames is empty
+	 * @see Module#getExtensions()
+	 */
+	@Test
+	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionNamesIsEmpty() throws Exception {
+		ArrayList<Extension> extensions = new ArrayList<Extension>();
+
+		Extension mockExtension = new MockExtension();
+		extensions.add(mockExtension);
+
+		mockModule.setExtensions(extensions);
+		mockModule.setExtensionNames(new IdentityHashMap<String, String>());
+		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
+
+		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+	}
+
+	/*
+         * @verifies not expand extensionNames if extensions matches extensionNames
+	 * @see Module#getExtensions()
+	 */
+	@Test
+	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionsMatchesExtensionNames() throws Exception {
+		ArrayList<Extension> extensions = new ArrayList<Extension>();
+		IdentityHashMap<String, String> extensionNames = new IdentityHashMap<String, String>();
+
+		Extension mockExtension = new MockExtension();
+		mockExtension.setPointId("1");
+		extensions.add(mockExtension);
+		extensionNames.put("1", mockExtension.getClass().getName());
+
+		mockModule.setExtensions(extensions);
+		mockModule.setExtensionNames(extensionNames);
+		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
+
+		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+	}
+
+	/*
+         * @verifies expand extensionNames if extensions does not match extensionNames
+	 * @see Module#getExtensions()
+	 */
+	@Test
+	public void getExtensions_shouldExpandExtensionNamesIfExtensionsDoesNotMatchExtensionNames() throws Exception {
+		ArrayList<Extension> extensions = new ArrayList<Extension>();
+		IdentityHashMap<String, String> extensionNames = new IdentityHashMap<String, String>();
+
+		Extension mockExtension = new MockExtension();
+		mockExtension.setPointId("1");
+		extensions.add(mockExtension);
+		extensionNames.put("2", mockExtension.getClass().getName());
+
+		mockModule.setExtensions(extensions);
+		mockModule.setExtensionNames(extensionNames);
+		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
+
+		verifyPrivate(mockModule).invoke("expandExtensionNames");
+	}
+
+	private class MockExtension extends Extension {
+		public Extension.MEDIA_TYPE getMediaType() {
+			return null;
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/module/ModuleTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleTest.java
@@ -9,116 +9,171 @@
  */
 package org.openmrs.module;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
-import static org.powermock.api.mockito.PowerMockito.spy;
-import static org.mockito.Mockito.never;
-
 import org.junit.Test;
 import org.junit.Before;
-import org.junit.runner.RunWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
-import java.util.Properties;
 
 /**
  * Tests Module Methods
  */
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Module.class)
 public class ModuleTest {
 
-	private Module mockModule;
+	private Module testModule;
 
 	@Before
 	public void before() throws Exception {
-		mockModule = spy(new Module("mockmodule"));
+		testModule = new Module("test");
 	}
 
 	/*
-	 * @verifies not expand extensionNames if extensionNames is null
-	 * @see Module#getExtensions()
+	 * @verifies throw exception when message is null
+	 * @see Module#setStartupErrorMessage(String)
 	 */
-	@Test
-	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionNamesIsNull() throws Exception {
-		ArrayList<Extension> extensions = new ArrayList<Extension>();
-
-		Extension mockExtension = new MockExtension();
-		extensions.add(mockExtension);
-
-		mockModule.setExtensions(extensions);
-		mockModule.setExtensionNames(null);
-		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
-
-		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+	@Test(expected = ModuleException.class)
+	public void setStartupErrorMessage_shouldThrowExceptionWhenMessageIsNull() throws Exception {
+		testModule.setStartupErrorMessage(null);
 	}
 
 	/*
-         * @verifies not expand extensionNames if extensionNames is empty
-	 * @see Module#getExtensions()
+	 * @verifies throw exception when throwable is null
+	 * @see Module#setStartupErrorMessage(String, Throwable)
 	 */
-	@Test
-	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionNamesIsEmpty() throws Exception {
-		ArrayList<Extension> extensions = new ArrayList<Extension>();
-
-		Extension mockExtension = new MockExtension();
-		extensions.add(mockExtension);
-
-		mockModule.setExtensions(extensions);
-		mockModule.setExtensionNames(new IdentityHashMap<String, String>());
-		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
-
-		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+	@Test(expected = ModuleException.class)
+	public void setStartupErrorMessage_shouldThrowExceptionWhenThrowableIsNull() throws Exception {
+		testModule.setStartupErrorMessage("error", null);
 	}
 
 	/*
-         * @verifies not expand extensionNames if extensions matches extensionNames
-	 * @see Module#getExtensions()
+	 * @verifies set startupErrorMessage when exceptionMessage is null
+	 * @see Module#setStartupErrorMessage(String, Throwable)
 	 */
 	@Test
-	public void getExtensions_shouldNotExpandExtensionNamesIfExtensionsMatchesExtensionNames() throws Exception {
-		ArrayList<Extension> extensions = new ArrayList<Extension>();
-		IdentityHashMap<String, String> extensionNames = new IdentityHashMap<String, String>();
+	public void setStartupErrorMessage_shouldsetStartupErrorMessageWhenExceptionMessageIsNull () {
+		ModuleException modException = new ModuleException("error");
 
-		Extension mockExtension = new MockExtension();
-		mockExtension.setPointId("1");
-		extensions.add(mockExtension);
-		extensionNames.put("1", mockExtension.getClass().getName());
+		assertFalse(testModule.hasStartupError());
+		testModule.setStartupErrorMessage(null, modException);
+		assertTrue(testModule.hasStartupError());
 
-		mockModule.setExtensions(extensions);
-		mockModule.setExtensionNames(extensionNames);
-		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
-
-		verifyPrivate(mockModule, never()).invoke("expandExtensionNames");
+		assertEquals("error\n", testModule.getStartupErrorMessage());
 	}
 
 	/*
-         * @verifies expand extensionNames if extensions does not match extensionNames
-	 * @see Module#getExtensions()
+	 * @verifies append the throwable's message to exceptionMessage
+ 	 * @see Module#setStartupErrorMessage(String, Throwable)
 	 */
 	@Test
-	public void getExtensions_shouldExpandExtensionNamesIfExtensionsDoesNotMatchExtensionNames() throws Exception {
-		ArrayList<Extension> extensions = new ArrayList<Extension>();
-		IdentityHashMap<String, String> extensionNames = new IdentityHashMap<String, String>();
+	public void setStartupErrorMessage_shouldAppendTheThrowablesMessageToExceptionMessage() {
+		ModuleException modException = new ModuleException("error2");
 
-		Extension mockExtension = new MockExtension();
-		mockExtension.setPointId("1");
-		extensions.add(mockExtension);
-		extensionNames.put("2", mockExtension.getClass().getName());
+		assertNull(testModule.getStartupErrorMessage());
+		testModule.setStartupErrorMessage("error1", modException);
 
-		mockModule.setExtensions(extensions);
-		mockModule.setExtensionNames(extensionNames);
-		ArrayList<Extension> ret = new ArrayList<Extension>(mockModule.getExtensions());
-
-		verifyPrivate(mockModule).invoke("expandExtensionNames");
+		assertEquals("error1\nerror2\n", testModule.getStartupErrorMessage());
 	}
 
-	private class MockExtension extends Extension {
-		public Extension.MEDIA_TYPE getMediaType() {
-			return null;
-		}
+	/*
+	 * @verifies set modules when there is a null required modules map
+	 * @see Module#setRequiredModules(List<String>)
+	 */
+	@Test
+	public void setRequiredModules_shouldSetModulesWhenThereIsANullRequiredModulesMap() {
+		testModule.setRequiredModulesMap(null);
+		assertNull(testModule.getRequiredModulesMap());
+
+		ArrayList<String> first = new ArrayList<String>();
+		ArrayList<String> second = new ArrayList<String>();
+
+		first.add("mod1");
+		first.add("mod2");
+		second.add("mod2");
+		second.add("mod3");
+
+		testModule.setRequiredModules(first);
+		testModule.setRequiredModules(second);
+
+		ArrayList<String> ret = new ArrayList<String>(testModule.getRequiredModules());
+		assertTrue(ret.contains("mod1"));
+		assertTrue(ret.contains("mod2"));
+		assertTrue(ret.contains("mod3"));
+		assertEquals(3, ret.size());
+	}
+
+	/*
+	 * @verifies return null if no required modules exist
+	 * @see Module#getRequiredModuleVersion(String)
+	 */
+	@Test
+	public void getRequiredModuleVersion_shouldReturnNullIfNoRequiredModulesExist() {
+		testModule.setRequiredModulesMap(null);
+		assertNull(testModule.getRequiredModules());
+
+		testModule.addRequiredModule("mod1", "1.0");
+		assertNull(testModule.getRequiredModuleVersion("mod1"));
+	}
+
+	/*
+	 * @verifies return null if no required module by given name exists
+	 * @see Module#getRequiredModuleVersion(String)
+	 */
+	@Test
+	public void getRequiredModuleVersion_shouldReturnNullIfNoRequiredModuleByGivenNameExists () {
+		IdentityHashMap<String, String> requiredModules = new IdentityHashMap<String, String>();
+		
+		requiredModules.put("mod1", "1.0");
+		testModule.setRequiredModulesMap(requiredModules);
+
+		assertEquals("1.0", testModule.getRequiredModuleVersion("mod1"));
+		assertNull(testModule.getRequiredModuleVersion("mod2"));
+	}
+
+	/*
+	 * @verifies should add module to required modules map
+	 * @see Module#addRequiredModule(String, String)
+	 */
+	@Test
+	public void addRequiredModule_shouldAddModuleToRequiredModulesMap () {
+		testModule.setRequiredModulesMap(new IdentityHashMap<String, String>());		
+		testModule.addRequiredModule("mod1", "1.0");
+		
+		assertEquals("1.0", testModule.getRequiredModuleVersion("mod1"));
+	}
+
+	/*
+	 * @verifies dispose all classInstances, not AdvicePoints
+	 * @see Module#disposeAdvicePointsClassInstance()
+	 */
+	@Test
+	public void disposeAdvicePointsClassInstance_shouldDisposeAllClassInstancesNotAdvicePoints() {
+		ArrayList<AdvicePoint> points = new ArrayList<AdvicePoint>();
+		String obj1 = "string";
+		ArrayList<String> obj2 = new ArrayList<String>();
+		AdvicePoint point1 = new AdvicePoint("point1", obj1.getClass());
+		AdvicePoint point2 = new AdvicePoint("point2", obj2.getClass());
+
+		points.add(point1);
+		points.add(point2);
+
+		testModule.setAdvicePoints(null);
+		testModule.disposeAdvicePointsClassInstance();
+
+		assertEquals(obj1.getClass(), point1.getClassInstance().getClass());
+		assertEquals(obj2.getClass(), point2.getClassInstance().getClass());
+
+		testModule.setAdvicePoints(points);
+		testModule.disposeAdvicePointsClassInstance();
+
+		assertNotNull(point1);
+		assertNotNull(point2);
+		assertNull(point1.getClassInstance());
+		assertNull(point2.getClassInstance());
 	}
 }


### PR DESCRIPTION
The accompanying JIRA ticket is: https://issues.openmrs.org/browse/APPTEST-56

Since the Module.getExtensions() tests in ModuleTest.java used PowerMock, their test coverage is not tracked by jacoco.  These tests were moved into their own file, ModuleExtensionsTest.java, so that new tests could be added to ModuleTest.java and still be trackied with jacoco and Sonarqube.  