### PR TITLE
TRUNK-4913 Concept.hbm.xml not-null on optional changedBy

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
@@ -98,8 +98,7 @@
 			<column name="class_id" />
 		</many-to-one>
 		<!-- bi-directional many-to-one association to User -->
-		<many-to-one name="changedBy" class="User"
-			not-null="true">
+		<many-to-one name="changedBy" class="User">
 			<column name="changed_by" />
 		</many-to-one>
 		<!-- bi-directional many-to-one association to User -->


### PR DESCRIPTION
## Description
Removed the not-null requirement from the many-to-many relationship on the changedBy column. Confirmed against a newly generated Concept.hbm.xml that this constraint doesn't belong.
Build Success.
All tests passed.
No new tests required.


## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
