### PR TITLE
Apptest 57

### DIFF
--- a/api/src/test/java/org/openmrs/api/FormServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/FormServiceTest.java
@@ -716,41 +716,6 @@ public class FormServiceTest extends BaseContextSensitiveTest {
 		Assert.assertFalse(previous.equals(actual.getValue()));
 		Assert.assertEquals(expected, actual.getValue());
 	}
-
-	//Added tests to check if getForm(String, String) can have null features
-	@Test
-	@Verifies(method = "getForm(String, String)", value = "should return null if either name or version are null")
-	public void getForm_shouldReturnNullFormIfBothNameAndVersionAreNull() throws Exception {
-		FormService fs = Context.getFormService();
-		createFormsLockedGPAndSetValue("true");
-		
-		Form form = fs.getForm(null, null);
-		Assert.assertNull(form);
-	}
-
-	@Test
-	@Verifies(method = "getForm(String, String)", value = "should return null if version is null")
-	public void getForm_shouldReturnNullFormIVersionIsNull() throws Exception {
-		FormService fs = Context.getFormService();
-		createFormsLockedGPAndSetValue("true");
-		Form form = new Form();
-		form.setName("new form");
-	
-		Assert.assertNull(fs.getForm("new form", null));
-	}
-
-	@Test
-	@Verifies(method = "getForm(String, String)", value = "should return null if name is null")
-	public void getForm_shouldReturnNullFormIfNameIsNull() throws Exception {
-		FormService fs = Context.getFormService();
-		createFormsLockedGPAndSetValue("true");
-		
-		Form form = new Form();
-		form.setVersion("1.0");
-
-		Assert.assertNull(fs.getForm(null, "1.0"));
-
-	}
 	
 	/**
 	 * @see FormService#purgeForm(Form)

--- a/api/src/test/java/org/openmrs/api/FormServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/FormServiceTest.java
@@ -716,6 +716,41 @@ public class FormServiceTest extends BaseContextSensitiveTest {
 		Assert.assertFalse(previous.equals(actual.getValue()));
 		Assert.assertEquals(expected, actual.getValue());
 	}
+
+	//Added tests to check if getForm(String, String) can have null features
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if either name or version are null")
+	public void getForm_shouldReturnNullFormIfBothNameAndVersionAreNull() throws Exception {
+		FormService fs = Context.getFormService();
+		createFormsLockedGPAndSetValue("true");
+		
+		Form form = fs.getForm(null, null);
+		Assert.assertNull(form);
+	}
+
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if version is null")
+	public void getForm_shouldReturnNullFormIVersionIsNull() throws Exception {
+		FormService fs = Context.getFormService();
+		createFormsLockedGPAndSetValue("true");
+		Form form = new Form();
+		form.setName("new form");
+	
+		Assert.assertNull(fs.getForm("new form", null));
+	}
+
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if name is null")
+	public void getForm_shouldReturnNullFormIfNameIsNull() throws Exception {
+		FormService fs = Context.getFormService();
+		createFormsLockedGPAndSetValue("true");
+		
+		Form form = new Form();
+		form.setVersion("1.0");
+
+		Assert.assertNull(fs.getForm(null, "1.0"));
+
+	}
 	
 	/**
 	 * @see FormService#purgeForm(Form)

--- a/api/src/test/java/org/openmrs/api/FormServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/FormServiceTest.java
@@ -484,7 +484,6 @@ public class FormServiceTest extends BaseContextSensitiveTest {
 		FormService fs = Context.getFormService();
 		Form form = new Form();
 		createFormsLockedGPAndSetValue("true");
-		
 		form.setVersion("1.0");
 
 		Assert.assertNull(fs.getForm(null, "1.0"));

--- a/api/src/test/java/org/openmrs/api/FormServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/FormServiceTest.java
@@ -449,6 +449,48 @@ public class FormServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
+	 * @see FormService#getForm(String, String)
+	 */
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if either name or version are null")
+	public void getForm_shouldReturnNullFormIfBothNameAndVersionAreNull() throws Exception {
+		FormService fs = Context.getFormService();
+		Form form = fs.getForm(null, null);
+		createFormsLockedGPAndSetValue("true");
+		
+		Assert.assertNull(form);
+	}
+
+	/**
+	 * @see FormService#getForm(String, String)
+	 */
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if version is null")
+	public void getForm_shouldReturnNullFormIVersionIsNull() throws Exception {
+		FormService fs = Context.getFormService();
+		Form form = new Form();
+		createFormsLockedGPAndSetValue("true");
+		form.setName("new form");
+	
+		Assert.assertNull(fs.getForm("new form", null));
+	}
+
+	/**
+	 * @see FormService#getForm(String, String)
+	 */
+	@Test
+	@Verifies(method = "getForm(String, String)", value = "should return null if name is null")
+	public void getForm_shouldReturnNullFormIfNameIsNull() throws Exception {
+		FormService fs = Context.getFormService();
+		Form form = new Form();
+		createFormsLockedGPAndSetValue("true");
+		
+		form.setVersion("1.0");
+
+		Assert.assertNull(fs.getForm(null, "1.0"));
+	}
+
+	/**
 	 * @see FormService#getFieldAnswerByUuid(String)
 	 */
 	@Test


### PR DESCRIPTION
Increased coverage for getForm(String, String) in the FormService class. Some combinational input values were not covered (in this case, null values). A test was written to check two null inputs, 1 null input and string name, and another null input and string version. These tests pass using assertNull. 