### PR TITLE
TRUNK-4924: BaseCustomizableData setAttribute fail on minOccurs and maxOccurs

### DIFF
--- a/api/src/main/java/org/openmrs/BaseCustomizableData.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableData.java
@@ -9,124 +9,46 @@
  */
 package org.openmrs;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.openmrs.attribute.Attribute;
-import org.openmrs.customdatatype.CustomValueDescriptor;
 import org.openmrs.customdatatype.Customizable;
 
 /**
- * Extension of {@link BaseOpenmrsData} for classes that support customization via user-defined attributes.
+ * Extension of {@link BaseOpenmrsData} for classes that support customization via user-defined
+ * attributes.
+ * 
  * @param <A> the type of attribute held
  * @since 1.9
  */
 public abstract class BaseCustomizableData<A extends Attribute> extends BaseOpenmrsData implements Customizable<A> {
 	
-	private Set<A> attributes = new LinkedHashSet<A>();
+	private Collection<A> attributes = new LinkedHashSet<A>();
 	
 	/**
 	 * @see org.openmrs.customdatatype.Customizable#getAttributes()
 	 */
 	@Override
-	public Set<A> getAttributes() {
+	public Collection<A> getAttributes() {
 		return attributes;
 	}
 	
 	/**
-	 * @param attributes the attributes to set
+	 * @see org.openmrs.customdatatype.Customizable#setAttributes()
 	 */
-	public void setAttributes(Set<A> attributes) {
+	@Override
+	public void setAttributes(Collection<A> attributes) {
 		this.attributes = attributes;
 	}
 	
 	/**
 	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes()
+	 * @hint has do be passed through, otherwise BeanWrapper.getPropertyValue() throws
+	 *       NotReadablePropertyException
 	 */
 	@Override
 	public Collection<A> getActiveAttributes() {
-		List<A> ret = new ArrayList<A>();
-		if (getAttributes() != null) {
-			for (A attr : getAttributes()) {
-				if (!attr.getVoided()) {
-					ret.add(attr);
-				}
-			}
-		}
-		return ret;
+		return Customizable.super.getActiveAttributes();
 	}
-	
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes(org.openmrs.customdatatype.CustomValueDescriptor)
-	 */
-	@Override
-	public List<A> getActiveAttributes(CustomValueDescriptor ofType) {
-		List<A> ret = new ArrayList<A>();
-		if (getAttributes() != null) {
-			for (A attr : getAttributes()) {
-				if (attr.getAttributeType().equals(ofType) && !attr.getVoided()) {
-					ret.add(attr);
-				}
-			}
-		}
-		return ret;
-	}
-	
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#addAttribute(Attribute)
-	 */
-	@Override
-	public void addAttribute(A attribute) {
-		if (getAttributes() == null) {
-			setAttributes(new LinkedHashSet<A>());
-		}
-		getAttributes().add(attribute);
-		attribute.setOwner(this);
-	}
-	
-	/**
-	 * Convenience method that voids all existing attributes of the given type, and sets this new one.
-	 * @should void the attribute if an attribute with same attribute type already exists and the maxOccurs is set to 1
-	 *
-	 * @param attribute
-	 */
-	@SuppressWarnings("unchecked")
-	public void setAttribute(A attribute) {
-		if (getAttributes() == null) {
-			addAttribute(attribute);
-			return;
-		}
-		
-		if (getActiveAttributes(attribute.getAttributeType()).size() == 1) {
-			A existing = getActiveAttributes(attribute.getAttributeType()).get(0);
-			if (existing.getValue().equals(attribute.getValue())) {
-				// do nothing, since the value is already as-specified
-			} else {
-				if (existing.getId() != null) {
-					existing.setVoided(true);
-				} else {
-					getAttributes().remove(existing);
-				}
-				getAttributes().add(attribute);
-				attribute.setOwner(this);
-			}
-			
-		} else {
-			for (A existing : getActiveAttributes(attribute.getAttributeType())) {
-				if (existing.getAttributeType().equals(attribute.getAttributeType())) {
-					if (existing.getId() != null) {
-						existing.setVoided(true);
-					} else {
-						getAttributes().remove(existing);
-					}
-				}
-			}
-			getAttributes().add(attribute);
-			attribute.setOwner(this);
-		}
-	}
-	
 }

--- a/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
@@ -9,126 +9,46 @@
  */
 package org.openmrs;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 import org.openmrs.attribute.Attribute;
-import org.openmrs.customdatatype.CustomValueDescriptor;
 import org.openmrs.customdatatype.Customizable;
 
 /**
- * Extension of {@link org.openmrs.BaseOpenmrsMetadata} for classes that support customization via user-defined attributes.
+ * Extension of {@link org.openmrs.BaseOpenmrsMetadata} for classes that support customization via
+ * user-defined attributes.
+ * 
  * @param <A> the type of attribute held
  * @since 1.9
  */
 public abstract class BaseCustomizableMetadata<A extends Attribute> extends BaseOpenmrsMetadata implements Customizable<A> {
 	
-	private Set<A> attributes = new LinkedHashSet<A>();
+	private Collection<A> attributes = new LinkedHashSet<A>();
 	
 	/**
 	 * @see org.openmrs.customdatatype.Customizable#getAttributes()
 	 */
 	@Override
-	public Set<A> getAttributes() {
+	public Collection<A> getAttributes() {
 		return attributes;
 	}
 	
 	/**
-	 * @param attributes the attributes to set
+	 * @see org.openmrs.customdatatype.Customizable#setAttributes()
 	 */
-	public void setAttributes(Set<A> attributes) {
+	@Override
+	public void setAttributes(Collection<A> attributes) {
 		this.attributes = attributes;
 	}
 	
 	/**
 	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes()
+	 * @hint has do be passed through, otherwise BeanWrapper.getPropertyValue() throws
+	 *       NotReadablePropertyException
 	 */
 	@Override
 	public Collection<A> getActiveAttributes() {
-		List<A> ret = new ArrayList<A>();
-		if (getAttributes() != null) {
-			for (A attr : getAttributes()) {
-				if (!attr.getVoided()) {
-					ret.add(attr);
-				}
-			}
-		}
-		return ret;
+		return Customizable.super.getActiveAttributes();
 	}
-	
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes(org.openmrs.customdatatype.CustomValueDescriptor)
-	 */
-	@Override
-	public List<A> getActiveAttributes(CustomValueDescriptor ofType) {
-		List<A> ret = new ArrayList<A>();
-		if (getAttributes() != null) {
-			for (A attr : getAttributes()) {
-				if (attr.getAttributeType().equals(ofType) && !attr.getVoided()) {
-					ret.add(attr);
-				}
-			}
-		}
-		return ret;
-	}
-	
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#addAttribute(Attribute)
-	 */
-	@Override
-	public void addAttribute(A attribute) {
-		if (getAttributes() == null) {
-			setAttributes(new LinkedHashSet<A>());
-		}
-		getAttributes().add(attribute);
-		attribute.setOwner(this);
-	}
-	
-	/**
-	 * Convenience method that voids all existing attributes of the given type, and sets this new one.
-	 * TODO fail if minOccurs &gt; 1
-	 * TODO decide whether this should require maxOccurs=1
-	 * @should void the attribute if an attribute with same attribute type already exists and the maxOccurs is set to 1
-	 * @should work for attributes with datatypes whose values are stored in other tables
-	 *
-	 * @param attribute
-	 */
-	public void setAttribute(A attribute) {
-		if (getAttributes() == null) {
-			addAttribute(attribute);
-			return;
-		}
-		
-		if (getActiveAttributes(attribute.getAttributeType()).size() == 1) {
-			A existing = getActiveAttributes(attribute.getAttributeType()).get(0);
-			if (existing.getValue().equals(attribute.getValue())) {
-				// do nothing, since the value is already as-specified
-			} else {
-				if (existing.getId() != null) {
-					existing.setVoided(true);
-				} else {
-					getAttributes().remove(existing);
-				}
-				getAttributes().add(attribute);
-				attribute.setOwner(this);
-			}
-			
-		} else {
-			for (A existing : getActiveAttributes(attribute.getAttributeType())) {
-				if (existing.getAttributeType().equals(attribute.getAttributeType())) {
-					if (existing.getId() != null) {
-						existing.setVoided(true);
-					} else {
-						getAttributes().remove(existing);
-					}
-				}
-			}
-			getAttributes().add(attribute);
-			attribute.setOwner(this);
-		}
-	}
-	
 }

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -40,7 +40,6 @@ import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.hibernate.search.TermsFilterFactory;
-import org.openmrs.customdatatype.CustomValueDescriptor;
 import org.openmrs.customdatatype.Customizable;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsUtil;
@@ -128,7 +127,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 */
 	private Map<Locale, List<ConceptName>> compatibleCache;
 
-	private Set<ConceptAttribute> attributes = new LinkedHashSet<>();
+	private Collection<ConceptAttribute> attributes = new LinkedHashSet<>();
 
 	/** default constructor */
 	public Concept() {
@@ -1625,47 +1624,25 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @see org.openmrs.customdatatype.Customizable#getAttributes()
 	 */
 	@Override
-	public Set<ConceptAttribute> getAttributes() {
-		if (attributes == null) {
-			attributes = new LinkedHashSet<ConceptAttribute>();
-		}
+	public Collection<ConceptAttribute> getAttributes() {
 		return attributes;
 	}
-
+	
+	/**
+	 * @see org.openmrs.customdatatype.Customizable#setAttributes()
+	 */
+	@Override
+	public void setAttributes(Collection<ConceptAttribute> attributes) {
+		this.attributes = attributes;
+	}
+	
 	/**
 	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes()
+	 * @hint has do be passed through, otherwise BeanWrapper.getPropertyValue() throws
+	 *       NotReadablePropertyException
 	 */
 	@Override
 	public Collection<ConceptAttribute> getActiveAttributes() {
-		return getAttributes().stream()
-				.filter(attr -> !attr.getVoided())
-				.collect(Collectors.toList());
+		return Customizable.super.getActiveAttributes();
 	}
-
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#getActiveAttributes(org.openmrs.customdatatype.CustomValueDescriptor)
-	 */
-	@Override
-	public List<ConceptAttribute> getActiveAttributes(CustomValueDescriptor ofType) {
-		return getAttributes().stream()
-				.filter(attr -> attr.getAttributeType().equals(ofType) && !attr.getVoided())
-				.collect(Collectors.toList());
-	}
-
-	/**
-	 * @param attributes the attributes to set
-	 */
-	public void setAttributes(Set<ConceptAttribute> attributes) {
-		this.attributes = attributes;
-	}
-
-	/**
-	 * @see org.openmrs.customdatatype.Customizable#addAttribute(Attribute)
-	 */
-	@Override
-	public void addAttribute(ConceptAttribute attribute) {
-		getAttributes().add(attribute);
-		attribute.setOwner(this);
-	}
-
 }

--- a/api/src/main/java/org/openmrs/customdatatype/Customizable.java
+++ b/api/src/main/java/org/openmrs/customdatatype/Customizable.java
@@ -11,12 +11,14 @@ package org.openmrs.customdatatype;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.openmrs.attribute.Attribute;
 
 /**
- * Marker interface for classes that may be customized by the user by adding custom attributes, e.g. Visit
- * has VisitAttributes, so it implements {@link Customizable}&lt;VisitAttribute&gt;
+ * Marker interface for classes that may be customized by the user by adding custom attributes, e.g.
+ * Visit has VisitAttributes, so it implements {@link Customizable}&lt;VisitAttribute&gt;
+ * 
  * @param <A> the type of attribute held
  * @since 1.9
  */
@@ -24,26 +26,103 @@ import org.openmrs.attribute.Attribute;
 public interface Customizable<A extends Attribute> {
 	
 	/**
-	 * @return all attributes (including voided ones)
+	 * @return all attributes (including voided ones), must not be null
 	 */
 	Collection<A> getAttributes();
 	
 	/**
-	 * @return non-voided attributes
+	 * @param attributes the attributes to set
+	 * @since 2.2
 	 */
-	Collection<A> getActiveAttributes();
+	void setAttributes(Collection<A> attributes);
 	
 	/**
-	 * @param ofType
-	 * @return non-voided attributes of the given type
+	 * @return non-voided attributes
+	 * @should return empty collection if attributes collection is empty
+	 * @should return only non voided attributes
 	 */
-	List<A> getActiveAttributes(CustomValueDescriptor ofType);
+	public default Collection<A> getActiveAttributes() {
+		return getAttributes().stream()
+				.filter(attr -> !attr.getVoided())
+				.collect(Collectors.toList());
+	}
+	
+	/**
+	 * @param ofType the type of the active attributes to get
+	 * @return non-voided attributes of the given type
+	 * @should return empty collection if attributes collection is empty
+	 * @should return only non voided attributes of type
+	 */
+	public default List<A> getActiveAttributes(CustomValueDescriptor ofType) {
+		return getAttributes().stream()
+		        .filter(attr -> attr.getAttributeType().equals(ofType))
+		        .filter(attr -> !attr.getVoided())
+		        .collect(Collectors.toList());
+	}
 	
 	/**
 	 * Adds an attribute.
 	 * 
-	 * @param attribute
+	 * @param attribute the attribute to add
+	 * @should add attribute if attributes collection is empty
+	 * @should add attribute if attributes collection is not empty
 	 */
-	void addAttribute(A attribute);
+	@SuppressWarnings("unchecked")
+	public default void addAttribute(A attribute) {
+		getAttributes().add(attribute);
+		attribute.setOwner(this);
+	}
 	
+	/**
+	 * Convenience method that voids all existing attributes of the given type, and sets this new
+	 * one.
+	 * 
+	 * @param attribute the attribute to set
+	 * @should add attribute if attribute collection is null
+	 * @should do nothing if has single existing attribute of same type and value
+	 * @should remove existing attribute with id null and add attribute
+	 * @should void the attribute if an attribute with same attribute type already exists and add
+	 *         attribute
+	 * @should set all existing attributes with non null id to voided and add attribute
+	 * @should set all existing attributes with non null id to voided and remove attribute with null
+	 *         id and add attribute
+	 */
+	@SuppressWarnings("unchecked")
+	public default void setAttribute(A attribute) {
+		if (getAttributes().isEmpty()) {
+			addAttribute(attribute);
+			return;
+		}
+		
+		Collection<A> activeAttributesOfAttributeType = getActiveAttributes(attribute.getAttributeType());
+		
+		if (activeAttributesOfAttributeType.size() == 1) {
+			A existing = activeAttributesOfAttributeType.iterator().next();
+			if (existing.getValue().equals(attribute.getValue())) {
+				// do nothing, since the value is already as-specified
+				return;
+			} else {
+				if (existing.getId() != null) {
+					existing.setVoided(true);
+				} else {
+					getAttributes().remove(existing);
+				}
+				
+				getAttributes().add(attribute);
+				attribute.setOwner(this);
+			}
+		} else {
+			activeAttributesOfAttributeType.stream()
+			        .filter(existing -> existing.getAttributeType().equals(attribute.getAttributeType()))
+			        .forEach(existing -> {
+				        if (existing.getId() != null) {
+					        existing.setVoided(true);
+				        } else {
+					        getAttributes().remove(existing);
+				        }
+			        });
+			getAttributes().add(attribute);
+			attribute.setOwner(this);
+		}
+	}
 }

--- a/api/src/main/java/org/openmrs/validator/VisitValidator.java
+++ b/api/src/main/java/org/openmrs/validator/VisitValidator.java
@@ -41,8 +41,14 @@ public class VisitValidator extends BaseCustomizableValidator implements Validat
 	 * @see org.springframework.validation.Validator#validate(java.lang.Object,
 	 *      org.springframework.validation.Errors)
 	 * @should accept a visit that has the right number of attribute occurrences
+	 * @should accept a visit when expected min occurs of an attribute is zero
+	 * @should accept a visit with attributes when expected min occurs is zero
+	 * 
 	 * @should reject a visit if it has fewer than min occurs of an attribute
 	 * @should reject a visit if it has more than max occurs of an attribute
+	 * @should reject a visit if it has more than max occurs of an attribute when expected exactly one
+	 * @should reject a visit if it has less than min occurs of an attribute when expected exactly one
+
 	 * @should fail if patient is not set
 	 * @should fail if visit type is not set
 	 * @should fail if startDatetime is not set

--- a/api/src/test/java/org/openmrs/customdatatype/CustomizableTest.java
+++ b/api/src/test/java/org/openmrs/customdatatype/CustomizableTest.java
@@ -1,0 +1,383 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.customdatatype;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+import org.junit.Test;
+import org.openmrs.attribute.BaseAttribute;
+import org.openmrs.attribute.BaseAttributeType;
+import org.openmrs.customdatatype.Customizable;
+
+public class CustomizableTest {
+	
+	/**
+	 * @see Customizable#addAttribute(A)
+	 * @verifies add attribute if attributes collection is empty
+	 */
+	@Test
+	public void addAttribute_shouldAddAttributeIfAttributesCollectionIsEmpty() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		assertThat(customizable.getAttributes(), empty());
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		customizable.addAttribute(attribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(1), hasItem(attribute)));
+	}
+	
+	/**
+	 * @see Customizable#addAttribute(A)
+	 * @verifies add attribute if attributes collection is not empty
+	 */
+	@Test
+	public void addAttribute_shouldAddAttributeIfAttributesCollectionIsNotEmpty() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		customizable.setAttributes(new HashSet<>());
+		
+		assertThat(customizable.getAttributes(), empty());
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		customizable.addAttribute(attribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(1), hasItem(attribute)));
+	}
+	
+	/**
+	 * @see Customizable#getActiveAttributes()
+	 * @verifies return empty collection if attributes collection is empty
+	 */
+	@Test
+	public void getActiveAttributes_shouldReturnEmptyCollectionIfAttributesCollectionIsEmpty() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		Collection<SimpleAttribute> activeAttributes = customizable.getActiveAttributes();
+		
+		assertThat(activeAttributes, empty());
+	}
+	
+	/**
+	 * @see Customizable#getActiveAttributes()
+	 * @verifies return only non voided attributes
+	 */
+	@Test
+	public void getActiveAttributes_shouldReturnOnlyNonVoidedAttributes() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttribute nonVoidedAttribute1 = new SimpleAttribute();
+		customizable.addAttribute(nonVoidedAttribute1);
+		
+		SimpleAttribute nonVoidedAttribute2 = new SimpleAttribute();
+		customizable.addAttribute(nonVoidedAttribute2);
+		
+		SimpleAttribute voidedAttribute1 = new SimpleVoidedAttribute();
+		customizable.addAttribute(voidedAttribute1);
+		
+		SimpleAttribute voidedAttribute2 = new SimpleVoidedAttribute();
+		customizable.addAttribute(voidedAttribute2);
+		
+		Collection<SimpleAttribute> activeAttributes = customizable.getActiveAttributes();
+		
+		assertThat(activeAttributes, allOf(iterableWithSize(2), hasItems(nonVoidedAttribute1, nonVoidedAttribute2)));
+		
+	}
+	
+	/**
+	 * @see Customizable#getActiveAttributes(CustomValueDescriptor)
+	 * @verifies return empty collection if attributes collection is empty
+	 */
+	@Test
+	public void getActiveAttributesOfType_shouldReturnEmptyCollectionIfAttributesCollectionIsEmpty() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		Collection<SimpleAttribute> activeAttributes = customizable.getActiveAttributes(attributeType);
+		
+		assertThat(activeAttributes, empty());
+	}
+	
+	/**
+	 * @see Customizable#getActiveAttributes(CustomValueDescriptor)
+	 * @verifies return only non voided attributes of type
+	 */
+	@Test
+	public void getActiveAttributesOfType_shouldReturnOnlyNonVoidedAttributesOfType() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		SimpleAttributeType2 attributeType2 = new SimpleAttributeType2();
+		
+		SimpleAttribute nonVoidedAttribute1 = new SimpleAttribute();
+		nonVoidedAttribute1.setAttributeType(attributeType);
+		customizable.addAttribute(nonVoidedAttribute1);
+		
+		SimpleAttribute nonVoidedAttribute2 = new SimpleAttribute();
+		nonVoidedAttribute2.setAttributeType(attributeType);
+		customizable.addAttribute(nonVoidedAttribute2);
+		
+		SimpleAttribute voidedAttribute1 = new SimpleVoidedAttribute();
+		voidedAttribute1.setAttributeType(attributeType);
+		customizable.addAttribute(voidedAttribute1);
+		
+		SimpleAttribute voidedAttribute2 = new SimpleVoidedAttribute();
+		voidedAttribute2.setAttributeType(attributeType);
+		customizable.addAttribute(voidedAttribute2);
+		
+		Collection<SimpleAttribute> activeAttributes = customizable.getActiveAttributes(attributeType);
+		assertThat(activeAttributes, allOf(iterableWithSize(2), hasItems(nonVoidedAttribute1, nonVoidedAttribute2)));
+		
+		activeAttributes = customizable.getActiveAttributes(attributeType2);
+		assertThat(activeAttributes, empty());
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies add attribute if attribute collection is null
+	 */
+	@Test
+	public void setAttribute_shouldAddAttributeIfAttributeCollectionIsNull() throws Exception {
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		customizable.setAttribute(attribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(1), hasItem(attribute)));
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies do nothing if has single existing attribute of same type and value
+	 */
+	@Test
+	public void setAttribute_shouldDoNothingIfHasSingleExistingAttributeOfSameTypeAndValue() throws Exception {
+		final Object value = "value";
+		
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		attribute.setValue(value);
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		attribute.setAttributeType(attributeType);
+		customizable.addAttribute(attribute);
+		
+		SimpleAttribute newAttribute = new SimpleAttribute();
+		newAttribute.setAttributeType(attributeType);
+		newAttribute.setValue(value);
+		customizable.setAttribute(newAttribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(1), hasItem(attribute)));
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies remove existing attribute with id null and add attribute
+	 */
+	@Test
+	public void setAttribute_shouldRemoveExistingAttributeWithIdNullAndAddAttribute() throws Exception {
+		final Object value = "value";
+		final Object otherValue = "otherValue";
+		
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		attribute.setValue(value);
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		attribute.setAttributeType(attributeType);
+		customizable.addAttribute(attribute);
+		
+		SimpleAttribute newAttribute = new SimpleAttribute();
+		newAttribute.setAttributeType(attributeType);
+		newAttribute.setValue(otherValue);
+		customizable.setAttribute(newAttribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(1), hasItem(newAttribute)));
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies void the attribute if an attribute with same attribute type already exists and add
+	 */
+	@Test
+	public void setAttribute_shouldVoidTheAttributeIfAnAttributeWithSameAttributeTypeAlreadyExistsAndAdd() throws Exception {
+		final Object value = "value";
+		final Object otherValue = "otherValue";
+		final int id = 1;
+		
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		
+		SimpleAttribute attribute = new SimpleAttribute();
+		attribute.setId(id);
+		attribute.setValue(value);
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		attribute.setAttributeType(attributeType);
+		customizable.addAttribute(attribute);
+		
+		SimpleAttribute newAttribute = new SimpleAttribute();
+		newAttribute.setAttributeType(attributeType);
+		newAttribute.setValue(otherValue);
+		customizable.setAttribute(newAttribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(2), hasItems(attribute, newAttribute)));
+		assertThat(customizable.getActiveAttributes(), allOf(iterableWithSize(1), hasItem(newAttribute)));
+		assertTrue("existing attribute should be voided", attribute.getVoided());
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies set all existing attributes with non null id to voided and add attribute
+	 */
+	@Test
+	public void setAttribute_shouldSetAllExistingAttributesWithNonNullIdToVoidedAndAddAttribute() throws Exception {
+		final Object value = "value";
+		final Object otherValue = "otherValue";
+		final int id = 1;
+		final int id2 = 1;
+		
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		
+		SimpleAttribute attributeWithId = new SimpleAttribute();
+		attributeWithId.setId(id);
+		attributeWithId.setValue(value);
+		attributeWithId.setAttributeType(attributeType);
+		customizable.addAttribute(attributeWithId);
+		
+		SimpleAttribute attribute2WithId = new SimpleAttribute();
+		attribute2WithId.setId(id2);
+		attribute2WithId.setValue(value);
+		attribute2WithId.setAttributeType(attributeType);
+		customizable.addAttribute(attribute2WithId);
+		
+		SimpleAttribute newAttribute = new SimpleAttribute();
+		newAttribute.setAttributeType(attributeType);
+		newAttribute.setValue(otherValue);
+		customizable.setAttribute(newAttribute);
+		
+		assertThat(customizable.getAttributes(),
+		    allOf(iterableWithSize(3), hasItems(attributeWithId, attribute2WithId, newAttribute)));
+		assertThat(customizable.getActiveAttributes(), allOf(iterableWithSize(1), hasItem(newAttribute)));
+		assertTrue("existing attribute should be voided", attributeWithId.getVoided());
+		assertTrue("existing attribute should be voided", attribute2WithId.getVoided());
+	}
+	
+	/**
+	 * @see Customizable#setAttribute(A)
+	 * @verifies set all existing attributes with non null id to voided and remove attribute with
+	 *           null
+	 */
+	@Test
+	public void setAttribute_shouldSetAllExistingAttributesWithNonNullIdToVoidedAndRemoveAttributeWithNull()
+	    throws Exception {
+		final Object value = "value";
+		final Object otherValue = "otherValue";
+		final int id = 1;
+		
+		SimpleCustomizable customizable = new SimpleCustomizable();
+		SimpleAttributeType attributeType = new SimpleAttributeType();
+		
+		SimpleAttribute attributeWithId = new SimpleAttribute();
+		attributeWithId.setId(id);
+		attributeWithId.setValue(value);
+		attributeWithId.setAttributeType(attributeType);
+		customizable.addAttribute(attributeWithId);
+		
+		SimpleAttribute attribute2WithIdNull = new SimpleAttribute();
+		attribute2WithIdNull.setId(null);
+		attribute2WithIdNull.setValue(value);
+		attribute2WithIdNull.setAttributeType(attributeType);
+		customizable.addAttribute(attribute2WithIdNull);
+		
+		SimpleAttribute newAttribute = new SimpleAttribute();
+		newAttribute.setAttributeType(attributeType);
+		newAttribute.setValue(otherValue);
+		customizable.setAttribute(newAttribute);
+		
+		assertThat(customizable.getAttributes(), allOf(iterableWithSize(2), hasItems(attributeWithId, newAttribute)));
+		assertThat(customizable.getActiveAttributes(), allOf(iterableWithSize(1), hasItem(newAttribute)));
+		assertTrue("existing attribute should be voided", attributeWithId.getVoided());
+		
+	}
+	
+	private static class SimpleCustomizable implements Customizable<SimpleAttribute> {
+		
+		private Collection<SimpleAttribute> attributes = new LinkedHashSet<SimpleAttribute>();
+		
+		@Override
+		public Collection<SimpleAttribute> getAttributes() {
+			return attributes;
+		}
+		
+		@Override
+		public void setAttributes(Collection<SimpleAttribute> attributes) {
+			this.attributes = attributes;
+		}
+		
+	}
+	
+	private static class SimpleAttribute extends BaseAttribute<SimpleAttributeType, SimpleCustomizable> {
+		
+		private Integer id;
+		
+		@Override
+		public Integer getId() {
+			return id;
+		}
+		
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+	
+	private static class SimpleVoidedAttribute extends SimpleAttribute {
+		
+		SimpleVoidedAttribute() {
+			setVoided(true);
+		}
+	}
+	
+	private static class SimpleAttributeType extends BaseAttributeType<SimpleCustomizable> {
+		
+		private Integer id;
+		
+		@Override
+		public Integer getId() {
+			return id;
+		}
+		
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+	
+	private static class SimpleAttributeType2 extends BaseAttributeType<SimpleCustomizable> {
+		
+		private Integer id;
+		
+		@Override
+		public Integer getId() {
+			return id;
+		}
+		
+		@Override
+		public void setId(Integer id) {
+			this.id = id;
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/validator/VisitValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/VisitValidatorTest.java
@@ -12,6 +12,7 @@ package org.openmrs.validator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -27,6 +28,7 @@ import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.VisitAttribute;
 import org.openmrs.api.APIException;
+import org.openmrs.api.ValidationException;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
@@ -93,6 +95,79 @@ public class VisitValidatorTest extends BaseContextSensitiveTest {
 	public void validate_shouldRejectAVisitIfItHasFewerThanMinOccursOfAnAttribute() throws Exception {
 		Visit visit = makeVisit();
 		visit.addAttribute(makeAttribute("one"));
+		ValidateUtil.validate(visit);
+	}
+	
+	/**
+	 * @see VisitValidator#validate(Object,Errors)
+	 * @verifies reject a visit if it has more than max occurs of an attribute when expected exactly one
+	 */
+	@Test
+	public void validate_shouldRejectAVisitIfItHasMoreThanMaxOccursOfAnAttributeWhenExpectedExactlyOne() throws Exception {
+		executeDataSet("org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType1.xml");
+		
+		Visit visit = makeVisit();
+		visit.addAttribute(makeAttribute("one"));
+		visit.addAttribute(makeAttribute("two"));
+		visit.addAttribute(makeAttribute("three"));
+		visit.addAttribute(makeAttribute("four"));
+		try {
+			ValidateUtil.validate(visit);
+			fail();
+		}
+		catch (ValidationException e) {
+			Errors errors = e.getErrors();
+			assertEquals(1, errors.getErrorCount());
+			assertEquals("attribute.error.maxOccurs", errors.getFieldError("activeAttributes").getCode());
+		}
+	}
+	
+	/**
+	 * @see VisitValidator#validate(Object,Errors)
+	 * @verifies reject a visit if it has less than min occurs of an attribute when expected exactly one
+	 */
+	@Test
+	public void validate_shouldRejectAVisitIfItHasLessThanMinOccursOfAnAttributeWhenExpectedExactlyOne() throws Exception {
+		executeDataSet("org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType1.xml");
+		
+		Visit visit = makeVisit();
+		try {
+			ValidateUtil.validate(visit);
+			fail();
+		}
+		catch (ValidationException e) {
+			Errors errors = e.getErrors();
+			assertEquals(1, errors.getErrorCount());
+			assertEquals("error.required", errors.getFieldError("activeAttributes").getCode());
+		}
+	}
+	
+	/**
+	 * @see VisitValidator#validate(Object,Errors)
+	 * @verifies accept a visit when expected min occurs of an attribute is zero
+	 */
+	@Test
+	public void validate_shouldAcceptAVisitWhenExpectedMinOccursOfAnAttributeIsZero() throws Exception {
+		executeDataSet("org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType2.xml");
+		
+		Visit visit = makeVisit();
+		ValidateUtil.validate(visit);
+	}
+	
+	/**
+	 * @see VisitValidator#validate(Object,Errors)
+	 * @verifies accept a visit with attributes when expected min occurs is zero
+	 */
+	@Test
+	public void validate_shouldAcceptAVisitWithAttributesWhenExpectedMinOccursIsZero() throws Exception {
+		executeDataSet("org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType2.xml");
+		
+		Visit visit = makeVisit();
+		visit.addAttribute(makeAttribute("one"));
+		visit.addAttribute(makeAttribute("two"));
+		visit.addAttribute(makeAttribute("three"));
+		visit.addAttribute(makeAttribute("four"));
+		
 		ValidateUtil.validate(visit);
 	}
 	

--- a/api/src/test/resources/org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType1.xml
+++ b/api/src/test/resources/org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType1.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <visit_attribute_type visit_attribute_type_id="1" name="Exactly One" datatype="org.openmrs.customdatatype.datatype.DateDatatype" uuid="9516cc50-6f9f-11e0-8414-001e378eb67e" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" min_occurs="1" max_occurs="1" />
+</dataset>

--- a/api/src/test/resources/org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType2.xml
+++ b/api/src/test/resources/org/openmrs/validator/include/VisitValidatorTest-additionalAttributeType2.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <visit_attribute_type visit_attribute_type_id="1" name="Zero or more" datatype="org.openmrs.customdatatype.datatype.DateDatatype" uuid="9516cc50-6f9f-11e0-8414-001e378eb67e" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" min_occurs="0" max_occurs="[NULL]"/>
+</dataset>


### PR DESCRIPTION
Refactoring of Customizable implementations, added tests

## Description
Merged duplicated code of Customizable implementation from
BaseCustomizableData, BaseCustomizableMetadata & Concept to Customizable
interface as default methods. Customizable interface added setAttributes
method. BaseCustomizableData, BaseCustomizableMetadata & Concept:
getAttributes method returns Collection instead of Set. Added unit-tests
of Customizable interface. Added test-cases to VisitValidatorTest for
minOccurs/maxOccurs properties of attributes.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4924

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. <- not really since there is a failing test in current master (EncounterTest.getObsAtTopLevel_shouldGetObsInTheSameOrderObsIsAddedToTheEncounter) otherwise yes

