### PR TITLE
RESTWS-641 Added MIME types support for BinaryDataHandler

### DIFF
--- a/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
@@ -9,21 +9,20 @@
  */
 package org.openmrs.obs.handler;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
-import org.springframework.util.Assert;
-
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.OpenmrsUtil;
+import org.springframework.util.Assert;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 /**
  * Handler for storing files for complex obs to the file system. Files are stored in the location
@@ -72,8 +71,7 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 			catch (IOException e) {
 				log.error("Trying to read file: " + file.getAbsolutePath(), e);
 			}
-			
-			obs.setComplexData(complexData);
+
 		} else {
 			// No other view supported
 			// NOTE: if adding support for another view, don't forget to update supportedViews list above
@@ -81,7 +79,17 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 		}
 		
 		Assert.notNull(complexData, "Complex data must not be null");
-		complexData.setMimeType("application/octet-stream");
+
+		String mimeType;
+		try {
+			mimeType = Files.probeContentType(file.toPath());
+		} catch (IOException e) {
+			log.error("Trying to read file: " + file.getAbsolutePath(), e);
+			mimeType = null;
+		}
+		mimeType = mimeType != null ? mimeType : "application/octet-stream";
+
+		complexData.setMimeType(mimeType);
 		obs.setComplexData(complexData);
 		
 		return obs;

--- a/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
@@ -10,13 +10,26 @@
 package org.openmrs.obs;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openmrs.Obs;
+import org.openmrs.obs.handler.AbstractHandler;
 import org.openmrs.obs.handler.BinaryDataHandler;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.File;
+
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AbstractHandler.class)
 public class BinaryDataHandlerTest {
 
     @Test
@@ -45,6 +58,21 @@ public class BinaryDataHandlerTest {
         assertFalse(handler.supportsView(ComplexObsHandler.TITLE_VIEW));
         assertFalse(handler.supportsView(ComplexObsHandler.URI_VIEW));
         assertFalse(handler.supportsView(""));
-        assertFalse(handler.supportsView((String) null));
+        assertFalse(handler.supportsView(null));
+    }
+
+    @Test
+    public void shouldSupportMimeTypesForComplexData() throws Exception {
+        BinaryDataHandler handler = new BinaryDataHandler();
+
+        File file = new File(getClass().getClassLoader().getResource("TestingApplicationContext.xml").getFile());
+        Obs obs = new Obs();
+        obs.setValueComplex("TestingApplicationContext.xml");
+
+        mockStatic(AbstractHandler.class);
+        when(AbstractHandler.getComplexDataFile(obs)).thenReturn(file);
+
+        Obs complexObs = handler.getObs(obs, "RAW_VIEW");
+        assertThat(complexObs.getComplexData().getMimeType(), is("application/xml"));
     }
 }


### PR DESCRIPTION
## Description
This change makes `BinaryDataHandler`  able to guess Complex Data File's MIME type (it had fixed value before), so it will be possible to add support for MIME types when posting Complex Obs.
See this OpenMRS Talk topic for more details about this change:
https://talk.openmrs.org/t/support-for-mime-types-core-issue/9864
## Related Issue
see https://issues.openmrs.org/browse/RESTWS-641