### PR TITLE
TRUNK-4720 Encounter search will not match on id unless it contains digits

### DIFF
--- a/api/src/main/java/org/openmrs/api/EncounterService.java
+++ b/api/src/main/java/org/openmrs/api/EncounterService.java
@@ -381,6 +381,8 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get all unvoided encounters for the given patient identifier
 	 * @should throw error if given null parameter
 	 * @should include voided encounters in the returned list if includedVoided is true
+	 * @should get all unvoided encounters for the given substring of patient names
+	 * @should not get encounters for the given substring of patient identifiers
 	 * @since 1.7
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -423,16 +423,8 @@ public class HibernateEncounterDAO implements EncounterDAO {
 				criteria.add(or);
 			}
 		} else {
-			String name = null;
-			String identifier = null;
-			if (query.matches(".*\\d+.*")) {
-				identifier = query;
-			} else {
-				// there is no number in the string, search on name
-				name = query;
-			}
-			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(name, identifier,
-			    new ArrayList<PatientIdentifierType>(), false, orderByNames, false);
+			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(query, query,
+				    new ArrayList<PatientIdentifierType>(), true, orderByNames, true);
 		}
 		
 		return criteria;

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2959,4 +2959,30 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		
 		assertEquals("Two New Order Groups Get Saved", 2, orderGroups.size());
 	}
+
+	/**
+	 * @see EncounterService#getEncountersByPatient(String,boolean)
+	 */
+	@Test
+	@Verifies(value = "get all unvoided encounters for the given substring of patient names", method = "getEncountersByPatient(String,boolean)")
+	public void getEncountersByPatient_shouldGetAllUnvoidedEncountersForTheGivenSubstringOfPatientNames() throws Exception {
+		EncounterService encounterService = Context.getEncounterService();
+		
+		List<Encounter> encounters = encounterService.getEncountersByPatient("Joh", false);
+		assertEquals(3, encounters.size());
+	}
+	
+	/**
+	 * @see EncounterService#getEncountersByPatient(String,boolean)
+	 */
+	@Test
+	@Verifies(value = "not get encounters for the given substring of patient identifiers", method = "getEncountersByPatient(String,boolean)")
+	public void getEncountersByPatient_shouldNotGetEncountersForTheGivenSubstringOfPatientIdentifiers() throws Exception {
+		EncounterService encounterService = Context.getEncounterService();
+		
+		List<Encounter> encounters = encounterService.getEncountersByPatient("123", false);
+		assertEquals(0, encounters.size());
+		encounters = encounterService.getEncountersByPatient("1234", false);
+		assertEquals(1, encounters.size());
+	}
 }

--- a/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.BinaryDataHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class BinaryDataHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.BinaryStreamHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class BinaryStreamHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.ImageHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class ImageHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        ImageHandler handler = new ImageHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        ImageHandler handler = new ImageHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        ImageHandler handler = new ImageHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.MediaHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class MediaHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        MediaHandler handler = new MediaHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        MediaHandler handler = new MediaHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        MediaHandler handler = new MediaHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.TextHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class TextHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        TextHandler handler = new TextHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.TEXT_VIEW, ComplexObsHandler.RAW_VIEW, ComplexObsHandler.URI_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        TextHandler handler = new TextHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+        assertTrue(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertTrue(handler.supportsView(ComplexObsHandler.URI_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        TextHandler handler = new TextHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
Previously, the code made a decision on whether the query was a name or identifier by using a regex to determine if the query contained one or more digits, then created the appropriate PatientSearchCriteria. In cases of identifiers without digits, or names with them, it was not possible to obtain the correct result. Now, both names and identifiers are searched, without attempting to categorize the query beforehand.

Behavior has also been slightly changed: An exact match is now required for identifier to produce a result. Note: this only applies to identifier; name will still match on partial search terms. This is consistent with how other "name or identifier" queries are handled (e.g.: Find Patient, Find Provider) and is presumably for performance reasons.

Two test cases were added to ensure that results are returned on substring matches for patient name, and not patient identifier.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


…igits