### PR TITLE
TRUNK-5077: AbstractHandler doesn't fail to purge obs with missing file.

### DIFF
--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -144,7 +144,9 @@ public class AbstractHandler {
 	 */
 	public boolean purgeComplexData(Obs obs) {
 		File file = getComplexDataFile(obs);
-		if (file.exists() && file.delete()) {
+		if (!file.exists()) {
+			return true;
+		} else if (file.delete()) {
 			obs.setComplexData(null);
 			// obs.setValueComplex(null);
 			return true;

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -9,8 +9,37 @@
  */
 package org.openmrs.api;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.CharArrayReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.imageio.ImageIO;
+
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -36,38 +65,6 @@ import org.openmrs.util.DateUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsConstants.PERSON_TYPE;
 import org.openmrs.util.OpenmrsUtil;
-import org.springframework.validation.BindException;
-import org.springframework.validation.Errors;
-
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.awt.image.WritableRaster;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.CharArrayReader;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.Reader;
-import java.io.Writer;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * TODO clean up and add tests for all methods in ObsService
@@ -91,8 +88,6 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		ObsService os = Context.getObsService();
 		Obs o = os.saveObs(null,"Null Obs");
 	}
-
-
 	
 	/**
 	 * This test tests multi-level heirarchy obsGroup cascades for create, delete, update, void, and
@@ -1352,6 +1347,22 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		obsService.purgeObs(obs);
 		
 		Assert.assertNull(obsService.getObs(7));
+		
+		executeDataSet(COMPLEX_OBS_XML);
+		Obs complexObs = obsService.getComplexObs(44, ComplexObsHandler.RAW_VIEW);
+		// obs #44 is coded by the concept complex #8473 pointing to ImageHandler
+		// ImageHandler inherits AbstractHandler which handles complex data files on disk
+		assertNotNull(complexObs.getComplexData());
+		AdministrationService as = Context.getAdministrationService();
+		File complexObsDir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(as
+		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
+		for (File file : complexObsDir.listFiles()) {
+			file.delete();
+		}
+
+		obsService.purgeObs(complexObs);
+		
+		assertNull(obsService.getObs(obs.getObsId()));
 	}
 	
 	/**


### PR DESCRIPTION
## Description
We ensure that `AbstractHandler`'s purge method returns true when the file is missing on disk. We assume that in that case the complex data purge is already successful. 
Until know, when purging a complex obs through `ObsService`, and whose complex data file is missing on disk, the above scenario would produce an `APIException`.
<!--- Describe your changes in detail -->
We also added a unit test that validates that purging a complex obs handled by `AbstractHandler` and whose complex data file is missing on disk is a valid scenario.
Note that the XML testing dataset that can be loaded in a unit test with
```java
executeDataSet(COMPLEX_OBS_XML);
```
does **not** generate test files on disk. This state of things permits to not bother about deleting them beforehand for the sake of our test.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-5077

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [ ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.