### PR TITLE
TRUNK-4859 Add redirect url parameter to login page

### DIFF
--- a/web/src/main/java/org/openmrs/web/WebConstants.java
+++ b/web/src/main/java/org/openmrs/web/WebConstants.java
@@ -111,4 +111,9 @@ public class WebConstants {
 	 * Session attribute name for the referer url
 	 */
 	public static final String REFERER_URL = "referer_url";
+	
+	/**
+	 * Session parameter name for redirect url
+	 */
+	public static final String REDIRECT_URL = "redirect_url";
 }

--- a/web/src/main/java/org/openmrs/web/controller/LoginController.java
+++ b/web/src/main/java/org/openmrs/web/controller/LoginController.java
@@ -127,6 +127,14 @@ public class LoginController {
 			model.put("refererUrl", refererUrl);
 		}
 		
+		if (webRequest.getParameter(WebConstants.REDIRECT_URL) != null) {
+			String redirectUrlTemp = webRequest.getParameter(WebConstants.REDIRECT_URL).toString();
+			if (StringUtils.isNotBlank(redirectUrlTemp) && !redirectUrlTemp.contains("login.")) {
+				redirectUrlTemp = redirectUrlTemp.replace("_HASHTAG_", "#");
+				webRequest.setAttribute(WebConstants.OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR, redirectUrlTemp, 1);
+			}
+		}
+		
 		return LOGIN_FORM;
 	}
 }

--- a/web/src/test/java/org/openmrs/web/controller/LoginControllerTest.java
+++ b/web/src/test/java/org/openmrs/web/controller/LoginControllerTest.java
@@ -1,0 +1,63 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.controller;
+
+import org.junit.Test;
+import org.openmrs.web.WebConstants;
+import org.openmrs.web.test.BaseWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class LoginControllerTest extends BaseWebContextSensitiveTest {
+	
+	@Autowired
+	private LoginController controller;
+	
+	@Test
+	public void shouldReplaceHashtagInRedirectUrl() {
+		String redirectUrl = "www.openmrs.org/_HASHTAG_";
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.setParameter("redirect_url", redirectUrl);
+		
+		WebRequest webRequest = new ServletWebRequest(mockRequest);
+		webRequest.setAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, true, WebRequest.SCOPE_SESSION);
+		
+		ModelMap model = new ModelMap();
+		
+		controller.handleRequest(webRequest, model);
+		assertEquals(webRequest.getAttribute(WebConstants.OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR, 1), "www.openmrs.org/#");
+	}
+	
+	@Test
+	public void shouldSetTheRedirectAttribute() {
+		String redirectUrl = "www.openmrs.org/index";
+		
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+		mockRequest.setParameter("redirect_url", redirectUrl);
+		
+		WebRequest webRequest = new ServletWebRequest(mockRequest);
+		webRequest.setAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, true, WebRequest.SCOPE_SESSION);
+		
+		ModelMap model = new ModelMap();
+		
+		controller.handleRequest(webRequest, model);
+		assertEquals(webRequest.getAttribute(WebConstants.OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR, 1),
+		    "www.openmrs.org/index");
+	}
+}


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
The existing code was not working properly. The referel_url was being cut after '#" so it was redirecting only to the main page.
Now all hashes in redirect_url attribute has to be changed to 'HASHTAG', so the link won't be sliced.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RA-1111

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


