### PR TITLE
TRUNK-5086 Remove unused and organize imports in tests

### DIFF
--- a/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
@@ -12,6 +12,7 @@ package org.openmrs.api;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.Cohort;
@@ -20,8 +21,6 @@ import org.openmrs.PatientProgram;
 import org.openmrs.Program;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
-
-import org.junit.Assert;
 
 /**
  * Contains methods to test behavior of OpenmrsService methods

--- a/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -38,8 +39,6 @@ import org.openmrs.customdatatype.datatype.FreeTextDatatype;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
-
-import org.junit.Assert;
 
 /**
  * This test class (should) contain tests for all of the ProviderService

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,8 +43,6 @@ import org.openmrs.test.Verifies;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 import org.openmrs.util.Security;
-
-import org.junit.Assert;
 
 /**
  * TODO add more tests to cover the methods in <code>UserService</code>

--- a/api/src/test/java/org/openmrs/attribute/AttributeIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/attribute/AttributeIntegrationTest.java
@@ -11,6 +11,7 @@ package org.openmrs.attribute;
 
 import java.text.SimpleDateFormat;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Visit;
@@ -20,8 +21,6 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
-
-import org.junit.Assert;
 
 /**
  * Integration tests for using {@link BaseAttribute}, {@link BaseAttributeType}, and {@link AttributeHandler}

--- a/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
+++ b/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
@@ -16,11 +16,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.PersonName;
-
-import org.junit.Assert;
 
 public class NameTemplateTest {
 	

--- a/api/src/test/java/org/openmrs/propertyeditor/ConceptAnswersEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/ConceptAnswersEditorTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.propertyeditor;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
@@ -16,8 +17,6 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
-
-import org.junit.Assert;
 
 /**
  *

--- a/api/src/test/java/org/openmrs/test/StartModuleAnnotatioTest.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleAnnotatioTest.java
@@ -9,10 +9,9 @@
  */
 package org.openmrs.test;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
-
-import org.junit.Assert;
 
 @StartModule( { "org/openmrs/module/include/dssmodule-1.44.omod", "org/openmrs/module/include/atdproducer-0.51.omod" })
 public class StartModuleAnnotatioTest extends BaseModuleContextSensitiveTest {

--- a/api/src/test/java/org/openmrs/util/DrugsByNameComparatorTest.java
+++ b/api/src/test/java/org/openmrs/util/DrugsByNameComparatorTest.java
@@ -9,10 +9,9 @@
  */
 package org.openmrs.util;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Drug;
-
-import org.junit.Assert;
 
 /**
  * The Class DrugsByNameComparatorTest. Contains tests for DrugsByNameComparator

--- a/api/src/test/java/org/openmrs/util/ReflectTest.java
+++ b/api/src/test/java/org/openmrs/util/ReflectTest.java
@@ -16,14 +16,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.BaseOpenmrsObject;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Visit;
 import org.openmrs.test.Verifies;
 import org.springframework.util.ReflectionUtils;
-
-import org.junit.Assert;
 
 /**
  * Tests the {@link Reflect} class.

--- a/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
@@ -9,13 +9,12 @@
  */
 package org.openmrs.web.filter.update.util;
 
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.filter.util.FilterUtil;
 import org.openmrs.web.test.BaseWebContextSensitiveTest;
-
-import org.junit.Assert;
 
 /**
  * Tests some of the methods on the {@link FilterUtil}


### PR DESCRIPTION


<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
used eclipse cleanup feature on all packages, now tests are also clean
of unused imports and are organized according to our convention

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5086

