### PR TITLE
TRUNK-4900 Travis CI buffer overflow in openjdk6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,8 @@ notifications:
       - "irc.freenode.org#OpenMRS"
     template:
       - "[%{repository}] [%{commit}] [%{author}] %{message} - %{build_url}"
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
travis CI builds of openjdk6 fail due to
https://github.com/travis-ci/travis-ci/issues/5227

* updated travis.yml with workaround

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4900
