### PR TITLE
RAD-151 radiolgyOrderForm looses Orderer on error

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/dwr.xml
+++ b/webapp/src/main/webapp/WEB-INF/dwr.xml
@@ -237,6 +237,7 @@
 			<param name="class" value="org.openmrs.web.dwr.DWRProviderService" />
 			<include method="findProviderCountAndProvider"/>
 			<include method="findProvider"/>
+			<include method="getProvider"/>
 		</create>
 				
 	</allow>

--- a/webapp/src/main/webapp/WEB-INF/tags/providerField.tag
+++ b/webapp/src/main/webapp/WEB-INF/tags/providerField.tag
@@ -44,8 +44,8 @@
 		<c:if test="${not empty initialValue}">
 			jquerySelectEscaped("${formFieldId}").val("${initialValue}");
 			DWRProviderService.getProvider("${initialValue}", function(provider) {
-				jquerySelectEscaped("${displayNameInputId}").val(provider.name);
-				jquerySelectEscaped("${displayNameInputId}").autocomplete("option", "initialValue", provider.name);
+				jquerySelectEscaped("${displayNameInputId}").val(provider.displayName);
+				jquerySelectEscaped("${displayNameInputId}").autocomplete("option", "initialValue", provider.displayName);
 				<c:if test="${not empty callback}">
 					${callback}("${formFieldName}", provider);
 			</c:if>


### PR DESCRIPTION
Orderer input field no longer loses data after form error messages. The Oderer is now populated with the data the user had previously typed before clicking "Save Order".
Changed provider.name to provider.displayName in providerField.tag. Additionally added the getProvider method for DWRProviderService in the dwr.xml file

![](https://cloud.githubusercontent.com/assets/3146497/15001716/92391b8e-115f-11e6-9973-9a6c047e3122.png)


![](https://cloud.githubusercontent.com/assets/3146497/15001719/9682b4b6-115f-11e6-86e0-5995ecb8e4be.png)

![](https://cloud.githubusercontent.com/assets/3146497/15001723/98ed9cac-115f-11e6-9134-f1890fa0b744.png)

![](https://cloud.githubusercontent.com/assets/3146497/15001724/9bfbe610-115f-11e6-80c4-e986a864ddf7.png)

![](https://cloud.githubusercontent.com/assets/3146497/15001728/9e672c5c-115f-11e6-8dd5-a750a4b69d98.png)

![](https://cloud.githubusercontent.com/assets/3146497/15001732/a1664af0-115f-11e6-8d38-3ddf60b7c135.png)


