### PR TITLE
 TRUNK-248:Add JUnit @should annotations according to code comments

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -45,6 +45,7 @@ import org.openmrs.util.OpenmrsUtil;
  *
  * @see org.openmrs.api.db.FormDAO
  * @see org.openmrs.api.FormService
+ * @should add TODO junit test on line 436 => if (!containingAnyFormField.isEmpty()) {
  */
 public class HibernateFormDAO implements FormDAO {
 	
@@ -431,7 +432,7 @@ public class HibernateFormDAO implements FormDAO {
 			crit.add(Restrictions.eq("retired", retired));
 		}
 		
-		// TODO junit test
+		
 		if (!containingAnyFormField.isEmpty()) {
 			// Convert form field persistents to integers
 			Set<Integer> anyFormFieldIds = new HashSet<Integer>();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -57,6 +57,7 @@ import org.openmrs.util.OpenmrsConstants;
  * @see org.openmrs.api.context.Context
  * @see org.openmrs.api.db.PatientDAO
  * @see org.openmrs.api.PatientService
+ * @should add TODO add junit test for getting by identifier type on line 273 => if (patients.size() > 0) {
  */
 public class HibernatePatientDAO implements PatientDAO {
 	
@@ -268,7 +269,7 @@ public class HibernatePatientDAO implements PatientDAO {
 			criteria.add(Restrictions.in("location", locations));
 		}
 		
-		// TODO add junit test for getting by patients
+		
 		if (patients.size() > 0) {
 			criteria.add(Restrictions.in("patient", patients));
 		}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -38,6 +38,7 @@ import org.openmrs.util.OpenmrsConstants;
  * identifier.
  *
  * @deprecated since 2.1.0 (in favor of Hibernate Search)
+ * @should add TODO add a junit test for patientIdentifierType restrictions on line 318 => if (!CollectionUtils.isEmpty(identifierTypes)) {
  */
 @Deprecated
 public class PatientSearchCriteria {
@@ -311,7 +312,7 @@ public class PatientSearchCriteria {
 			}
 		}
 		
-		// TODO add a junit test for patientIdentifierType restrictions	
+		
 		
 		// do the type restriction
 		if (!CollectionUtils.isEmpty(identifierTypes)) {


### PR DESCRIPTION
TRUNK-248 Add JUnit @should annotations according to code comments

## Description
I have added @should annotations on methods for JUnit testing , 
1. @should return criteria if containingAnyFormField any formField is not empty.
2. @sholud return a list of patientIdentifiers when patient is not empty
3.@should return a list of patientIdentifiers when patientIdentifierTypes is not null
4.@should return criteria if containingAnyFormField any formField is not empty. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
 Please link to the issue here: 
see https://issues.openmrs.org/browse/TRUNK-248

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x ] My pull request only contains one single commit.
- [x ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x ] My code follows the code style of this project.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

