### PR TITLE
TRUNK-4899 ModuleFileParser missing some validConfigVersions

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -69,6 +69,8 @@ public class ModuleFileParser {
 		validConfigVersions.add("1.2");
 		validConfigVersions.add("1.3");
 		validConfigVersions.add("1.4");
+		validConfigVersions.add("1.5");
+		validConfigVersions.add("1.6");
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
ModuleFileParser is missing 1.5 and 1.6 as valid config versions.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4899

