### PR TITLE
TRUNK-4942 - Dirty Flag should not be set for new obs

### DIFF
--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -9,18 +9,6 @@
  */
 package org.openmrs;
 
-import java.text.DateFormat;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Locale;
-import java.util.Set;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -33,6 +21,18 @@ import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.Format;
 import org.openmrs.util.Format.FORMAT_TYPE;
 import org.openmrs.util.OpenmrsUtil;
+
+import java.text.DateFormat;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
 
 /**
  * An observation is a single unit of clinical information. <br>
@@ -441,11 +441,11 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 	 */
 	public void setGroupMembers(Set<Obs> groupMembers) {
 		if (CollectionUtils.isNotEmpty(this.groupMembers) && CollectionUtils.isNotEmpty(groupMembers)) {
-			dirty = !CollectionUtils.disjunction(this.groupMembers, groupMembers).isEmpty();
+			setDirty(!CollectionUtils.disjunction(this.groupMembers, groupMembers).isEmpty());
 		} else if (CollectionUtils.isEmpty(this.groupMembers) && CollectionUtils.isNotEmpty(groupMembers)) {
-			dirty = true;
+			setDirty(true);
 		} else if (CollectionUtils.isNotEmpty(this.groupMembers) && CollectionUtils.isEmpty(groupMembers)) {
-			dirty = true;
+			setDirty(true);
 		}
 		this.groupMembers = new HashSet<Obs>(groupMembers); //Copy over the entire list
 		
@@ -478,7 +478,7 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 		
 		member.setObsGroup(this);
 		if (groupMembers.add(member)) {
-			dirty = true;
+			setDirty(true);
 		}
 	}
 	
@@ -499,7 +499,7 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 		
 		if (groupMembers.remove(member)) {
 			member.setObsGroup(null);
-			dirty = true;
+			setDirty(true);
 		}
 	}
 	
@@ -1275,8 +1275,14 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 	
 	private void markAsDirty(Object oldValue, Object newValue) {
 		//Should we ignore the case for Strings?
-		if (!isDirty() && !OpenmrsUtil.nullSafeEquals(oldValue, newValue)) {
+		if (!isDirty() && obsId != null && !OpenmrsUtil.nullSafeEquals(oldValue, newValue)) {
 			dirty = true;
+		}
+	}
+
+	private void setDirty(Boolean dirty){
+		if(obsId != null){
+			this.dirty = dirty;
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.apache.commons.beanutils.BeanUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.obs.ComplexData;
+import org.openmrs.test.Verifies;
+import org.openmrs.util.Reflect;
 
 import java.lang.reflect.Field;
 import java.text.DateFormat;
@@ -29,13 +29,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.beanutils.BeanUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.openmrs.api.APIException;
-import org.openmrs.obs.ComplexData;
-import org.openmrs.test.Verifies;
-import org.openmrs.util.Reflect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * This class tests all methods that are not getter or setters in the Obs java object TODO: finish
@@ -67,8 +67,8 @@ public class ObsTest {
 		assertFalse(obs.isDirty());
 	}
 	
-	private Obs createObs() throws Exception {
-		Obs obs = new Obs();
+	private Obs createObs(Integer id) throws Exception {
+		Obs obs = new Obs(id);
 		List<Field> fields = Reflect.getAllFields(Obs.class);
 		for (Field field : fields) {
 			if (IGNORED_FIELDS.contains(field.getName())) {
@@ -79,7 +79,7 @@ public class ObsTest {
 		assertFalse(obs.isDirty());
 		return obs;
 	}
-	
+
 	private void setFieldValue(Obs obs, Field field, boolean setAlternateValue) throws Exception {
 		final boolean accessible = field.isAccessible();
 		if (!accessible) {
@@ -656,7 +656,14 @@ public class ObsTest {
 		assertFalse(new Obs().isDirty());
 		
 		//Should also work if setters are called with same values as the original
-		Obs obs = createObs();
+		Obs obs = createObs(2);
+		obs.setGroupMembers(new LinkedHashSet<>());
+		obs.getConcept().setDatatype(new ConceptDatatype());
+		assertFalse(obs.isDirty());
+		BeanUtils.copyProperties(obs, BeanUtils.cloneBean(obs));
+		assertFalse(obs.isDirty());
+
+		obs = createObs(null);
 		obs.setGroupMembers(new LinkedHashSet<>());
 		obs.getConcept().setDatatype(new ConceptDatatype());
 		assertFalse(obs.isDirty());
@@ -666,14 +673,30 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#isDirty()
-	 * @verifies return true when any immutable field has been changed
+	 * @verifies return true when any immutable field has been changed with edited obs
 	 */
 	@Test
-	public void isDirty_shouldReturnTrueWhenAnyImmutableFieldHasBeenChanged() throws Exception {
+	public void isDirty_shouldReturnTrueWhenAnyImmutableFieldHasBeenChangedForEditedObs() throws Exception {
+		Obs obs = createObs(2);
+		assertFalse(obs.isDirty());
+		updateImmutableFieldsAndAssert(obs, true);
+	}
+
+	/**
+	 * @see Obs#isDirty()
+	 * @verifies return false when any immutable field has been changed with new obs
+	 */
+	@Test
+	public void isDirty_shouldReturnFalseWhenAnyImmutableFieldHasBeenChangedForNewObs() throws Exception {
+		Obs obs = createObs(null);
+		assertFalse(obs.isDirty());
+		updateImmutableFieldsAndAssert(obs, false);
+	}
+
+	private void updateImmutableFieldsAndAssert(Obs obs, boolean assertion) throws Exception {
 		//Set all fields to some random values via reflection
 		List<Field> fields = Reflect.getAllFields(Obs.class);
-		Obs obs = createObs();
-		assertFalse(obs.isDirty());
+
 		final Integer originalPersonId = obs.getPersonId();
 		//call each setter and check that dirty has been set to true for each
 		for (Field field : fields) {
@@ -688,8 +711,7 @@ public class ObsTest {
 			} else {
 				BeanUtils.setProperty(obs, fieldName, generateValue(field, true));
 			}
-			
-			assertTrue("Obs was not marked as dirty after changing: " + fieldName, obs.isDirty());
+			assertEquals("Obs was not marked as dirty after changing: " + fieldName, obs.isDirty(), assertion);
 			if ("person".equals(fieldName)) {
 				//Because setPerson updates the personId we need to reset personId to its original value 
 				//that matches that of person otherwise the test will fail for the personId field
@@ -698,8 +720,6 @@ public class ObsTest {
 			
 			//reset for next field
 			resetObs(obs);
-			
-			assertFalse("Failed to rest Obs.dirty after testing field: " + fieldName, obs.isDirty());
 		}
 	}
 	
@@ -715,30 +735,62 @@ public class ObsTest {
 		obs.setVoidReason("some other reason");
 		obs.setDateVoided(new Date());
 		assertFalse(obs.isDirty());
+
+		Obs obsEdited = new Obs(5);
+		obsEdited.setVoided(true);
+		obsEdited.setVoidedBy(new User(1000));
+		obsEdited.setVoidReason("some other reason");
+		obsEdited.setDateVoided(new Date());
+		assertFalse(obsEdited.isDirty());
 	}
-	
+
+
 	/**
 	 * @see Obs#isDirty()
-	 * @verifies return true when a field is changed from a non null to a null value
+	 * @verifies return true when a field is changed from a non null to a null value for edited obs
 	 */
 	@Test
-	public void isDirty_shouldReturnTrueWhenAnImmutableFieldIsChangedFromANonNullToANullValue() throws Exception {
-		Obs obs = createObs();
+	public void isDirty_shouldReturnTrueWhenAnImmutableFieldIsChangedFromANonNullToANullValueForEditedObs() throws Exception {
+		Obs obs = createObs(2);
 		assertNotNull(obs.getComment());
 		obs.setComment(null);
 		assertTrue(obs.isDirty());
 	}
-	
+
 	/**
 	 * @see Obs#isDirty()
-	 * @verifies return true when a field is changed from a null to a non null value
+	 * @verifies return true when a field is changed from a non null to a null value for new obs
 	 */
 	@Test
-	public void isDirty_shouldReturnTrueWhenAnImmutableFieldIsChangedFromANullToANonNullValue() throws Exception {
-		Obs obs = new Obs();
+	public void isDirty_shouldReturnFalsWhenAnImmutableFieldIsChangedFromANonNullToANullValueForNewObs() throws Exception {
+		Obs obs = createObs(null);
+		assertNotNull(obs.getComment());
+		obs.setComment(null);
+		assertFalse(obs.isDirty());
+	}
+
+	/**
+	 * @see Obs#isDirty()
+	 * @verifies return true when a field is changed from a null to a non null value in existing obs
+	 */
+	@Test
+	public void isDirty_shouldReturnTrueWhenAnImmutableFieldIsChangedFromANullToANonNullValueInExistingObs() throws Exception {
+		Obs obs = new Obs(5);
 		assertNull(obs.getComment());
 		obs.setComment("some non null value");
 		assertTrue(obs.isDirty());
+	}
+
+	/**
+	 * @see Obs#isDirty()
+	 * @verifies return true when a field is changed from a null to a non null value in new obs
+	 */
+	@Test
+	public void isDirty_shouldReturnFalseWhenAnImmutableFieldIsChangedFromANullToANonNullValueInNewObs() throws Exception {
+		Obs obs = new Obs();
+		assertNull(obs.getComment());
+		obs.setComment("some non null value");
+		assertFalse(obs.isDirty());
 	}
 	
 	/**
@@ -747,7 +799,7 @@ public class ObsTest {
 	 */
 	@Test
 	public void setFormField_shouldNotMarkTheObsAsDirtyWhenTheValueHasNotBeenChanged() throws Exception {
-		Obs obs = createObs();
+		Obs obs = createObs(3);
 		obs.setFormField(obs.getFormFieldNamespace(), obs.getFormFieldPath());
 		assertFalse(obs.isDirty());
 	}
@@ -758,7 +810,7 @@ public class ObsTest {
 	 */
 	@Test
 	public void setFormField_shouldMarkTheObsAsDirtyWhenTheValueHasBeenChanged() throws Exception {
-		Obs obs = createObs();
+		Obs obs = createObs(5);
 		final String newNameSpace = "someNameSpace";
 		final String newPath = "somePath";
 		assertNotEquals(newPath, obs.getFormFieldNamespace());
@@ -773,7 +825,7 @@ public class ObsTest {
 	 */
 	@Test
 	public void setFormField_shouldMarkTheObsAsDirtyWhenTheValueIsChangedFromANonNullToANullValue() throws Exception {
-		Obs obs = new Obs();
+		Obs obs = new Obs(2);
 		obs.setFormField("someNameSpace", "somePath");
 		resetObs(obs);
 		assertFalse(obs.isDirty());
@@ -782,14 +834,14 @@ public class ObsTest {
 		obs.setFormField(null, null);
 		assertTrue(obs.isDirty());
 	}
-	
+
 	/**
 	 * @see Obs#setFormField(String,String)
 	 * @verifies mark the obs as dirty when the value is changed from a null to a non null value
 	 */
 	@Test
 	public void setFormField_shouldMarkTheObsAsDirtyWhenTheValueIsChangedFromANullToANonNullValue() throws Exception {
-		Obs obs = new Obs();
+		Obs obs = new Obs(5);
 		assertNull(obs.getFormFieldNamespace());
 		assertNull(obs.getFormFieldPath());
 		obs.setFormField("someNameSpace", "somePath");
@@ -798,14 +850,29 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#addGroupMember(Obs)
-	 * @verifies return false when a duplicate obs is added as a member
+	 * @verifies return dirtyflag as false when a duplicate obs is added as a member to existing obs
 	 */
 	@Test
 	public void addGroupMember_shouldReturnFalseWhenADuplicateObsIsAddedAsAMember() throws Exception {
-		Obs obs = new Obs();
+		Obs obs = new Obs(2);
 		Obs member = new Obs();
 		obs.addGroupMember(member);
 		assertTrue(obs.isDirty());
+		resetObs(obs);
+		obs.addGroupMember(member);
+		assertFalse(obs.isDirty());
+	}
+
+	/**
+	 * @see Obs#addGroupMember(Obs)
+	 * @verifies return dirtyflag as false when a duplicate obs is added as a member to existing obs
+	 */
+	@Test
+	public void addGroupMember_shouldReturnFalseWhenADuplicateObsIsAddedAsAMemberToNewObs() throws Exception {
+		Obs obs = new Obs();
+		Obs member = new Obs();
+		obs.addGroupMember(member);
+		assertFalse(obs.isDirty());
 		resetObs(obs);
 		obs.addGroupMember(member);
 		assertFalse(obs.isDirty());
@@ -817,7 +884,7 @@ public class ObsTest {
 	 */
 	@Test
 	public void addGroupMember_shouldReturnTrueWhenANewObsIsAddedAsAMember() throws Exception {
-		Obs obs = new Obs();
+		Obs obs = new Obs(2);
 		Obs member1 = new Obs();
 		obs.addGroupMember(member1);
 		assertTrue(obs.isDirty());
@@ -840,11 +907,11 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#removeGroupMember(Obs)
-	 * @verifies return true when an obs is removed
+	 * @verifies return true when an existing obs is removed from the group
 	 */
 	@Test
 	public void removeGroupMember_shouldReturnTrueWhenAnObsIsRemoved() throws Exception {
-		Obs obs = new Obs();
+		Obs obs = new Obs(2);
 		Obs member = new Obs();
 		obs.addGroupMember(member);
 		assertTrue(obs.isDirty());
@@ -852,29 +919,58 @@ public class ObsTest {
 		obs.removeGroupMember(member);
 		assertTrue(obs.isDirty());
 	}
+
+	/**
+	 * @see Obs#removeGroupMember(Obs)
+	 * @verifies return false when an new obs is removed from the group
+	 */
+	@Test
+	public void removeGroupMember_shouldReturnFalseForDirtyFlagWhenAnObsIsRemovedFromGroup() throws Exception {
+		Obs obs = new Obs();
+		Obs member = new Obs();
+		obs.addGroupMember(member);
+		assertFalse(obs.isDirty());
+		resetObs(obs);
+		obs.removeGroupMember(member);
+		assertFalse(obs.isDirty());
+	}
 	
 	/**
 	 * @see Obs#setGroupMembers(Set)
-	 * @verifies mark the obs as dirty when the set is changed from null to a non empty one
+	 * @verifies mark the existing obs as dirty when the set is changed from null to a non empty one
 	 */
 	@Test
-	public void setGroupMembers_shouldMarkTheObsAsDirtyWhenTheSetIsChangedFromNullToANonEmptyOne() throws Exception {
-		Obs obs = new Obs();
+	public void setGroupMembers_shouldMarkTheExistingObsAsDirtyWhenTheSetIsChangedFromNullToANonEmptyOne() throws Exception {
+		Obs obs = new Obs(5);
 		assertNull(Obs.class.getDeclaredField("groupMembers").get(obs));
 		Set members = new HashSet<>();
 		members.add(new Obs());
 		obs.setGroupMembers(members);
 		assertTrue(obs.isDirty());
 	}
-	
+
 	/**
 	 * @see Obs#setGroupMembers(Set)
-	 * @verifies mark the obs as dirty when the set is replaced with another with different members
+	 * @verifies do not mark the new obs as dirty when the set is changed from null to a non empty one
 	 */
 	@Test
-	public void setGroupMembers_shouldMarkTheObsAsDirtyWhenTheSetIsReplacedWithAnotherWithDifferentMembers()
-	    throws Exception {
+	public void setGroupMembers_shouldNotMarkNewObsAsDirtyWhenTheSetIsChangedFromNullToANonEmptyOne() throws Exception {
 		Obs obs = new Obs();
+		assertNull(Obs.class.getDeclaredField("groupMembers").get(obs));
+		Set members = new HashSet<>();
+		members.add(new Obs());
+		obs.setGroupMembers(members);
+		assertFalse(obs.isDirty());
+	}
+
+	/**
+	 * @see Obs#setGroupMembers(Set)
+	 * @verifies mark the existing obs as dirty when the set is replaced with another with different members
+	 */
+	@Test
+	public void setGroupMembers_shouldMarkTheExistingObsAsDirtyWhenTheSetIsReplacedWithAnotherWithDifferentMembers()
+	    throws Exception {
+		Obs obs = new Obs(2);
 		Set members1 = new HashSet<>();
 		members1.add(new Obs());
 		obs.setGroupMembers(members1);
@@ -883,6 +979,24 @@ public class ObsTest {
 		members2.add(new Obs());
 		obs.setGroupMembers(members2);
 		assertTrue(obs.isDirty());
+	}
+
+	/**
+	 * @see Obs#setGroupMembers(Set)
+	 * @verifies do not mark the new obs as dirty when the set is replaced with another with different members
+	 */
+	@Test
+	public void setGroupMembers_shouldNotMarkTheNewObsAsDirtyWhenTheSetIsReplacedWithAnotherWithDifferentMembers()
+			throws Exception {
+		Obs obs = new Obs();
+		Set members1 = new HashSet<>();
+		members1.add(new Obs());
+		obs.setGroupMembers(members1);
+		assertFalse(obs.isDirty());
+		Set members2 = new HashSet<>();
+		members2.add(new Obs());
+		obs.setGroupMembers(members2);
+		assertFalse(obs.isDirty());
 	}
 	
 	/**


### PR DESCRIPTION
## Description
The Dirty Flag should not be set for new Obs that are still not saved in the database.  Refer to the design form [here](https://notes.openmrs.org/2016-09-15-Developers-Forum) and the talk [here](https://talk.openmrs.org/t/openmrs-2-0-saving-visit-saves-the-encounters-under-it-but-not-the-obs-of-the-encounters/7925/34).

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-4942

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


