### PR TITLE
TRUNK-4922 ConceptDAO filters concept classes only if results were found

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneQuery.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneQuery.java
@@ -236,7 +236,7 @@ public abstract class LuceneQuery<T> extends SearchQuery<T> {
 		String idPropertyName = getSession().getSessionFactory().getClassMetadata(getType()).getIdentifierPropertyName();
 		
 		List<Object> documents = listProjection(idPropertyName, field);
-		
+
 		TermsFilter termsFilter = null;
 		if (!documents.isEmpty()) {
 			Set<Object> uniqueFieldValues = new HashSet<Object>();
@@ -250,9 +250,8 @@ public abstract class LuceneQuery<T> extends SearchQuery<T> {
 			termsFilter = new TermsFilter(terms);
 		}
 		
-		buildQuery();
-		
 		if (termsFilter != null) {
+			buildQuery();
 			fullTextQuery.setFilter(termsFilter);
 		}
 		
@@ -281,7 +280,7 @@ public abstract class LuceneQuery<T> extends SearchQuery<T> {
 		
 		@SuppressWarnings("unchecked")
 		List<T> list = fullTextQuery.list();
-		
+
 		return ListPart.newListPart(list, firstResult, maxResults, Long.valueOf(fullTextQuery.getResultSize()),
 		    !fullTextQuery.hasPartialResults());
 	}

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -2756,6 +2756,20 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	 * @see ConceptService#getConcepts(String, List, boolean, List, List, List, List, Concept, Integer, Integer)
 	 */
 	@Test
+	@Verifies(value = "should return empty list if no concept within specified classes was found", method = "getConcepts(String,List<QLocale;>,boolean,List<QConceptClass;>,List<QConceptClass;>,List<QConceptDatatype;>,List<QConceptDatatype;>,Concept,Integer,Integer)")
+	public void getConcepts_shouldReturnEmptyListIfNoConceptWithinSpecifiedClassesWasFound() throws Exception {
+		executeDataSet("org/openmrs/api/include/ConceptServiceTest-names.xml");
+		List<ConceptClass> classes = new ArrayList<ConceptClass>();
+		classes.add(Context.getConceptService().getConceptClassByName("Finding"));
+		List<ConceptSearchResult> searchResults = conceptService.getConcepts("SALBUTAMOL", null, false, classes, null, null, null,
+		    null, null, null);
+		Assert.assertEquals(0, searchResults.size());
+	}
+	
+	/**
+	 * @see ConceptService#getConcepts(String, List, boolean, List, List, List, List, Concept, Integer, Integer)
+	 */
+	@Test
 	@Verifies(value = "should include retired concepts in the search results", method = "getConcepts(String,List<QLocale;>,boolean,List<QConceptClass;>,List<QConceptClass;>,List<QConceptDatatype;>,List<QConceptDatatype;>,Concept,Integer,Integer)")
 	public void getConcepts_shouldIncludeRetiredConceptsInTheSearchResults() throws Exception {
 		executeDataSet("org/openmrs/api/include/ConceptServiceTest-names.xml");


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
The skipSame-method in LuceneQuery generates a new instance of
fullTextQuery even if there are no search results. In this way all
concepts will be returned without filtering them.

* only call buildQuery() in skipSame when results were found
* add test to ConceptServiceTest

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4922