### PR TITLE
TRUNK-5077: AbstractHandler doesn't fail to purge obs with missing file.

### DIFF
--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -142,7 +142,10 @@ public class AbstractHandler {
 	 */
 	public boolean purgeComplexData(Obs obs) {
 		File file = getComplexDataFile(obs);
-		if (file.exists() && file.delete()) {
+		if (!file.exists()) {
+			return true;
+		}
+		else if (file.delete()) {
 			obs.setComplexData(null);
 			// obs.setValueComplex(null);
 			return true;

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -59,8 +59,8 @@ import org.openmrs.obs.handler.TextHandler;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
-import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.OpenmrsConstants.PERSON_TYPE;
+import org.openmrs.util.OpenmrsUtil;
 
 /**
  * TODO clean up and add tests for all methods in ObsService
@@ -517,6 +517,21 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		ComplexObsHandler textHandler = os.getHandler("TextHandler");
 		Assert.assertNotNull(textHandler);
+	}
+	
+	@Test
+	@Verifies(value = "should purge complex obs when complex data file is missing from disk", method = "purgeObs(Obs)")
+	public void purgeComplexObs_shouldSucceedWhenCompleDataFileMissingFromDisk() throws Exception {
+		executeDataSet(COMPLEX_OBS_XML);
+		
+		ObsService os = Context.getObsService();
+		Obs obs = os.getComplexObs(44, OpenmrsConstants.RAW_VIEW);
+		// obs #44 is coded by the concept complex #8473 pointing to ImageHandler
+		// ImageHandler inherits AbstractHandler which handles complex data files on disk
+
+		os.purgeObs(obs);
+		
+		assertNull(os.getObs(obs.getObsId()));
 	}
 	
 	/**


### PR DESCRIPTION
  modified:   api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
This unit test was throwing an APIException prior to the change.
  modified:   api/src/test/java/org/openmrs/api/ObsServiceTest.java
