### PR TITLE
TRUNK-5056:Use apache StringUtils in OrderSetServiceImpl

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
@@ -10,6 +10,7 @@
 package org.openmrs.api.impl;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.APIException;
@@ -17,7 +18,6 @@ import org.openmrs.api.OrderSetService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.OrderSetDAO;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.Date;
 import java.util.List;
@@ -45,7 +45,7 @@ public class OrderSetServiceImpl extends BaseOpenmrsService implements OrderSetS
 	@Override
 	@Transactional(readOnly = false)
 	public OrderSet retireOrderSet(OrderSet orderSet, String retireReason) throws APIException {
-		if (!StringUtils.hasLength(retireReason)) {
+		if (StringUtils.isBlank(retireReason)) {
 			throw new IllegalArgumentException("retire reason cannot be empty or null");
 		}
 		for (OrderSetMember orderSetMember : orderSet.getOrderSetMembers()) {


### PR DESCRIPTION
TRUNK-5056: To Increase readability replaced  org.springframework.util.StringUtils.hasLength to apache StringUtils.isBlank

## Description
Replaced org.springframework.util.StringUtils.hasLength used in
https://github.com/openmrs/openmrs-core/blob/master/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java#L48
with the apache commons StringUtils.isEmpty to increase readability. apache StringUtils.isBlank returns true is the given string is null, whitespace(" ") or empty("") values 

## Related Issue
https://issues.openmrs.org/browse/TRUNK-5056

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.

