### PR TITLE
TRUNK-4940 | Preethi | Not validating voided obs in ObsValidator

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ObsValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ObsValidator.java
@@ -66,6 +66,9 @@ public class ObsValidator implements Validator {
 	 */
 	public void validate(Object obj, Errors errors) {
 		Obs obs = (Obs) obj;
+		if(obs.getVoided()){
+			return;
+		}
 		List<Obs> ancestors = new ArrayList<Obs>();
 		//ancestors.add(obs);
 		validateHelper(obs, errors, ancestors, true);

--- a/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
@@ -440,4 +440,27 @@ public class ObsValidatorTest extends BaseContextSensitiveTest {
 		assertTrue(obsValidator.supports(Obs.class));
 		assertFalse(obsValidator.supports(Concept.class));
 	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	@Verifies(value = "should not validate if obs is voided", method = "validate(java.lang.Object, org.springframework.validation.Errors)")
+	public void validate_shouldNotValidateIfObsIsVoided() throws Exception {
+		Obs obs = new Obs();
+		obs.setPerson(Context.getPersonService().getPerson(2));
+		obs.setConcept(Context.getConceptService().getConcept(5089));
+		obs.setObsDatetime(new Date());
+		obs.setValueNumeric(null);
+
+		Errors errors = new BindException(obs, "obs");
+		new ObsValidator().validate(obs, errors);
+		assertTrue(errors.hasFieldErrors("valueNumeric"));
+
+		obs.setVoided(true);
+		errors = new BindException(obs, "obs");
+		new ObsValidator().validate(obs, errors);
+		assertFalse(errors.hasErrors());
+
+	}
 }


### PR DESCRIPTION
 TRUNK-4940

## Description
When obs is to be voided, skipped the validation in ObsValidator.java

## Related Issue
https://issues.openmrs.org/browse/TRUNK-4940

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


