### PR TITLE
TRUNK-4915 Concept validator should require datatype and conceptClass fields

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ConceptValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptValidator.java
@@ -85,6 +85,8 @@ public class ConceptValidator extends BaseCustomizableValidator implements Valid
 	 * @should fail validation if field lengths are not correct
 	 * @should pass if fully specified name is the same as short name
 	 * @should pass if different concepts have the same short name
+	 * @should fail if the concept datatype is null
+	 * @should fail if the concept class is null
 	 */
 	public void validate(Object obj, Errors errors) throws APIException, DuplicateConceptNameException {
 		
@@ -102,6 +104,9 @@ public class ConceptValidator extends BaseCustomizableValidator implements Valid
 			errors.rejectValue("descriptions","Concept.description.atLeastOneRequired");
 			return;
 		}
+
+		ValidationUtils.rejectIfEmpty(errors, "datatype", "Concept.datatype.empty");
+		ValidationUtils.rejectIfEmpty(errors, "conceptClass", "Concept.conceptClass.empty");
 
 		boolean hasFullySpecifiedName = false;
 		for (Locale conceptNameLocale : conceptToValidate.getAllConceptNameLocales()) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -591,6 +591,8 @@ Concept.drugFormulations=Drug Formulations for this Concept
 Concept.manageDrugFormulary=Manage Drug Formulary
 Concept.contains.itself.as.answer=Concept cannot have itself as an answer
 ConceptReferenceTerm.add.null=Cannot add a null concept reference term map
+Concept.datatype.empty=Concept datatype cannot be empty
+Concept.conceptClass.empty=Concept class cannot be empty
 
 ConceptStopWord.manage=Manage Concept Stop Word
 ConceptStopWord.title=Concept Stop Word

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -1198,7 +1198,9 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept(1);
 		concept.addName(new ConceptName("findPossibleValueTest", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("en desc", Context.getLocale()));
-		
+		concept.setDatatype(new ConceptDatatype(1));
+		concept.setConceptClass(new ConceptClass(1));
+
 		List<Concept> expectedConcepts = new Vector<Concept>();
 		
 		concept = Context.getConceptService().saveConcept(concept);
@@ -1206,6 +1208,8 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		Concept newConcept = new Concept(2);
 		newConcept.addName(new ConceptName("New Test Concept", Context.getLocale()));
 		newConcept.addDescription(new ConceptDescription("new desc", Context.getLocale()));
+		newConcept.setDatatype(new ConceptDatatype(1));
+		newConcept.setConceptClass(new ConceptClass(1));
 		newConcept = Context.getConceptService().saveConcept(newConcept);
 		
 		Context.updateSearchIndexForType(ConceptName.class);

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -189,8 +189,8 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		ConceptName cn = new ConceptName("not a numeric anymore", Locale.US);
 		c2.addName(cn);
 		c2.addDescription(new ConceptDescription("some description",null));
-		
 		c2.setDatatype(new ConceptDatatype(3));
+		c2.setConceptClass(new ConceptClass(1));
 		conceptService.saveConcept(c2);
 		
 		Concept secondConcept = conceptService.getConcept(2);
@@ -214,7 +214,8 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		// this tests saving a never before in the database conceptnumeric
 		ConceptNumeric cn3 = new ConceptNumeric();
 		cn3.setDatatype(new ConceptDatatype(1));
-		
+		cn3.setConceptClass(new ConceptClass(1));
+
 		ConceptName cn = new ConceptName("a brand new conceptnumeric", Locale.US);
 		cn3.addName(cn);
 		cn3.addDescription(new ConceptDescription("some description",null));
@@ -241,6 +242,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		// with a concept id of #1
 		ConceptNumeric cn = new ConceptNumeric(1);
 		cn.setDatatype(new ConceptDatatype(1));
+		cn.setConceptClass(new ConceptClass(1));
 		cn.addName(new ConceptName("a new conceptnumeric", Locale.US));
 		cn.addDescription(new ConceptDescription("some description",null));
 		cn.setHiAbsolute(20.0);
@@ -268,6 +270,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		// with a concept id of #1
 		ConceptComplex cn = new ConceptComplex(1);
 		cn.setDatatype(new ConceptDatatype(13));
+		cn.setConceptClass(new ConceptClass(1));
 		cn.addName(new ConceptName("a new conceptComplex", Locale.US));
 		cn.addDescription(new ConceptDescription("some description",null));
 		cn.setHandler("SomeHandler");
@@ -292,6 +295,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		//save a concept numeric
 		ConceptNumeric cn = new ConceptNumeric(1);
 		cn.setDatatype(new ConceptDatatype(1));
+		cn.setConceptClass(new ConceptClass(1));
 		cn.addName(new ConceptName("a new conceptnumeric", Locale.US));
 		cn.addDescription(new ConceptDescription("some description",null));
 		cn.setHiAbsolute(20.0);
@@ -307,6 +311,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		//change to concept complex
 		ConceptComplex cn2 = new ConceptComplex(1);
 		cn2.setDatatype(new ConceptDatatype(13));
+		cn2.setConceptClass(new ConceptClass(1));
 		cn2.addName(new ConceptName("a new conceptComplex", Locale.US));
 		cn2.addDescription(new ConceptDescription("some description",null));
 		cn2.setHandler("SomeHandler");
@@ -324,6 +329,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		ConceptDatatype dt = new ConceptDatatype(1);
 		dt.setName("Numeric");
 		cn.setDatatype(dt);
+		cn.setConceptClass(new ConceptClass(1));
 		cn.addName(new ConceptName("a new conceptnumeric", Locale.US));
 		cn.addDescription(new ConceptDescription("some description",null));
 		cn.setHiAbsolute(20.0);
@@ -339,6 +345,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		//change to concept complex
 		cn2 = new ConceptComplex(1);
 		cn2.setDatatype(new ConceptDatatype(13));
+		cn2.setConceptClass(new ConceptClass(1));
 		cn2.addName(new ConceptName("a new conceptComplex", Locale.US));
 		cn2.addDescription(new ConceptDescription("some description",null));
 		cn2.setHandler("SomeHandler");
@@ -1140,6 +1147,8 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		ConceptName cn = new ConceptName("new name", Context.getLocale());
 		conceptToAdd.addName(cn);
 		conceptToAdd.addDescription(new ConceptDescription("some description",null));
+		conceptToAdd.setDatatype(new ConceptDatatype(1));
+		conceptToAdd.setConceptClass(new ConceptClass(1));
 		assertFalse(conceptService.getAllConcepts().contains(conceptToAdd));
 		conceptService.saveConcept(conceptToAdd);
 		assertTrue(conceptService.getAllConcepts().contains(conceptToAdd));
@@ -1813,7 +1822,9 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		concept.addName(new ConceptName("name5", Locale.JAPANESE));
 		concept.addName(new ConceptName("name6", Locale.JAPANESE));
 		concept.addDescription(new ConceptDescription("some description",null));
-		
+		concept.setDatatype(new ConceptDatatype(1));
+		concept.setConceptClass(new ConceptClass(1));
+
 		concept = Context.getConceptService().saveConcept(concept);
 		Assert.assertNotNull(concept.getPreferredName(Locale.ENGLISH));
 		Assert.assertNotNull(concept.getPreferredName(Locale.FRENCH));
@@ -2374,16 +2385,22 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		Concept concept1 = new Concept();
 		concept1.addName(new ConceptName(name, new Locale("en", "US")));
 		concept1.addDescription(new ConceptDescription("some description",null));
+		concept1.setDatatype(new ConceptDatatype(1));
+		concept1.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept1);
 		
 		Concept concept2 = new Concept();
 		concept2.addName(new ConceptName(name, new Locale("en", "GB")));
 		concept2.addDescription(new ConceptDescription("some description",null));
+		concept2.setDatatype(new ConceptDatatype(1));
+		concept2.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept2);
 		
 		Concept concept3 = new Concept();
 		concept3.addName(new ConceptName(name, new Locale("en")));
 		concept3.addDescription(new ConceptDescription("some description",null));
+		concept3.setDatatype(new ConceptDatatype(1));
+		concept3.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept3);
 		
 		updateSearchIndex();
@@ -2409,16 +2426,22 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		Concept concept1 = new Concept();
 		concept1.addName(new ConceptName(name, new Locale("en", "US")));
 		concept1.addDescription(new ConceptDescription("some description",null));
+		concept1.setDatatype(new ConceptDatatype(1));
+		concept1.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept1);
 		
 		Concept concept2 = new Concept();
 		concept2.addName(new ConceptName(name, new Locale("en", "GB")));
 		concept2.addDescription(new ConceptDescription("some description",null));
+		concept2.setDatatype(new ConceptDatatype(1));
+		concept2.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept2);
 		
 		Concept concept3 = new Concept();
 		concept3.addName(new ConceptName(name, new Locale("en")));
 		concept3.addDescription(new ConceptDescription("some description",null));
+		concept3.setDatatype(new ConceptDatatype(1));
+		concept3.setConceptClass(new ConceptClass(1));
 		Context.getConceptService().saveConcept(concept3);
 		
 		updateSearchIndex();
@@ -2442,6 +2465,8 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("test name", Context.getLocale()));
+		concept.setDatatype(new ConceptDatatype(1));
+		concept.setConceptClass(new ConceptClass(1));
 		ConceptMap map = new ConceptMap();
 		map.getConceptReferenceTerm().setCode("unique code");
 		map.getConceptReferenceTerm().setConceptSource(conceptService.getConceptSource(1));

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -46,6 +46,7 @@ import org.junit.rules.ExpectedException;
 import org.openmrs.CareSetting;
 import org.openmrs.Concept;
 import org.openmrs.ConceptClass;
+import org.openmrs.ConceptDatatype;
 import org.openmrs.ConceptDescription;
 import org.openmrs.ConceptName;
 import org.openmrs.Drug;
@@ -1444,6 +1445,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("new name", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description", null));
+		concept.setDatatype(new ConceptDatatype(1));
 		concept.setConceptClass(conceptService.getConceptClassByName("Frequency"));
 		concept = conceptService.saveConcept(concept);
 		Integer originalSize = orderService.getOrderFrequencies(true).size();

--- a/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 
 import org.junit.Test;
 import org.openmrs.Concept;
+import org.openmrs.ConceptClass;
+import org.openmrs.ConceptDatatype;
 import org.openmrs.ConceptDescription;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;
@@ -44,6 +46,8 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		ConceptName fullySpecifiedName = new ConceptName("requires one name min", new Locale("fr", "CA"));
 		c.addName(fullySpecifiedName);
 		c.addDescription(new ConceptDescription("some description",null));
+		c.setDatatype(new ConceptDatatype(1));
+		c.setConceptClass(new ConceptClass(1));
 		Concept savedC = Context.getConceptService().saveConcept(c);
 		assertNotNull(savedC);
 		assertTrue(savedC.getConceptId() > 0);
@@ -60,6 +64,8 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		ConceptName fullySpecifiedName = new ConceptName("requires one name min", new Locale("fr", "CA"));
 		c.addName(fullySpecifiedName);
 		c.addDescription(new ConceptDescription("some description",null));
+		c.setDatatype(new ConceptDatatype(1));
+		c.setConceptClass(new ConceptClass(1));
 		Concept savedC = Context.getConceptService().saveConcept(c);
 		assertNotNull(savedC);
 		Concept updatedC = Context.getConceptService().saveConcept(c);
@@ -160,6 +166,8 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		c.addName(indexTerm);
 		c.addName(shortName);
 		c.addDescription(new ConceptDescription("some description",null));
+		c.setDatatype(new ConceptDatatype(1));
+		c.setConceptClass(new ConceptClass(1));
 		assertFalse("check test assumption - the API didn't automatically set preferred vlag", c.getFullySpecifiedName(loc)
 		        .isPreferred());
 		
@@ -200,7 +208,9 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		allNames.add(synonym);
 		c.setNames(allNames);
 		c.addDescription(new ConceptDescription("some description",null));
-		
+		c.setDatatype(new ConceptDatatype(1));
+		c.setConceptClass(new ConceptClass(1));
+
 		assertNull("check test assumption - the API hasn't promoted a name to a fully specified name", c
 		        .getFullySpecifiedName(loc));
 		
@@ -220,6 +230,8 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		String nameWithSpaces = "  jwm  ";
 		concept.addName(new ConceptName(nameWithSpaces, new Locale("en", "US")));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setDatatype(new ConceptDatatype(1));
+		concept.setConceptClass(new ConceptClass(1));
 		//When
 		Context.getConceptService().saveConcept(concept);
 		//Then
@@ -237,9 +249,13 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("Concept", new Locale("en", "US")));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setDatatype(new ConceptDatatype(1));
+		concept.setConceptClass(new ConceptClass(1));
 		Concept conceptSetMember = new Concept();
 		conceptSetMember.addName(new ConceptName("Set Member", new Locale("en", "US")));
 		conceptSetMember.addDescription(new ConceptDescription("some description",null));
+		conceptSetMember.setConceptClass(new ConceptClass(1));
+		conceptSetMember.setDatatype(new ConceptDatatype(1));
 		Context.getConceptService().saveConcept(conceptSetMember);
 		concept.addSetMember(conceptSetMember);
 		concept.setSet(false);

--- a/api/src/test/java/org/openmrs/validator/ConceptValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ConceptValidatorTest.java
@@ -21,6 +21,8 @@ import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptDescription;
 import org.openmrs.ConceptMap;
 import org.openmrs.ConceptName;
+import org.openmrs.ConceptClass;
+import org.openmrs.ConceptDatatype;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
@@ -115,6 +117,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		concept.addName(new ConceptName("same name", Context.getLocale()));
 		concept.addName(new ConceptName("same name", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
 	}
@@ -184,6 +188,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("one name", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
 		Assert.assertEquals(false, errors.hasErrors());
@@ -255,6 +261,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("CD4", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		// Add the short name. Because the short name is not counted as a Synonym. 
 		// ConceptValidator will not record any errors.
 		ConceptName name = new ConceptName("CD4", Context.getLocale());
@@ -272,6 +280,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should fail if a term is mapped multiple times to the same concept", method = "validate(Object,Errors)")
 	public void validate_shouldFailIfATermIsMappedMultipleTimesToTheSameConcept() throws Exception {
 		Concept concept = new Concept();
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		ConceptService cs = Context.getConceptService();
 		concept.addName(new ConceptName("my name", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
@@ -345,6 +355,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("test name", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		ConceptMap map = new ConceptMap();
 		map.getConceptReferenceTerm().setCode("unique code");
 		map.getConceptReferenceTerm().setConceptSource(cs.getConceptSource(1));
@@ -402,7 +414,9 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		concept.addDescription(new ConceptDescription("some description",null));
 		concept.setVersion("version");
 		concept.setRetireReason("retireReason");
-		
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
+
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
 		Assert.assertFalse(errors.hasErrors());
@@ -417,6 +431,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("CD4", Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		concept.setVersion("too long text too long text too long text too long text");
 		concept
 		        .setRetireReason("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
@@ -444,7 +460,9 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		concept.addName(conceptFullySpecifiedName);
 		concept.addName(conceptShortName);
 		concept.addDescription(new ConceptDescription("some description",null));
-		
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
+
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
 		Assert.assertEquals(false, errors.hasErrors());
@@ -464,6 +482,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		        .equalsIgnoreCase("HSM"));
 		
 		Concept concept = new Concept();
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		ConceptName conceptFullySpecifiedName = new ConceptName("holosystolic murmur", Context.getLocale());
 		conceptFullySpecifiedName.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
 		
@@ -517,6 +537,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Concept concept = new Concept();
 		concept.addName(new ConceptName("some name",Context.getLocale()));
 		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass());
+		concept.setDatatype(new ConceptDatatype());
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
 		Assert.assertFalse(errors.hasErrors());
@@ -536,4 +558,33 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		Assert.assertTrue(errors.hasFieldErrors("descriptions"));
 	}
 
+	/**
+	 * @see ConceptValidator#validate(Object,Errors)
+	 **/
+	@Test
+	@Verifies(value = "should fail if the concept datatype is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailIfTheConceptDatatypeIsNull() throws Exception {
+		Concept concept = new Concept();
+		concept.addName(new ConceptName("some name",Context.getLocale()));
+		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setConceptClass(new ConceptClass(1));
+		Errors errors = new BindException(concept, "concept");
+		new ConceptValidator().validate(concept, errors);
+		Assert.assertEquals(errors.getFieldError("datatype").getCode(), "Concept.datatype.empty");
+	}
+
+	/**
+	 * @see ConceptValidator#validate(Object,Errors)
+	 **/
+	@Test
+	@Verifies(value = "should fail if the concept class is null", method = "validate(Object,Errors)")
+	public void validate_shouldFailIfTheConceptClassIsNull() throws Exception {
+		Concept concept = new Concept();
+		concept.addName(new ConceptName("some name",Context.getLocale()));
+		concept.addDescription(new ConceptDescription("some description",null));
+		concept.setDatatype(new ConceptDatatype(1));
+		Errors errors = new BindException(concept, "concept");
+		new ConceptValidator().validate(concept, errors);
+		Assert.assertEquals(errors.getFieldError("conceptClass").getCode(), "Concept.conceptClass.empty");
+	}
 }

--- a/api/src/test/java/org/openmrs/validator/OrderFrequencyValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/OrderFrequencyValidatorTest.java
@@ -98,6 +98,7 @@ public class OrderFrequencyValidatorTest extends BaseContextSensitiveTest {
 		ConceptService cs = Context.getConceptService();
 		Concept concept = new Concept();
 		ConceptName cn = new ConceptName("new name", Context.getLocale());
+		concept.setDatatype(cs.getConceptDatatype(1));
 		concept.setConceptClass(cs.getConceptClass(19));
 		concept.addName(cn);
 		concept.addDescription(new ConceptDescription("some description",null));
@@ -148,6 +149,7 @@ public class OrderFrequencyValidatorTest extends BaseContextSensitiveTest {
 		ConceptService cs = Context.getConceptService();
 		Concept concept = new Concept();
 		ConceptName cn = new ConceptName("new name", Context.getLocale());
+		concept.setDatatype(cs.getConceptDatatype(1));
 		concept.setConceptClass(cs.getConceptClass(19));
 		concept.addName(cn);
 		concept.addDescription(new ConceptDescription("some description",null));
@@ -173,6 +175,7 @@ public class OrderFrequencyValidatorTest extends BaseContextSensitiveTest {
 		ConceptService cs = Context.getConceptService();
 		Concept concept = new Concept();
 		ConceptName cn = new ConceptName("new name", Context.getLocale());
+		concept.setDatatype(cs.getConceptDatatype(1));
 		concept.setConceptClass(cs.getConceptClass(19));
 		concept.addName(cn);
 		concept.addDescription(new ConceptDescription("some description",null));


### PR DESCRIPTION
## Description
Concept validator now requires datatype and conceptClass fields. I have added two unit tests to verify those changes and updated the others where necessary (wherever the test checked against `errors.hasErrors()`

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-4915

## Checklist:
- [X] My pull request only contains one single commit.
- [X] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.


