### PR TITLE
TRUNK-4954 ObsService.saveObs should throw a validation exception if the obs and its encounter point to different persons

### DIFF
--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1990,4 +1990,32 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 			}
 		}
 	}
+
+	@Test
+	@Verifies(value = "should add person with encounter patient for a new obs", method = "saveObs(Obs,String)")
+	public void saveObs_shouldUpdateObsPersonValueWithEncounterPatientForNewObs() throws Exception {
+		executeDataSet(ENCOUNTER_OBS_XML);
+
+		ObsService os = Context.getObsService();
+		ConceptService cs = Context.getConceptService();
+		EncounterService es = Context.getEncounterService();
+		PersonService ps = Context.getPersonService();
+
+		Obs o = new Obs();
+		o.setConcept(cs.getConcept(3));
+		o.setDateCreated(new Date());
+		o.setCreator(Context.getAuthenticatedUser());
+		o.setLocation(new Location(1));
+		o.setObsDatetime(new Date());
+		o.setValueText("Testing");
+		// Setting this person (2) as different from that of encounter person (7)
+		o.setPerson(ps.getPerson(2));
+		o.setEncounter(es.getEncounter(2));
+		assertTrue(es.getEncounter(2).getPatient().getId().equals(7));
+		try{
+			Obs obs = os.saveObs(o,null);
+		}catch (Exception e){
+			assertEquals("Obs.error.patient.id.mismatch",e.getMessage());
+		}
+	}
 }


### PR DESCRIPTION
added a new method check_patient(obs) which checks whether the obs person id matches that of its encounters patient. It also takes of null pointer exceptions in case either of them are null.

see: https://issues.openmrs.org/browse/TRUNK-4954
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

