### PR TITLE
TRUNK-5017 Encounter.removeProvider fails if same provider has already been removed once before

### DIFF
--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -669,7 +669,7 @@ public class Encounter extends BaseOpenmrsData {
 	 */
 	public void removeProvider(EncounterRole role, Provider provider) {
 		for (EncounterProvider encounterProvider : encounterProviders) {
-			if (encounterProvider.getEncounterRole().equals(role) && encounterProvider.getProvider().equals(provider)) {
+			if (encounterProvider.getEncounterRole().equals(role) && encounterProvider.getProvider().equals(provider) && !encounterProvider.isVoided()) {
 				encounterProvider.setVoided(true);
 				encounterProvider.setDateVoided(new Date());
 				encounterProvider.setVoidedBy(Context.getAuthenticatedUser());

--- a/api/src/test/java/org/openmrs/EncounterTest.java
+++ b/api/src/test/java/org/openmrs/EncounterTest.java
@@ -1289,4 +1289,35 @@ public class EncounterTest extends BaseContextSensitiveTest {
 		
 		Assert.assertEquals(patient, encounterCopy.getPatient());
 	}
+
+	/**
+	 * @see Encounter#removeProvider(EncounterRole,Provider)
+	 * @verifies multiple adding and removing of same provider not failing
+	 */
+	@Test
+	@Verifies(value = "multiple adding and removing of same provider should not fail", method = "removeProvider(EncounterRole,Provider)")
+	public void multipleAddingAndRemovingOfSameProvider_shouldNotFail() throws Exception {
+
+		Encounter encounter = new Encounter();
+		EncounterRole role = new EncounterRole();
+		Provider provider = new Provider();
+
+		encounter.addProvider(role, provider);
+
+		Assert.assertEquals(1, encounter.getProvidersByRole(role).size());
+		Assert.assertTrue(encounter.getProvidersByRole(role).contains(provider));
+
+		encounter.removeProvider(role, provider);
+
+		//the size should be 0 for non voided providers
+		Assert.assertEquals(0, encounter.getProvidersByRole(role).size());
+
+		encounter.addProvider(role, provider);
+		Assert.assertEquals(1, encounter.getProvidersByRole(role).size());
+
+		encounter.removeProvider(role, provider);
+		Assert.assertEquals(0, encounter.getProvidersByRole(role).size());
+
+	}
+
 }


### PR DESCRIPTION
before removing a provider a check has been added to see if it has already been voided or not. added test case.
see: https://issues.openmrs.org/browse/TRUNK-5017

- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

