### PR TITLE
TRUNK-4863 Add github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- This project only accepts pull requests related to open issues -->
+<!--- If suggesting a new feature or change, please discuss it in an issue
+first -->
+<!--- If fixing a bug, there should be an issue describing it with steps to
+reproduce -->
+<!--- Please link to the issue here: -->
+see https://issues.openmrs.org/browse/TRUNK-
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that
+apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
+help! -->
+- [ ] My pull request only contains one single commit.
+- [ ] My pull request is based on the latest master branch
+  `git pull --rebase upstream master`.
+- [ ] I ran `mvn clean package` right before creating this pull request and
+  added all formatting changes to my commit.
+- [ ] My code follows the code style of this project.
+- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.
+

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ nb-configuration.xml
 !.gitignore
 !.gitattributes
 !.tx
+!.github/
 *~
 #############
 


### PR DESCRIPTION
* added .github/PULL_REQUEST_TEMPLATE.md which will be shown
to every contributor opening a new PR. Its used as a guidance
to ensure PRs will be created in a consistent format with all
required information.

see https://issues.openmrs.org/browse/TRUNK-4863