### PR TITLE
TRUNK-4018 Initial Setup (installer) sits at 100% too long before actually finishing

### DIFF
--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -239,11 +239,11 @@ public class Encounter extends BaseOpenmrsData {
 	 * @should only return the grouped top level obs
 	 * @should get both child and parent obs after removing child from parent grouping
 	 */
-	public Set<Obs> getObsAtTopLevel(boolean includeVoided) {
+public Set<Obs> getObsAtTopLevel(boolean includeVoided) {
 	
 		return getAllObs(includeVoided).stream()
 				.filter(o -> o.getObsGroup() == null)
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 	
 	/**

--- a/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
+++ b/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
@@ -25,7 +25,11 @@
 								jQuery("#"+data.executedTasks[i]+"_task_loading").hide();
 							if(!jQuery("#"+data.executedTasks[i]+"_task_checkmark").is(':visible'))
 								jQuery("#"+data.executedTasks[i]+"_task_checkmark").show();
-								
+							//Ensuring that the last checkmark does not show up
+							if(data.executedTasks[i]=="UPDATE_TO_LATEST"){
+								jQuery("#"+data.executedTasks[i]+"_task_loading").show();
+								jQuery("#"+data.executedTasks[i]+"_task_checkmark").hide();
+								}
 							if(jQuery("#"+data.executedTasks[i]+"_progressbar")){
 								//show and initialize the progress bar the first time it is updated, if the task takes a short
 								//time to execute it is possible that its progress bar was never shown at all since it was 
@@ -34,9 +38,16 @@
 									jQuery("#"+data.executedTasks[i]+"_progressbar").progressbar({ disabled : false});
 									
 								if(jQuery("#"+data.executedTasks[i]+"_progressbar").progressbar("option","value") < 100){
+									//Ensuring that the last progress bar does not show 100% so as to avoid confusion
+									if(data.executedTasks[i]=="UPDATE_TO_LATEST"){
+										jQuery("#"+data.executedTasks[i]+"_progressbar").progressbar("option", "value", 99);
+										jQuery("#"+data.executedTasks[i]+"_progressPercentage").html("99%");
+									}
+									else{
 									//set to complete status
 									jQuery("#"+data.executedTasks[i]+"_progressbar").progressbar("option", "value", 100);
 									jQuery("#"+data.executedTasks[i]+"_progressPercentage").html("100%");
+									}
 								}
 							}													
 						}						
@@ -49,7 +60,12 @@
 							//show and initialize the progress bar the first time it is updated
 							if(jQuery("#"+data.executingTask+"_progressbar").progressbar("option", "disabled"))
 								jQuery("#"+data.executingTask+"_progressbar").progressbar({ disabled : false});
-								
+							//To ensure that last progress bar shows a maximum of 99%
+							if(data.executingTask=="UPDATE_TO_LATEST"){
+								if(Number(data.completedPercentage)>98){
+									Number(data.completedPercentage)=99;
+								}
+							}	
 							updateProgressBar(data.executingTask, data.completedPercentage);
 						}															
 					}									


### PR DESCRIPTION
TRUNK-4018 Initial Setup (installer) sits at 100% too long before actually finishing

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Added a fix by which the last progress bar does not show 100% thereby not confusing the user who may think it has got stuck.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-4018

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

