### PR TITLE
TRUNK-2136: Add unit tests

### DIFF
--- a/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.BinaryDataHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class BinaryDataHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        BinaryDataHandler handler = new BinaryDataHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.BinaryStreamHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class BinaryStreamHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        BinaryStreamHandler handler = new BinaryStreamHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.ImageHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class ImageHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        ImageHandler handler = new ImageHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        ImageHandler handler = new ImageHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        ImageHandler handler = new ImageHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.MediaHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class MediaHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        MediaHandler handler = new MediaHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.RAW_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        MediaHandler handler = new MediaHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        MediaHandler handler = new MediaHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}

--- a/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import org.junit.Test;
+import org.openmrs.obs.handler.TextHandler;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+
+public class TextHandlerTest {
+
+    @Test
+    public void shouldReturnSupportedViews() {
+        TextHandler handler = new TextHandler();
+        String[] actualViews = handler.getSupportedViews();
+        String[] expectedViews = { ComplexObsHandler.TEXT_VIEW, ComplexObsHandler.RAW_VIEW, ComplexObsHandler.URI_VIEW };
+
+        assertArrayEquals(actualViews, expectedViews);
+    }
+
+    @Test
+    public void shouldSupportRawView() {
+        TextHandler handler = new TextHandler();
+
+        assertTrue(handler.supportsView(ComplexObsHandler.RAW_VIEW));
+        assertTrue(handler.supportsView(ComplexObsHandler.TEXT_VIEW));
+        assertTrue(handler.supportsView(ComplexObsHandler.URI_VIEW));
+    }
+
+    @Test
+    public void shouldNotSupportOtherViews() {
+        TextHandler handler = new TextHandler();
+
+        assertFalse(handler.supportsView(ComplexObsHandler.HTML_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.PREVIEW_VIEW));
+        assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
+        assertFalse(handler.supportsView(""));
+        assertFalse(handler.supportsView((String) null));
+    }
+}


### PR DESCRIPTION
TRUNK-2136: Add unit tests

## Description
Add unit tests for ComplexObsHandler.getSupportedViews() and ComplexObsHandler.supportsView(), as discussed in review notes

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-2136

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
