### PR TITLE
TRUNK-4936 Fix integration-test on h2 due to liquibase changeset

### DIFF
--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -9534,16 +9534,16 @@
             AND NOT EXISTS (SELECT role, privilege FROM role_privilege rp2 WHERE rp2.privilege='Add Visits'                     AND rp2.role=rp.role);
         </sql>
     </changeSet>
-	<changeSet id="TRUNK-4936-20160930-1000" author="teleivo">
+	<changeSet id="TRUNK-4936-20160930-1000" author="teleivo" >
 		<preConditions onFail="MARK_RAN">
 			<not><columnExists tableName="concept_reference_source" columnName="unique_id"/></not>
 		</preConditions>
 		<comment>Add unique_id column to concept_reference_source</comment>
 		<addColumn tableName="concept_reference_source">
 			<column name="unique_id" type="varchar(250)">
-				<constraints unique="true"/>
 			</column>
 		</addColumn>
+		<addUniqueConstraint tableName="concept_reference_source" columnNames="unique_id" constraintName="concept_reference_source_unique_id_unique"/>
 	</changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Some integration-test's failed on h2 due to the introduced liquibase changeset
for TRUNK-4936. ALTER TABLE sql statement generated by h2 contains a
syntax error. h2 does only seem to handle unique constraints well when
creating the table, or on its own and not when adding the column.

* remove the nested <constraints> element from the changeset
* use addColumn and addUniqueConstraint

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4936


