### PR TITLE
TRUNK-5085 Add checkstyle rule UnusedImports

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -109,6 +109,9 @@
 		<module name="RedundantImport">
 			<property name="severity" value="error"/>
 		</module>
+		<module name="UnusedImports">
+			<property name="severity" value="error"/>
+		</module>
 		<module name="IllegalImport">
 			<property name="severity" value="error"/>
 		</module>


### PR DESCRIPTION

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
we already flag unused imports using codacy but the rule is currently
manually configured in the codacy UI using the PMD checker.

* add the checkstyle rule which flags introduction of UnusedImports as
error so we keep the style in the repository and do not rely on manual
configurations in codacy

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5085

