### PR TITLE
TRUNK-2877 Don't set password values in the UI in the installation wizard

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -260,6 +260,11 @@ public class InitializationFilter extends StartupFilter {
 			renderTemplate(PROGRESS_VM, referenceMap, httpResponse);
 		} else if (page == null) {
 			httpResponse.setContentType("text/html");// if any body has already started installation
+			
+			//If someone came straight here without setting the hidden page input,
+			// then we need to clear out all the passwords
+			clearPasswords();
+			
 			renderTemplate(DEFAULT_PAGE, referenceMap, httpResponse);
 		} else if (INSTALL_METHOD.equals(page)) {
 			// get props and render the second page
@@ -356,6 +361,14 @@ public class InitializationFilter extends StartupFilter {
 			
 			wizardModel.adminUserPassword = script.getProperty("admin_user_password", wizardModel.adminUserPassword);
 		}
+	}
+	
+	private void clearPasswords(){
+		wizardModel.databaseRootPassword = "";
+		wizardModel.createDatabasePassword = "";
+		wizardModel.createUserPassword = "";
+		wizardModel.currentDatabasePassword = "";
+		wizardModel.remotePassword = "";
 	}
 	
 	/**


### PR DESCRIPTION
## Description
Password values were pre-filled in the installation wizard UI because they were stored in the wizardModel. I interpreted "run the installation wizard" to mean any access where the hidden page variable was not set. In that case we set all password entries in the model back to an empty string.

I was not able to find working tests for the InstallationWizard. It appears that UI tests are non-working ... probably because most of the UI was moved to a module.

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.