### PR TITLE
TRUNK-4912: BaseOpenmrsData creator, dateCreated, uuid should be not …

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -31,10 +31,10 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	
 	//***** Properties *****
 	@ManyToOne(optional = false)
-	@JoinColumn(name = "creator")
+	@JoinColumn(name = "creator", updatable = false)
 	protected User creator;
 	
-	@Column(name = "date_created", nullable = false)
+	@Column(name = "date_created", nullable = false, updatable = false)
 	private Date dateCreated;
 	
 	@ManyToOne

--- a/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
@@ -26,7 +26,7 @@ import javax.persistence.Column;
 @MappedSuperclass
 public abstract class BaseOpenmrsObject implements Serializable, OpenmrsObject {
 	
-	@Column(name = "uuid", unique = true, nullable = false, length = 38)
+	@Column(name = "uuid", unique = true, nullable = false, length = 38, updatable = false)
 	private String uuid = UUID.randomUUID().toString();
 	
 	/**


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
Made creator and dateCreated columns updatable = false. Could not find uuid column though.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4912?jql=filter%3D12852%20

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


…updatable