### PR TITLE
TRUNK-5110 | Fix NPE when a provider doesn't have a role

### DIFF
--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -532,7 +533,14 @@ public class Encounter extends BaseOpenmrsData {
 		
 		return encounterProviders.stream()
 				.filter(ep -> includeVoided || !ep.getVoided())
-				.collect(Collectors.groupingBy(EncounterProvider::getEncounterRole, Collectors.mapping(EncounterProvider::getProvider, Collectors.toSet())));
+				.collect(Collectors.toMap((ep) -> (ep).getEncounterRole(),
+                                          (ep) -> {
+                                                    Set s = new HashSet<Provider>();
+                                                    s.add((ep).getProvider());
+                                                    return s; },
+                                          (ep1,ep2) -> {
+                                                         ep1.addAll(ep2);
+                                                         return  ep1; }));
 		
 	}
 	

--- a/api/src/test/java/org/openmrs/EncounterTest.java
+++ b/api/src/test/java/org/openmrs/EncounterTest.java
@@ -1126,6 +1126,24 @@ public class EncounterTest extends BaseContextSensitiveTest {
 		Assert.assertEquals(0, providersByRoles.size());
 	}
 	
+	
+	/**
+	 * @see Encounter#getProvidersByRoles()
+	 * @verifies return provider with null roles as well
+	 */
+	@Test
+	public void getProvidersByRoles_shouldReturnProvidersWithNullRole() throws Exception {
+		//given
+		Encounter encounter = new Encounter();
+		Provider provider = new Provider();
+		encounter.addProvider(null, provider);
+		//when
+		Map<EncounterRole, Set<Provider>> providersByRoles = encounter.getProvidersByRoles();
+		
+		//then
+		Assert.assertEquals(1, providersByRoles.size());
+	}
+	
 	/**
 	 * @see Encounter#setProvider(EncounterRole,Provider)
 	 * @verifies clear providers and set provider for role


### PR DESCRIPTION
Collectors.groupingby does not allow null as a key value.
Workaround is to use Collectors.toMap.

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5110

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ ] My pull request only contains one single commit.
- [ ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

