### PR TITLE
TRUNK-4955 | Obs not made dirty when obsdatetime is set with same val…

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -617,15 +617,14 @@ public class OpenmrsUtil {
 		}
 		return ret;
 	}
-	
+
 	public static <Arg1, Arg2 extends Arg1> boolean nullSafeEquals(Arg1 d1, Arg2 d2) {
 		if (d1 == null) {
 			return d2 == null;
 		} else if (d2 == null) {
 			return false;
-		} else {
-			return d1.equals(d2);
 		}
+		return (d1 instanceof Date && d2 instanceof Date) ? compare((Date) d1, (Date) d2) == 0 : d1.equals(d2);
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -18,6 +18,7 @@ import org.openmrs.test.Verifies;
 import org.openmrs.util.Reflect;
 
 import java.lang.reflect.Field;
+import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -1028,4 +1029,23 @@ public class ObsTest {
 		obs.setGroupMembers(members2);
 		assertFalse(obs.isDirty());
 	}
+
+	/**
+	 * @see Obs#setObsDatetime(Date)
+	 * @verifies not mark the obs as dirty when same date is set again and existing value is of Timestamp instance
+	 */
+	@Test
+	public void setObsDateTime_shouldNotMarkTheObsAsDirtyWhenDateIsNotChangedAndExistingValueIsOfTimeStampType(){
+		Obs obs = new Obs();
+		Date date = new Date();
+		Timestamp timestamp = new Timestamp(date.getTime());
+		obs.setObsDatetime(timestamp);
+		obs.setId(1);
+		assertFalse(obs.isDirty());
+
+		obs.setObsDatetime(date);
+
+		assertFalse(obs.isDirty());
+	}
+
 }


### PR DESCRIPTION

## Description
Obs.setObsDateTime makes obs as dirty when comparing timestamp against date. So Changed OpenmrsUtil.nullSafeEquals to use compare(Date, Date) method when any of its argument is of Timestamp type.

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-4955

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


…ue but compared against timestamp instance