### PR TITLE
TRUNK-4720 search will not match on id unless it contains digits

### DIFF
--- a/api/src/main/java/org/openmrs/api/EncounterService.java
+++ b/api/src/main/java/org/openmrs/api/EncounterService.java
@@ -381,6 +381,8 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get all unvoided encounters for the given patient identifier
 	 * @should throw error if given null parameter
 	 * @should include voided encounters in the returned list if includedVoided is true
+	 * @should get all unvoided encounters for the given substring of patient names
+	 * @should not get encounters for the given substring of patient identifiers
 	 * @since 1.7
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -423,16 +423,8 @@ public class HibernateEncounterDAO implements EncounterDAO {
 				criteria.add(or);
 			}
 		} else {
-			String name = null;
-			String identifier = null;
-			if (query.matches(".*\\d+.*")) {
-				identifier = query;
-			} else {
-				// there is no number in the string, search on name
-				name = query;
-			}
-			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(name, identifier,
-			    new ArrayList<PatientIdentifierType>(), false, orderByNames, false);
+			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(query, query,
+				    new ArrayList<PatientIdentifierType>(), true, orderByNames, true);
 		}
 		
 		return criteria;

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -9421,4 +9421,115 @@
 								 referencedColumnNames="user_id"/>
 	</changeSet>
 
+    <changeSet id="TRUNK-3422-20160216-1700" author="Wyclif" >
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM privilege  WHERE privilege='Get Visits';
+            </sqlCheck>
+        </preConditions>
+        <comment>Add "Get Visits" privilege</comment>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Visits" />
+            <column name="description" value="Able to get visits" />
+            <column name="uuid" value="4e7bdbc8-3975-11e6-899a-a4d646d86a8a" />
+        </insert>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1701" author="Wyclif" >
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM privilege  WHERE privilege='Get Providers';
+            </sqlCheck>
+        </preConditions>
+        <comment>Add "Get Providers" privilege</comment>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Providers" />
+            <column name="description" value="Able to get Providers" />
+            <column name="uuid" value="5594745c-3988-11e6-899a-a4d646d86a8a" />
+        </insert>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1702" author="Wyclif" >
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(*) FROM privilege  WHERE privilege='Add Visits';
+            </sqlCheck>
+        </preConditions>
+        <comment>Add "Add Visits" privilege</comment>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Visits" />
+            <column name="description" value="Able to add visits" />
+            <column name="uuid" value="65d14b28-3989-11e6-899a-a4d646d86a8a" />
+        </insert>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1703" author="PralayRamteke" >
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(*) FROM role_privilege  WHERE privilege='Get Encounters';
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <comment>Add "Get Visits" privilege to the roles having "Get Encounter"</comment>
+        <sql>
+            INSERT INTO role_privilege (role, privilege)
+            SELECT role, 'Get Visits' from role_privilege rp
+            WHERE rp.privilege = 'Get Encounters'
+            AND NOT EXISTS (SELECT role, privilege FROM role_privilege rp2 WHERE rp2.privilege='Get Visits'
+            AND rp2.role=rp.role);
+        </sql>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1704" author="PralayRamteke" >
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(*) FROM role_privilege  WHERE privilege='Get Encounters';
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <comment>Add "Get Providers" privilege to the roles having "Get Encounter"</comment>
+        <sql>
+            INSERT INTO role_privilege (role, privilege)
+            SELECT role, 'Get Providers' from role_privilege rp
+            WHERE rp.privilege = 'Get Encounters'
+            AND NOT EXISTS (SELECT role, privilege FROM role_privilege rp2 WHERE rp2.privilege='Get Providers'                  AND rp2.role=rp.role);
+        </sql>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1705" author="Wyclif" >
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(*) FROM role_privilege  WHERE privilege='Add Encounters';
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <comment>Add "Add Visits" privilege to the roles having "Add Encounters"</comment>
+        <sql>
+            INSERT INTO role_privilege (role, privilege)
+            SELECT role, 'Add Visits' from role_privilege rp
+            WHERE rp.privilege = 'Add Encounters'
+            AND NOT EXISTS (SELECT role, privilege FROM role_privilege rp2 WHERE rp2.privilege='Add Visits'                     AND rp2.role=rp.role);
+        </sql>
+    </changeSet>
+
+    <changeSet id="TRUNK-3422-20160216-1706" author="Wyclif" >
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(*) FROM role_privilege  WHERE privilege='Edit Encounters';
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <comment>Add "Add Visits" privilege to the roles having "Edit Encounters"</comment>
+        <sql>
+            INSERT INTO role_privilege (role, privilege)
+            SELECT role, 'Add Visits' from role_privilege rp
+            WHERE rp.privilege = 'Edit Encounters'
+            AND NOT EXISTS (SELECT role, privilege FROM role_privilege rp2 WHERE rp2.privilege='Add Visits'                     AND rp2.role=rp.role);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2977,6 +2977,7 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	@Verifies(value = "should not get encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
+	@Verifies(value = "should not get unvoided encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
 		EncounterService encounterService = Context.getEncounterService();
 		

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2958,14 +2958,14 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		}
 		
 		assertEquals("Two New Order Groups Get Saved", 2, orderGroups.size());
-	}	
+	}
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
 	@Test
 	@Verifies(value = "should get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldGetAllUnvoidedEncountersForTheGivenSubstringOfPatientNames() throws Exception {
-		EncounterService encounterService = Context.getEncounterService();		
+		EncounterService encounterService = Context.getEncounterService();
 		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
 		assertEquals(3, encounters.size());
 	}

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2959,4 +2959,30 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		
 		assertEquals("Two New Order Groups Get Saved", 2, orderGroups.size());
 	}
+	
+	/**
+	 * @see EncounterService#getEncountersByPatient(String,boolean)
+	 */
+	@Test
+	@Verifies(value = "should get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
+	public void getEncountersByPatient_shouldGetAllUnvoidedEncountersForTheGivenSubstringOfPatientNames() throws Exception {
+		EncounterService encounterService = Context.getEncounterService();
+		
+		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
+		assertEquals(3, encounters.size());
+	}
+
+	/**
+	 * @see EncounterService#getEncountersByPatient(String,boolean)
+	 */
+	@Test
+	@Verifies(value = "should not get unvoided encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
+	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
+		EncounterService encounterService = Context.getEncounterService();
+		
+		List<Encounter> encounters = encounterService.getEncountersByPatient("123", false);
+		assertEquals(0, encounters.size());
+		encounters = encounterService.getEncountersByPatient("1234", false);
+		assertEquals(1, encounters.size());
+	}
 }

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2958,24 +2958,17 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		}
 		
 		assertEquals("Two New Order Groups Get Saved", 2, orderGroups.size());
-	}
-	
+	}	
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
 	@Test
 	@Verifies(value = "should get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldGetAllUnvoidedEncountersForTheGivenSubstringOfPatientNames() throws Exception {
-		EncounterService encounterService = Context.getEncounterService();
-		
+		EncounterService encounterService = Context.getEncounterService();		
 		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
 		assertEquals(3, encounters.size());
 	}
-<<<<<<< HEAD
-//tst
-=======
-	
->>>>>>> 62bb35e35f82dc4959131b03b2e483c02b0094de
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
@@ -2984,7 +2977,6 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should not get unvoided encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
 		EncounterService encounterService = Context.getEncounterService();
-		
 		List<Encounter> encounters = encounterService.getEncountersByPatient("123", false);
 		assertEquals(0, encounters.size());
 		encounters = encounterService.getEncountersByPatient("1234", false);

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2971,7 +2971,7 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
 		assertEquals(3, encounters.size());
 	}
-
+//tst
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2976,7 +2976,7 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
 	@Test
-	@Verifies(value = "should not get unvoided encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
+	@Verifies(value = "should not get encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
 		EncounterService encounterService = Context.getEncounterService();
 		

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2959,24 +2959,27 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		
 		assertEquals("Two New Order Groups Get Saved", 2, orderGroups.size());
 	}
+	
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
 	@Test
-	@Verifies(value = "should get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
+	@Verifies(value = "get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldGetAllUnvoidedEncountersForTheGivenSubstringOfPatientNames() throws Exception {
 		EncounterService encounterService = Context.getEncounterService();
+		
 		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
 		assertEquals(3, encounters.size());
 	}
+	
 	/**
 	 * @see EncounterService#getEncountersByPatient(String,boolean)
 	 */
 	@Test
-	@Verifies(value = "should not get encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
-	@Verifies(value = "should not get unvoided encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
+	@Verifies(value = "not get encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
 	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
 		EncounterService encounterService = Context.getEncounterService();
+		
 		List<Encounter> encounters = encounterService.getEncountersByPatient("123", false);
 		assertEquals(0, encounters.size());
 		encounters = encounterService.getEncountersByPatient("1234", false);

--- a/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
@@ -467,8 +467,6 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		final String PROVIDER_ROLE = "Provider";
 		final String AUTHENTICATED_ROLE = "Authenticated";
 		Connection connection = upgradeTestUtil.getConnection();
-		//Add Visits exists in the test db above, first get rid of it
-		//DatabaseUtil.executeSQL(connection, "delete from privilege where privilege = 'Add Visits'", false);
 		//Insert Get encounters privilege for testing purposes
 		final String insertPrivilegeQuery = "insert into privilege (privilege,uuid) values ('" + GET_ENCOUNTERS
 		        + "','a6a521de-3992-11e6-899a-a4d646d86a8a')";

--- a/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
@@ -11,12 +11,15 @@ package org.openmrs.util.databasechange;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringReader;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -162,14 +165,15 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		expectedException.expect(IOException.class);
 		String errorMsgSubString1 = "liquibase.exception.MigrationFailedException: Migration failed for change set liquibase-update-to-latest.xml::201401101647-TRUNK-4187::wyclif";
 		expectedException.expectMessage(errorMsgSubString1);
-		String errorMsgSubString2 = Context.getMessageSourceService().getMessage("upgrade.settings.file.not.have.mapping", new Object[] { "mg" }, null);
+		String errorMsgSubString2 = Context.getMessageSourceService().getMessage("upgrade.settings.file.not.have.mapping",
+		    new Object[] { "mg" }, null);
 		expectedException.expectMessage(errorMsgSubString2);
 		upgradeTestUtil.upgrade();
 	}
 	
 	@Test
 	public void shouldFailMigratingDrugOrdersIfUnitsToConceptsMappingsDoesNotPointToValidCodedDoseUnits()
-	        throws IOException, SQLException {
+	    throws IOException, SQLException {
 		upgradeTestUtil.executeDataset(STANDARD_TEST_1_9_7_DATASET);
 		upgradeTestUtil.executeDataset(UPGRADE_TEST_1_9_7_TO_1_10_DATASET);
 		createOrderEntryUpgradeFileWithTestData("mg=111\ntab(s)=112\n1/day\\ x\\ 7\\ days/week=113\n2/day\\ x\\ 7\\ days/week=114");
@@ -197,19 +201,22 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		Assert.assertThat(orderFrequencySelect.size(), Matchers.is(2));
 		
 		Map<String, String> conceptsToFrequencies = new HashMap<String, String>();
-		conceptsToFrequencies.put(orderFrequencySelect.get(0).get("concept_id"), orderFrequencySelect.get(0).get(
-		    "order_frequency_id"));
-		conceptsToFrequencies.put(orderFrequencySelect.get(1).get("concept_id"), orderFrequencySelect.get(1).get(
-		    "order_frequency_id"));
+		conceptsToFrequencies.put(orderFrequencySelect.get(0).get("concept_id"),
+		    orderFrequencySelect.get(0).get("order_frequency_id"));
+		conceptsToFrequencies.put(orderFrequencySelect.get(1).get("concept_id"),
+		    orderFrequencySelect.get(1).get("order_frequency_id"));
 		
 		Assert.assertThat(conceptsToFrequencies.keySet(), Matchers.containsInAnyOrder("113", "114"));
 		
 		List<Map<String, String>> drugOrderSelect = upgradeTestUtil.select("drug_order", null, "order_id", "frequency");
 		
-		Assert.assertThat(drugOrderSelect, Matchers.containsInAnyOrder(row("order_id", "1", "frequency",
-		    conceptsToFrequencies.get("113")), row("order_id", "2", "frequency", conceptsToFrequencies.get("113")), row(
-		    "order_id", "3", "frequency", conceptsToFrequencies.get("114")), row("order_id", "4", "frequency",
-		    conceptsToFrequencies.get("113")), row("order_id", "5", "frequency", conceptsToFrequencies.get("114"))));
+		Assert.assertThat(
+		    drugOrderSelect,
+		    Matchers.containsInAnyOrder(row("order_id", "1", "frequency", conceptsToFrequencies.get("113")),
+		        row("order_id", "2", "frequency", conceptsToFrequencies.get("113")),
+		        row("order_id", "3", "frequency", conceptsToFrequencies.get("114")),
+		        row("order_id", "4", "frequency", conceptsToFrequencies.get("113")),
+		        row("order_id", "5", "frequency", conceptsToFrequencies.get("114"))));
 	}
 	
 	@Test
@@ -364,7 +371,7 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 	
 	@Test
 	public void shouldFailIfThereAreAnyOrderTypesInTheDatabaseOtherThanDrugOrderTypeAndNoNewColumns() throws IOException,
-	        SQLException {
+	    SQLException {
 		upgradeTestUtil.executeDataset(STANDARD_TEST_1_9_7_DATASET);
 		upgradeTestUtil.executeDataset(UPGRADE_TEST_1_9_7_TO_1_10_DATASET);
 		upgradeTestUtil.executeDataset("/org/openmrs/util/databasechange/UpgradeTest-otherOrderTypes.xml");
@@ -378,12 +385,12 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 	
 	@Test
 	public void shouldPassIfThereAreAnyOrderTypesInTheDatabaseOtherThanDrugOrderTypeAndTheNewColumnsExist()
-	        throws IOException, SQLException {
+	    throws IOException, SQLException {
 		upgradeTestUtil.executeDataset(STANDARD_TEST_1_9_7_DATASET);
 		upgradeTestUtil.executeDataset(UPGRADE_TEST_1_9_7_TO_1_10_DATASET);
 		upgradeTestUtil.executeDataset("UpgradeTest-otherOrderTypes.xml");
-		upgradeTestUtil.getConnection().createStatement().executeUpdate(
-		    "alter table `order_type` add java_class_name varchar(255) default 'org.openmrs.Order'");
+		upgradeTestUtil.getConnection().createStatement()
+		        .executeUpdate("alter table `order_type` add java_class_name varchar(255) default 'org.openmrs.Order'");
 		upgradeTestUtil.getConnection().createStatement().executeUpdate("alter table `order_type` add parent int(11)");
 		createOrderEntryUpgradeFileWithTestData("mg=111\ntab(s)=112\n1/day\\ x\\ 7\\ days/week=113\n2/day\\ x\\ 7\\ days/week=114");
 		
@@ -443,7 +450,56 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		List<Map<String, String>> drug_orders = upgradeTestUtil.select("drug_order", "order_id = 6 or order_id = 7",
 		    "order_id", "dose_units", "frequency");
 		
-		assertThat(drug_orders, containsInAnyOrder(row("order_id", "6", "dose_units", null, "frequency", null), row(
-		    "order_id", "7", "dose_units", null, "frequency", null)));
+		assertThat(
+		    drug_orders,
+		    containsInAnyOrder(row("order_id", "6", "dose_units", null, "frequency", null),
+		        row("order_id", "7", "dose_units", null, "frequency", null)));
+	}
+	
+	@Test
+	public void shouldAddTheNecessaryPrivilegesAndAssignThemToSpecificRoles() throws Exception {
+		final String GET_ENCOUNTERS = "Get Encounters";
+		final String ADD_VISITS = "Add Visits";
+		final String ADD_ENCOUNTERS = "Add Encounters";
+		final String EDIT_ENCOUNTERS = "Edit Encounters";
+		final String GET_VISITS = "Get Visits";
+		final String GET_PROVIDERS = "Get Providers";
+		final String PROVIDER_ROLE = "Provider";
+		final String AUTHENTICATED_ROLE = "Authenticated";
+		Connection connection = upgradeTestUtil.getConnection();
+		//Add Visits exists in the test db above, first get rid of it
+		//DatabaseUtil.executeSQL(connection, "delete from privilege where privilege = 'Add Visits'", false);
+		//Insert Get encounters privilege for testing purposes
+		final String insertPrivilegeQuery = "insert into privilege (privilege,uuid) values ('" + GET_ENCOUNTERS
+		        + "','a6a521de-3992-11e6-899a-a4d646d86a8a')";
+		DatabaseUtil.executeSQL(connection, insertPrivilegeQuery, false);
+		//Assign some privileges to some roles for testing purposes
+		DatabaseUtil.executeSQL(connection, "insert into role_privilege (role,privilege) values ('" + PROVIDER_ROLE + "', '"
+		        + GET_ENCOUNTERS + "'), ('" + PROVIDER_ROLE + "', '" + EDIT_ENCOUNTERS + "'), ('" + AUTHENTICATED_ROLE
+		        + "', '" + ADD_ENCOUNTERS + "')", false);
+		connection.commit();
+		
+		String query = "select privilege from privilege where privilege = '" + GET_VISITS + "' or " + "privilege = '"
+		        + GET_PROVIDERS + "'";
+		assertEquals(0, DatabaseUtil.executeSQL(connection, query, true).size());
+		assertTrue(roleHasPrivilege(PROVIDER_ROLE, GET_ENCOUNTERS));
+		assertTrue(roleHasPrivilege(PROVIDER_ROLE, EDIT_ENCOUNTERS));
+		assertFalse(roleHasPrivilege(PROVIDER_ROLE, GET_VISITS));
+		assertFalse(roleHasPrivilege(PROVIDER_ROLE, GET_PROVIDERS));
+		assertFalse(roleHasPrivilege(PROVIDER_ROLE, ADD_VISITS));
+		assertTrue(roleHasPrivilege(AUTHENTICATED_ROLE, ADD_ENCOUNTERS));
+		
+		upgradeTestUtil.upgrade();
+		connection = upgradeTestUtil.getConnection();
+		assertEquals(2, DatabaseUtil.executeSQL(connection, query, true).size());
+		assertTrue(roleHasPrivilege(PROVIDER_ROLE, GET_VISITS));
+		assertTrue(roleHasPrivilege(PROVIDER_ROLE, GET_PROVIDERS));
+		assertTrue(roleHasPrivilege(PROVIDER_ROLE, ADD_VISITS));
+		assertTrue(roleHasPrivilege(AUTHENTICATED_ROLE, ADD_VISITS));
+	}
+	
+	private boolean roleHasPrivilege(String role, String privilege) {
+		final String query = "select * from role_privilege where role='" + role + "' and privilege ='" + privilege + "'";
+		return DatabaseUtil.executeSQL(upgradeTestUtil.getConnection(), query, true).size() == 1;
 	}
 }


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Previously, the code made a decision on whether the query was a name or identifier by using a regex to determine if the query contained one or more digits, then created the appropriate PatientSearchCriteria. In cases of identifiers without digits, or names with them, it was not possible to obtain the correct result. Now, both names and identifiers are searched, without attempting to categorize the query beforehand.

Behavior has also been slightly changed: An exact match is now required for identifier to produce a result. Note: this only applies to identifier; name will still match on partial search terms. This is consistent with how other "name or identifier" queries are handled (e.g.: Find Patient, Find Provider) and is presumably for performance reasons.

Code changes:
Removed local vars "name" and "identifier" since "query" is used in both cases
Removed conditional branching based upon query type
Arguments to prepareCriteria have had the following changes applied:
  "query" is now passed as both name and identifier
  "true" is now passed for both matchIdentifierExactly and searchOnNamesOrIdentifiers

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


