### PR TITLE
TRUNK - 5036 HibernateConceptDAO.getConceptByName() method logs incorrect warning message

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -1735,6 +1735,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 		
 		if (list.size() == 1) {
 			return list.get(0).getConcept();
+		} else if (list.size() == 0) {
+			log.warn("No concept found for '" + name + "'");
 		} else {
 			log.warn("Multiple concepts found for '" + name + "'");
 			


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Added a check to see if size of list is zero and then logged a warning "No concept found..."
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5036

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

