### PR TITLE
Refactored obsService#saveObs(org.openmrs.Obs,String)

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1422,6 +1422,7 @@ Obs.encounterDate=Encounter date
 Obs.error.cannot.save.complex=Cannot save complex obs where obsId={0} because its ComplexData.getData() is null.
 Obs.error.cascading.purge.not.implemented=Cascading purge of obs not yet implemented
 Obs.error.ChangeMessage.required=ChangeMessage is required when updating an obs in the database
+Obs.error.cannot.be.null=Cannot save null obs
 Obs.error.groupContainsItself=Obs group contains itself recursively
 Obs.error.groupCannotHaveItselfAsAMentor=An obsGroup cannot have itself as a mentor. obsGroup: {0} obsMember attempting to add: {1}
 Obs.error.inGroupMember=A member of this obs group has an error

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -9,39 +9,10 @@
  */
 package org.openmrs.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
-import java.awt.image.BufferedImage;
-import java.awt.image.WritableRaster;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.CharArrayReader;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.Reader;
-import java.io.Writer;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.imageio.ImageIO;
-
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.ConceptProposal;
@@ -64,6 +35,38 @@ import org.openmrs.util.DateUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsConstants.PERSON_TYPE;
 import org.openmrs.util.OpenmrsUtil;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * TODO clean up and add tests for all methods in ObsService
@@ -75,6 +78,18 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	protected static final String ENCOUNTER_OBS_XML = "org/openmrs/api/include/ObsServiceTest-EncounterOverwrite.xml";
 	
 	protected static final String COMPLEX_OBS_XML = "org/openmrs/api/include/ObsServiceTest-complex.xml";
+
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+
+	@Test
+	@Verifies(value = "should throw APIException when obs is null", method = "saveObs(Obs,String)")
+	public void shouldReturnAPIExceptionWhenObsIsNull(){
+		expectedException.expect(APIException.class);
+		expectedException.expectMessage(Context.getMessageSourceService().getMessage("Obs.error.cannot.be.null"));
+		ObsService os = Context.getObsService();
+		Obs o = os.saveObs(null,"Null Obs");
+	}
 	
 	/**
 	 * This test tests multi-level heirarchy obsGroup cascades for create, delete, update, void, and


### PR DESCRIPTION
TRUNK-4944

## Description
This PR refactors the existing org.openmrs.api.ObsService#saveObs(org.openmrs.Obs, String).  No additional functionality is added in this PR.  The subsequent PRs will add a fix for the saving the childObs if it is dirty and not the complete obs hierarchy as mentioned by @bmamlin [here](org.openmrs.api.ObsService#saveObs(org.openmrs.Obs, String))

## Related Issue

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x ] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


