### PR TITLE
TRUNK-248:Add JUnit @should annotations according to code comments

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -45,7 +45,6 @@ import org.openmrs.util.OpenmrsUtil;
  *
  * @see org.openmrs.api.db.FormDAO
  * @see org.openmrs.api.FormService
- * @should add  TODO junit test on line on line 436 ==> if (!containingAnyFormField.isEmpty()) {
  */
 public class HibernateFormDAO implements FormDAO {
 	
@@ -409,6 +408,7 @@ public class HibernateFormDAO implements FormDAO {
 	 * @param containingAllFormFields
 	 * @param fields
 	 * @return
+	 * @should return criteria if containingAnyFormField any formField is not empty
 	 */
 	private Criteria getFormCriteria(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
 	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -45,6 +45,7 @@ import org.openmrs.util.OpenmrsUtil;
  *
  * @see org.openmrs.api.db.FormDAO
  * @see org.openmrs.api.FormService
+ * @should add  TODO junit test on line on line 436 ==> if (!containingAnyFormField.isEmpty()) {
  */
 public class HibernateFormDAO implements FormDAO {
 	
@@ -431,7 +432,7 @@ public class HibernateFormDAO implements FormDAO {
 			crit.add(Restrictions.eq("retired", retired));
 		}
 		
-		// TODO junit test
+		
 		if (!containingAnyFormField.isEmpty()) {
 			// Convert form field persistents to integers
 			Set<Integer> anyFormFieldIds = new HashSet<Integer>();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -57,7 +57,6 @@ import org.openmrs.util.OpenmrsConstants;
  * @see org.openmrs.api.context.Context
  * @see org.openmrs.api.db.PatientDAO
  * @see org.openmrs.api.PatientService
- * @should add TODO add junit test for getting by identifier type on line 264 ==> if (!patientIdentifierTypes.isEmpty()) {
  */
 public class HibernatePatientDAO implements PatientDAO {
 	
@@ -240,6 +239,8 @@ public class HibernatePatientDAO implements PatientDAO {
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifiers(java.lang.String, java.util.List, java.util.List, java.util.List, java.lang.Boolean)
+	 * @should return a list of patientIdentifiers when patientIdentifierTypes is not null
+	 * @sholud return a list of patientIdentifiers when patient is not empty
 	 */
 	@SuppressWarnings("unchecked")
         @Override
@@ -269,8 +270,13 @@ public class HibernatePatientDAO implements PatientDAO {
 			criteria.add(Restrictions.in("location", locations));
 		}
 		
-		// TODO add junit test for getting by patients
+
+		
 		if (!patients.isEmpty()) {
+
+		
+		if (patients.size() > 0) {
+
 			criteria.add(Restrictions.in("patient", patients));
 		}
 		

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -57,6 +57,7 @@ import org.openmrs.util.OpenmrsConstants;
  * @see org.openmrs.api.context.Context
  * @see org.openmrs.api.db.PatientDAO
  * @see org.openmrs.api.PatientService
+ * @should add TODO add junit test for getting by identifier type on line 264 ==> if (!patientIdentifierTypes.isEmpty()) {
  */
 public class HibernatePatientDAO implements PatientDAO {
 	
@@ -259,7 +260,7 @@ public class HibernatePatientDAO implements PatientDAO {
 			criteria.add(Restrictions.eq("identifier", identifier));
 		}
 		
-		// TODO add junit test for getting by identifier type
+		
 		if (!patientIdentifierTypes.isEmpty()) {
 			criteria.add(Restrictions.in("identifierType", patientIdentifierTypes));
 		}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -38,7 +38,6 @@ import org.openmrs.util.OpenmrsConstants;
  * identifier.
  *
  * @deprecated since 2.1.0 (in favor of Hibernate Search)
- * @should add TODO add a junit test for patientIdentifierType restrictions	on line 318 ==> if (!CollectionUtils.isEmpty(identifierTypes)) {
  */
 @Deprecated
 public class PatientSearchCriteria {
@@ -265,6 +264,7 @@ public class PatientSearchCriteria {
 	 * @param identifierTypes
 	 * @param matchIdentifierExactly
 	 * @param includeVoided true/false whether or not to included voided patients
+	 * @should return a criterion when identifierTypes is not empty
 	 */
 	private Criterion prepareCriterionForIdentifier(String identifier, List<PatientIdentifierType> identifierTypes,
 	        boolean matchIdentifierExactly, boolean includeVoided) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -38,6 +38,7 @@ import org.openmrs.util.OpenmrsConstants;
  * identifier.
  *
  * @deprecated since 2.1.0 (in favor of Hibernate Search)
+ * @should add TODO add a junit test for patientIdentifierType restrictions	on line 318 ==> if (!CollectionUtils.isEmpty(identifierTypes)) {
  */
 @Deprecated
 public class PatientSearchCriteria {
@@ -311,7 +312,7 @@ public class PatientSearchCriteria {
 			}
 		}
 		
-		// TODO add a junit test for patientIdentifierType restrictions	
+		
 		
 		// do the type restriction
 		if (!CollectionUtils.isEmpty(identifierTypes)) {


### PR DESCRIPTION
<!---  'TRUNK-248 - Add JUnit @should annotations according to code comments' -->

## Description
<!--- There are TODO comments spread throughout the code that contain the word 'junit'. These need to be translated into @should annotations on the interface/class level, I have added a few @should on some classes,  which were not yet fixed, and i have listed them below and also indicated the lines of code plus their classes. 
@should add TODO add a junit test for patientIdentifierType restrictions on line 318 => if (!CollectionUtils.isEmpty(identifierTypes)) {
@should add TODO add junit test for getting by identifier type on line 273 => if (patients.size() > 0) {
@should add TODO junit test on line 436 => if (!containingAnyFormField.isEmpty()) {  -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ ] My pull request only contains one single commit.
- [x ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x ] My code follows the code style of this project.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

