### PR TITLE
Fix for editing a child obs makes the parent obs dirty and creates a new instance

### DIFF
--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -440,13 +440,6 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 	 * @should not mark the obs as dirty when the set is replaced with another with same members
 	 */
 	public void setGroupMembers(Set<Obs> groupMembers) {
-		if (CollectionUtils.isNotEmpty(this.groupMembers) && CollectionUtils.isNotEmpty(groupMembers)) {
-			setDirty(!CollectionUtils.disjunction(this.groupMembers, groupMembers).isEmpty());
-		} else if (CollectionUtils.isEmpty(this.groupMembers) && CollectionUtils.isNotEmpty(groupMembers)) {
-			setDirty(true);
-		} else if (CollectionUtils.isNotEmpty(this.groupMembers) && CollectionUtils.isEmpty(groupMembers)) {
-			setDirty(true);
-		}
 		this.groupMembers = new HashSet<Obs>(groupMembers); //Copy over the entire list
 		
 	}
@@ -477,9 +470,7 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 		}
 		
 		member.setObsGroup(this);
-		if (groupMembers.add(member)) {
-			setDirty(true);
-		}
+		groupMembers.add(member);
 	}
 	
 	/**
@@ -499,7 +490,6 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 		
 		if (groupMembers.remove(member)) {
 			member.setObsGroup(null);
-			setDirty(true);
 		}
 	}
 	
@@ -1277,12 +1267,6 @@ public class Obs extends BaseOpenmrsData implements java.io.Serializable {
 		//Should we ignore the case for Strings?
 		if (!isDirty() && obsId != null && !OpenmrsUtil.nullSafeEquals(oldValue, newValue)) {
 			dirty = true;
-		}
-	}
-
-	private void setDirty(Boolean dirty){
-		if(obsId != null){
-			this.dirty = dirty;
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -9,15 +9,6 @@
  */
 package org.openmrs.api.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
-
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.Cohort;
 import org.openmrs.Encounter;
@@ -50,6 +41,15 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Vector;
 
 /**
  * Default implementation of the {@link EncounterService}
@@ -202,7 +202,7 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 		ObsService os = Context.getObsService();
 		List<Obs> toRemove = new ArrayList<>();
 		List<Obs> toAdd = new ArrayList<>();
-		for (Obs o : encounter.getAllObs(true)) {
+		for (Obs o : encounter.getObsAtTopLevel(true)) {
 			if (o.getId() == null) {
 				os.saveObs(o, null);
 			} else {

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -187,11 +187,11 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 				os.saveObs(o, null);
 			} else {
 				Obs replacement = os.saveObs(o, changeMessage);
-				//The logic in saveObs evicts the old obs instance, so we need to update
-				//the collection with the newly loaded and voided instance
-				toRemove.add(o);
-				toAdd.add(os.getObs(o.getId()));
-				toAdd.add(replacement);
+				if(!replacement.equals(o)){
+					toRemove.add(o);
+					toAdd.add(os.getObs(o.getId()));
+					toAdd.add(replacement);
+				}
 			}
 		}
 

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -857,7 +857,7 @@ public class ObsTest {
 		Obs obs = new Obs(2);
 		Obs member = new Obs();
 		obs.addGroupMember(member);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 		resetObs(obs);
 		obs.addGroupMember(member);
 		assertFalse(obs.isDirty());
@@ -880,18 +880,18 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#addGroupMember(Obs)
-	 * @verifies return true when a new obs is added as a member
+	 * @verifies return isDirty false when a new obs is added as a member
 	 */
 	@Test
-	public void addGroupMember_shouldReturnTrueWhenANewObsIsAddedAsAMember() throws Exception {
+	public void addGroupMember_shouldReturnFalseWhenANewObsIsAddedAsAMember() throws Exception {
 		Obs obs = new Obs(2);
 		Obs member1 = new Obs();
 		obs.addGroupMember(member1);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 		resetObs(obs);
 		Obs member2 = new Obs();
 		obs.addGroupMember(member2);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 	}
 	
 	/**
@@ -907,22 +907,22 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#removeGroupMember(Obs)
-	 * @verifies return true when an existing obs is removed from the group
+	 * @verifies return isDirty as false when an existing obs is removed from the group
 	 */
 	@Test
-	public void removeGroupMember_shouldReturnTrueWhenAnObsIsRemoved() throws Exception {
+	public void removeGroupMember_shouldReturnDirtyFalseWhenAnObsIsRemoved() throws Exception {
 		Obs obs = new Obs(2);
 		Obs member = new Obs();
 		obs.addGroupMember(member);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 		resetObs(obs);
 		obs.removeGroupMember(member);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 	}
 
 	/**
 	 * @see Obs#removeGroupMember(Obs)
-	 * @verifies return false when an new obs is removed from the group
+	 * @verifies return isDirty false when an new obs is removed from the group
 	 */
 	@Test
 	public void removeGroupMember_shouldReturnFalseForDirtyFlagWhenAnObsIsRemovedFromGroup() throws Exception {
@@ -937,16 +937,16 @@ public class ObsTest {
 	
 	/**
 	 * @see Obs#setGroupMembers(Set)
-	 * @verifies mark the existing obs as dirty when the set is changed from null to a non empty one
+	 * @verifies do not mark the existing obs as dirty when the set is changed from null to a non empty one
 	 */
 	@Test
-	public void setGroupMembers_shouldMarkTheExistingObsAsDirtyWhenTheSetIsChangedFromNullToANonEmptyOne() throws Exception {
+	public void setGroupMembers_shouldNotMarkTheExistingObsAsDirtyWhenTheSetIsChangedFromNullToANonEmptyOne() throws Exception {
 		Obs obs = new Obs(5);
 		assertNull(Obs.class.getDeclaredField("groupMembers").get(obs));
 		Set members = new HashSet<>();
 		members.add(new Obs());
 		obs.setGroupMembers(members);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 	}
 
 	/**
@@ -965,10 +965,10 @@ public class ObsTest {
 
 	/**
 	 * @see Obs#setGroupMembers(Set)
-	 * @verifies mark the existing obs as dirty when the set is replaced with another with different members
+	 * @verifies do not mark the existing obs as dirty when the set is replaced with another with different members
 	 */
 	@Test
-	public void setGroupMembers_shouldMarkTheExistingObsAsDirtyWhenTheSetIsReplacedWithAnotherWithDifferentMembers()
+	public void setGroupMembers_shouldNotMarkTheExistingObsAsDirtyWhenTheSetIsReplacedWithAnotherWithDifferentMembers()
 	    throws Exception {
 		Obs obs = new Obs(2);
 		Set members1 = new HashSet<>();
@@ -978,7 +978,7 @@ public class ObsTest {
 		Set members2 = new HashSet<>();
 		members2.add(new Obs());
 		obs.setGroupMembers(members2);
-		assertTrue(obs.isDirty());
+		assertFalse(obs.isDirty());
 	}
 
 	/**

--- a/api/src/test/resources/org/openmrs/api/include/EncounterServiceTest-saveObsHierarchyTests.xml
+++ b/api/src/test/resources/org/openmrs/api/include/EncounterServiceTest-saveObsHierarchyTests.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+    <!-- Encounter with a parent obs and two child obs -->
+    <encounter encounter_id="100" encounter_type="1" form_id="1" encounter_datetime="2005-01-01 00:00:00.0" patient_id="3" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="0" uuid="6bdec581-23aa-45fd-b578-413807aa6e8a"/>
+    <encounter_provider encounter_provider_id="100" encounter_id="4" provider_id="2" encounter_role_id="2" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="1596c524-013f-40f2-aa49-c993f0acab4d" />
+    <obs obs_id="100" person_id="3" encounter_id="100" concept_id="23" obs_datetime="2005-01-01 00:00:00.0" location_id="1" creator="1" date_created="2006-02-10 15:57:35.0" voided="false" uuid="4bf4d001-65e3-4203-ba87-6b1add8c2a52"/>
+    <obs obs_id="101" person_id="3" encounter_id="100" concept_id="3" obs_datetime="2005-01-01 00:00:00.0" location_id="1" obs_group_id="100" value_text="original obs value text" creator="1" date_created="2006-02-11 15:57:35.0" voided="false" uuid="46a6e808-8190-489c-89da-bbe2b37acb8f"/>
+    <obs obs_id="102" person_id="3" encounter_id="100" concept_id="3" obs_datetime="2005-01-01 00:00:00.0" location_id="1" obs_group_id="100" value_text="second obs value text" creator="1" date_created="2006-02-11 15:57:35.0" voided="false" uuid="d43df3eb-2846-41d8-9124-ddc922a8412e"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-EncounterOverwrite.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-EncounterOverwrite.xml
@@ -14,4 +14,7 @@
   <encounter encounter_id="2" encounter_type="2" patient_id="7" location_id="1" form_id="1" encounter_datetime="2008-08-01 00:00:00.0" creator="1" date_created="2008-08-18 14:09:05.0" voided="false" uuid="8382158d-401e-4190-a75d-347b5f04a893"/>
   <encounter_provider encounter_provider_id="1" encounter_id="2" provider_id="1" encounter_role_id="1" creator="1" date_created="2006-03-11 15:57:35.0" voided="false" uuid="363fe09b-c1e8-4bdf-aa7d-dd212632f295"/>
   <obs obs_id="13" person_id="6" concept_id="5089" encounter_id="2" obs_datetime="2008-07-01 00:00:00.0" location_id="1" value_numeric="50.0" comments="" creator="1" date_created="2008-08-18 14:09:35.0" voided="false" uuid="4db1b07d-2fc5-46ad-8aa1-ac8357f88457"/>
+  <obs obs_id="14" person_id="7" concept_id="23" encounter_id="2" obs_datetime="2008-07-01 00:00:00.0" location_id="1"  comments="" creator="1" date_created="2008-08-18 14:09:35.0" voided="false" uuid="4db1b07d-2fc5-46ad-8aa1-ac8357f88458"/>
+  <obs obs_id="15" person_id="7" obs_group_id="14" concept_id="19" encounter_id="2" obs_datetime="2008-07-01 00:00:00.0" location_id="1" value_text="some value" comments="" creator="1" date_created="2008-08-18 14:09:35.0" voided="false" uuid="4db1b07d-2fc5-46ad-8aa1-ac8357f88459"/>
+  <obs obs_id="16" person_id="7" obs_group_id="14" concept_id="20" encounter_id="2" obs_datetime="2008-07-01 00:00:00.0" location_id="1" value_datetime="2008-08-14 00:00:00.0" comments="" creator="1" date_created="2008-08-18 14:09:35.0" voided="true" uuid="4db1b07d-2fc5-46ad-8aa1-ac8357f88460"/>
 </dataset>


### PR DESCRIPTION
TRUNK-4944

## Description
This PR fixes the cloning of parent obs when a child (leaf) obs is edited.   The following are the things that are done

- Removed setting the dirty flag when obs.setGroupMembers(), obs.addGroupMember() and obs.removeGroupMember() is called
- EncounterService.saveEncounter() will use encounter.getObsAtTopLevel() so that we just pick up the top level obs.  Saving a top level obs using obsService.saveObs() will take care of individually saving the leaf obs.
- Added integration tests for various obs hirearchies and saving of obs at different levels - leaf, middle level, top level and peer at top level

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4944

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


