### PR TITLE
TRUNK-5019 Error Scenario in Obs Save : New child Obs not saving when entire Obs group is updated

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -128,7 +128,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 			// fetch a clean copy of this obs from the database so that
 			// we don't write the changes to the database when we save
 			// the fact that the obs is now voided
-			Context.evictFromSession(obs);
+			evictObsAndChildren(obs);
 			obs = Context.getObsService().getObs(obs.getObsId());
 			//delete the previous file from the appdata/complex_obs folder
 			if (newObs.hasPreviousVersion() && newObs.getPreviousVersion().isComplex()) {
@@ -200,6 +200,15 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 		Obs ret = dao.saveObs(obs);
 		saveObsGroup(ret,changeMessage);
 		return ret;
+	}
+
+	private void evictObsAndChildren(Obs obs) {
+		Context.evictFromSession(obs);
+		if(obs.hasGroupMembers()) {
+			for(Obs member : obs.getGroupMembers()) {
+				evictObsAndChildren(member);
+			}
+		}
 	}
 
 	private void ensureRequirePrivilege(Obs obs){

--- a/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-initial.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-initial.xml
@@ -29,6 +29,8 @@
   <obs obs_id="9" person_id="9" concept_id="1" obs_datetime="2004-01-01 00:00:00.0" location_id="1" value_numeric="9.0" obs_group_id="2" creator="1" date_created="2006-02-17 15:57:35.0" voided="false" uuid="0ee1248e-08aa-4a2c-9f38-fb3875f605e1"/>
   <obs obs_id="10" person_id="9" concept_id="1" obs_datetime="2009-01-01 00:00:00.0" location_id="1" value_numeric="10.0" obs_group_id="2" creator="1" date_created="2006-02-17 15:57:35.0" voided="true" void_reason="testing" voided_by="1" date_voided="2006-03-17 15:57:35.0" uuid="0ee1248e-08aa-4a2c-9f38-fb3875f605e2"/>
   <obs obs_id="11" person_id="2" concept_id="21" obs_datetime="2009-01-01 00:00:00.0" location_id="1" value_coded="7" creator="1" date_created="2006-02-17 15:57:35.0" voided="false" uuid="0ee1248e-08aa-4a2c-9f38-fb3875f605e3"/>
+  <obs obs_id="17" person_id="2" concept_id="1" obs_datetime="2006-02-10 00:00:00.0" location_id="1" obs_group_id="2" creator="1" date_created="2006-02-11 15:57:35.0" voided="false" uuid="b5499df2-b17c-4b39-88a6-44591c165369"/>
+  <obs obs_id="18" person_id="2" concept_id="21" obs_datetime="2009-01-01 00:00:00.0" location_id="1" obs_group_id="17" value_coded="7" creator="1" date_created="2006-02-17 15:57:35.0" voided="false" uuid="0ee1248e-08aa-4a2c-9f34-fb3875f605e3"/>
 
   <!-- an obs assigned to a user only -->
   <obs obs_id="12" person_id="1" concept_id="1" obs_datetime="2009-02-09 00:00:00.0" location_id="1" value_numeric="1.0" creator="1" date_created="2006-02-10 15:57:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda3"/>


### PR DESCRIPTION
## Description
The line of code which is used to evict obs from session is causing the issue as it doesn't evict its children. Hence written a recursive method which is called to evict Obs, and its children also from session.

## Related Issue
https://issues.openmrs.org/browse/TRUNK-5019

## Steps to reproduce
1.Edit an existing observation so that all the observations are dirty and there is a new obs added as a child at depth >1 i.e 
If A->B->C is the obs tree, then add new obs D under B.
Expected : New A(B(CD)) obs tree will be created.
Actual : New A(B(CD)) obs tree is created but D is voided.

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document. **_Can any one point me to doc_**
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

