### PR TITLE
TRUNK-5077: Aligning ObsServiceTest with branch 2.0.x.

### DIFF
--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -519,21 +519,6 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		Assert.assertNotNull(textHandler);
 	}
 	
-	@Test
-	@Verifies(value = "should purge complex obs when complex data file is missing from disk", method = "purgeObs(Obs)")
-	public void purgeComplexObs_shouldSucceedWhenCompleDataFileMissingFromDisk() throws Exception {
-		executeDataSet(COMPLEX_OBS_XML);
-		
-		ObsService os = Context.getObsService();
-		Obs obs = os.getComplexObs(44, OpenmrsConstants.RAW_VIEW);
-		// obs #44 is coded by the concept complex #8473 pointing to ImageHandler
-		// ImageHandler inherits AbstractHandler which handles complex data files on disk
-
-		os.purgeObs(obs);
-		
-		assertNull(os.getObs(obs.getObsId()));
-	}
-	
 	/**
 	 * @see ObsService#getHandler(String)
 	 */
@@ -1346,6 +1331,22 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		obsService.purgeObs(obs);
 		
 		Assert.assertNull(obsService.getObs(7));
+		
+		executeDataSet(COMPLEX_OBS_XML);
+		Obs complexObs = obsService.getComplexObs(44, OpenmrsConstants.RAW_VIEW);
+		// obs #44 is coded by the concept complex #8473 pointing to ImageHandler
+		// ImageHandler inherits AbstractHandler which handles complex data files on disk
+		assertNotNull(complexObs.getComplexData());
+		AdministrationService as = Context.getAdministrationService();
+		File complexObsDir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(as
+		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
+		for (File file : complexObsDir.listFiles()) {
+			file.delete();
+		}
+		
+		obsService.purgeObs(complexObs);
+		
+		assertNull(obsService.getObs(obs.getObsId()));
 	}
 	
 	/**


### PR DESCRIPTION
## Description
Second commit to align the new test case added in `ObsServiceTest` with what was pushed on all other branches (1.10.x, 1.12.x, 2.0.x and master).
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-5077

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [ ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
I ran `git pull --rebase upstream 1.11.x`.
- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
I ran `mvn -U clean install`
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.