### PR TITLE
TRUNK-5106 Replace use of deprecated isPreferred

### DIFF
--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -220,7 +220,7 @@ public class Patient extends Person {
 		// has fetched a Patient, changed their identifiers around, and then calls this method, so we have to be careful.
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.isPreferred() && !id.isVoided()) {
+				if (id.getPreferred() && !id.isVoided()) {
 					return id;
 				}
 			}
@@ -245,7 +245,7 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(PatientIdentifierType pit) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.isPreferred() && !id.isVoided() && pit.equals(id.getIdentifierType())) {
+				if (id.getPreferred() && !id.isVoided() && pit.equals(id.getIdentifierType())) {
 					return id;
 				}
 			}
@@ -268,7 +268,7 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(Integer identifierTypeId) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.isPreferred() && !id.isVoided()
+				if (id.getPreferred() && !id.isVoided()
 				        && identifierTypeId.equals(id.getIdentifierType().getPatientIdentifierTypeId())) {
 					return id;
 				}
@@ -293,7 +293,7 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(String identifierTypeName) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.isPreferred() && !id.isVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
+				if (id.getPreferred() && !id.isVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
 					return id;
 				}
 			}
@@ -321,7 +321,7 @@ public class Patient extends Person {
 			List<PatientIdentifier> nonPreferred = new LinkedList<PatientIdentifier>();
 			for (PatientIdentifier pi : getIdentifiers()) {
 				if (!pi.isVoided()) {
-					if (pi.isPreferred()) {
+					if (pi.getPreferred()) {
 						ids.add(pi);
 					} else {
 						nonPreferred.add(pi);

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -742,7 +742,7 @@ public class Person extends BaseOpenmrsData {
 	 * 
 	 * @return the "preferred" person name.
 	 * @see #getNames()
-	 * @see PersonName#isPreferred()
+	 * @see PersonName#getPreferred()
 	 * @should get preferred and not-voided person name if exist
 	 * @should get not-voided person name if preferred address does not exist
 	 * @should get voided person address if person is voided and not-voided address does not exist
@@ -753,7 +753,7 @@ public class Person extends BaseOpenmrsData {
 		// has fetched a Person, changed their names around, and then calls this method, so we have to be careful.
 		if (getNames() != null && !getNames().isEmpty()) {
 			for (PersonName name : getNames()) {
-				if (name.isPreferred() && !name.isVoided()) {
+				if (name.getPreferred() && !name.isVoided()) {
 					return name;
 				}
 			}
@@ -813,7 +813,8 @@ public class Person extends BaseOpenmrsData {
 	}
 	
 	/**
-	 * Convenience method to get the {@link PersonAddress} object that is marked as "preferred". <br>
+	 * Convenience method to get the {@link PersonAddress} object that is marked as "preferred".
+	 * <br>
 	 * <br>
 	 * If two addresses are marked as preferred (or no addresses), the database ordering comes into
 	 * effect and the one that was created most recently will be returned. <br>
@@ -824,7 +825,7 @@ public class Person extends BaseOpenmrsData {
 	 * 
 	 * @return the "preferred" person address.
 	 * @see #getAddresses()
-	 * @see PersonAddress#isPreferred()
+	 * @see PersonAddress#getPreferred()
 	 * @should get preferred and not-voided person address if exist
 	 * @should get not-voided person address if preferred address does not exist
 	 * @should get voided person address if person is voided and not-voided address does not exist
@@ -835,7 +836,7 @@ public class Person extends BaseOpenmrsData {
 		// has fetched a Person, changed their addresses around, and then calls this method, so we have to be careful.
 		if (getAddresses() != null && !getAddresses().isEmpty()) {
 			for (PersonAddress addr : getAddresses()) {
-				if (addr.isPreferred() && !addr.isVoided()) {
+				if (addr.getPreferred() && !addr.isVoided()) {
 					return addr;
 				}
 			}

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -136,7 +136,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		PatientIdentifier preferredIdentifier = null;
 		PatientIdentifier possiblePreferredId = patient.getPatientIdentifier();
-		if (possiblePreferredId != null && possiblePreferredId.isPreferred() && !possiblePreferredId.isVoided()) {
+		if (possiblePreferredId != null && possiblePreferredId.getPreferred() && !possiblePreferredId.isVoided()) {
 			preferredIdentifier = possiblePreferredId;
 		}
 		
@@ -154,7 +154,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		PersonName preferredName = null;
 		PersonName possiblePreferredName = patient.getPersonName();
-		if (possiblePreferredName != null && possiblePreferredName.isPreferred() && !possiblePreferredName.isVoided()) {
+		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.isVoided()) {
 			preferredName = possiblePreferredName;
 		}
 		
@@ -172,7 +172,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		PersonAddress preferredAddress = null;
 		PersonAddress possiblePreferredAddress = patient.getPersonAddress();
-		if (possiblePreferredAddress != null && possiblePreferredAddress.isPreferred()
+		if (possiblePreferredAddress != null && possiblePreferredAddress.getPreferred()
 		        && !possiblePreferredAddress.isVoided()) {
 			preferredAddress = possiblePreferredAddress;
 		}

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -296,7 +296,7 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 	public Person savePerson(Person person) throws APIException {
 		PersonName preferredName = null;
 		PersonName possiblePreferredName = person.getPersonName();
-		if (possiblePreferredName != null && possiblePreferredName.isPreferred() && !possiblePreferredName.isVoided()) {
+		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.isVoided()) {
 			preferredName = possiblePreferredName;
 		}
 		
@@ -314,7 +314,7 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 		
 		PersonAddress preferredAddress = null;
 		PersonAddress possiblePreferredAddress = person.getPersonAddress();
-		if (possiblePreferredAddress != null && possiblePreferredAddress.isPreferred()
+		if (possiblePreferredAddress != null && possiblePreferredAddress.getPreferred()
 		        && !possiblePreferredAddress.isVoided()) {
 			preferredAddress = possiblePreferredAddress;
 		}

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -1716,7 +1716,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// make sure only the address from the preferred patient is marked as preferred
 		for (PersonAddress pa : preferred.getAddresses()) {
 			if (pa.getCityVillage().equals("Jabali")) {
-				Assert.assertFalse(pa.isPreferred());
+				Assert.assertFalse(pa.getPreferred());
 			}
 		}
 		
@@ -3120,9 +3120,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		patient.addAddress(address);
 		
 		Context.getPatientService().savePatient(patient);
-		Assert.assertTrue(identifier.isPreferred());
-		Assert.assertTrue(name.isPreferred());
-		Assert.assertTrue(address.isPreferred());
+		Assert.assertTrue(identifier.getPreferred());
+		Assert.assertTrue(name.getPreferred());
+		Assert.assertTrue(address.getPreferred());
 	}
 	
 	/**
@@ -3156,12 +3156,12 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		patient.addAddress(preferredAddress);
 		
 		patientService.savePatient(patient);
-		Assert.assertTrue(preferredIdentifier.isPreferred());
-		Assert.assertTrue(preferredName.isPreferred());
-		Assert.assertTrue(preferredAddress.isPreferred());
-		Assert.assertFalse(identifier.isPreferred());
-		Assert.assertFalse(name.isPreferred());
-		Assert.assertFalse(address.isPreferred());
+		Assert.assertTrue(preferredIdentifier.getPreferred());
+		Assert.assertTrue(preferredName.getPreferred());
+		Assert.assertTrue(preferredAddress.getPreferred());
+		Assert.assertFalse(identifier.getPreferred());
+		Assert.assertFalse(name.getPreferred());
+		Assert.assertFalse(address.getPreferred());
 	}
 	
 	/**
@@ -3198,12 +3198,12 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		patient.addAddress(preferredAddress);
 		
 		patientService.savePatient(patient);
-		Assert.assertFalse(preferredIdentifier.isPreferred());
-		Assert.assertFalse(preferredName.isPreferred());
-		Assert.assertFalse(preferredAddress.isPreferred());
-		Assert.assertTrue(identifier.isPreferred());
-		Assert.assertTrue(name.isPreferred());
-		Assert.assertTrue(address.isPreferred());
+		Assert.assertFalse(preferredIdentifier.getPreferred());
+		Assert.assertFalse(preferredName.getPreferred());
+		Assert.assertFalse(preferredAddress.getPreferred());
+		Assert.assertTrue(identifier.getPreferred());
+		Assert.assertTrue(name.getPreferred());
+		Assert.assertTrue(address.getPreferred());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/PersonServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PersonServiceTest.java
@@ -1590,7 +1590,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 		savedRelationshipType.setPreferred(true);
 		RelationshipType updatedRelationshipType = personService.saveRelationshipType(savedRelationshipType);
-		Assert.assertEquals(true, updatedRelationshipType.isPreferred());
+		Assert.assertEquals(true, updatedRelationshipType.getPreferred());
 	}
 	
 	/**
@@ -2057,8 +2057,8 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		person.addAddress(address);
 		
 		personService.savePerson(person);
-		Assert.assertTrue(name.isPreferred());
-		Assert.assertTrue(address.isPreferred());
+		Assert.assertTrue(name.getPreferred());
+		Assert.assertTrue(address.getPreferred());
 	}
 	
 	/**
@@ -2084,10 +2084,10 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		person.addAddress(preferredAddress);
 		
 		personService.savePerson(person);
-		Assert.assertTrue(preferredName.isPreferred());
-		Assert.assertTrue(preferredAddress.isPreferred());
-		Assert.assertFalse(name.isPreferred());
-		Assert.assertFalse(address.isPreferred());
+		Assert.assertTrue(preferredName.getPreferred());
+		Assert.assertTrue(preferredAddress.getPreferred());
+		Assert.assertFalse(name.getPreferred());
+		Assert.assertFalse(address.getPreferred());
 	}
 	
 	/**
@@ -2115,10 +2115,10 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		person.addAddress(preferredAddress);
 		
 		personService.savePerson(person);
-		Assert.assertFalse(preferredName.isPreferred());
-		Assert.assertFalse(preferredAddress.isPreferred());
-		Assert.assertTrue(name.isPreferred());
-		Assert.assertTrue(address.isPreferred());
+		Assert.assertFalse(preferredName.getPreferred());
+		Assert.assertFalse(preferredAddress.getPreferred());
+		Assert.assertTrue(name.getPreferred());
+		Assert.assertTrue(address.getPreferred());
 	}
 	
 	/**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace use of PersonAdress/PatientIdentifier/PersonName/RelationshipType.isPreferred
which is deprecated with getPreferred

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5106


