### PR TITLE
TRUNK-4925 Deep copy all fields of Person

### DIFF
--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -45,7 +45,6 @@ public class Patient extends Person {
 	 * attributes are copied over to the new object. NOTE! All child collection objects are copied
 	 * as pointers, each individual element is not copied. <br>
 	 * <br>
-	 * TODO Should the patient specific attributes be copied? (like identifiers)
 	 * 
 	 * @param person the person object to copy onto a new Patient
 	 * @see Person#Person(Person)

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -101,10 +101,9 @@ public class Person extends BaseOpenmrsData {
 	/**
 	 * This constructor is used to build a new Person object copy from another person object
 	 * (usually a patient or a user subobject). All attributes are copied over to the new object.
-	 * NOTE! All child collection objects are copied as pointers, each individual element is not
-	 * copied. <br>
 	 * 
 	 * @param person Person to create this person object from
+	 * @should deep copy all collections
 	 */
 	public Person(Person person) {
 		if (person == null) {
@@ -113,9 +112,10 @@ public class Person extends BaseOpenmrsData {
 		
 		personId = person.getPersonId();
 		setUuid(person.getUuid());
-		addresses = person.getAddresses();
-		names = person.getNames();
-		attributes = person.getAttributes();
+		
+		deepCopyAddresses(person.getAddresses());
+		deepCopyNames(person.getNames());
+		deepCopyAttributes(person.getAttributes());
 		
 		gender = person.getGender();
 		birthdate = person.getBirthdate();
@@ -1055,4 +1055,48 @@ public class Person extends BaseOpenmrsData {
 		
 	}
 	
+	// Deep copy helpers
+	
+	/**
+	 * Creates deep copy of set of addresses.
+	 * 
+	 * @param personAddressesSrc Set of addresses to be copied.
+	 * @return Deep copy of given set of addresses.
+	 */
+	private void deepCopyAddresses(Set<PersonAddress> personAddressesSrc) {
+		for(PersonAddress personAddressSrc : personAddressesSrc) {
+			PersonAddress personAddressDst = (PersonAddress) personAddressSrc.clone();
+			personAddressDst.setPerson(this);
+			this.getAddresses().add(personAddressDst);
+		}
+	}
+	
+	/**
+	 * Creates deep copy of set of names.
+	 * 
+	 * @param personNamesSrc Set of names to be copied.
+	 * @return Deep copy of given set of names. 
+	 */
+	private void deepCopyNames(Set<PersonName> personNamesSrc) {
+		for(PersonName personNameSrc : personNamesSrc) {
+			PersonName personNameDst = PersonName.newInstance(personNameSrc);
+			personNameDst.setPerson(this);
+			this.getNames().add(personNameDst);
+		}
+	}
+	
+	/**
+	 * Creates deep copy of set of attributes.
+	 * 
+	 * @param personAttributesSrc Set of attributes to be copied.
+	 * @return Deep copy of given set of attributes. 
+	 */
+	private void deepCopyAttributes(Set<PersonAttribute> personAttributesSrc) {
+		for(PersonAttribute personAttributeSrc : personAttributesSrc) {
+			PersonAttribute personAttributeDst = personAttributeSrc.copy();
+			personAttributeDst.setPerson(this);
+			personAttributeDst.setPersonAttributeId(personAttributeSrc.getPersonAttributeId());
+			this.getAttributes().add(personAttributeDst);
+		}
+	}
 }

--- a/api/src/test/java/org/openmrs/PersonTest.java
+++ b/api/src/test/java/org/openmrs/PersonTest.java
@@ -911,4 +911,39 @@ public class PersonTest extends BaseContextSensitiveTest {
 			return personAddress;
 		}
 	}
+
+	/**
+	 * @see Person#Person(Person)
+	 * @verifies deep copy all collections
+	 */
+	@Test
+	public void Person_shouldDeepCopyAllCollections() throws Exception {
+		Person personSrc = personHelper(false, 1, 2, 3, "name1", "name2", "name3", "value1", "value2", "value3");
+		personSrc.setPersonId(1);
+		PersonAddress pa = new PersonAddress(222);
+		pa.setAddress1("Test Address");
+		personSrc.getAddresses().add(pa);
+		PersonName pn = new PersonName(333);
+		pn.setGivenName("A");
+		personSrc.getNames().add(pn);
+
+		Person personDst = new Person(personSrc);
+		
+		// check deep copy of Person
+		assertFalse(personDst == personSrc);
+		assertTrue(personDst.equals(personSrc));
+		// check deep copy of PersonAddress
+		PersonAddress paSrc = personSrc.getAddresses().iterator().next();
+		PersonAddress paDst = personDst.getAddresses().iterator().next();
+		assertFalse(paDst == paSrc);
+		assertTrue(paDst.equalsContent(paSrc));
+		// check deep copy of PersonName
+		PersonName pnSrc = personSrc.getNames().iterator().next();
+		PersonName pnDst = personDst.getNames().iterator().next();
+		assertFalse(pnDst == pnSrc);
+		assertTrue(pnDst.equalsContent(pnSrc));
+		// check deep copy of PersonAttribute
+		assertFalse(personDst.getAttribute(1) == personSrc.getAttribute(1));
+		assertTrue(personDst.getAttribute(1).equalsContent(personSrc.getAttribute(1)));
+	}
 }


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
Changed `Person` copying constructor so that it makes deep copy of an object. This includes also sets of addresses, names and attributes. To achieve those `deepCopy()` functions were added to `PersonAddress`, `PersonName` and `PersonAttribute`. 

Fields of following data types are deep copied:
- String
- Integer
- Date
- Boolean
- Set and each element in it
- PersonAddress
- PersonName
- PersonAttribute

Fields of following data types are shallow copied:
- User
- Person
- PersonAttributeType
- Concept

Two new classes were added:
- `DeepCopyUtil` - provides helper functions to make deep copies of `String`, `Date`, `Integer`, and `Boolean` objects
- `DeepCopyUtilTestHelper` - via reflection tests if all private (non-static, non-final) fields of a class and its super classes are properly copied. This assures that if a new field is added to any of classes then unit test will fails. This will indicate that new field should be explicitly included in `deepCopy()` function.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-4925

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

