### PR TITLE
TRUNK-4953 ConceptSourceValidator doesnt fail on empty description

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ConceptSourceValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptSourceValidator.java
@@ -40,7 +40,7 @@ public class ConceptSourceValidator implements Validator {
 	 * 	 * @see org.springframework.validation.Validator#validate(java.lang.Object,
 	 *      org.springframework.validation.Errors)
 	 * @should fail validation if name is null or empty or whitespace
-	 * @should pass validation if description is null or empty or whitespace
+	 * @should fail validation if description is null or empty or whitespace
 	 * @should pass validation if HL7 Code is null or empty or whitespace
 	 * @should pass validation if all required fields have proper values
 	 * @should pass validation if field lengths are correct
@@ -52,6 +52,7 @@ public class ConceptSourceValidator implements Validator {
 			        + ConceptSource.class);
 		} else {
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "name", "error.name");
+			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "description", "error.null");
 			ValidateUtil.validateFieldLengths(errors, obj.getClass(), "name", "hl7Code", "uniqueId", "description",
 			    "retireReason");
 		}

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/ConceptSource.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/ConceptSource.hbm.xml
@@ -27,9 +27,9 @@
 			column="uuid" length="38" unique="true" />
 
 		<property name="name" type="java.lang.String"
-			column="name" length="50" />
+			column="name" length="50" not-null="true" />
 		<property name="description" type="java.lang.String"
-			column="description" length="1024" />
+			column="description" length="1024" not-null="true" />
 		<property name="hl7Code" type="java.lang.String"
 			column="hl7_code" length="50" />
 		<property name="uniqueId" type="java.lang.String"

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -1271,6 +1271,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		String aNullString = null;
 		String sourceName = "A concept source with null HL7 code";
 		source.setName(sourceName);
+		source.setDescription("A concept source description");
 		source.setHl7Code(aNullString);
 		conceptService.saveConceptSource(source);
 		assertEquals("Did not save a ConceptSource with a null hl7Code", source, conceptService

--- a/api/src/test/java/org/openmrs/validator/ConceptSourceValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ConceptSourceValidatorTest.java
@@ -44,27 +44,31 @@ public class ConceptSourceValidatorTest extends BaseContextSensitiveTest {
 		new ConceptSourceValidator().validate(conceptSource, errors);
 		Assert.assertTrue(errors.hasFieldErrors("name"));
 	}
-	
+
+	/**
+	 * @verifies fail validation if description is null or empty or whitespace
+	 * @see ConceptSourceValidator#validate(Object, Errors)
+	 */
 	@Test
-	@Verifies(value = "should pass validation if description is null or empty or whitespace", method = "validate(Object,Errors)")
-	public void validate_shouldPassValidationIfDescriptionIsNullOrEmptyOrWhitespace() throws Exception {
+	public void validate_shouldFailValidationIfDescriptionIsNullOrEmptyOrWhitespace() throws Exception {
+
 		ConceptSource conceptSource = new ConceptSource();
 		conceptSource.setName("New name");
+
 		conceptSource.setDescription(null);
-		
 		Errors errors = new BindException(conceptSource, "conceptSource");
 		new ConceptSourceValidator().validate(conceptSource, errors);
-		Assert.assertFalse(errors.hasFieldErrors("description"));
+		Assert.assertTrue(errors.hasFieldErrors("description"));
 		
 		conceptSource.setDescription("");
 		errors = new BindException(conceptSource, "conceptSource");
 		new ConceptSourceValidator().validate(conceptSource, errors);
-		Assert.assertFalse(errors.hasFieldErrors("description"));
+		Assert.assertTrue(errors.hasFieldErrors("description"));
 		
 		conceptSource.setDescription("   ");
 		errors = new BindException(conceptSource, "conceptSource");
 		new ConceptSourceValidator().validate(conceptSource, errors);
-		Assert.assertFalse(errors.hasFieldErrors("description"));
+		Assert.assertTrue(errors.hasFieldErrors("description"));
 	}
 	
 	@Test


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Fixes ConceptSourceValidator which does not fail if "description" is
empty altough the description column is required.

* add not-null="true" to name and description fields in ConceptSource.hbm.xml
* Validator now fails on empty "description"

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4953



