### PR TITLE
TRUNK-5075 EncounterTest random failures

### DIFF
--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -243,7 +243,7 @@ public class Encounter extends BaseOpenmrsData {
 	
 		return getAllObs(includeVoided).stream()
 				.filter(o -> o.getObsGroup() == null)
-				.collect(Collectors.toSet());
+				.collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 	
 	/**


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
TRUNK-5075 EncounterTest random failures
## Description
<!--- Describe your changes in detail -->
There is a certain build failure that occurs randomly. Here is the maven build error : 
Failed tests: 
EncounterTest.getObsAtTopLevel_shouldGetObsInTheSameOrderObsIsAddedToTheEncounter:195 expected:<[secon]d obs> but was:<[thir]d obs>
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5075

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

