### PR TITLE
RA-1256: Throws null pointer exception when clicked on add allergy an…

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -611,7 +611,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		if (!exact) {
 			Locale broaderLocale = new Locale(locale.getLanguage());
 			ConceptName name = getNameInLocale(broaderLocale);
-			return name;
+			return name != null ? name : getName();
 		}
 		return null;
 	}

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -1093,6 +1093,18 @@ public class ConceptTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see Concept#getName()
+	 * @verifies return any name If no locale match and exact is false
+	 */
+	@Test
+	public void getName_shouldReturnNameAnyNameIfNoLocaleMatchGivenExactEqualsFalse() throws Exception {
+		Locale locale = new Locale("en");
+		Locale localeToSearch = new Locale("fr");
+		Concept concept = new Concept();
+		concept.addName(new ConceptName("Test Concept", locale));
+		Assert.assertNotNull((concept.getName(localeToSearch, false)));
+	}
+	/**
 	 * @see Concept#getDescriptions()
 	 */
 	@Test


### PR DESCRIPTION
RA-1256: Throws null pointer exception when clicked on add allergy and locale french

## Description
getName(Locale locale, boolean exact) should return default name if exact is false and locale name not found.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RA-1256

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ x] My pull request only contains one single commit.
- [ x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ x] My code follows the code style of this project.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
