### PR TITLE
TRUNK-4813 Fix SQLException during the setup on MySQL:5.7

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -6004,6 +6004,7 @@
      	<validCheckSum><comment>Copying user.retired to person.voided so that generated providers for retired users are retired</comment>3:f338c9ea12ce38b0695db335d983b4e1</validCheckSum>
      	<validCheckSum><comment>Correcting checksum</comment>3:216ab5057dca5471de69124e93953d96</validCheckSum>
      	<validCheckSum><comment>TRUNK-3853 and TRUNK-3414</comment>3:04bc8aa9859f6f8dda065e272ba12e0d</validCheckSum>
+	    <validCheckSum><comment>TRUNK-4813</comment>3:5da8f64332ca386c7bd4c9bc1f0ac73c</validCheckSum>
      	<preConditions onFail="MARK_RAN">
  			<columnExists tableName="encounter" columnName="provider_id"/>
  		</preConditions>
@@ -6020,8 +6021,8 @@
  				select distinct person.person_id, user.system_id, 1, CURRENT_TIMESTAMP, user.retired, user.retired_by, user.date_retired, user.retire_reason, CONCAT('prov', SUBSTRING(person.uuid, 5))
  				from person as person
  					inner join encounter as encounter on encounter.provider_id = person.person_id
- 					left join (select max(users.user_id) as user_id, users.system_id, users.person_id, users.retired, users.retired_by, users.date_retired, users.retire_reason 
- 							from users as users group by users.person_id) as user 
+ 					left join (select max(users.user_id) as user_id, users.system_id, users.person_id, users.retired, users.retired_by, users.date_retired, users.retire_reason
+						from users as users group by users.system_id, users.person_id, users.retired, users.retired_by, users.date_retired, users.retire_reason) as user
  						on person.person_id = user.person_id
  				where user.user_id is not null and encounter.provider_id not in (select person_id from provider);
          </sql>


### PR DESCRIPTION
## Description
Changed GROUP BY clause in changest: `20110825-1000-creating-providers-for-persons-from-encounter` because it violated ` ONLY_FULL_GROUP_BY` SQL mode which is automatically enabled in MySQL 5.7, see https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-4813

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


