### PR TITLE
TRUNK-4867 Allowed to manually set person deathdate before their birthdate

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonValidator.java
@@ -96,7 +96,7 @@ public class PersonValidator implements Validator {
 		}
 		
 		validateBirthDate(errors, person.getBirthdate());
-		validateDeathDate(errors, person.getDeathDate());
+		validateDeathDate(errors, person.getDeathDate(),person.getBirthdate());
 		
 		if (person.isVoided()) {
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "voidReason", "error.null");
@@ -128,11 +128,12 @@ public class PersonValidator implements Validator {
 	 * @param errors Stores information about errors encountered during validation
 	 * @param deathDate the deathdate to validate
 	 */
-	private void validateDeathDate(Errors errors, Date deathDate) {
+	private void validateDeathDate(Errors errors, Date deathDate, Date birthDate) {
 		if (deathDate == null) {
 			return;
 		}
 		rejectIfFutureDate(errors, deathDate, "deathDate");
+		rejectDeathDateIfBeforeBirthDate(errors, deathDate, birthdate, "deathDate");
 	}
 	
 	/**
@@ -160,6 +161,20 @@ public class PersonValidator implements Validator {
 		c.setTime(new Date());
 		c.add(Calendar.YEAR, -120);
 		if (date.before(c.getTime())) {
+			errors.rejectValue(dateField, "error.date.nonsensical");
+		}
+	}
+
+	/**
+	 * Rejects a death date if it is before birth date
+	 * 
+	 * @param errors the error object
+	 * @param deathdate the date to check
+	 * @param birthdate to check with
+	 * @param dateField the name of the field
+	 */
+	private void rejectDeathDateIfBeforeBirthDate(Errors errors, Date deathdate, Date birthdate, String dateField) {
+		if (deathdate.before(birthdate)) {
 			errors.rejectValue(dateField, "error.date.nonsensical");
 		}
 	}

--- a/api/src/main/java/org/openmrs/validator/PersonValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonValidator.java
@@ -133,7 +133,7 @@ public class PersonValidator implements Validator {
 			return;
 		}
 		rejectIfFutureDate(errors, deathDate, "deathDate");
-		rejectDeathDateIfBeforeBirthDate(errors, deathDate, birthdate, "deathDate");
+		rejectDeathDateIfBeforeBirthDate(errors, deathDate,birthDate, "deathDate");
 	}
 	
 	/**
@@ -164,7 +164,7 @@ public class PersonValidator implements Validator {
 			errors.rejectValue(dateField, "error.date.nonsensical");
 		}
 	}
-
+	
 	/**
 	 * Rejects a death date if it is before birth date
 	 * 
@@ -175,7 +175,8 @@ public class PersonValidator implements Validator {
 	 */
 	private void rejectDeathDateIfBeforeBirthDate(Errors errors, Date deathdate, Date birthdate, String dateField) {
 		if (deathdate.before(birthdate)) {
-			errors.rejectValue(dateField, "error.date.nonsensical");
+			errors.rejectValue(dateField, "error.deathdate.notpossible");
+			
 		}
 	}
 	


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
**TRUNK-4867 Allowed to manually set person deathdate before their **birthdate****
## Description
<!--- Describe your changes in detail -->
Added a new method to check if death date is after birth date or not. If it's not ,then it raises an exception.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4867

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.

