### PR TITLE
TRUNK-4916 Validators should be called when unretiring/unvoiding an object

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -302,7 +302,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 */
 	@Override
 	public Drug unretireDrug(Drug drug) throws APIException {
-		return dao.saveDrug(drug);
+		return Context.getConceptService().saveDrug(drug);
 	}
 	
 	/**
@@ -1649,7 +1649,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 */
 	@Override
 	public ConceptMapType unretireConceptMapType(ConceptMapType conceptMapType) throws APIException {
-		return dao.saveConceptMapType(conceptMapType);
+		return Context.getConceptService().saveConceptMapType(conceptMapType);
 	}
 	
 	/**
@@ -1751,7 +1751,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 */
 	@Override
 	public ConceptReferenceTerm unretireConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException {
-		return dao.saveConceptReferenceTerm(conceptReferenceTerm);
+		return Context.getConceptService().saveConceptReferenceTerm(conceptReferenceTerm);
 	}
 	
 	/**
@@ -1968,7 +1968,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 */
 	@Override
 	public ConceptAttributeType unretireConceptAttributeType(ConceptAttributeType conceptAttributeType) {
-		return dao.saveConceptAttributeType(conceptAttributeType);
+		return Context.getConceptService().saveConceptAttributeType(conceptAttributeType);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
@@ -441,7 +441,7 @@ public class LocationServiceImpl extends BaseOpenmrsService implements LocationS
 	 */
 	@Override
 	public LocationAttributeType unretireLocationAttributeType(LocationAttributeType locationAttributeType) {
-		return dao.saveLocationAttributeType(locationAttributeType);
+		return Context.getLocationService().saveLocationAttributeType(locationAttributeType);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -283,7 +283,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 	 */
 	@Override
 	public Obs unvoidObs(Obs obs) throws APIException {
-		return dao.saveObs(obs);
+		return Context.getObsService().saveObs(obs,"unvoid obs");
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -812,7 +812,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	 */
 	@Override
 	public OrderFrequency unretireOrderFrequency(OrderFrequency orderFrequency) {
-		return dao.saveOrderFrequency(orderFrequency);
+		return Context.getOrderService().saveOrderFrequency(orderFrequency);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -345,7 +345,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		// patient and patientidentifier attributes taken care of by the BaseUnvoidHandler
 		
-		return dao.savePatient(patient);
+		return Context.getPatientService().savePatient(patient);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -228,8 +228,8 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 		type.setDateRetired(null);
 		type.setRetiredBy(null);
 		type.setRetireReason(null);
-		dao.savePersonAttributeType(type);
-		
+		Context.getPersonService().savePersonAttributeType(type);
+
 	}
 	
 	/**
@@ -357,7 +357,7 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 			return null;
 		}
 		
-		return dao.savePerson(person);
+		return Context.getPersonService().savePerson(person);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
@@ -79,7 +79,7 @@ public class ProviderServiceImpl extends BaseOpenmrsService implements ProviderS
 	 */
 	@Override
 	public Provider unretireProvider(Provider provider) {
-		return dao.saveProvider(provider);
+		return Context.getProviderService().saveProvider(provider);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -206,7 +206,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public Visit unvoidVisit(Visit visit) throws APIException {
-		return dao.saveVisit(visit);
+		return Context.getVisitService().saveVisit(visit);
 	}
 	
 	/**
@@ -326,7 +326,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public VisitAttributeType unretireVisitAttributeType(VisitAttributeType visitAttributeType) {
-		return dao.saveVisitAttributeType(visitAttributeType);
+		return Context.getVisitService().saveVisitAttributeType(visitAttributeType);
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -1343,22 +1343,23 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void unretireOrderFrequency_shouldUnretireGivenOrderFrequency() {
-		OrderFrequency orderFrequency = orderService.getOrderFrequency(3);
+		executeDataSet("org/openmrs/api/include/OrderServiceTest-otherOrderFrequencies.xml");
+		OrderFrequency orderFrequency = orderService.getOrderFrequency(103);
 		assertNotNull(orderFrequency);
 		assertTrue(orderFrequency.getRetired());
-		assertEquals("Some Retire Reason", orderFrequency.getRetireReason());
+		assertEquals(null,orderFrequency.getRetireReason());
 		assertNotNull(orderFrequency.getDateRetired());
-		
+
 		orderService.unretireOrderFrequency(orderFrequency);
 		
-		orderFrequency = orderService.getOrderFrequency(3);
+		orderFrequency = orderService.getOrderFrequency(103);
 		assertNotNull(orderFrequency);
 		assertFalse(orderFrequency.getRetired());
 		assertNull(orderFrequency.getRetireReason());
 		assertNull(orderFrequency.getDateRetired());
-		
+
 		//Should not change the number of order frequencies.
-		assertEquals(3, orderService.getOrderFrequencies(true).size());
+		assertEquals(7, orderService.getOrderFrequencies(true).size());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
@@ -294,7 +294,7 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void unretireProvider_shouldUnretireAProvider() {
-		Provider provider = service.getProvider(1);
+		Provider provider = service.getProvider(2);
 		service.unretireProvider(provider);
 		assertFalse(provider.getRetired());
 		assertNull(provider.getRetireReason());


### PR DESCRIPTION
made changes to unretireXXX() and unvoidXXX() methods such that they call save methods on  spring proxy object obtained from calling Context.getXXXService().
see https://issues.openmrs.org/browse/TRUNK-4916

- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All existing tests passed.

