### PR TITLE
TRUNK-4902 HibernateOrderDAO exception uses wrong message code

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
@@ -253,13 +253,11 @@ public class HibernateOrderDAO implements OrderDAO {
 	 */
 	@Override
 	public Long getNextOrderNumberSeedSequenceValue() {
-		Criteria searchCriteria = sessionFactory.getCurrentSession().createCriteria(GlobalProperty.class);
-		searchCriteria.add(Restrictions.eq("property", OpenmrsConstants.GP_NEXT_ORDER_NUMBER_SEED));
 		GlobalProperty globalProperty = (GlobalProperty) sessionFactory.getCurrentSession().get(GlobalProperty.class,
 		    OpenmrsConstants.GP_NEXT_ORDER_NUMBER_SEED, LockOptions.UPGRADE);
 		
 		if (globalProperty == null) {
-			throw new APIException("GlobalProperty.missing ", new Object[] { OpenmrsConstants.GP_NEXT_ORDER_NUMBER_SEED });
+			throw new APIException("GlobalProperty.missing", new Object[] { OpenmrsConstants.GP_NEXT_ORDER_NUMBER_SEED });
 		}
 		
 		String gpTextValue = globalProperty.getPropertyValue();


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
HibernateOrderDAO has a whitespace in one of its exceptions message codes in
getNextOrderNumberSeedSequenceValue

* remove whitespace in message code string
* remove unused code in getNextOrderNumberSeedSequenceValue

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4902 