### PR TITLE
TRUNK-5038 Replace StringBuffer with StringBuilder

### DIFF
--- a/api/src/main/java/org/openmrs/api/EventListeners.java
+++ b/api/src/main/java/org/openmrs/api/EventListeners.java
@@ -38,7 +38,7 @@ public class EventListeners {
 	 */
 	public void setGlobalPropertyListeners(List<GlobalPropertyListener> globalPropertyListeners) {
 		if (log.isDebugEnabled()) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			for (GlobalPropertyListener gpl : globalPropertyListeners) {
 				if (sb.length() > 0) {
 					sb.append(", ");

--- a/api/src/main/java/org/openmrs/hl7/HL7Util.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Util.java
@@ -78,7 +78,7 @@ public class HL7Util {
 			throw new HL7Exception("Invalid date '" + s + "'");
 		}
 		
-		StringBuffer dateString = new StringBuffer();
+		StringBuilder dateString = new StringBuilder();
 		dateString.append(s.substring(0, 4)); // year
 		if (s.length() >= 6) {
 			dateString.append(s.substring(4, 6)); // month
@@ -225,7 +225,7 @@ public class HL7Util {
 		String timeZoneOffset = getTimeZoneOffset(s, new Date());
 		s = s.replace(timeZoneOffset, ""); // remove the timezone from the string
 		
-		StringBuffer timeString = new StringBuffer();
+		StringBuilder timeString = new StringBuilder();
 		
 		if (s.length() < 2 || s.length() > 16) {
 			throw new HL7Exception("Invalid time format '" + s + "'");

--- a/api/src/main/java/org/openmrs/logic/LogicTransform.java
+++ b/api/src/main/java/org/openmrs/logic/LogicTransform.java
@@ -51,7 +51,7 @@ public class LogicTransform {
 	}
 	
 	public String toString() {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		
 		if (transformOperator != null) {
 			result.append(transformOperator);

--- a/api/src/main/java/org/openmrs/logic/result/Result.java
+++ b/api/src/main/java/org/openmrs/logic/result/Result.java
@@ -634,7 +634,7 @@ public class Result extends ArrayList<Result> {
 					return valueText;
 			}
 		}
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		for (Result r : this) {
 			if (s.length() > 0) {
 				s.append(",");

--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -751,7 +751,7 @@ public final class Module {
 			throw new ModuleException("Startup error value cannot be null", this.getModuleId());
 		}
 		
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		
 		// if exceptionMessage is not null, append it
 		if (exceptionMessage != null) {

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -498,7 +498,7 @@ public class ModuleClassLoader extends URLClassLoader {
 		}
 		
 		if (log.isDebugEnabled()) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append("New code URL's populated for module " + getModule() + ":\r\n");
 			for (URL u : newUrls) {
 				buf.append("\t");

--- a/api/src/main/java/org/openmrs/util/DoubleRange.java
+++ b/api/src/main/java/org/openmrs/util/DoubleRange.java
@@ -145,7 +145,7 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	 * @should print empty string if low and high are infinite
 	 */
 	public String toString() {
-		StringBuffer ret = new StringBuffer();
+		StringBuilder ret = new StringBuilder();
 		if (low != null && low.doubleValue() != Double.NEGATIVE_INFINITY) {
 			ret.append(">");
 			if (closedLow) {

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -218,7 +218,7 @@ public class OpenmrsUtil {
 	 * @throws IOException
 	 */
 	public static String getFileAsString(File file) throws IOException {
-		StringBuffer fileData = new StringBuffer(1000);
+		StringBuilder fileData = new StringBuilder(1000);
 		BufferedReader reader = new BufferedReader(new FileReader(file));
 		char[] buf = new char[1024];
 		int numRead = 0;
@@ -1583,7 +1583,7 @@ public class OpenmrsUtil {
 	 */
 	public static String generateUid(Integer size) {
 		Random gen = new Random();
-		StringBuffer sb = new StringBuffer(size);
+		StringBuilder sb = new StringBuilder(size);
 		for (int i = 0; i < size; i++) {
 			int ch = gen.nextInt() * 62;
 			if (ch < 10) {

--- a/api/src/main/java/org/openmrs/util/Security.java
+++ b/api/src/main/java/org/openmrs/util/Security.java
@@ -139,7 +139,7 @@ public class Security {
 	 * @return Hexidecimal based string
 	 */
 	private static String hexString(byte[] block) {
-		StringBuffer buf = new StringBuffer();
+		StringBuilder buf = new StringBuilder();
 		char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 		int len = block.length;
 		int high = 0;
@@ -194,7 +194,7 @@ public class Security {
 		if (b == null || b.length < 1) {
 			return "";
 		}
-		StringBuffer s = new StringBuffer();
+		StringBuilder s = new StringBuilder();
 		for (int i = 0; i < b.length; i++) {
 			s.append(Integer.toHexString(b[i] & 0xFF));
 		}

--- a/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
@@ -127,7 +127,7 @@ public class SourceMySqldiffFile implements CustomTaskChange {
 		        + databaseName;
 		
 		// run the command line string
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		Integer exitValue = -1; // default to a non-zero exit value in case of exceptions
 		try {
 			exitValue = execCmd(tmpOutputFile.getParentFile(), commands.toArray(new String[] {}), output);
@@ -190,7 +190,7 @@ public class SourceMySqldiffFile implements CustomTaskChange {
 	 * @param the string
 	 * @return process exit value
 	 */
-	private Integer execCmd(File wd, String[] cmdWithArguments, StringBuffer out) throws Exception {
+	private Integer execCmd(File wd, String[] cmdWithArguments, StringBuilder out) throws Exception {
 		log.debug("executing command: " + Arrays.toString(cmdWithArguments));
 		
 		Integer exitValue = -1;

--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -153,7 +153,7 @@ public class WebModuleUtil {
 						// trim out the starting path of "web/module/"
 						String filepath = name.substring(11);
 						
-						StringBuffer absPath = new StringBuffer(realPath + "/WEB-INF");
+						StringBuilder absPath = new StringBuilder(realPath + "/WEB-INF");
 						
 						// If this is within the tag file directory, copy it into /WEB-INF/tags/module/moduleId/...
 						if (filepath.startsWith("tags/")) {


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Replaced instances of synchronized class StringBuffer with unsynchronized class StringBuilder
where StringBuffer is used for local variables in which the state will not be shared among threads and thus the synchronization is not needed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5038

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

