### PR TITLE
Added unit tests as per TRUNK-4880

### DIFF
--- a/api/src/test/java/org/openmrs/customdatatype/CustomDatatypeUtilTest.java
+++ b/api/src/test/java/org/openmrs/customdatatype/CustomDatatypeUtilTest.java
@@ -11,6 +11,7 @@ package org.openmrs.customdatatype;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,4 +36,75 @@ public class CustomDatatypeUtilTest extends BaseContextSensitiveTest {
 		Assert.assertEquals("one value", deserialized.get("one property"));
 		Assert.assertEquals("another value < with > strange&nbsp;characters", deserialized.get("another property"));
 	}
+	/**
+	 * @see CustomDatatypeUtil#serializeSimpleConfiguration(String)
+	 * @verifies serialize a deserialized null
+	 */
+
+	@Test
+	public void serializeSimpleConfiguration_shouldSerializeaDeserializedNullWithoutException() 
+		throws Exception {
+		String serialized = CustomDatatypeUtil.serializeSimpleConfiguration(null);
+		Map<String, String> deserialized = CustomDatatypeUtil.deserializeSimpleConfiguration(serialized);
+		Assert.assertEquals(0, deserialized.size());
+                Assert.assertEquals(null, deserialized.get(""));
+	}
+        /**
+         * @see CustomDatatypeUtil#getDatatypeClassnames()
+         * @see CustomDatatypeUtil#getHandlerClassnames()
+         * @verifies length of datatype and handlers, tests get methods
+         */
+
+	@Test
+        public void getDatatypeHandlerClassnames_shouldGetClassnames()
+                throws Exception {
+		Assert.assertEquals(10,CustomDatatypeUtil.getDatatypeClassnames().size());
+		Assert.assertEquals(2,CustomDatatypeUtil.getHandlerClassnames().size());
+        }
+        /**
+         * @see CustomDatatypeUtil#getDatatype(String,String)
+         * @verifies null strings for getDatatype
+         */
+
+	@Test(expected = CustomDatatypeException.class)
+        public void getDatatype_shouldThrowCustomDatatypeException()
+                throws Exception {
+		CustomDatatypeUtil.getDatatype(null,null);
+	}
+        /**
+         * @see CustomDatatypeUtil#getDatatypeOrDefault(CustomValueDescriptor)
+         * not sure if this is a bug or a feature
+         * throws null pointer exception
+         */
+
+	@Test(expected = NullPointerException.class)
+        public void getDatatypeOrDefault_shouldThrowNullPointer()
+                throws Exception {
+                CustomDatatypeUtil.getDatatypeOrDefault(null);
+        }
+
+	/**
+         * @see CustomDatatypeUtil#getDatatype(CustomValueDescriptor)
+         * not sure if this is a bug or a feature
+         * throws null pointer exception
+         */
+
+        @Test(expected = NullPointerException.class)
+        public void getDatatype_shouldThrowNullPointer()
+                throws Exception {
+                CustomDatatypeUtil.getDatatype(null);
+        }
+
+	/**
+         * @see CustomDatatypeUtil#getHandler(CustomValueDescriptor)
+         * not sure if this is a bug or a feature
+         * throws null pointer exception
+         */
+
+        @Test(expected = NullPointerException.class)
+        public void getHandler_shouldThrowNullPointer()
+                throws Exception {
+                CustomDatatypeUtil.getHandler(null);
+        }
+        
 }


### PR DESCRIPTION
Added unit tests for exception handling and two get methods. Upon testing, I have found that getDatatypeOrDefault() can return a NullPointerException is null is passed in, however the paramater dictates that a CustomValueDescriptor should be passed into it.
Similarly, getDatatype() and getHandler() will also throw a NullPointerException if null is passed in. This could be a bug or a feature, and in my tests I assume it is a feature.