### PR TITLE
TRUNK-248:Add JUnit @should annotations according to code comments

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -408,6 +408,7 @@ public class HibernateFormDAO implements FormDAO {
 	 * @param containingAllFormFields
 	 * @param fields
 	 * @return
+	 * @should return criteria if containingAnyFormField is not empty.
 	 */
 	private Criteria getFormCriteria(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
 	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
@@ -431,7 +432,6 @@ public class HibernateFormDAO implements FormDAO {
 			crit.add(Restrictions.eq("retired", retired));
 		}
 		
-		// TODO junit test
 		if (!containingAnyFormField.isEmpty()) {
 			// Convert form field persistents to integers
 			Set<Integer> anyFormFieldIds = new HashSet<Integer>();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -239,6 +239,8 @@ public class HibernatePatientDAO implements PatientDAO {
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifiers(java.lang.String, java.util.List, java.util.List, java.util.List, java.lang.Boolean)
+	 * @should return a list of patientIdentifiers when patientIdentifierTypes and patient is not null
+	 * @should return a list of patientIdentifiers when patient is not empty
 	 */
 	@SuppressWarnings("unchecked")
         @Override
@@ -259,7 +261,6 @@ public class HibernatePatientDAO implements PatientDAO {
 			criteria.add(Restrictions.eq("identifier", identifier));
 		}
 		
-		// TODO add junit test for getting by identifier type
 		if (!patientIdentifierTypes.isEmpty()) {
 			criteria.add(Restrictions.in("identifierType", patientIdentifierTypes));
 		}
@@ -268,7 +269,6 @@ public class HibernatePatientDAO implements PatientDAO {
 			criteria.add(Restrictions.in("location", locations));
 		}
 		
-		// TODO add junit test for getting by patients
 		if (!patients.isEmpty()) {
 			criteria.add(Restrictions.in("patient", patients));
 		}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -264,6 +264,7 @@ public class PatientSearchCriteria {
 	 * @param identifierTypes
 	 * @param matchIdentifierExactly
 	 * @param includeVoided true/false whether or not to included voided patients
+	 * @should return criterion of given identifierTypes
 	 */
 	private Criterion prepareCriterionForIdentifier(String identifier, List<PatientIdentifierType> identifierTypes,
 	        boolean matchIdentifierExactly, boolean includeVoided) {
@@ -309,9 +310,7 @@ public class PatientSearchCriteria {
 					conjunction.add(Restrictions.sqlRestriction("identifier regexp ?", regex, StringType.INSTANCE));
 				}
 			}
-		}
-		
-		// TODO add a junit test for patientIdentifierType restrictions	
+		}	
 		
 		// do the type restriction
 		if (!CollectionUtils.isEmpty(identifierTypes)) {


### PR DESCRIPTION
TRUNK-248 Add JUnit @should annotations according to code comments

## Description
I have added JUnit @should annotations on methods as follows;
1.@should return criteria if containingAnyFormField is not empty.
2.@should return a list of patientIdentifiers when patientIdentifierTypes and patient is not null 
3.@should return criterion of given identifierTypes 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-248

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ x] My pull request only contains one single commit.
- [ x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x ] My code follows the code style of this project.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

