### PR TITLE
Add tests for TRUNK-4864 and fix NullPointerException issue

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientSetServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientSetServiceImpl.java
@@ -249,7 +249,9 @@ public class PatientSetServiceImpl extends BaseOpenmrsService implements Patient
 		} else {
 			if (groupMethod == GroupMethod.NONE) {
 				// Patients taking none of the specified drugs
-				
+				if (patientIds == null) {
+					patientIds = getAllPatients().getMemberIds();
+				}
 				// first get all patients taking no drugs at all
 				ret.addAll(patientIds);
 				ret.removeAll(activeDrugs.keySet());

--- a/api/src/test/java/org/openmrs/api/PatientSetServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientSetServiceTest.java
@@ -167,7 +167,45 @@ public class PatientSetServiceTest extends BaseContextSensitiveTest {
 		Assert.assertEquals(1, cohort.size());
 		Assert.assertTrue(cohort.contains(2));
 	}
-	
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients with no drug orders", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsWithNoDrugOrders() throws Exception {
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, null, null);
+		Assert.assertEquals(2, cohort.size());
+		Assert.assertTrue(cohort.contains(6));
+		Assert.assertTrue(cohort.contains(8));
+	}
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients with any drug order", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsWithDrugInDrugOrder() throws Exception {
+		List<Integer> drugIds = new ArrayList<Integer>();
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, drugIds, null);
+		Assert.assertEquals(2, cohort.size());
+		Assert.assertTrue(cohort.contains(2));
+		Assert.assertTrue(cohort.contains(7));
+	}
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients with any drug in the drug list", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsWithAnyDrugInTheDrugList() throws Exception {
+		List<Integer> drugIds = new ArrayList<Integer>();
+		drugIds.add(2);
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, drugIds, null);
+		Assert.assertEquals(1, cohort.size());
+		Assert.assertTrue(cohort.contains(2));
+	}
+
 	/**
 	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, GroupMethod, Date, Date)
 	 */
@@ -204,7 +242,51 @@ public class PatientSetServiceTest extends BaseContextSensitiveTest {
 		Assert.assertEquals(1, cohort.size());
 		Assert.assertTrue(cohort.contains(2));
 	}
-	
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, GroupMethod, Date, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients do not contain any drug in the drug list", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,GroupMethod,Date,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsDoNotContainAnyDrugInTheDrugList() throws Exception {
+		List<Integer> drugIds = new ArrayList<Integer>();
+		drugIds.add(2);
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, drugIds, GroupMethod.NONE, null, null);
+		Assert.assertEquals(3, cohort.size());
+		Assert.assertTrue(cohort.contains(6));
+		Assert.assertTrue(cohort.contains(7));
+		Assert.assertTrue(cohort.contains(8));
+	}
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, GroupMethod, Date, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients contain all drugs in the drug list", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,GroupMethod,Date,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsContainAllDrugsInTheDrugList() throws Exception {
+		List<Integer> drugIds = new ArrayList<Integer>();
+		drugIds.add(2);
+		drugIds.add(3);
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, drugIds, GroupMethod.ALL, null, null);
+		Assert.assertEquals(1, cohort.size());
+		Assert.assertTrue(cohort.contains(2));
+	}
+
+	/**
+	 * @see PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, GroupMethod, Date, Date)
+	 */
+	@Test
+	@Verifies(value = "should get all patients does contain any drug in the drug list", method = "getPatientsHavingDrugOrder(Collection<QInteger;>,Collection<QInteger;>,GroupMethod,Date,Date)")
+	public void getPatientsHavingDrugOrder_shouldGetAllPatientsContainAnyDrugInTheDrugList() throws Exception {
+		List<Integer> drugIds = new ArrayList<Integer>();
+		drugIds.add(2);
+		drugIds.add(3);
+		Cohort cohort = service.getPatientsHavingDrugOrder(null, drugIds, GroupMethod.ANY, null, null);
+		Assert.assertEquals(2, cohort.size());
+		Assert.assertTrue(cohort.contains(2));
+		Assert.assertTrue(cohort.contains(7));
+	}
+
 	/**
 	 * @see PatientSetService#getPatientsHavingObs(Integer,TimeModifier,Modifier,Object,Date,Date)
 	 *      test = should get patients by concept and false boolean value


### PR DESCRIPTION
If we call method PatientSetService#getPatientsHavingDrugOrder(java.util.Collection, java.util.Collection, GroupMethod, Date, Date) with following parameters, it will throw NullPointerException.

Parameters:
patientIds = null
takingIds = a collection list with number of element larger than zero
groupMethod = GroupMethod.NONE
fromDate = null
toDate = null

Original code fails for added test: getPatientsHavingDrugOrder_shouldGetAllPatientsDoNotContainAnyDrugInTheDrugList

Ticket: https://issues.openmrs.org/browse/TRUNK-4864