### PR TITLE
TRUNK-4720 createEncounterQuery now no longer assumes that identifiers always contain digits.

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -423,16 +423,12 @@ public class HibernateEncounterDAO implements EncounterDAO {
 				criteria.add(or);
 			}
 		} else {
-			String name = null;
-			String identifier = null;
-			if (query.matches(".*\\d+.*")) {
-				identifier = query;
-			} else {
-				// there is no number in the string, search on name
-				name = query;
-			}
+			//As identifier could be all alpha, no heuristic here will work in determining intent of user for querying by name versus identifier
+			//So search by both!
+			String name = query;
+			String identifier = query;
 			criteria = new PatientSearchCriteria(sessionFactory, criteria).prepareCriteria(name, identifier,
-			    new ArrayList<PatientIdentifierType>(), false, orderByNames, false);
+			    new ArrayList<PatientIdentifierType>(), true, orderByNames, true);	
 		}
 		
 		return criteria;

--- a/api/src/test/resources/org/openmrs/api/db/include/EncounterDAOTest-initialData.xml
+++ b/api/src/test/resources/org/openmrs/api/db/include/EncounterDAOTest-initialData.xml
@@ -15,6 +15,7 @@
   <encounter_type encounter_type_id="1" name="Test Enc Type B" description="Some desc" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="2b377dba-62c3-4e53-91ef-b51c68899890"/>
   <location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="3941dd4b-0b6d-4481-b979-ccdd38c76cb4"/>
   <patient patient_id="2" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="2" patient_id="2" identifier="abcd" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="f78bc0fe-6370-4766-b46f-8f4c658fe22b"/>
   <patient_identifier patient_identifier_id="1" patient_id="2" identifier="1234" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="e78bc0fe-6370-4766-b46f-8f4c658fe22b"/>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2005-01-01 00:00:00.0" required="false" retired="false" uuid="2238b039-7f77-4384-a912-360dd154f0d1"/>
   <person person_id="2" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="b9cb4fb6-6ce3-4475-b08d-6e1a7d4345ce"/>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
1. Added a new patient identifier to the encounter test file with strings instead of numeric. 
2. Added a test that fails.

TRUNK-4720: createEncounterQuery now no longer assumes that identifiers always contain digits. Refactored the method. Added a test to make sure that partial identifiers would not be matched.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4720

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


