### PR TITLE
TRUNK-5111 Replace use of deprecated isVoided

### DIFF
--- a/api/src/main/java/org/openmrs/BaseCustomizableData.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableData.java
@@ -51,7 +51,7 @@ public abstract class BaseCustomizableData<A extends Attribute> extends BaseOpen
 		List<A> ret = new ArrayList<A>();
 		if (getAttributes() != null) {
 			for (A attr : getAttributes()) {
-				if (!attr.isVoided()) {
+				if (!attr.getVoided()) {
 					ret.add(attr);
 				}
 			}
@@ -67,7 +67,7 @@ public abstract class BaseCustomizableData<A extends Attribute> extends BaseOpen
 		List<A> ret = new ArrayList<A>();
 		if (getAttributes() != null) {
 			for (A attr : getAttributes()) {
-				if (attr.getAttributeType().equals(ofType) && !attr.isVoided()) {
+				if (attr.getAttributeType().equals(ofType) && !attr.getVoided()) {
 					ret.add(attr);
 				}
 			}

--- a/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseCustomizableMetadata.java
@@ -51,7 +51,7 @@ public abstract class BaseCustomizableMetadata<A extends Attribute> extends Base
 		List<A> ret = new ArrayList<A>();
 		if (getAttributes() != null) {
 			for (A attr : getAttributes()) {
-				if (!attr.isVoided()) {
+				if (!attr.getVoided()) {
 					ret.add(attr);
 				}
 			}
@@ -67,7 +67,7 @@ public abstract class BaseCustomizableMetadata<A extends Attribute> extends Base
 		List<A> ret = new ArrayList<A>();
 		if (getAttributes() != null) {
 			for (A attr : getAttributes()) {
-				if (attr.getAttributeType().equals(ofType) && !attr.isVoided()) {
+				if (attr.getAttributeType().equals(ofType) && !attr.getVoided()) {
 					ret.add(attr);
 				}
 			}

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -418,7 +418,7 @@ public class Obs extends BaseOpenmrsData {
 		Iterator<Obs> i = nonVoided.iterator();
 		while (i.hasNext()) {
 			Obs obs = i.next();
-			if (obs.isVoided()) {
+			if (obs.getVoided()) {
 				i.remove();
 			}
 		}

--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -220,12 +220,12 @@ public class Patient extends Person {
 		// has fetched a Patient, changed their identifiers around, and then calls this method, so we have to be careful.
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.getPreferred() && !id.isVoided()) {
+				if (id.getPreferred() && !id.getVoided()) {
 					return id;
 				}
 			}
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (!id.isVoided()) {
+				if (!id.getVoided()) {
 					return id;
 				}
 			}
@@ -245,12 +245,12 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(PatientIdentifierType pit) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.getPreferred() && !id.isVoided() && pit.equals(id.getIdentifierType())) {
+				if (id.getPreferred() && !id.getVoided() && pit.equals(id.getIdentifierType())) {
 					return id;
 				}
 			}
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (!id.isVoided() && pit.equals(id.getIdentifierType())) {
+				if (!id.getVoided() && pit.equals(id.getIdentifierType())) {
 					return id;
 				}
 			}
@@ -268,13 +268,13 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(Integer identifierTypeId) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.getPreferred() && !id.isVoided()
+				if (id.getPreferred() && !id.getVoided()
 				        && identifierTypeId.equals(id.getIdentifierType().getPatientIdentifierTypeId())) {
 					return id;
 				}
 			}
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (!id.isVoided() && identifierTypeId.equals(id.getIdentifierType().getPatientIdentifierTypeId())) {
+				if (!id.getVoided() && identifierTypeId.equals(id.getIdentifierType().getPatientIdentifierTypeId())) {
 					return id;
 				}
 			}
@@ -293,12 +293,12 @@ public class Patient extends Person {
 	public PatientIdentifier getPatientIdentifier(String identifierTypeName) {
 		if (getIdentifiers() != null && !getIdentifiers().isEmpty()) {
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (id.getPreferred() && !id.isVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
+				if (id.getPreferred() && !id.getVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
 					return id;
 				}
 			}
 			for (PatientIdentifier id : getIdentifiers()) {
-				if (!id.isVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
+				if (!id.getVoided() && identifierTypeName.equals(id.getIdentifierType().getName())) {
 					return id;
 				}
 			}
@@ -320,7 +320,7 @@ public class Patient extends Person {
 		if (getIdentifiers() != null) {
 			List<PatientIdentifier> nonPreferred = new LinkedList<PatientIdentifier>();
 			for (PatientIdentifier pi : getIdentifiers()) {
-				if (!pi.isVoided()) {
+				if (!pi.getVoided()) {
 					if (pi.getPreferred()) {
 						ids.add(pi);
 					} else {
@@ -347,7 +347,7 @@ public class Patient extends Person {
 		List<PatientIdentifier> ids = new Vector<PatientIdentifier>();
 		if (getIdentifiers() != null) {
 			for (PatientIdentifier pi : getIdentifiers()) {
-				if (!pi.isVoided() && pit.equals(pi.getIdentifierType())) {
+				if (!pi.getVoided() && pit.equals(pi.getIdentifierType())) {
 					ids.add(pi);
 				}
 			}

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -223,6 +223,7 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 	 * @deprecated since 1.12. Use DefaultComparator instead.
 	 * Note: this comparator imposes orderings that are inconsistent with equals.
 	 */
+	@Deprecated
 	@Override
 	@SuppressWarnings("squid:S1210")
 	public int compareTo(PatientIdentifier other) {
@@ -274,7 +275,7 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 		public int compare(PatientIdentifier pi1, PatientIdentifier pi2) {
 			int retValue = 0;
 			if (pi2 != null) {
-				retValue = pi1.isVoided().compareTo(pi2.isVoided());
+				retValue = pi1.getVoided().compareTo(pi2.getVoided());
 				if (retValue == 0) {
 					retValue = pi1.isPreferred().compareTo(pi2.isPreferred());
 				}

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -392,7 +392,7 @@ public class Person extends BaseOpenmrsData {
 	public List<PersonAttribute> getActiveAttributes() {
 		List<PersonAttribute> attrs = new Vector<PersonAttribute>();
 		for (PersonAttribute attr : getAttributes()) {
-			if (!attr.isVoided()) {
+			if (!attr.getVoided()) {
 				attrs.add(attr);
 			}
 		}
@@ -443,7 +443,7 @@ public class Person extends BaseOpenmrsData {
 				
 				// if the to-be-added attribute isn't already voided itself
 				// and if we have the same type, different value
-				if (!newAttribute.isVoided() || newIsNull) {
+				if (!newAttribute.getVoided() || newIsNull) {
 					if (currentAttribute.getCreator() != null) {
 						currentAttribute.voidAttribute("New value: " + newAttribute.getValue());
 					} else {
@@ -495,7 +495,7 @@ public class Person extends BaseOpenmrsData {
 	public PersonAttribute getAttribute(PersonAttributeType pat) {
 		if (pat != null) {
 			for (PersonAttribute attribute : getAttributes()) {
-				if (pat.equals(attribute.getAttributeType()) && !attribute.isVoided()) {
+				if (pat.equals(attribute.getAttributeType()) && !attribute.getVoided()) {
 					return attribute;
 				}
 			}
@@ -520,7 +520,7 @@ public class Person extends BaseOpenmrsData {
 		if (attributeName != null) {
 			for (PersonAttribute attribute : getAttributes()) {
 				PersonAttributeType type = attribute.getAttributeType();
-				if (type != null && attributeName.equals(type.getName()) && !attribute.isVoided()) {
+				if (type != null && attributeName.equals(type.getName()) && !attribute.getVoided()) {
 					return attribute;
 				}
 			}
@@ -601,7 +601,7 @@ public class Person extends BaseOpenmrsData {
 	public List<PersonAttribute> getAttributes(PersonAttributeType personAttributeType) {
 		List<PersonAttribute> ret = new Vector<PersonAttribute>();
 		for (PersonAttribute attribute : getAttributes()) {
-			if (personAttributeType.equals(attribute.getAttributeType()) && !attribute.isVoided()) {
+			if (personAttributeType.equals(attribute.getAttributeType()) && !attribute.getVoided()) {
 				ret.add(attribute);
 			}
 		}
@@ -663,7 +663,7 @@ public class Person extends BaseOpenmrsData {
 		
 		for (PersonAttribute attribute : getAttributes()) {
 			s.append(attribute.getAttributeType()).append(" : ").append(attribute.getValue()).append(" : voided? ").append(
-			    attribute.isVoided()).append("\n");
+			    attribute.getVoided()).append("\n");
 		}
 		
 		return s.toString();
@@ -753,17 +753,17 @@ public class Person extends BaseOpenmrsData {
 		// has fetched a Person, changed their names around, and then calls this method, so we have to be careful.
 		if (getNames() != null && !getNames().isEmpty()) {
 			for (PersonName name : getNames()) {
-				if (name.getPreferred() && !name.isVoided()) {
+				if (name.getPreferred() && !name.getVoided()) {
 					return name;
 				}
 			}
 			for (PersonName name : getNames()) {
-				if (!name.isVoided()) {
+				if (!name.getVoided()) {
 					return name;
 				}
 			}
 			
-			if (isVoided()) {
+			if (getVoided()) {
 				return getNames().iterator().next();
 			}
 		}
@@ -836,17 +836,17 @@ public class Person extends BaseOpenmrsData {
 		// has fetched a Person, changed their addresses around, and then calls this method, so we have to be careful.
 		if (getAddresses() != null && !getAddresses().isEmpty()) {
 			for (PersonAddress addr : getAddresses()) {
-				if (addr.getPreferred() && !addr.isVoided()) {
+				if (addr.getPreferred() && !addr.getVoided()) {
 					return addr;
 				}
 			}
 			for (PersonAddress addr : getAddresses()) {
-				if (!addr.isVoided()) {
+				if (!addr.getVoided()) {
 					return addr;
 				}
 			}
 			
-			if (isVoided()) {
+			if (getVoided()) {
 				return getAddresses().iterator().next();
 			}
 		}

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -384,7 +384,7 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	public int compareTo(PersonAddress other) {
 		int retValue = 0;
 		if (other != null) {
-			retValue = isVoided().compareTo(other.isVoided());
+			retValue = getVoided().compareTo(other.getVoided());
 			if (retValue == 0) {
 				retValue = other.isPreferred().compareTo(isPreferred());
 			}

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -109,7 +109,7 @@ public class PersonAttribute extends BaseOpenmrsData implements java.io.Serializ
 		target.setChangedBy(getChangedBy());
 		target.setDateChanged(getDateChanged());
 		target.setVoidedBy(getVoidedBy());
-		target.setVoided(isVoided());
+		target.setVoided(getVoided());
 		target.setDateVoided(getDateVoided());
 		target.setVoidReason(getVoidReason());
 		return target;
@@ -343,7 +343,7 @@ public class PersonAttribute extends BaseOpenmrsData implements java.io.Serializ
 				return retValue;
 			}
 			
-			if ((retValue = pa1.isVoided().compareTo(pa2.isVoided())) != 0) {
+			if ((retValue = pa1.getVoided().compareTo(pa2.getVoided())) != 0) {
 				return retValue;
 			}
 			

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -509,7 +509,7 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 		
 		@Override
 		public int compare(PersonName pn1, PersonName pn2) {
-			int ret = pn1.isVoided().compareTo(pn2.isVoided());
+			int ret = pn1.getVoided().compareTo(pn2.getVoided());
 			if (ret == 0) {
 				ret = pn2.isPreferred().compareTo(pn1.isPreferred());
 			}

--- a/api/src/main/java/org/openmrs/Relationship.java
+++ b/api/src/main/java/org/openmrs/Relationship.java
@@ -71,7 +71,7 @@ public class Relationship extends BaseOpenmrsData {
 		target.personB = getPersonB();
 		target.setCreator(getCreator());
 		target.setDateCreated(getDateCreated());
-		target.setVoided(isVoided());
+		target.setVoided(getVoided());
 		target.setVoidedBy(getVoidedBy());
 		target.setDateVoided(getDateVoided());
 		target.setVoidReason(getVoidReason());

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -1867,7 +1867,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 	 */
 	@Override
 	public boolean isConceptNameDuplicate(ConceptName name) {
-		if (name.isVoided()) {
+		if (name.getVoided()) {
 			return false;
 		}
 		if (name.getConcept() != null) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSerializedObjectDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSerializedObjectDAO.java
@@ -245,7 +245,7 @@ public class HibernateSerializedObjectDAO implements SerializedObjectDAO {
 		
 		if (object instanceof OpenmrsData) {
 			OpenmrsData dataObj = (OpenmrsData) object;
-			serializedObject.setRetired(dataObj.isVoided());
+			serializedObject.setRetired(dataObj.getVoided());
 			serializedObject.setRetiredBy(dataObj.getVoidedBy());
 			serializedObject.setDateRetired(dataObj.getDateVoided());
 			serializedObject.setRetireReason(dataObj.getVoidReason());

--- a/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
@@ -20,7 +20,7 @@ import org.openmrs.aop.RequiredDataAdvice;
  * This is the super interface for all unvoid* actions that take place on all services. The
  * {@link RequiredDataAdvice} class uses AOP around each method in every service to check to see if
  * its a unvoid* method. If it is a unvoid* method, this class is called to handle setting the
- * {@link Voidable#isVoided()}, {@link Voidable#setVoidReason(String)},
+ * {@link Voidable#getVoided()}, {@link Voidable#setVoidReason(String)},
  * {@link Voidable#setVoidedBy(User)}, and {@link Voidable#setDateVoided(Date)} all to null. <br>
  * <br>
  * Child collections on this {@link Voidable} that are themselves a {@link Voidable} are looped over
@@ -51,7 +51,7 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 	public void handle(Voidable voidableObject, User voidingUser, Date origParentVoidedDate, String unused) {
 		
 		// only operate on voided objects
-		if (voidableObject.isVoided()
+		if (voidableObject.getVoided()
 		        && (origParentVoidedDate == null || origParentVoidedDate.equals(voidableObject.getDateVoided()))) {
 			
 			// only unvoid objects that were voided at the same time as the parent object

--- a/api/src/main/java/org/openmrs/api/handler/BaseVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseVoidHandler.java
@@ -20,7 +20,7 @@ import org.openmrs.aop.RequiredDataAdvice;
  * This is the super interface for all void* actions that take place on all services. The
  * {@link RequiredDataAdvice} class uses AOP around each method in every service to check to see if
  * its a void* method. If it is a void* method, this class is called to handle setting the
- * {@link Voidable#isVoided()}, {@link Voidable#setVoidReason(String)},
+ * {@link Voidable#getVoided()}, {@link Voidable#setVoidReason(String)},
  * {@link Voidable#setVoidedBy(User)}, and {@link Voidable#setDateVoided(Date)}. <br>
  * <br>
  * Child collections on this {@link Voidable} that are themselves a {@link Voidable} are looped over
@@ -56,7 +56,7 @@ public class BaseVoidHandler implements VoidHandler<Voidable> {
 	public void handle(Voidable voidableObject, User voidingUser, Date voidedDate, String voidReason) {
 		
 		// skip over all work if the object is already voided
-		if (!voidableObject.isVoided() || voidableObject.getVoidedBy() == null) {
+		if (!voidableObject.getVoided() || voidableObject.getVoidedBy() == null) {
 			
 			voidableObject.setVoided(true);
 			voidableObject.setVoidReason(voidReason);

--- a/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
@@ -110,7 +110,7 @@ public class OpenmrsObjectSaveHandler implements SaveHandler<OpenmrsObject> {
 					continue;
 				}
 				
-				if ("".equals(value) && !(openmrsObject instanceof Voidable && ((Voidable) openmrsObject).isVoided())) {
+				if ("".equals(value) && !(openmrsObject instanceof Voidable && ((Voidable) openmrsObject).getVoided())) {
 					//Set to null only if object is not already voided
 					PropertyUtils.setProperty(openmrsObject, property.getName(), null);
 				}

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
@@ -54,7 +54,7 @@ public class PatientDataUnvoidHandler implements UnvoidHandler<Patient> {
 			List<Encounter> encounters = es.getEncounters(encounterSearchCriteria);
 			if (CollectionUtils.isNotEmpty(encounters)) {
 				for (Encounter encounter : encounters) {
-					if (encounter.isVoided() && encounter.getDateVoided().equals(origParentVoidedDate)
+					if (encounter.getVoided() && encounter.getDateVoided().equals(origParentVoidedDate)
 					        && encounter.getVoidedBy().equals(originalVoidingUser)) {
 						es.unvoidEncounter(encounter);
 					}
@@ -66,7 +66,7 @@ public class PatientDataUnvoidHandler implements UnvoidHandler<Patient> {
 			List<Order> orders = os.getAllOrdersByPatient(patient);
 			if (CollectionUtils.isNotEmpty(orders)) {
 				for (Order order : orders) {
-					if (order.isVoided() && order.getDateVoided().equals(origParentVoidedDate)
+					if (order.getVoided() && order.getDateVoided().equals(origParentVoidedDate)
 					        && order.getVoidedBy().equals(originalVoidingUser)) {
 						os.unvoidOrder(order);
 					}

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
@@ -49,7 +49,7 @@ public class PatientDataVoidHandler implements VoidHandler<Patient> {
 		List<Encounter> encounters = es.getEncountersByPatient(patient);
 		if (CollectionUtils.isNotEmpty(encounters)) {
 			for (Encounter encounter : encounters) {
-				if (!encounter.isVoided()) {
+				if (!encounter.getVoided()) {
 					// EncounterServiceImpl.voidEncounter and the requiredDataAdvice will set dateVoided to current date 
 					//if it is null, we need to set it now to match the patient's date voided so that the unvoid 
 					//handler's logic doesn't fail when comparing dates while unvoiding encounters that were voided 

--- a/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonSaveHandler.java
@@ -45,7 +45,7 @@ public class RequireVoidReasonSaveHandler implements SaveHandler<Voidable> {
 	@Override
 	public void handle(Voidable voidableObject, User currentUser, Date currentDate, String notUsed) {
 		
-		if (voidableObject.isVoided() && StringUtils.isBlank(voidableObject.getVoidReason())) {
+		if (voidableObject.getVoided() && StringUtils.isBlank(voidableObject.getVoidReason())) {
 			throw new APIException("voided.bit.was.set.true", new Object[] { voidableObject, voidableObject.getClass() });
 		}
 	}

--- a/api/src/main/java/org/openmrs/api/handler/VisitUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/VisitUnvoidHandler.java
@@ -35,7 +35,7 @@ public class VisitUnvoidHandler implements UnvoidHandler<Visit> {
 	public void handle(Visit visit, User voidingUser, Date origParentVoidedDate, String unused) {
 		List<Encounter> encountersByVisit = Context.getEncounterService().getEncountersByVisit(visit, true);
 		for (Encounter encounter : encountersByVisit) {
-			if (encounter.isVoided() && encounter.getDateVoided().equals(visit.getDateVoided())
+			if (encounter.getVoided() && encounter.getDateVoided().equals(visit.getDateVoided())
 			        && encounter.getVoidReason().equals(visit.getVoidReason())) {
 				Context.getEncounterService().unvoidEncounter(encounter);
 			}

--- a/api/src/main/java/org/openmrs/api/handler/VoidSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/VoidSaveHandler.java
@@ -64,7 +64,7 @@ public class VoidSaveHandler implements SaveHandler<Voidable> {
 		// void reason is not set here, it should be set prior to this method
 		
 		// only set the values if the user saved this object and set the voided bit
-		if (voidableObject.isVoided()) {
+		if (voidableObject.getVoided()) {
 			
 			if (voidableObject.getVoidedBy() == null) {
 				voidableObject.setVoidedBy(currentUser);

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -351,14 +351,14 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 		
 		ObsService os = Context.getObsService();
 		for (Obs o : encounter.getObsAtTopLevel(false)) {
-			if (!o.isVoided()) {
+			if (!o.getVoided()) {
 				os.voidObs(o, reason);
 			}
 		}
 		
 		OrderService orderService = Context.getOrderService();
 		for (Order o : encounter.getOrders()) {
-			if (!o.isVoided()) {
+			if (!o.getVoided()) {
 				orderService.voidOrder(o, reason);
 			}
 		}

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -122,26 +122,26 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		} else {
 			Context.requirePrivilege(PrivilegeConstants.EDIT_PATIENTS);
 		}
-		if (patient.isVoided()) {
+		if (patient.getVoided()) {
 			Context.requirePrivilege(PrivilegeConstants.DELETE_PATIENTS);
 		}
 		
-		if (!patient.isVoided() && patient.getIdentifiers().size() == 1) {
+		if (!patient.getVoided() && patient.getIdentifiers().size() == 1) {
 			patient.getPatientIdentifier().setPreferred(true);
 		}
 		
-		if (!patient.isVoided()) {
+		if (!patient.getVoided()) {
 			checkPatientIdentifiers(patient);
 		}
 		
 		PatientIdentifier preferredIdentifier = null;
 		PatientIdentifier possiblePreferredId = patient.getPatientIdentifier();
-		if (possiblePreferredId != null && possiblePreferredId.getPreferred() && !possiblePreferredId.isVoided()) {
+		if (possiblePreferredId != null && possiblePreferredId.getPreferred() && !possiblePreferredId.getVoided()) {
 			preferredIdentifier = possiblePreferredId;
 		}
 		
 		for (PatientIdentifier id : patient.getIdentifiers()) {
-			if (preferredIdentifier == null && !id.isVoided()) {
+			if (preferredIdentifier == null && !id.getVoided()) {
 				id.setPreferred(true);
 				preferredIdentifier = id;
 				continue;
@@ -154,12 +154,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		PersonName preferredName = null;
 		PersonName possiblePreferredName = patient.getPersonName();
-		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.isVoided()) {
+		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.getVoided()) {
 			preferredName = possiblePreferredName;
 		}
 		
 		for (PersonName name : patient.getNames()) {
-			if (preferredName == null && !name.isVoided()) {
+			if (preferredName == null && !name.getVoided()) {
 				name.setPreferred(true);
 				preferredName = name;
 				continue;
@@ -173,12 +173,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		PersonAddress preferredAddress = null;
 		PersonAddress possiblePreferredAddress = patient.getPersonAddress();
 		if (possiblePreferredAddress != null && possiblePreferredAddress.getPreferred()
-		        && !possiblePreferredAddress.isVoided()) {
+		        && !possiblePreferredAddress.getVoided()) {
 			preferredAddress = possiblePreferredAddress;
 		}
 		
 		for (PersonAddress address : patient.getAddresses()) {
-			if (preferredAddress == null && !address.isVoided()) {
+			if (preferredAddress == null && !address.getVoided()) {
 				address.setPreferred(true);
 				preferredAddress = address;
 				continue;
@@ -263,7 +263,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Transactional(readOnly = true)
 	public void checkPatientIdentifiers(Patient patient) throws PatientIdentifierException {
 		// check patient has at least one identifier
-		if (!patient.isVoided() && patient.getActiveIdentifiers().isEmpty()) {
+		if (!patient.getVoided() && patient.getActiveIdentifiers().isEmpty()) {
 			throw new InsufficientIdentifiersException("At least one nonvoided Patient Identifier is required");
 		}
 		
@@ -278,7 +278,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		List<PatientIdentifierType> foundRequiredTypes = new ArrayList<PatientIdentifierType>();
 		
 		for (PatientIdentifier pi : identifiers) {
-			if (pi.isVoided()) {
+			if (pi.getVoided()) {
 				continue;
 			}
 			
@@ -679,7 +679,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		}
 		// iterate over notPreferred's relationships and only copy them if they are needed
 		for (Relationship rel : personService.getRelationshipsByPerson(notPreferred)) {
-			if (!rel.isVoided()) {
+			if (!rel.getVoided()) {
 				boolean personAisPreferred = rel.getPersonA().equals(preferred);
 				boolean personAisNotPreferred = rel.getPersonA().equals(notPreferred);
 				boolean personBisPreferred = rel.getPersonB().equals(preferred);
@@ -723,7 +723,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		// TODO: this should be a copy, not a move
 		ObsService obsService = Context.getObsService();
 		for (Obs obs : obsService.getObservationsByPerson(notPreferred)) {
-			if (obs.getEncounter() == null && !obs.isVoided()) {
+			if (obs.getEncounter() == null && !obs.getVoided()) {
 				obs.setPerson(preferred);
 				Obs persisted = obsService.saveObs(obs, "Merged from patient #" + notPreferred.getPatientId());
 				mergedData.addMovedIndependentObservation(persisted.getUuid());
@@ -792,7 +792,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	private void mergePersonAttributes(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
 		// copy person attributes
 		for (PersonAttribute attr : notPreferred.getAttributes()) {
-			if (!attr.isVoided()) {
+			if (!attr.getVoided()) {
 				PersonAttribute tmpAttr = attr.copy();
 				tmpAttr.setPerson(null);
 				tmpAttr.setUuid(UUID.randomUUID().toString());
@@ -870,7 +870,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		
 		// copy person attributes
 		for (PersonAttribute attr : notPreferred.getAttributes()) {
-			if (!attr.isVoided()) {
+			if (!attr.getVoided()) {
 				PersonAttribute tmpAttr = attr.copy();
 				tmpAttr.setPerson(null);
 				tmpAttr.setUuid(UUID.randomUUID().toString());

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -296,12 +296,12 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 	public Person savePerson(Person person) throws APIException {
 		PersonName preferredName = null;
 		PersonName possiblePreferredName = person.getPersonName();
-		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.isVoided()) {
+		if (possiblePreferredName != null && possiblePreferredName.getPreferred() && !possiblePreferredName.getVoided()) {
 			preferredName = possiblePreferredName;
 		}
 		
 		for (PersonName name : person.getNames()) {
-			if (preferredName == null && !name.isVoided()) {
+			if (preferredName == null && !name.getVoided()) {
 				name.setPreferred(true);
 				preferredName = name;
 				continue;
@@ -315,12 +315,12 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 		PersonAddress preferredAddress = null;
 		PersonAddress possiblePreferredAddress = person.getPersonAddress();
 		if (possiblePreferredAddress != null && possiblePreferredAddress.getPreferred()
-		        && !possiblePreferredAddress.isVoided()) {
+		        && !possiblePreferredAddress.getVoided()) {
 			preferredAddress = possiblePreferredAddress;
 		}
 		
 		for (PersonAddress address : person.getAddresses()) {
-			if (preferredAddress == null && !address.isVoided()) {
+			if (preferredAddress == null && !address.getVoided()) {
 				address.setPreferred(true);
 				preferredAddress = address;
 				continue;
@@ -478,7 +478,7 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 	 */
 	@Override
 	public Relationship voidRelationship(Relationship relationship, String voidReason) throws APIException {
-		if (relationship.isVoided()) {
+		if (relationship.getVoided()) {
 			return relationship;
 		}
 		

--- a/api/src/main/java/org/openmrs/attribute/BaseAttribute.java
+++ b/api/src/main/java/org/openmrs/attribute/BaseAttribute.java
@@ -136,7 +136,7 @@ public abstract class BaseAttribute<AT extends AttributeType, OwningType extends
 		if (other == null) {
 			return -1;
 		}
-		int retValue = isVoided().compareTo(other.isVoided());
+		int retValue = getVoided().compareTo(other.getVoided());
 		if (retValue == 0) {
 			retValue = OpenmrsUtil.compareWithNullAsGreatest(getAttributeType().getId(), other.getAttributeType().getId());
 		}

--- a/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
@@ -686,11 +686,11 @@ public class ConceptValidatorChangeSet implements CustomTaskChange {
 				pStmt.setString(2, (conceptName.getConceptNameType() != null) ? conceptName.getConceptNameType().toString()
 				        : null);
 				pStmt.setBoolean(3, conceptName.isLocalePreferred());
-				pStmt.setBoolean(4, conceptName.isVoided());
-				pStmt.setDate(5, conceptName.isVoided() ? new Date(System.currentTimeMillis()) : null);
+				pStmt.setBoolean(4, conceptName.getVoided());
+				pStmt.setDate(5, conceptName.getVoided() ? new Date(System.currentTimeMillis()) : null);
 				pStmt.setString(6, conceptName.getVoidReason());
 				// "Not all databases allow for a non-typed Null to be sent to the backend", so we can't use setInt
-				pStmt.setObject(7, (conceptName.isVoided() && userId != null) ? userId : null, Types.INTEGER);
+				pStmt.setObject(7, (conceptName.getVoided() && userId != null) ? userId : null, Types.INTEGER);
 				pStmt.setInt(8, conceptName.getConceptNameId());
 				
 				pStmt.addBatch();

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -65,14 +65,14 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(2, allCohorts.size());
-		assertTrue(allCohorts.get(0).isVoided());
-		assertFalse(allCohorts.get(1).isVoided());
+		assertTrue(allCohorts.get(0).getVoided());
+		assertFalse(allCohorts.get(1).getVoided());
 		
 		// now do the actual test: getCohort by name and expect a non voided cohort
 		Cohort exampleCohort = service.getCohort("Example Cohort");
 		assertNotNull(exampleCohort);
 		assertEquals(1, exampleCohort.size());
-		assertFalse(exampleCohort.isVoided());
+		assertFalse(exampleCohort.getVoided());
 	}
 	
 	/**
@@ -185,12 +185,12 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		// Get a non-voided, valid Cohort and try to void it with a null reason
 		Cohort exampleCohort = service.getCohort("Example Cohort");
 		assertNotNull(exampleCohort);
-		assertFalse(exampleCohort.isVoided());
+		assertFalse(exampleCohort.getVoided());
 		
 		// Now get the Cohort and try to void it with an empty reason
 		exampleCohort = service.getCohort("Example Cohort");
 		assertNotNull(exampleCohort);
-		assertFalse(exampleCohort.isVoided());
+		assertFalse(exampleCohort.getVoided());
 		
 		try {
 			service.voidCohort(exampleCohort, "");
@@ -211,7 +211,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		// Get a non-voided, valid Cohort and try to void it with a null reason
 		Cohort exampleCohort = service.getCohort("Example Cohort");
 		assertNotNull(exampleCohort);
-		assertFalse(exampleCohort.isVoided());
+		assertFalse(exampleCohort.getVoided());
 		
 		try {
 			service.voidCohort(exampleCohort, null);
@@ -222,7 +222,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		// Now get the Cohort and try to void it with an empty reason
 		exampleCohort = service.getCohort("Example Cohort");
 		assertNotNull(exampleCohort);
-		assertFalse(exampleCohort.isVoided());
+		assertFalse(exampleCohort.getVoided());
 		
 		try {
 			service.voidCohort(exampleCohort, "");
@@ -244,7 +244,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(2, allCohorts.size());
-		assertTrue(allCohorts.get(0).isVoided());
+		assertTrue(allCohorts.get(0).getVoided());
 		
 		// Make sure the void reason is different from the reason to be given in the test
 		assertNotNull(allCohorts.get(0).getVoidReason());
@@ -272,11 +272,11 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(2, allCohorts.size());
-		assertFalse(allCohorts.get(1).isVoided());
+		assertFalse(allCohorts.get(1).getVoided());
 		
 		// now void the cohort and see if it's voided
 		Cohort voidedCohort = service.voidCohort(allCohorts.get(1), "voided for Test");
-		assertTrue(allCohorts.get(1).isVoided());
+		assertTrue(allCohorts.get(1).getVoided());
 	}
 	
 	/**
@@ -319,8 +319,8 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(allCohorts.get(0).getName(), allCohorts.get(1).getName());
-		assertTrue(allCohorts.get(0).isVoided());
-		assertFalse(allCohorts.get(1).isVoided());
+		assertTrue(allCohorts.get(0).getVoided());
+		assertFalse(allCohorts.get(1).getVoided());
 		// the non-voided cohort should have an id of 2
 		assertTrue(allCohorts.get(1).getCohortId() == 2);
 		
@@ -344,7 +344,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		assertNotNull(allCohorts);
 		// there is only one non-voided cohort in the data set
 		assertEquals(1, allCohorts.size());
-		assertFalse(allCohorts.get(0).isVoided());
+		assertFalse(allCohorts.get(0).getVoided());
 	}
 	
 	/**
@@ -360,15 +360,15 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(2, allCohorts.size());
-		assertTrue(allCohorts.get(0).isVoided());
-		assertFalse(allCohorts.get(1).isVoided());
+		assertTrue(allCohorts.get(0).getVoided());
+		assertFalse(allCohorts.get(1).getVoided());
 		
 		// now call the target method and see if the voided cohort shows up
 		allCohorts = service.getAllCohorts();
 		assertNotNull(allCohorts);
 		// only the non-voided cohort should be returned
 		assertEquals(1, allCohorts.size());
-		assertFalse(allCohorts.get(0).isVoided());
+		assertFalse(allCohorts.get(0).getVoided());
 	}
 	
 	/**
@@ -384,15 +384,15 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		List<Cohort> allCohorts = service.getAllCohorts(true);
 		assertNotNull(allCohorts);
 		assertEquals(2, allCohorts.size());
-		assertTrue(allCohorts.get(0).isVoided());
-		assertFalse(allCohorts.get(1).isVoided());
+		assertTrue(allCohorts.get(0).getVoided());
+		assertFalse(allCohorts.get(1).getVoided());
 		
 		// if called with false parameter, should not return the voided one
 		allCohorts = service.getAllCohorts(false);
 		assertNotNull(allCohorts);
 		// only the non-voided cohort should be returned
 		assertEquals(1, allCohorts.size());
-		assertFalse(allCohorts.get(0).isVoided());
+		assertFalse(allCohorts.get(0).getVoided());
 	}
 	
 	/**
@@ -420,8 +420,8 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		executeDataSet(COHORT_XML);
 		
 		// make sure we have two cohorts, the first of which is voided
-		assertTrue(service.getCohort(1).isVoided());
-		assertFalse(service.getCohort(2).isVoided());
+		assertTrue(service.getCohort(1).getVoided());
+		assertFalse(service.getCohort(2).getVoided());
 		
 		// add a patient to both cohorts
 		Patient patientToAdd = new Patient(7);

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -1652,7 +1652,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should void the conceptName if the text of the name has changed", method = "saveConcept(Concept)")
 	public void saveConcept_shouldVoidTheConceptNameIfTheTextOfTheNameHasChanged() throws Exception {
 		Concept concept = conceptService.getConceptByName("cd4 count");
-		Assert.assertEquals(false, conceptService.getConceptName(1847).isVoided().booleanValue());
+		Assert.assertEquals(false, conceptService.getConceptName(1847).getVoided().booleanValue());
 		for (ConceptName cn : concept.getNames()) {
 			if (cn.getConceptNameId().equals(1847))
 				cn.setName("new name");
@@ -1660,7 +1660,7 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		//ensure that the conceptName has actually been found and replaced
 		Assert.assertEquals(true, concept.hasName("new name", new Locale("en", "GB")));
 		conceptService.saveConcept(concept);
-		Assert.assertEquals(true, conceptService.getConceptName(1847).isVoided().booleanValue());
+		Assert.assertEquals(true, conceptService.getConceptName(1847).getVoided().booleanValue());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -274,37 +274,37 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		//unvoid:
 		obsThatWasVoided.setVoided(false);
-		assertFalse(obsThatWasVoided.isVoided());
+		assertFalse(obsThatWasVoided.getVoided());
 		
 		//Now test voiding cascade:
 		// i.e. by voiding the grandparent, we void the n-th generation leaf obs
 		os.voidObs(oGGGPThatWasUpdated, "testing void cascade");
-		assertTrue(oGGGPThatWasUpdated.isVoided());
+		assertTrue(oGGGPThatWasUpdated.getVoided());
 		
 		Obs childLeafObs = os.getObs(childOneId);
-		assertTrue(childLeafObs.isVoided());
+		assertTrue(childLeafObs.getVoided());
 		
 		//now test the un-void:
 		os.unvoidObs(oGGGPThatWasUpdated);
-		assertFalse(oGGGPThatWasUpdated.isVoided());
-		assertFalse(childLeafObs.isVoided());
+		assertFalse(oGGGPThatWasUpdated.getVoided());
+		assertFalse(childLeafObs.getVoided());
 		
 		//test this again using just the os.updateObs method on the great great grandparent:
 		
 		os.voidObs(oGGGPThatWasUpdated, "testing void cascade");
 		childLeafObs = os.getObs(childOneId);
-		assertTrue(childLeafObs.isVoided());
+		assertTrue(childLeafObs.getVoided());
 		
 		os.unvoidObs(oGGGPThatWasUpdated);
 		childLeafObs = os.getObs(childOneId);
-		assertFalse(childLeafObs.isVoided());
+		assertFalse(childLeafObs.getVoided());
 		
 		//now, test the feature that unvoid doesn't happen unless child obs has the same dateVoided as
 		// the Obj argument that gets passed into unvoid:
 		
 		os.voidObs(oGGGPThatWasUpdated, "testing void cascade");
 		childLeafObs = os.getObs(childOneId);
-		assertTrue(childLeafObs.isVoided());
+		assertTrue(childLeafObs.getVoided());
 		
 		childLeafObs.setDateVoided(new Date(childLeafObs.getDateVoided().getTime() - 5000));
 		//os.saveObs(childLeafObs, "saving child leaf obs");
@@ -785,7 +785,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		// fetch the obs from the database again
 		obs = Context.getObsService().getObs(7);
-		Assert.assertTrue(obs.isVoided());
+		Assert.assertTrue(obs.getVoided());
 	}
 	
 	/**
@@ -1475,8 +1475,8 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		obsService.voidObs(parentObs, "testing void cascade to child obs groups");
 		
-		Assert.assertTrue(obsService.getObs(9).isVoided());
-		Assert.assertTrue(obsService.getObs(10).isVoided());
+		Assert.assertTrue(obsService.getObs(9).getVoided());
+		Assert.assertTrue(obsService.getObs(10).getVoided());
 	}
 	
 	/**
@@ -1491,7 +1491,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		obsService.unvoidObs(obs);
 		
-		assertFalse(obs.isVoided());
+		assertFalse(obs.getVoided());
 	}
 	
 	/**
@@ -1519,7 +1519,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		obsService.voidObs(obs, "testing void function");
 		
-		assertTrue(obs.isVoided());
+		assertTrue(obs.getVoided());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -1057,7 +1057,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	public void discontinueOrder_shouldFailForAVoidedOrder() throws Exception {
 		Order orderToDiscontinue = orderService.getOrder(8);
 		Encounter encounter = encounterService.getEncounter(3);
-		assertTrue(orderToDiscontinue.isVoided());
+		assertTrue(orderToDiscontinue.getVoided());
 		expectedException.expect(CannotDiscontinueAlreadyDiscontinuedOrderException.class);
 		expectedException.expectMessage("Order.stopped.cannot.discontinued");
 		orderService.discontinueOrder(orderToDiscontinue, "testing", null, null, encounter);
@@ -1165,7 +1165,7 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void saveOrder_shouldNotAllowRevisingAVoidedOrder() throws Exception {
 		Order originalOrder = orderService.getOrder(8);
-		assertTrue(originalOrder.isVoided());
+		assertTrue(originalOrder.getVoided());
 		Order revisedOrder = originalOrder.cloneForRevision();
 		revisedOrder.setEncounter(encounterService.getEncounter(6));
 		revisedOrder.setInstructions("Take after a meal");

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -720,7 +720,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient notPreferred = patientService.getPatient(2);
 		voidOrders(Collections.singleton(notPreferred));
 		Context.getPatientService().mergePatients(patientService.getPatient(6), notPreferred);
-		Assert.assertTrue(Context.getPersonService().getPerson(2).isVoided());
+		Assert.assertTrue(Context.getPersonService().getPerson(2).getVoided());
 	}
 	
 	/**
@@ -886,7 +886,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 			// XYZ
 			Patient p = patientService.getPatient(999);
 			Assert.assertNotNull(p);
-			Assert.assertTrue(p.isVoided());
+			Assert.assertTrue(p.getVoided());
 			boolean found = false;
 			for (PatientIdentifier id : p.getIdentifiers()) {
 				if (id.getIdentifier().equals("XYZ") && id.getIdentifierType().getId() == 2) {
@@ -1519,13 +1519,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		
 		Patient voidedPatient = Context.getPatientService().voidPatient(patient, "Void for testing");
-		Assert.assertTrue(voidedPatient.isVoided());
+		Assert.assertTrue(voidedPatient.getVoided());
 		Assert.assertNotNull(voidedPatient.getVoidedBy());
 		Assert.assertNotNull(voidedPatient.getVoidReason());
 		Assert.assertNotNull(voidedPatient.getDateVoided());
 		
 		Patient unvoidedPatient = Context.getPatientService().unvoidPatient(voidedPatient);
-		Assert.assertFalse(unvoidedPatient.isVoided());
+		Assert.assertFalse(unvoidedPatient.getVoided());
 		Assert.assertNull(unvoidedPatient.getVoidedBy());
 		Assert.assertNull(unvoidedPatient.getVoidReason());
 		Assert.assertNull(unvoidedPatient.getDateVoided());
@@ -1540,13 +1540,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		
 		Patient voidedPatient = Context.getPatientService().voidPatient(patient, "Void for testing");
-		Assert.assertTrue(voidedPatient.isVoided());
+		Assert.assertTrue(voidedPatient.getVoided());
 		Assert.assertNotNull(voidedPatient.getVoidedBy());
 		Assert.assertNotNull(voidedPatient.getVoidReason());
 		Assert.assertNotNull(voidedPatient.getDateVoided());
 		
 		Patient unvoidedPatient = Context.getPatientService().unvoidPatient(voidedPatient);
-		Assert.assertFalse(unvoidedPatient.isVoided());
+		Assert.assertFalse(unvoidedPatient.getVoided());
 		Assert.assertNull(unvoidedPatient.getVoidedBy());
 		Assert.assertNull(unvoidedPatient.getVoidReason());
 		Assert.assertNull(unvoidedPatient.getDateVoided());
@@ -1561,7 +1561,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		Patient voidedPatient = Context.getPatientService().voidPatient(patient, "Void for testing");
 		
-		Assert.assertTrue(voidedPatient.isVoided());
+		Assert.assertTrue(voidedPatient.getVoided());
 		Assert.assertEquals("Void for testing", voidedPatient.getVoidReason());
 	}
 	
@@ -1574,7 +1574,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		Patient voidedPatient = Context.getPatientService().voidPatient(patient, "Void for testing");
 		for (PatientIdentifier patientIdentifier : voidedPatient.getIdentifiers()) {
-			Assert.assertTrue(patientIdentifier.isVoided());
+			Assert.assertTrue(patientIdentifier.getVoided());
 			Assert.assertNotNull(patientIdentifier.getVoidedBy());
 			Assert.assertNotNull(patientIdentifier.getVoidReason());
 			Assert.assertNotNull(patientIdentifier.getDateVoided());
@@ -1591,7 +1591,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		Patient patient = Context.getPatientService().getPatient(2);
 		Patient voidedPatient = Context.getPatientService().voidPatient(patient, "Void for testing");
 		
-		Assert.assertTrue(voidedPatient.isVoided());
+		Assert.assertTrue(voidedPatient.getVoided());
 		Assert.assertNotNull(voidedPatient.getVoidedBy());
 		Assert.assertNotNull(voidedPatient.getVoidReason());
 		Assert.assertNotNull(voidedPatient.getDateVoided());
@@ -1845,16 +1845,16 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	public void getPatientIdentifiers_shouldReturnOnlyNonVoidedPatientsAndPatientIdentifiers() throws Exception {
 		// sanity check. make sure there is at least one voided patient
 		Patient patient = patientService.getPatient(999);
-		Assert.assertTrue("This patient should be voided", patient.isVoided());
+		Assert.assertTrue("This patient should be voided", patient.getVoided());
 		Assert.assertFalse("This test expects the patient to be voided BUT the identifier to be NONvoided",
-		    ((PatientIdentifier) (patient.getIdentifiers().toArray()[0])).isVoided());
+		    ((PatientIdentifier) (patient.getIdentifiers().toArray()[0])).getVoided());
 		
 		// now fetch all identifiers
 		List<PatientIdentifier> patientIdentifiers = patientService.getPatientIdentifiers(null, null, null, null, null);
 		for (PatientIdentifier patientIdentifier : patientIdentifiers) {
-			Assert.assertFalse("No voided identifiers should be returned", patientIdentifier.isVoided());
+			Assert.assertFalse("No voided identifiers should be returned", patientIdentifier.getVoided());
 			Assert.assertFalse("No identifiers of voided patients should be returned", patientIdentifier.getPatient()
-			        .isVoided());
+			        .getVoided());
 		}
 	}
 	
@@ -2050,7 +2050,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		authenticate();
 		
 		// verify patient is voided
-		assertTrue(patientService.getPatient(3).isVoided());
+		assertTrue(patientService.getPatient(3).getVoided());
 		// ask for list of patients with this name, expect none back because
 		// patient is voided
 		List<Patient> patients = patientService.getPatients("I am voided", null, null, false);
@@ -2249,9 +2249,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		notPreferred.add(patientService.getPatient(8));
 		voidOrders(notPreferred);
 		patientService.mergePatients(preferred, notPreferred);
-		Assert.assertFalse(patientService.getPatient(6).isVoided());
-		Assert.assertTrue(patientService.getPatient(7).isVoided());
-		Assert.assertTrue(patientService.getPatient(8).isVoided());
+		Assert.assertFalse(patientService.getPatient(6).getVoided());
+		Assert.assertTrue(patientService.getPatient(7).getVoided());
+		Assert.assertTrue(patientService.getPatient(8).getVoided());
 	}
 	
 	private void assertEqualsInt(int expected, Integer actual) throws Exception {

--- a/api/src/test/java/org/openmrs/api/PersonServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PersonServiceTest.java
@@ -616,7 +616,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 		boolean foundVoided = false;
 		for (Relationship relationship : relationships) {
-			if (relationship.isVoided()) {
+			if (relationship.getVoided()) {
 				foundVoided = true;
 				break;
 			}
@@ -640,7 +640,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 		boolean foundVoided = false;
 		for (Relationship relationship : relationships) {
-			if (relationship.isVoided()) {
+			if (relationship.getVoided()) {
 				foundVoided = true;
 				break;
 			}
@@ -665,7 +665,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 		boolean foundVoided = false;
 		for (Relationship relationship : relationships) {
-			if (relationship.isVoided()) {
+			if (relationship.getVoided()) {
 				foundVoided = true;
 				break;
 			}
@@ -1604,12 +1604,12 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		executeDataSet("org/openmrs/api/include/PersonServiceTest-createPersonPurgeVoidTest.xml");
 		Person person = Context.getPersonService().getPerson(1002);
 		
-		Assert.assertTrue(person.isVoided());
+		Assert.assertTrue(person.getVoided());
 		Assert.assertNotNull(person.getDateVoided());
 		
 		Person unvoidedPerson = Context.getPersonService().unvoidPerson(person);
 		
-		Assert.assertFalse(unvoidedPerson.isVoided());
+		Assert.assertFalse(unvoidedPerson.getVoided());
 		Assert.assertNull(unvoidedPerson.getVoidedBy());
 		Assert.assertNull(unvoidedPerson.getPersonVoidReason());
 		Assert.assertNull(unvoidedPerson.getPersonDateVoided());
@@ -1625,14 +1625,14 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		Relationship voidedRelationship = Context.getPersonService().voidRelationship(relationship,
 		    "Test Voiding Relationship");
 		
-		Assert.assertTrue(voidedRelationship.isVoided());
+		Assert.assertTrue(voidedRelationship.getVoided());
 		Assert.assertNotNull(voidedRelationship.getVoidedBy());
 		Assert.assertNotNull(voidedRelationship.getVoidReason());
 		Assert.assertNotNull(voidedRelationship.getDateVoided());
 		
 		Relationship unvoidedRelationship = Context.getPersonService().unvoidRelationship(voidedRelationship);
 		
-		Assert.assertFalse(unvoidedRelationship.isVoided());
+		Assert.assertFalse(unvoidedRelationship.getVoided());
 		Assert.assertNull(unvoidedRelationship.getVoidedBy());
 		Assert.assertNull(unvoidedRelationship.getVoidReason());
 		Assert.assertNull(unvoidedRelationship.getDateVoided());
@@ -1653,7 +1653,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 		Person voidedPerson = Context.getPersonService().getPerson(1001);
 		
-		Assert.assertTrue(voidedPerson.isVoided());
+		Assert.assertTrue(voidedPerson.getVoided());
 		Assert.assertNotNull(voidedPerson.getVoidedBy());
 		Assert.assertNotNull(voidedPerson.getPersonVoidReason());
 		Assert.assertNotNull(voidedPerson.getPersonDateVoided());
@@ -1670,7 +1670,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		Relationship voidedRelationship = Context.getPersonService().voidRelationship(relationship,
 		    "Test Voiding Relationship");
 		
-		Assert.assertTrue(voidedRelationship.isVoided());
+		Assert.assertTrue(voidedRelationship.getVoided());
 		Assert.assertNotNull(voidedRelationship.getVoidedBy());
 		Assert.assertNotNull(voidedRelationship.getVoidReason());
 		Assert.assertNotNull(voidedRelationship.getDateVoided());
@@ -1874,11 +1874,11 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		executeDataSet("org/openmrs/api/include/PersionServiceTest-voidUnvoidPersonName.xml");
 		PersonName personName = Context.getPersonService().getPersonNameByUuid("5e6571cc-c7f2-41de-b289-f55f8fe79c6f");
 		
-		Assert.assertFalse(personName.isVoided());
+		Assert.assertFalse(personName.getVoided());
 		
 		PersonName voidedPersonName = Context.getPersonService().voidPersonName(personName, "Test Voiding PersonName");
 		
-		Assert.assertTrue(voidedPersonName.isVoided());
+		Assert.assertTrue(voidedPersonName.getVoided());
 		Assert.assertNotNull(voidedPersonName.getVoidedBy());
 		Assert.assertNotNull(voidedPersonName.getDateVoided());
 		Assert.assertEquals(voidedPersonName.getVoidReason(), "Test Voiding PersonName");
@@ -1893,11 +1893,11 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		executeDataSet("org/openmrs/api/include/PersionServiceTest-voidUnvoidPersonName.xml");
 		PersonName voidedPersonName = Context.getPersonService().getPersonNameByUuid("a6ghgh7e-1384-493a-a55b-d325924acd94");
 		
-		Assert.assertTrue(voidedPersonName.isVoided());
+		Assert.assertTrue(voidedPersonName.getVoided());
 		
 		PersonName unvoidedPersonName = Context.getPersonService().unvoidPersonName(voidedPersonName);
 		
-		Assert.assertFalse(unvoidedPersonName.isVoided());
+		Assert.assertFalse(unvoidedPersonName.getVoided());
 		Assert.assertNull(unvoidedPersonName.getVoidedBy());
 		Assert.assertNull(unvoidedPersonName.getDateVoided());
 		Assert.assertNull(unvoidedPersonName.getVoidReason());
@@ -1913,7 +1913,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 	public void savePersonName_shouldFailIfYouTryToVoidTheLastNonVoidedName() throws Exception {
 		executeDataSet("org/openmrs/api/include/PersionServiceTest-voidUnvoidPersonName.xml");
 		PersonName personName = Context.getPersonService().getPersonNameByUuid("39ghgh7b-6482-487d-94ce-c07bb3ca3cc1");
-		Assert.assertFalse(personName.isVoided());
+		Assert.assertFalse(personName.getVoided());
 		Context.getPersonService().voidPersonName(personName, "Test Voiding PersonName");
 	}
 	
@@ -1927,12 +1927,12 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		PersonAddress personAddress = Context.getPersonService().getPersonAddressByUuid(
 		    "33ghd0b5-821c-4e5e-ad1d-a9bce331e118");
 		
-		Assert.assertFalse(personAddress.isVoided());
+		Assert.assertFalse(personAddress.getVoided());
 		
 		PersonAddress voidedPersonAddress = Context.getPersonService().voidPersonAddress(personAddress,
 		    "Test Voiding PersonAddress");
 		
-		Assert.assertTrue(voidedPersonAddress.isVoided());
+		Assert.assertTrue(voidedPersonAddress.getVoided());
 		Assert.assertNotNull(voidedPersonAddress.getVoidedBy());
 		Assert.assertNotNull(voidedPersonAddress.getDateVoided());
 		Assert.assertEquals(voidedPersonAddress.getVoidReason(), "Test Voiding PersonAddress");
@@ -1948,11 +1948,11 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		PersonAddress voidedPersonAddress = Context.getPersonService().getPersonAddressByUuid(
 		    "33ghghb5-821c-4e5e-ad1d-a9bce331e777");
 		
-		Assert.assertTrue(voidedPersonAddress.isVoided());
+		Assert.assertTrue(voidedPersonAddress.getVoided());
 		
 		PersonAddress unvoidedPersonAddress = Context.getPersonService().unvoidPersonAddress(voidedPersonAddress);
 		
-		Assert.assertFalse(unvoidedPersonAddress.isVoided());
+		Assert.assertFalse(unvoidedPersonAddress.getVoided());
 		Assert.assertNull(unvoidedPersonAddress.getVoidedBy());
 		Assert.assertNull(unvoidedPersonAddress.getDateVoided());
 		Assert.assertNull(unvoidedPersonAddress.getVoidReason());
@@ -1992,7 +1992,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		personService.unvoidPerson(person);
 		
 		//then
-		Assert.assertFalse(person.isVoided());
+		Assert.assertFalse(person.getVoided());
 	}
 	
 	/**
@@ -2027,7 +2027,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		personService.voidPerson(person, "reason");
 		
 		//then
-		Assert.assertTrue(person.isVoided());
+		Assert.assertTrue(person.getVoided());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
@@ -380,7 +380,7 @@ public class PatientDAOTest extends BaseContextSensitiveTest {
 		Assert.assertEquals(8, patientIdentifiers.size());
 		
 		for (PatientIdentifier patientIdentifier : patientIdentifiers) {
-			Assert.assertFalse(patientIdentifier.isVoided());
+			Assert.assertFalse(patientIdentifier.getVoided());
 		}
 	}
 	

--- a/api/src/test/java/org/openmrs/api/db/hibernate/PersonAttributeHelper.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/PersonAttributeHelper.java
@@ -44,7 +44,7 @@ public class PersonAttributeHelper {
 		PersonAttribute personAttribute = getPersonAttribute(getPersonAttributeList(QUERY_ALL_VOIDED_PERSON_ATTRIBUTES),
 		    value);
 		if (personAttribute != null) {
-			return personAttribute.isVoided();
+			return personAttribute.getVoided();
 		}
 		return false;
 	}

--- a/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
@@ -33,7 +33,7 @@ public class BaseUnvoidHandlerTest {
 		Voidable voidable = new Person();
 		voidable.setVoided(true); // make sure isVoided is set
 		handler.handle(voidable, null, null, null);
-		Assert.assertFalse(voidable.isVoided());
+		Assert.assertFalse(voidable.getVoided());
 	}
 	
 	/**
@@ -105,6 +105,6 @@ public class BaseUnvoidHandlerTest {
 		voidable.setDateVoided(d);
 		
 		handler.handle(voidable, null, new Date(), "SOME REASON");
-		Assert.assertTrue(voidable.isVoided());
+		Assert.assertTrue(voidable.getVoided());
 	}
 }

--- a/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
@@ -33,7 +33,7 @@ public class BaseVoidHandlerTest {
 		Voidable voidable = new Person();
 		voidable.setVoided(false); // make sure isVoided is false
 		handler.handle(voidable, null, null, " ");
-		Assert.assertTrue(voidable.isVoided());
+		Assert.assertTrue(voidable.getVoided());
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
@@ -42,7 +42,7 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 	public void handle_shouldUnvoidTheOrdersAndEncountersAssociatedWithThePatient() throws Exception {
 		Patient patient = Context.getPatientService().getPatient(7);
 		patient = Context.getPatientService().voidPatient(patient, "Void Reason");
-		Assert.assertTrue(patient.isVoided());
+		Assert.assertTrue(patient.getVoided());
 		
 		EncounterService es = Context.getEncounterService();
 		EncounterSearchCriteria encounterSearchCriteria = new EncounterSearchCriteriaBuilder()
@@ -53,7 +53,7 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		Assert.assertTrue(CollectionUtils.isNotEmpty(encounters));
 		//all encounters void related fields should be null
 		for (Encounter encounter : encounters) {
-			Assert.assertTrue(encounter.isVoided());
+			Assert.assertTrue(encounter.getVoided());
 			Assert.assertNotNull(encounter.getDateVoided());
 			Assert.assertNotNull(encounter.getVoidedBy());
 			Assert.assertNotNull(encounter.getVoidReason());
@@ -64,7 +64,7 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		Assert.assertFalse(orders.isEmpty());
 		//all order void related fields should be null
 		for (Order order : orders) {
-			Assert.assertTrue(order.isVoided());
+			Assert.assertTrue(order.getVoided());
 			Assert.assertNotNull(order.getDateVoided());
 			Assert.assertNotNull(order.getVoidedBy());
 			Assert.assertNotNull(order.getVoidReason());
@@ -75,13 +75,13 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		
 		//check that the voided related fields were set null 
 		for (Encounter encounter : encounters) {
-			Assert.assertFalse(encounter.isVoided());
+			Assert.assertFalse(encounter.getVoided());
 			Assert.assertNull(encounter.getDateVoided());
 			Assert.assertNull(encounter.getVoidedBy());
 			Assert.assertNull(encounter.getVoidReason());
 		}
 		for (Order order : orders) {
-			Assert.assertFalse(order.isVoided());
+			Assert.assertFalse(order.getVoided());
 			Assert.assertNull(order.getDateVoided());
 			Assert.assertNull(order.getVoidedBy());
 			Assert.assertNull(order.getVoidReason());
@@ -102,7 +102,7 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		
 		Encounter testEncounter = es.getEncountersByPatient(patient).get(0);
 		//santy checks
-		Assert.assertFalse(testEncounter.isVoided());
+		Assert.assertFalse(testEncounter.getVoided());
 		Assert.assertNull(testEncounter.getDateVoided());
 		Assert.assertNull(testEncounter.getVoidedBy());
 		Assert.assertNull(testEncounter.getVoidReason());
@@ -110,15 +110,15 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		//void one of the encounter orders be voided at a different time for testing purposes
 		Assert.assertFalse(testEncounter.getOrders().isEmpty());
 		Order testOrder = testEncounter.getOrders().iterator().next();
-		Assert.assertFalse(testOrder.isVoided());
+		Assert.assertFalse(testOrder.getVoided());
 		Context.getOrderService().voidOrder(testOrder, "testing");
-		Assert.assertTrue(testOrder.isVoided());
+		Assert.assertTrue(testOrder.getVoided());
 		TestUtil.waitForClockTick();
 		
 		//void one of the unvoided encounters for testing purposes
 		es.voidEncounter(testEncounter, "random reason");
-		Assert.assertTrue(testEncounter.isVoided());
-		Assert.assertTrue(testOrder.isVoided());
+		Assert.assertTrue(testEncounter.getVoided());
+		Assert.assertTrue(testOrder.getVoided());
 		
 		List<Patient> patients = new ArrayList<Patient>();
 		patients.add(patient);
@@ -128,17 +128,17 @@ public class PatientDataUnvoidHandlerTest extends BaseContextSensitiveTest {
 		
 		//now void the patient for testing purposes
 		patient = Context.getPatientService().voidPatient(patient, "Void Reason");
-		Assert.assertTrue(patient.isVoided());
+		Assert.assertTrue(patient.getVoided());
 		new PatientDataUnvoidHandler().handle(patient, patient.getVoidedBy(), patient.getDateVoided(), null);
 		//the encounter that was initially voided separately should still be voided
 		testEncounter = es.getEncounter(testEncounter.getId());
-		Assert.assertTrue(testEncounter.isVoided());
+		Assert.assertTrue(testEncounter.getVoided());
 		Assert.assertNotNull(testEncounter.getDateVoided());
 		Assert.assertNotNull(testEncounter.getVoidedBy());
 		Assert.assertNotNull(testEncounter.getVoidReason());
 		
 		//the order that was initially voided separately should still be voided
-		Assert.assertTrue(testOrder.isVoided());
+		Assert.assertTrue(testOrder.getVoided());
 		Assert.assertNotNull(testOrder.getDateVoided());
 		Assert.assertNotNull(testOrder.getVoidedBy());
 		Assert.assertNotNull(testOrder.getVoidReason());

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
@@ -36,7 +36,7 @@ public class PatientDataVoidHandlerTest extends BaseContextSensitiveTest {
 	@Verifies(value = "should void the orders encounters and observations associated with the patient", method = "handle(Patient,User,Date,String)")
 	public void handle_shouldVoidTheOrdersEncountersAndObservationsAssociatedWithThePatient() throws Exception {
 		Patient patient = Context.getPatientService().getPatient(7);
-		Assert.assertFalse(patient.isVoided());
+		Assert.assertFalse(patient.getVoided());
 		
 		List<Encounter> encounters = Context.getEncounterService().getEncountersByPatient(patient);
 		List<Obs> observations = Context.getObsService().getObservationsByPerson(patient);
@@ -68,21 +68,21 @@ public class PatientDataVoidHandlerTest extends BaseContextSensitiveTest {
 		
 		//all encounters void related fields should have been set
 		for (Encounter encounter : encounters) {
-			Assert.assertTrue(encounter.isVoided());
+			Assert.assertTrue(encounter.getVoided());
 			Assert.assertNotNull(encounter.getDateVoided());
 			Assert.assertNotNull(encounter.getVoidedBy());
 			Assert.assertNotNull(encounter.getVoidReason());
 		}
 		//all obs void related fields should have been set
 		for (Obs obs : observations) {
-			Assert.assertTrue(obs.isVoided());
+			Assert.assertTrue(obs.getVoided());
 			Assert.assertNotNull(obs.getDateVoided());
 			Assert.assertNotNull(obs.getVoidedBy());
 			Assert.assertNotNull(obs.getVoidReason());
 		}
 		//all order void related fields should have been set
 		for (Order order : orders) {
-			Assert.assertTrue(order.isVoided());
+			Assert.assertTrue(order.getVoided());
 			Assert.assertNotNull(order.getDateVoided());
 			Assert.assertNotNull(order.getVoidedBy());
 			Assert.assertNotNull(order.getVoidReason());


### PR DESCRIPTION
<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Voidable.isVoided is deprecated in favor of getVoided. Replace the use of isVoided

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5111
