### PR TITLE
TRUNK-4932: Deprecate ObsService.getComplexObs

### DIFF
--- a/api/src/main/java/org/openmrs/api/ObsService.java
+++ b/api/src/main/java/org/openmrs/api/ObsService.java
@@ -375,10 +375,12 @@ public interface ObsService extends OpenmrsService {
 	 * @param obsId
 	 * @return Obs with a ComplexData
 	 * @since 1.5
+	 * @deprecated replaced by {@link #getObs(Integer)}
 	 * @should fill in complex data object for complex obs
 	 * @should return normal obs for non complex obs
 	 * @should not fail with null view
 	 */
+	@Deprecated
 	@Authorized( { PrivilegeConstants.GET_OBS })
 	public Obs getComplexObs(Integer obsId, String view) throws APIException;
 	


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
TRUNK-4932 Deprecate ObsService.getComplexObs

## Description
<!--- Describe your changes in detail -->
* Added the @Deprecated annotation to the method ObsService.getComplexObs
* Added the @deprecated javadoc clause to the doc comment of the method ObsService.getComplexObs
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4932

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [X] My pull request only contains one single commit.
- [X] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


