### PR TITLE
TRUNK-3675 Introduce caching to getSearchLocales()

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -84,6 +84,10 @@
          <artifactId>spring-jdbc</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.springframework</groupId>
+         <artifactId>spring-context-support</artifactId>
+      </dependency>
+      <dependency>
          <groupId>asm</groupId>
          <artifactId>asm-commons</artifactId>
       </dependency>

--- a/api/src/main/java/org/openmrs/api/AdministrationService.java
+++ b/api/src/main/java/org/openmrs/api/AdministrationService.java
@@ -18,12 +18,14 @@ import java.util.SortedMap;
 import org.openmrs.GlobalProperty;
 import org.openmrs.ImplementationId;
 import org.openmrs.OpenmrsObject;
+import org.openmrs.User;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.db.AdministrationDAO;
 import org.openmrs.util.HttpClient;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.ValidateUtil;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.validation.Errors;
 
 /**
@@ -213,6 +215,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should overwrite global property if exists
 	 * @should not allow different properties to have the same string with different case
 	 * @should save a global property whose typed value is handled by a custom datatype
+	 * @should evict all entries of search locale cache
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
 	public GlobalProperty saveGlobalProperty(GlobalProperty gp) throws APIException;
@@ -333,7 +336,17 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should throw throw APIException if the input is null
 	 */
 	public void validate(Object object, Errors errors) throws APIException;
-	
+
+	/**
+	 * Returns a list of locales used by the user when searching.
+	 *
+	 * @param currentLocale currently selected locale
+	 * @param user authenticated user
+	 * @return
+	 * @throws APIException
+     */
+	public List<Locale> getSearchLocales(Locale currentLocale, User user) throws APIException;
+
 	/**
 	 * Returns a list of locales used by the user when searching.
 	 * <p>
@@ -345,6 +358,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should include currently selected full locale and langugage
 	 * @should include users proficient locales
 	 * @should exclude not allowed locales
+	 * @should cache results for a user
 	 */
 	public List<Locale> getSearchLocales() throws APIException;
 	

--- a/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
@@ -9,11 +9,6 @@
  */
 package org.openmrs.api.impl;
 
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.collections.CollectionUtils;
 import org.openmrs.Address;
 import org.openmrs.Location;
@@ -29,6 +24,11 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Default implementation of the {@link LocationService}

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -40,6 +40,7 @@ import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -132,6 +133,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	/**
 	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User)
 	 */
+	@CacheEvict(value = "userSearchLocales", allEntries = true)
 	public User saveUser(User user) throws APIException {
 		if (user.getUserId() == null) {
 			throw new APIException("This method can be called only to update existing users");

--- a/api/src/main/resources/api-ehcache.xml
+++ b/api/src/main/resources/api-ehcache.xml
@@ -1,0 +1,31 @@
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<ehcache name="apiCache">
+
+    <diskStore path="user.home"/>
+
+    <defaultCache maxElementsInMemory="1000" eternal="false"
+                  timeToIdleSeconds="30" timeToLiveSeconds="30" overflowToDisk="false"
+                  diskPersistent="false" diskExpiryThreadIntervalSeconds="45"/>
+
+    <cache name="userSearchLocales"
+           maxElementsInMemory="500"
+           eternal="true"
+           overflowToDisk="false"
+           timeToIdleSeconds="12000"
+           timeToLiveSeconds="12000"
+           diskPersistent="false"
+           diskExpiryThreadIntervalSeconds="120"
+           memoryStoreEvictionPolicy="LRU"
+    />
+
+</ehcache>

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -16,11 +16,12 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:p="http://www.springframework.org/schema/p"
 	   xmlns:context="http://www.springframework.org/schema/context"
+	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:jee="http://www.springframework.org/schema/jee"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:util="http://www.springframework.org/schema/util"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   xmlns:tx="http://www.springframework.org/schema/tx"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
        		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 			http://www.springframework.org/schema/context
 			http://www.springframework.org/schema/context/spring-context-3.0.xsd
@@ -31,7 +32,9 @@
 			http://www.springframework.org/schema/aop
            	http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
             http://www.springframework.org/schema/util
-            http://www.springframework.org/schema/util/spring-util-3.0.xsd">
+            http://www.springframework.org/schema/util/spring-util-3.0.xsd
+			http://www.springframework.org/schema/cache
+			http://www.springframework.org/schema/cache/spring-cache.xsd">
 	<!--  **************************  Transactional Intercepter  *************************  -->
 	<!--  	
 		Looks for advisors (TransactionAttributeSourceAdvisor) in the context, and automatically 
@@ -80,6 +83,14 @@
 			</list>
 		</property>
 	</bean>
+
+	<!--  **************************  CACHE MANAGER CONFIGURATION  *************************  -->
+
+	<bean id="apiEhCacheManager" class="org.springframework.cache.ehcache.EhCacheManagerFactoryBean">
+		<property name="configLocation" value="classpath:api-ehcache.xml"/>
+	</bean>
+
+	<bean id="apiCacheManager" class="org.springframework.cache.ehcache.EhCacheCacheManager" p:cacheManager-ref="apiEhCacheManager" />
 	
 	<!--  **************************  SERVICE CONTEXT CONFIGURATION  *************************  -->
 
@@ -113,7 +124,7 @@
         <property name="serviceContext"><ref bean="serviceContext"/></property>
         <property name="contextDAO"><ref bean="contextDAO"/></property>
 	</bean>
-	
+
 	<!--  **************************  DATA ACCESS OBJECTS  *************************  -->		
 
 	<bean id="contextDAO" class="org.openmrs.api.db.hibernate.HibernateContextDAO">
@@ -536,11 +547,20 @@
 	<bean id="loggingInterceptor" class="org.openmrs.aop.LoggingAdvice"/>
 	<!-- AOP before advice that calls the SetRequiredDataHandler methods -->
 	<bean id="requiredDataInterceptor" class="org.openmrs.aop.RequiredDataAdvice"/>
+	<!-- AOP cache interceptor -->
+	<bean id="cacheInterceptor" class="org.springframework.cache.interceptor.CacheInterceptor">
+		<property name="cacheManager" ref="apiCacheManager"/>
+		<property name="cacheOperationSources" ref="annotationCacheOperationSource"/>
+	</bean>
+
+	<!-- finds all cache-related annotations to create available cache operations for CacheInterceptor -->
+	<bean id="annotationCacheOperationSource" class="org.springframework.cache.annotation.AnnotationCacheOperationSource"/>
 
 	<util:list id="serviceInterceptors">
 		<ref local="authorizationInterceptor"/>
 		<ref local="requiredDataInterceptor"/>
 		<ref local="loggingInterceptor"/>
+		<ref local="cacheInterceptor"/>
 	</util:list>
 	
 	
@@ -668,6 +688,6 @@
 		<context:include-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileIncludeFilter" />
 		<context:exclude-filter type="custom" expression="org.openmrs.util.TestTypeFilter"/> <!-- Excludes classes with unit test super classes -->
 		<context:exclude-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileExcludeFilter" />
-	</context:component-scan> 
-    
+	</context:component-scan>
+
 </beans>

--- a/api/src/main/resources/ehcache.xml
+++ b/api/src/main/resources/ehcache.xml
@@ -9,7 +9,7 @@
     graphic logo is a trademark of OpenMRS Inc.
 
 -->
-<ehcache>
+<ehcache name="hibernateCache">
 
     <!-- Sets the path to the directory where cache .data files are created.
 

--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -25,7 +25,7 @@ hibernate.generate_statistics=true
 hibernate.cache.use_structured_entries=false
 
 #Hibernate second level cache
-hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.SingletonEhCacheRegionFactory
+hibernate.cache.region.factory_class=org.hibernate.cache.ehcache.EhCacheRegionFactory
 hibernate.cache.use_second_level_cache=true
 
 hibernate.search.default.directory_provider=filesystem

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -9,8 +9,12 @@
  */
 package org.openmrs.api;
 
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -37,6 +41,9 @@ import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.HttpClient;
 import org.openmrs.util.OpenmrsConstants;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.SimpleKeyGenerator;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 
@@ -51,6 +58,8 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	protected static final String ADMIN_INITIAL_DATA_XML = "org/openmrs/api/include/AdministrationServiceTest-globalproperties.xml";
 	
 	private HttpClient implementationHttpClient;
+
+	private CacheManager cacheManager;
 	
 	/**
 	 * Run this before each unit test in this class. It simply assigns the services used in this
@@ -65,6 +74,7 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 			adminService = Context.getAdministrationService();
 			implementationHttpClient = mock(HttpClient.class);
 			adminService.setImplementationIdHttpClient(implementationHttpClient);
+			cacheManager = Context.getRegisteredComponent("apiCacheManager", CacheManager.class);
 		}
 		
 	}
@@ -963,5 +973,65 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		Assert.assertEquals(new Locale("es"), presentationLocales.get(1));
 		Assert.assertEquals(new Locale("it", "IT"), presentationLocales.get(2));
 		Assert.assertEquals(new Locale("pl", "PL"), presentationLocales.get(3));
+	}
+
+	/**
+	 * @see AdministrationService#getSearchLocales()
+	 * @verifies cache results for a user
+	 */
+	@Test
+	public void getSearchLocales_shouldCacheResultsForAnUser() throws Exception {
+		//given
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST, "en_GB, en_US, pl"));
+
+		User user = Context.getAuthenticatedUser();
+		user.setUserProperty(OpenmrsConstants.USER_PROPERTY_PROFICIENT_LOCALES, "en_GB, en_US");
+		Context.getUserService().saveUser(user);
+
+		//when
+		Context.getAdministrationService().getSearchLocales();
+
+		List<Locale> cachedSearchLocales = getCachedSearchLocalesForCurrentUser();
+
+		//then
+		assertThat(cachedSearchLocales, hasItem(Locale.ENGLISH));
+		assertThat(cachedSearchLocales, hasItem(new Locale("en", "US")));
+		assertThat(cachedSearchLocales, not(hasItem(new Locale("pl"))));
+	}
+
+	/**
+	 * @see AdministrationService#saveGlobalProperty(GlobalProperty)
+	 * @verifies evict search locale results
+	 */
+	@Test
+	public void saveGlobalProperty_shouldEvictCachedResults() throws Exception {
+		//given
+		Context.getAdministrationService().saveGlobalProperty(
+				new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST, "en_GB, en_US, pl"));
+
+		User user = Context.getAuthenticatedUser();
+		user.setUserProperty(OpenmrsConstants.USER_PROPERTY_PROFICIENT_LOCALES, "en_GB, en_US");
+		Context.getUserService().saveUser(user);
+
+		//sanity check that cache has been populated
+		Context.getAdministrationService().getSearchLocales();
+		List<Locale> cachedSearchLocales = getCachedSearchLocalesForCurrentUser();
+		assertThat(cachedSearchLocales, hasItem(new Locale("en", "US")));
+
+		//evict cache
+		Context.getAdministrationService().saveGlobalProperty(new GlobalProperty("test", "TEST"));
+
+		assertThat(getCacheForCurrentUser(), nullValue());
+	}
+
+	private Cache.ValueWrapper getCacheForCurrentUser(){
+		Object[] params = { Context.getLocale(), Context.getAuthenticatedUser() };
+		Object key = (new SimpleKeyGenerator()).generate(null, null, params);
+		return cacheManager.getCache("userSearchLocales").get(key);
+	}
+
+	private List<Locale> getCachedSearchLocalesForCurrentUser() {
+		return (List<Locale>) getCacheForCurrentUser().get();
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,11 @@
 				<artifactId>spring-oxm</artifactId>
 				<version>${springVersion}</version>
 			</dependency>
+		    <dependency>
+			   <groupId>org.springframework</groupId>
+			   <artifactId>spring-context-support</artifactId>
+			   <version>${springVersion}</version>
+		    </dependency>
 			<dependency>
 				<groupId>asm</groupId>
 				<artifactId>asm</artifactId>


### PR DESCRIPTION
# TRUNK-3675

## Description
This PR introduces Spring's caching functionality to OpenMRS. As proof of concept, results of `getSearchLocales` are cached. 

We couldn't use annotation driven cache configuration, because we are still using old `TransactionProxyFactoryBean` to handle transactions, so CacheInterceptor is added to preInterceptors of `TransactionProxyFactoryBean`, to handle cache. More info can be found [in Spring documentation](http://docs.spring.io/spring/docs/current/spring-framework-reference/html/cache.html).

~~In long run, we probably will want to replace SimpleCacheManager with EhCacheManager, but I couldn't properly inject it, I guess HIbernate's second level cache ehCache is colliding with it, because when it was disabled, I was able to register my API EhCacheManager~~

I managed to set up ehcache manager for API instead of SimpleCacheManager. Previously it didn't work because Hibernate used singleton factory, Right now we will have 2 caches  - `hibernateCache` and `apiCache`. I'm still working on making cache configuration extendable by modules.

## Related Issue
see https://issues.openmrs.org/browse/TRUNK-3675

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


