### PR TITLE
TRUNK-5114 Using different logging implementations instead of facade

### DIFF
--- a/api/src/main/java/org/openmrs/CohortMembership.java
+++ b/api/src/main/java/org/openmrs/CohortMembership.java
@@ -11,14 +11,14 @@ package org.openmrs;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CohortMembership extends BaseOpenmrsData implements Comparable<CohortMembership> {
 	
 	public static final long serialVersionUID = 0L;
 	
-	protected static final Log log = LogFactory.getLog(CohortMembership.class);
+	protected static final Logger log = LoggerFactory.getLogger(CohortMembership.class);
 
 	private Integer cohortMemberId;
 	

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -27,8 +27,6 @@ import java.util.Vector;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.ContainedIn;
 import org.hibernate.search.annotations.DocumentId;
@@ -46,6 +44,8 @@ import org.openmrs.customdatatype.CustomValueDescriptor;
 import org.openmrs.customdatatype.Customizable;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.ObjectUtils;
 
 /**
@@ -75,7 +75,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	
 	public static final long serialVersionUID = 57332L;
 	
-	private static final Log log = LogFactory.getLog(Concept.class);
+	private static final Logger log = LoggerFactory.getLogger(Concept.class);
 	
 	// Fields
 	@DocumentId

--- a/api/src/main/java/org/openmrs/ConceptProposal.java
+++ b/api/src/main/java/org/openmrs/ConceptProposal.java
@@ -11,9 +11,9 @@ package org.openmrs;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A ConceptProposal is a temporary holder for concept that should be in the system. When defining
@@ -26,7 +26,7 @@ public class ConceptProposal extends BaseOpenmrsObject {
 	
 	public static final long serialVersionUID = 57344L;
 	
-	private static final Log log = LogFactory.getLog(ConceptProposal.class);
+	private static final Logger log = LoggerFactory.getLogger(ConceptProposal.class);
 	
 	// Fields
 	

--- a/api/src/main/java/org/openmrs/ConceptStateConversion.java
+++ b/api/src/main/java/org/openmrs/ConceptStateConversion.java
@@ -9,8 +9,8 @@
  */
 package org.openmrs;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * ConceptStateConversion
@@ -19,7 +19,7 @@ public class ConceptStateConversion extends BaseOpenmrsObject {
 	
 	public static final long serialVersionUID = 3214511L;
 	
-	protected final Log log = LogFactory.getLog(ConceptStateConversion.class);
+	protected final Logger log = LoggerFactory.getLogger(ConceptStateConversion.class);
 	
 	// ******************
 	// Properties

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -22,8 +22,6 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.AllowDirectAccess;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
@@ -32,6 +30,8 @@ import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.Format;
 import org.openmrs.util.Format.FORMAT_TYPE;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An observation is a single unit of clinical information. <br>
@@ -72,7 +72,7 @@ public class Obs extends BaseOpenmrsData {
 	
 	public static final long serialVersionUID = 112342333L;
 	
-	private static final Log log = LogFactory.getLog(Obs.class);
+	private static final Logger log = LoggerFactory.getLogger(Obs.class);
 	
 	private static final String FORM_NAMESPACE_PATH_SEPARATOR = "^";
 	

--- a/api/src/main/java/org/openmrs/ObsPostLoadEventListener.java
+++ b/api/src/main/java/org/openmrs/ObsPostLoadEventListener.java
@@ -13,14 +13,14 @@ import java.lang.reflect.Field;
 
 import javax.annotation.PostConstruct;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.internal.SessionFactoryImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class ObsPostLoadEventListener implements PostLoadEventListener {
 	
-	private static final Log log = LogFactory.getLog(ObsPostLoadEventListener.class);
+	private static final Logger log = LoggerFactory.getLogger(ObsPostLoadEventListener.class);
 	
 	@Autowired
 	private SessionFactory sessionFactory;

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -13,8 +13,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Boost;
@@ -25,6 +23,8 @@ import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
 import org.openmrs.api.db.hibernate.search.LuceneAnalyzers;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A <code>Patient</code> can have zero to n identifying PatientIdentifier(s). PatientIdentifiers
@@ -39,7 +39,7 @@ public class PatientIdentifier extends BaseOpenmrsData implements java.io.Serial
 	
 	public static final long serialVersionUID = 1123121L;
 	
-	private static final Log log = LogFactory.getLog(PatientIdentifier.class);
+	private static final Logger log = LoggerFactory.getLogger(PatientIdentifier.class);
 	
 	// Fields
 	

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -20,13 +20,13 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.ContainedIn;
 import org.hibernate.search.annotations.DocumentId;
 import org.hibernate.search.annotations.Field;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -41,7 +41,7 @@ public class Person extends BaseOpenmrsData {
 	
 	public static final long serialVersionUID = 2L;
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 
 	@DocumentId
 	protected Integer personId;
@@ -260,7 +260,7 @@ public class Person extends BaseOpenmrsData {
             try {
                 return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(birthDateString + " " + birthTimeString);
             } catch (ParseException e) {
-                log.error(e);
+				log.error("Failed to parse birth date string", e);
             }
         }
         return null;

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -16,10 +16,10 @@ import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is the representation of a person's address. This class is many-to-one to the Person
@@ -29,7 +29,7 @@ public class PersonAddress extends BaseOpenmrsData implements java.io.Serializab
 	
 	public static final long serialVersionUID = 343333L;
 	
-	private static final Log log = LogFactory.getLog(PersonAddress.class);
+	private static final Logger log = LoggerFactory.getLogger(PersonAddress.class);
 	
 	// Fields
 

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -15,8 +15,6 @@ import java.util.Comparator;
 import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Boost;
 import org.hibernate.search.annotations.DocumentId;
@@ -28,6 +26,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.db.hibernate.search.LuceneAnalyzers;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A PersonAttribute is meant as way for implementations to add arbitrary information about a
@@ -45,7 +45,7 @@ public class PersonAttribute extends BaseOpenmrsData implements java.io.Serializ
 	
 	public static final long serialVersionUID = 11231211232111L;
 	
-	private static final Log log = LogFactory.getLog(PersonAttribute.class);
+	private static final Logger log = LoggerFactory.getLogger(PersonAttribute.class);
 	
 	// Fields
 	@DocumentId

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -17,8 +17,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Boost;
@@ -30,6 +28,8 @@ import org.hibernate.search.annotations.IndexedEmbedded;
 import org.openmrs.api.db.hibernate.search.LuceneAnalyzers;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -40,7 +40,7 @@ public class PersonName extends BaseOpenmrsData implements java.io.Serializable,
 	
 	public static final long serialVersionUID = 4353L;
 
-	private static final Log log = LogFactory.getLog(PersonName.class);
+	private static final Logger log = LoggerFactory.getLogger(PersonName.class);
 
 	// Fields
 	@DocumentId

--- a/api/src/main/java/org/openmrs/Provider.java
+++ b/api/src/main/java/org/openmrs/Provider.java
@@ -9,8 +9,8 @@
  */
 package org.openmrs;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents a person who may provide care to a patient during an encounter
@@ -19,7 +19,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class Provider extends BaseCustomizableMetadata<ProviderAttribute> {
 	
-	private final Log log = LogFactory.getLog(getClass());
+	private final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private Integer providerId;
 	

--- a/api/src/main/java/org/openmrs/Role.java
+++ b/api/src/main/java/org/openmrs/Role.java
@@ -13,9 +13,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Role is just an aggregater of {@link Privilege}s. {@link User}s contain a number of roles
@@ -29,7 +29,7 @@ public class Role extends BaseOpenmrsMetadata {
 	
 	public static final long serialVersionUID = 1234233L;
 	
-	private static final Log log = LogFactory.getLog(Role.class);
+	private static final Logger log = LoggerFactory.getLogger(Role.class);
 	
 	// Fields
 	

--- a/api/src/main/java/org/openmrs/User.java
+++ b/api/src/main/java/org/openmrs/User.java
@@ -21,13 +21,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Defines a User Account in the system. This account belongs to a {@link Person} in the system,
@@ -40,7 +40,7 @@ public class User extends BaseOpenmrsMetadata implements java.io.Serializable, A
 	
 	public static final long serialVersionUID = 2L;
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	// Fields
 	

--- a/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
@@ -13,12 +13,12 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.annotation.AuthorizedAnnotationAttributes;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.MethodBeforeAdvice;
 
 /**
@@ -30,7 +30,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	/**
 	 * Logger for this class and subclasses
 	 */
-	protected final Log log = LogFactory.getLog(AuthorizationAdvice.class);
+	protected final Logger log = LoggerFactory.getLogger(AuthorizationAdvice.class);
 	
 	/**
 	 * Allows us to check whether a user is authorized to access a particular method.

--- a/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
@@ -15,12 +15,12 @@ import java.util.List;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.annotation.Logging;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class provides the log4j aop around advice for our service layer. This advice is placed on
@@ -33,7 +33,7 @@ public class LoggingAdvice implements MethodInterceptor {
 	 * Logger for this class. Uses the name "org.openmrs.api" so that it seems to fit into the
 	 * log4j.xml configuration
 	 */
-	protected static final Log log = LogFactory.getLog("org.openmrs.api");
+	protected static final Logger log = LoggerFactory.getLogger("org.openmrs.api");
 	
 	/**
 	 * List of all method name prefixes that result in INFO-level log messages

--- a/api/src/main/java/org/openmrs/api/EventListeners.java
+++ b/api/src/main/java/org/openmrs/api/EventListeners.java
@@ -11,15 +11,15 @@ package org.openmrs.api;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Holds all OpenMRS event listeners
  */
 public class EventListeners {
 	
-	private static Log log = LogFactory.getLog(EventListeners.class);
+	private static Logger log = LoggerFactory.getLogger(EventListeners.class);
 	
 	private static List<GlobalPropertyListener> globalPropertyListeners = null;
 	

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -26,8 +26,6 @@ import javax.mail.Session;
 
 import org.aopalliance.aop.Advice;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Allergen;
 import org.openmrs.GlobalProperty;
 import org.openmrs.PersonName;
@@ -77,6 +75,8 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.ValidateUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.Advisor;
 
 /**
@@ -127,7 +127,7 @@ import org.springframework.aop.Advisor;
  */
 public class Context {
 
-	private static final Log log = LogFactory.getLog(Context.class);
+	private static final Logger log = LoggerFactory.getLogger(Context.class);
 
 	// Global resources
 	private static ContextDAO contextDAO;

--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.api.context;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
@@ -22,6 +20,8 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.timer.TimerSchedulerTask;
 import org.openmrs.util.OpenmrsSecurityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.support.AbstractRefreshableApplicationContext;
 
 /**
@@ -30,7 +30,7 @@ import org.springframework.context.support.AbstractRefreshableApplicationContext
  */
 public class Daemon {
 	
-	protected static final Log log = LogFactory.getLog(Daemon.class);
+	protected static final Logger log = LoggerFactory.getLogger(Daemon.class);
 	
 	/**
 	 * The uuid defined for the daemon user object
@@ -248,7 +248,7 @@ public class Daemon {
 		}
 		catch (InterruptedException e) {
 			// ignore
-			log.error(e);
+			log.error("Thread was interrupted", e);
 		}
 		
 		if (onStartupThread.exceptionThrown != null) {

--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -19,8 +19,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.aopalliance.aop.Advice;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.CohortService;
@@ -47,6 +45,8 @@ import org.openmrs.notification.AlertService;
 import org.openmrs.notification.MessageService;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
@@ -70,7 +70,7 @@ import org.springframework.context.ApplicationContextAware;
  */
 public class ServiceContext implements ApplicationContextAware {
 	
-	private static final Log log = LogFactory.getLog(ServiceContext.class);
+	private static final Logger log = LoggerFactory.getLogger(ServiceContext.class);
 
 	private ApplicationContext applicationContext;
 	

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -17,8 +17,6 @@ import java.util.Set;
 import java.util.Vector;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.Role;
 import org.openmrs.User;
@@ -27,6 +25,8 @@ import org.openmrs.api.db.ContextDAO;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents an OpenMRS <code>User Context</code> which stores the current user information. Only
@@ -44,7 +44,7 @@ public class UserContext implements Serializable {
 	/**
 	 * Logger - shared by entire class
 	 */
-	private static final Log log = LogFactory.getLog(UserContext.class);
+	private static final Logger log = LoggerFactory.getLogger(UserContext.class);
 	
 	/**
 	 * User object containing details about the authenticated user

--- a/api/src/main/java/org/openmrs/api/db/hibernate/AuditableInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/AuditableInterceptor.java
@@ -15,14 +15,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.CallbackException;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.type.Type;
 import org.openmrs.Auditable;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class looks for {@link OpenmrsObject} and {@link Auditable} that are being inserted into the
@@ -39,7 +39,7 @@ import org.openmrs.api.context.Context;
 
 public class AuditableInterceptor extends EmptyInterceptor {
 	
-	private static final Log log = LogFactory.getLog(AuditableInterceptor.class);
+	private static final Logger log = LoggerFactory.getLogger(AuditableInterceptor.class);
 	
 	private static final long serialVersionUID = 1L;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ChainingInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ChainingInterceptor.java
@@ -16,13 +16,13 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.CallbackException;
 import org.hibernate.EntityMode;
 import org.hibernate.Interceptor;
 import org.hibernate.Transaction;
 import org.hibernate.type.Type;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Used by the {@link HibernateSessionFactoryBean} to keep track of multiple interceptors <br>
@@ -33,7 +33,7 @@ import org.hibernate.type.Type;
  */
 public class ChainingInterceptor implements Interceptor {
 	
-	private static final Log log = LogFactory.getLog(ChainingInterceptor.class);
+	private static final Logger log = LoggerFactory.getLogger(ChainingInterceptor.class);
 	
 	// using a linkedhashset to preserve insert order and maintain a list of unique objects
 	public Collection<Interceptor> interceptors = new LinkedHashSet<Interceptor>();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
@@ -12,8 +12,6 @@ package org.openmrs.api.db.hibernate;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.SessionFactory;
@@ -36,6 +34,8 @@ import org.openmrs.api.db.DAOException;
 import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.HandlerUtil;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -51,7 +51,7 @@ import org.springframework.validation.Validator;
  */
 public class HibernateAdministrationDAO implements AdministrationDAO, ApplicationContextAware {
 	
-	protected Log log = LogFactory.getLog(getClass());
+	protected Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateCohortDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateCohortDAO.java
@@ -12,8 +12,6 @@ package org.openmrs.api.db.hibernate;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.CriteriaSpecification;
@@ -25,6 +23,8 @@ import org.openmrs.Cohort;
 import org.openmrs.Patient;
 import org.openmrs.api.db.CohortDAO;
 import org.openmrs.api.db.DAOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate implementation of the CohortDAO
@@ -35,7 +35,7 @@ import org.openmrs.api.db.DAOException;
  */
 public class HibernateCohortDAO implements CohortDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private SessionFactory sessionFactory;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -25,8 +25,6 @@ import java.util.Vector;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.Query;
@@ -71,6 +69,8 @@ import org.openmrs.api.db.hibernate.search.LuceneQuery;
 import org.openmrs.collection.ListPart;
 import org.openmrs.util.ConceptMapTypeComparator;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Hibernate class for Concepts, Drugs, and related classes. <br>
@@ -81,7 +81,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class HibernateConceptDAO implements ConceptDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private SessionFactory sessionFactory;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -17,8 +17,6 @@ import java.util.Properties;
 import java.util.concurrent.Future;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -39,6 +37,8 @@ import org.openmrs.api.db.ContextDAO;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.hibernate4.SessionFactoryUtils;
 import org.springframework.orm.hibernate4.SessionHolder;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +53,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  */
 public class HibernateContextDAO implements ContextDAO {
 	
-	private static Log log = LogFactory.getLog(HibernateContextDAO.class);
+	private static Logger log = LoggerFactory.getLogger(HibernateContextDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.SQLQuery;
@@ -45,6 +43,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.EncounterDAO;
 import org.openmrs.parameter.EncounterSearchCriteria;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific dao for the {@link EncounterService} All calls should be made on the
@@ -55,7 +55,7 @@ import org.openmrs.parameter.EncounterSearchCriteria;
  */
 public class HibernateEncounterDAO implements EncounterDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -38,6 +36,8 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.FormDAO;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate-specific Form-related functions. This class should not be used directly. All calls
@@ -48,7 +48,7 @@ import org.openmrs.util.OpenmrsUtil;
  */
 public class HibernateFormDAO implements FormDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
@@ -14,8 +14,6 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;
@@ -35,6 +33,8 @@ import org.openmrs.User;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.ObsDAO;
 import org.openmrs.util.OpenmrsConstants.PERSON_TYPE;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific Observation related functions This class should not be used directly. All
@@ -45,7 +45,7 @@ import org.openmrs.util.OpenmrsConstants.PERSON_TYPE;
  */
 public class HibernateObsDAO implements ObsDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	protected SessionFactory sessionFactory;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
@@ -17,8 +17,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.LockOptions;
@@ -45,6 +43,8 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.OrderDAO;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class should not be used directly. This is just a common implementation of the OrderDAO that
@@ -59,7 +59,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class HibernateOrderDAO implements OrderDAO {
 	
-	protected static final Log log = LogFactory.getLog(HibernateOrderDAO.class);
+	protected static final Logger log = LoggerFactory.getLogger(HibernateOrderDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderSetDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderSetDAO.java
@@ -11,8 +11,6 @@ package org.openmrs.api.db.hibernate;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -21,6 +19,8 @@ import org.openmrs.OrderSet;
 import org.openmrs.OrderSetMember;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.OrderSetDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class should not be used directly. This is just a common implementation of the OrderSetDAO that
@@ -36,7 +36,7 @@ import org.openmrs.api.db.OrderSetDAO;
  */
 public class HibernateOrderSetDAO implements OrderSetDAO {
 	
-	protected static final Log log = LogFactory.getLog(HibernateOrderSetDAO.class);
+	protected static final Logger log = LoggerFactory.getLogger(HibernateOrderSetDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -23,8 +23,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
@@ -49,6 +47,8 @@ import org.openmrs.api.db.hibernate.search.LuceneQuery;
 import org.openmrs.collection.ListPart;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific database methods for the PatientService
@@ -59,7 +59,7 @@ import org.openmrs.util.OpenmrsUtil;
  */
 public class HibernatePatientDAO implements PatientDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
@@ -39,6 +37,8 @@ import org.openmrs.api.db.hibernate.search.LuceneQuery;
 import org.openmrs.collection.ListPart;
 import org.openmrs.person.PersonMergeLog;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific Person database methods. <br>
@@ -56,7 +56,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class HibernatePersonDAO implements PersonDAO {
 	
-	protected final static Log log = LogFactory.getLog(HibernatePersonDAO.class);
+	protected final static Logger log = LoggerFactory.getLogger(HibernatePersonDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProgramWorkflowDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProgramWorkflowDAO.java
@@ -13,8 +13,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -32,6 +30,8 @@ import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.ProgramWorkflowDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific ProgramWorkflow related functions.<br>
@@ -44,7 +44,7 @@ import org.openmrs.api.db.ProgramWorkflowDAO;
  */
 public class HibernateProgramWorkflowDAO implements ProgramWorkflowDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private SessionFactory sessionFactory;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSerializedObjectDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSerializedObjectDAO.java
@@ -13,8 +13,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.MatchMode;
@@ -30,13 +28,15 @@ import org.openmrs.api.db.SerializedObjectDAO;
 import org.openmrs.serialization.OpenmrsSerializer;
 import org.openmrs.serialization.SerializationException;
 import org.openmrs.util.ExceptionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific database access methods for serialized objects
  */
 public class HibernateSerializedObjectDAO implements SerializedObjectDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private static HibernateSerializedObjectDAO instance;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -22,20 +22,21 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.orm.hibernate4.LocalSessionFactoryBean;
 
 public class HibernateSessionFactoryBean extends LocalSessionFactoryBean {
 	
-	private static Log log = LogFactory.getLog(HibernateSessionFactoryBean.class);
+	private static Logger log = LoggerFactory.getLogger(HibernateSessionFactoryBean.class);
 	
 	protected Set<String> mappingResources = new HashSet<String>();
 	
@@ -155,7 +156,7 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean {
 			
 		}
 		catch (IOException e) {
-			log.fatal("Unable to load default hibernate properties", e);
+			log.error(MarkerFactory.getMarker("FATAL"), "Unable to load default hibernate properties", e);
 		}
 		
 		log.debug("Replacing variables in hibernate properties");

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateTemplateDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateTemplateDAO.java
@@ -11,16 +11,16 @@ package org.openmrs.api.db.hibernate;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.TemplateDAO;
 import org.openmrs.notification.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HibernateTemplateDAO implements TemplateDAO {
 	
-	private final static Log log = LogFactory.getLog(HibernateTemplateDAO.class);
+	private final static Logger log = LoggerFactory.getLogger(HibernateTemplateDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
@@ -20,8 +20,6 @@ import java.util.Vector;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -39,6 +37,8 @@ import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.Security;
 import org.openmrs.util.UserByNameComparator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific database methods for the UserService
@@ -49,7 +49,7 @@ import org.openmrs.util.UserByNameComparator;
  */
 public class HibernateUserDAO implements UserDAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
@@ -14,8 +14,6 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;
@@ -31,13 +29,15 @@ import org.hibernate.jdbc.ReturningWork;
 import org.hibernate.proxy.HibernateProxy;
 import org.openmrs.Location;
 import org.openmrs.attribute.AttributeType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class holds common methods and utilities that are used across the hibernate related classes
  */
 public class HibernateUtil {
 	
-	private static Log log = LogFactory.getLog(HibernateUtil.class);
+	private static Logger log = LoggerFactory.getLogger(HibernateUtil.class);
 	
 	private static Dialect dialect = null;
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
@@ -15,14 +15,14 @@ import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.type.Type;
 import org.openmrs.Retireable;
 import org.openmrs.Voidable;
 import org.openmrs.api.UnchangeableObjectException;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Superclass for all Interceptors that would like to ensure that changes to immutable entities of
@@ -38,7 +38,7 @@ import org.openmrs.util.OpenmrsUtil;
  */
 public abstract class ImmutableEntityInterceptor extends EmptyInterceptor {
 	
-	private static final Log log = LogFactory.getLog(ImmutableEntityInterceptor.class);
+	private static final Logger log = LoggerFactory.getLogger(ImmutableEntityInterceptor.class);
 	
 	/**
 	 * Returns the class handled by the interceptor

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -15,8 +15,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Conjunction;
@@ -32,6 +30,8 @@ import org.openmrs.PatientIdentifierType;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The PatientSearchCriteria class. It has API to return a criteria from the Patient Name and
@@ -42,7 +42,7 @@ import org.openmrs.util.OpenmrsConstants;
 @Deprecated
 public class PatientSearchCriteria {
 	
-	private final static Log log = LogFactory.getLog(PatientSearchCriteria.class);
+	private final static Logger log = LoggerFactory.getLogger(PatientSearchCriteria.class);
 	
 	private final SessionFactory sessionFactory;
 	

--- a/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
@@ -15,8 +15,6 @@ import java.util.Date;
 import java.util.UUID;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.User;
@@ -26,6 +24,8 @@ import org.openmrs.annotation.AllowLeadingOrTrailingWhitespace;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
 import org.openmrs.api.APIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class deals with any object that implements {@link OpenmrsObject}. When an
@@ -42,7 +42,7 @@ import org.openmrs.api.APIException;
 @Handler(supports = OpenmrsObject.class)
 public class OpenmrsObjectSaveHandler implements SaveHandler<OpenmrsObject> {
 	
-	private static final Log log = LogFactory.getLog(OpenmrsObjectSaveHandler.class);
+	private static final Logger log = LoggerFactory.getLogger(OpenmrsObjectSaveHandler.class);
 	
 	/**
 	 * This sets the uuid property on the given OpenmrsObject if it is non-null.

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -29,8 +29,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptSource;
 import org.openmrs.GlobalProperty;
 import org.openmrs.ImplementationId;
@@ -49,6 +47,8 @@ import org.openmrs.module.ModuleUtil;
 import org.openmrs.util.HttpClient;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,7 +64,7 @@ import org.springframework.validation.Errors;
 @Transactional
 public class AdministrationServiceImpl extends BaseOpenmrsService implements AdministrationService, GlobalPropertyListener {
 	
-	protected Log log = LogFactory.getLog(getClass());
+	protected Logger log = LoggerFactory.getLogger(getClass());
 	
 	protected AdministrationDAO dao;
 	

--- a/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.time.DateUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
 import org.openmrs.CohortMembership;
 import org.openmrs.Patient;
@@ -25,6 +23,8 @@ import org.openmrs.api.CohortService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.CohortDAO;
 import org.openmrs.util.PrivilegeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class CohortServiceImpl extends BaseOpenmrsService implements CohortService {
 
-	protected final Log log = LogFactory.getLog(this.getClass());
+	protected final Logger log = LoggerFactory.getLogger(this.getClass());
 
 	private CohortDAO dao;
 

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -29,8 +29,6 @@ import java.util.Vector;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptAttribute;
@@ -68,6 +66,8 @@ import org.openmrs.customdatatype.CustomDatatypeUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.validator.ValidateUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
@@ -79,7 +79,7 @@ import org.springframework.util.StringUtils;
 @Transactional
 public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptService {
 	
-	private final Log log = LogFactory.getLog(getClass());
+	private final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private ConceptDAO dao;
 	

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -63,8 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class EncounterServiceImpl extends BaseOpenmrsService implements EncounterService {
 	
-	// private Log log = LogFactory.getLog(this.getClass());
-	
 	private EncounterDAO dao;
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
@@ -20,8 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.exception.ConstraintViolationException;
 import org.openmrs.Concept;
 import org.openmrs.ConceptComplex;
@@ -46,6 +44,8 @@ import org.openmrs.obs.SerializableComplexObsHandler;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.validator.FormValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindException;
 
@@ -61,7 +61,7 @@ import org.springframework.validation.BindException;
 @Transactional
 public class FormServiceImpl extends BaseOpenmrsService implements FormService {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private FormDAO dao;
 	

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -23,8 +23,6 @@ import java.util.Locale;
 import java.util.Vector;
 
 import org.apache.commons.lang.time.DateUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.proxy.HibernateProxy;
 import org.openmrs.CareSetting;
 import org.openmrs.Concept;
@@ -60,6 +58,8 @@ import org.openmrs.api.order.exception.OrderEntryException;
 import org.openmrs.order.OrderUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -75,7 +75,7 @@ import org.springframework.util.StringUtils;
 @Transactional
 public class OrderServiceImpl extends BaseOpenmrsService implements OrderService, OrderNumberGenerator, GlobalPropertyListener {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private static final String ORDER_NUMBER_PREFIX = "ORD-";
 	

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -22,8 +22,6 @@ import java.util.UUID;
 import java.util.Vector;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Allergen;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;
@@ -70,6 +68,8 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.PatientIdentifierValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -84,7 +84,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PatientServiceImpl extends BaseOpenmrsService implements PatientService {
 	
-	private final Log log = LogFactory.getLog(this.getClass());
+	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private PatientDAO dao;
 	

--- a/api/src/main/java/org/openmrs/api/impl/ProgramWorkflowServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ProgramWorkflowServiceImpl.java
@@ -15,8 +15,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
@@ -32,6 +30,8 @@ import org.openmrs.api.ProgramNameDuplicatedException;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.ProgramWorkflowDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -45,7 +45,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class ProgramWorkflowServiceImpl extends BaseOpenmrsService implements ProgramWorkflowService {
 	
-	protected final Log log = LogFactory.getLog(this.getClass());
+	protected final Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	protected ProgramWorkflowDAO dao;
 	

--- a/api/src/main/java/org/openmrs/api/impl/SerializationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/SerializationServiceImpl.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.SerializationService;
 import org.openmrs.api.context.Context;
@@ -24,6 +22,8 @@ import org.openmrs.serialization.OpenmrsSerializer;
 import org.openmrs.serialization.SerializationException;
 import org.openmrs.serialization.SimpleXStreamSerializer;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class SerializationServiceImpl extends BaseOpenmrsService implements SerializationService {
 	
-	public Log log = LogFactory.getLog(this.getClass());
+	public Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	//***** Properties (set by spring)
 	private static Map<Class<? extends OpenmrsSerializer>, OpenmrsSerializer> serializerMap;

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -18,8 +18,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Person;
 import org.openmrs.Privilege;
 import org.openmrs.PrivilegeListener;
@@ -39,6 +37,8 @@ import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,7 +53,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	
-	protected final Log log = LogFactory.getLog(UserServiceImpl.class);
+	protected final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
 	
 	protected UserDAO dao;
 	

--- a/api/src/main/java/org/openmrs/customdatatype/CustomDatatypeUtil.java
+++ b/api/src/main/java/org/openmrs/customdatatype/CustomDatatypeUtil.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
@@ -25,6 +23,8 @@ import org.openmrs.attribute.Attribute;
 import org.openmrs.attribute.AttributeType;
 import org.openmrs.serialization.SerializationException;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper methods for dealing with custom datatypes and their handlers
@@ -32,7 +32,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class CustomDatatypeUtil {
 	
-	private static Log log = LogFactory.getLog(CustomDatatypeUtil.class);
+	private static Logger log = LoggerFactory.getLogger(CustomDatatypeUtil.class);
 	
 	/**
 	 * @param descriptor

--- a/api/src/main/java/org/openmrs/hl7/HL7InQueueProcessor.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7InQueueProcessor.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.hl7;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -27,7 +27,7 @@ import ca.uhn.hl7v2.HL7Exception;
 @Transactional
 public class HL7InQueueProcessor /* implements Runnable */{
 	
-	private final Log log = LogFactory.getLog(this.getClass());
+	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private static Boolean isRunning = false; // allow only one running
 	

--- a/api/src/main/java/org/openmrs/hl7/HL7Util.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Util.java
@@ -16,12 +16,12 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.hl7v2.HL7Exception;
 
@@ -32,7 +32,7 @@ import ca.uhn.hl7v2.HL7Exception;
  */
 public class HL7Util {
 	
-	private static Log log = LogFactory.getLog(HL7Util.class);
+	private static Logger log = LoggerFactory.getLogger(HL7Util.class);
 	
 	// Date and time format parsers
 	private static final String TIMESTAMP_FORMAT = "yyyyMMddHHmmss.SSSZ";

--- a/api/src/main/java/org/openmrs/hl7/Hl7InArchivesMigrateThread.java
+++ b/api/src/main/java/org/openmrs/hl7/Hl7InArchivesMigrateThread.java
@@ -12,11 +12,11 @@ package org.openmrs.hl7;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Separate thread to move the hl7 in archives from the database tables to the filesystem. It is
@@ -25,7 +25,7 @@ import org.openmrs.api.context.UserContext;
  */
 public class Hl7InArchivesMigrateThread extends Thread {
 	
-	private static final Log log = LogFactory.getLog(Hl7InArchivesMigrateThread.class);
+	private static final Logger log = LoggerFactory.getLogger(Hl7InArchivesMigrateThread.class);
 	
 	/**
 	 * Map holds data about the progress of the transfer process, that is numberTransferred and

--- a/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
+++ b/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
@@ -12,8 +12,6 @@ package org.openmrs.hl7.db.hibernate;
 import java.util.Calendar;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
@@ -31,6 +29,8 @@ import org.openmrs.hl7.HL7InQueue;
 import org.openmrs.hl7.HL7Source;
 import org.openmrs.hl7.Hl7InArchivesMigrateThread;
 import org.openmrs.hl7.db.HL7DAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * OpenMRS HL7 API database default hibernate implementation This class shouldn't be instantiated by
@@ -41,7 +41,7 @@ import org.openmrs.hl7.db.HL7DAO;
  */
 public class HibernateHL7DAO implements HL7DAO {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/hl7/handler/ADTA28Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ADTA28Handler.java
@@ -14,8 +14,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -26,6 +24,8 @@ import org.openmrs.api.PatientIdentifierException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.validator.PatientIdentifierValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.app.Application;
@@ -94,7 +94,7 @@ import ca.uhn.hl7v2.model.v25.segment.PID;
  */
 public class ADTA28Handler implements Application {
 	
-	private Log log = LogFactory.getLog(ADTA28Handler.class);
+	private Logger log = LoggerFactory.getLogger(ADTA28Handler.class);
 	
 	/**
 	 * Always returns true, assuming that the router calling this handler will only call this

--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -18,8 +18,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptName;
@@ -46,6 +44,8 @@ import org.openmrs.hl7.HL7Service;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -96,7 +96,7 @@ import ca.uhn.hl7v2.parser.PipeParser;
  */
 public class ORUR01Handler implements Application {
 	
-	private Log log = LogFactory.getLog(ORUR01Handler.class);
+	private Logger log = LoggerFactory.getLogger(ORUR01Handler.class);
 	
 	private static EncounterRole unknownRole = null;
 	

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -26,8 +26,6 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -55,6 +53,8 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.PatientIdentifierValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -82,7 +82,7 @@ import ca.uhn.hl7v2.parser.GenericParser;
 @Transactional
 public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 	
-	private final Log log = LogFactory.getLog(this.getClass());
+	private final Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private static HL7ServiceImpl instance;
 	
@@ -777,7 +777,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 		if (cause == null) {
 			hl7InError.setErrorDetails("");
 		} else {
-			log.error(cause);
+			log.error("Fatal error", cause);
 			hl7InError.setErrorDetails(ExceptionUtils.getStackTrace(cause));
 		}
 		Context.getHL7Service().saveHL7InError(hl7InError);

--- a/api/src/main/java/org/openmrs/layout/LayoutSupport.java
+++ b/api/src/main/java/org/openmrs/layout/LayoutSupport.java
@@ -11,15 +11,15 @@ package org.openmrs.layout;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @since 1.12
  */
 public abstract class LayoutSupport<T extends LayoutTemplate> {
 	
-	private Log log = LogFactory.getLog(getClass());
+	private Logger log = LoggerFactory.getLogger(getClass());
 	
 	protected String defaultLayoutFormat;
 	

--- a/api/src/main/java/org/openmrs/layout/address/AddressSupport.java
+++ b/api/src/main/java/org/openmrs/layout/address/AddressSupport.java
@@ -13,14 +13,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;
 import org.openmrs.layout.LayoutSupport;
 import org.openmrs.serialization.SerializationException;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @since 1.12
@@ -31,7 +31,7 @@ public class AddressSupport extends LayoutSupport<AddressTemplate> implements Gl
 	
 	private boolean initialized = false;
 	
-	static Log log = LogFactory.getLog(AddressSupport.class);
+	static Logger log = LoggerFactory.getLogger(AddressSupport.class);
 	
 	private AddressSupport() {
 		if (singleton == null) {

--- a/api/src/main/java/org/openmrs/layout/name/NameSupport.java
+++ b/api/src/main/java/org/openmrs/layout/name/NameSupport.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.layout.name;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.layout.LayoutSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @since 1.12
@@ -21,7 +21,7 @@ public class NameSupport extends LayoutSupport<NameTemplate> {
 	
 	private static NameSupport singleton;
 	
-	static Log log = LogFactory.getLog(NameSupport.class);
+	static Logger log = LoggerFactory.getLogger(NameSupport.class);
 	
 	public NameSupport() {
 		if (singleton == null) {

--- a/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
@@ -15,12 +15,12 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.messagesource.MutableMessageSource;
 import org.openmrs.messagesource.PresentationMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.NoSuchMessageException;
@@ -34,7 +34,7 @@ import org.springframework.context.NoSuchMessageException;
  */
 public class MessageSourceServiceImpl implements MessageSourceService {
 	
-	private Log log = LogFactory.getLog(getClass());
+	private Logger log = LoggerFactory.getLogger(getClass());
 	
 	private Set<MutableMessageSource> availableMessageSources = new HashSet<MutableMessageSource>();
 	

--- a/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.messagesource.MutableMessageSource;
 import org.openmrs.messagesource.PresentationMessage;
 import org.openmrs.module.Module;
@@ -30,6 +28,8 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -41,7 +41,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  */
 public class MutableResourceBundleMessageSource extends ReloadableResourceBundleMessageSource implements MutableMessageSource {
 
-	private Log log = LogFactory.getLog(getClass());
+	private Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Local reference to basenames used to search for properties files.

--- a/api/src/main/java/org/openmrs/migration/MigrationHelper.java
+++ b/api/src/main/java/org/openmrs/migration/MigrationHelper.java
@@ -27,8 +27,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -50,6 +48,8 @@ import org.openmrs.api.PersonService;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -62,7 +62,7 @@ public class MigrationHelper {
 	
 	private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
 
-	protected final static Log log = LogFactory.getLog(MigrationHelper.class);
+	protected final static Logger log = LoggerFactory.getLogger(MigrationHelper.class);
 	
 	static DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 	

--- a/api/src/main/java/org/openmrs/module/AdvicePoint.java
+++ b/api/src/main/java/org/openmrs/module/AdvicePoint.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.module;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AdvicePoint {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private String point;
 	

--- a/api/src/main/java/org/openmrs/module/Extension.java
+++ b/api/src/main/java/org/openmrs/module/Extension.java
@@ -11,8 +11,8 @@ package org.openmrs.module;
 
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An extension is a small snippet of code that is run at certain "extension points" throughout the
@@ -25,7 +25,7 @@ import org.apache.commons.logging.LogFactory;
 
 public abstract class Extension {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	// point which this extension is extending
 	private String pointId;

--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -21,10 +21,10 @@ import java.util.Set;
 import java.util.Vector;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Privilege;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 /**
@@ -34,7 +34,7 @@ import org.w3c.dom.Document;
  */
 public final class Module {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private String name;
 	

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -41,12 +41,12 @@ import java.util.WeakHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Standard implementation of module class loader. <br>
@@ -55,7 +55,7 @@ import org.openmrs.util.OpenmrsUtil;
  */
 public class ModuleClassLoader extends URLClassLoader {
 	
-	static Log log = LogFactory.getLog(ModuleClassLoader.class);
+	static Logger log = LoggerFactory.getLogger(ModuleClassLoader.class);
 	
 	private final Module module;
 	

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -36,8 +36,6 @@ import java.util.zip.ZipEntry;
 
 import org.aopalliance.aop.Advice;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Privilege;
 import org.openmrs.api.AdministrationService;
@@ -54,6 +52,8 @@ import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.aop.Advisor;
 import org.springframework.context.support.AbstractRefreshableApplicationContext;
 import org.springframework.util.StringUtils;
@@ -63,7 +63,7 @@ import org.springframework.util.StringUtils;
  */
 public class ModuleFactory {
 	
-	private static Log log = LogFactory.getLog(ModuleFactory.class);
+	private static Logger log = LoggerFactory.getLogger(ModuleFactory.class);
 	
 	protected static volatile Map<String, Module> loadedModules = new WeakHashMap<String, Module>();
 	

--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -32,13 +32,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Privilege;
 import org.openmrs.api.context.Context;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -53,7 +53,7 @@ import org.xml.sax.SAXException;
  */
 public class ModuleFileParser {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private File moduleFile = null;
 	

--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -42,8 +42,6 @@ import java.util.zip.ZipEntry;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
@@ -52,6 +50,8 @@ import org.openmrs.scheduler.SchedulerUtil;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.support.AbstractRefreshableApplicationContext;
 
 /**
@@ -59,7 +59,7 @@ import org.springframework.context.support.AbstractRefreshableApplicationContext
  */
 public class ModuleUtil {
 	
-	private static Log log = LogFactory.getLog(ModuleUtil.class);
+	private static Logger log = LoggerFactory.getLogger(ModuleUtil.class);
 	
 	/**
 	 * Start up the module system with the given properties.

--- a/api/src/main/java/org/openmrs/module/SqlDiffFileParser.java
+++ b/api/src/main/java/org/openmrs/module/SqlDiffFileParser.java
@@ -22,8 +22,8 @@ import java.util.zip.ZipEntry;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -38,7 +38,7 @@ import org.xml.sax.SAXException;
  */
 public class SqlDiffFileParser {
 	
-	private static Log log = LogFactory.getLog(SqlDiffFileParser.class);
+	private static Logger log = LoggerFactory.getLogger(SqlDiffFileParser.class);
 	
 	private static final String SQLDIFF_CHANGELOG_FILENAME = "sqldiff.xml";
 	

--- a/api/src/main/java/org/openmrs/module/UpdateFileParser.java
+++ b/api/src/main/java/org/openmrs/module/UpdateFileParser.java
@@ -16,9 +16,9 @@ import java.util.Vector;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -32,7 +32,7 @@ import org.xml.sax.InputSource;
  */
 public class UpdateFileParser {
 	
-	private static Log log = LogFactory.getLog(UpdateFileParser.class);
+	private static Logger log = LoggerFactory.getLogger(UpdateFileParser.class);
 	
 	private String content;
 	

--- a/api/src/main/java/org/openmrs/notification/db/hibernate/HibernateAlertDAO.java
+++ b/api/src/main/java/org/openmrs/notification/db/hibernate/HibernateAlertDAO.java
@@ -13,8 +13,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Order;
@@ -23,13 +21,15 @@ import org.openmrs.User;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.notification.Alert;
 import org.openmrs.notification.db.AlertDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Hibernate specific implementation of the
  */
 public class HibernateAlertDAO implements AlertDAO {
 	
-	private final Log log = LogFactory.getLog(getClass());
+	private final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
+++ b/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
@@ -13,8 +13,6 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.APIException;
@@ -25,6 +23,8 @@ import org.openmrs.notification.AlertRecipient;
 import org.openmrs.notification.AlertService;
 import org.openmrs.notification.db.AlertDAO;
 import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -37,7 +37,7 @@ public class AlertServiceImpl extends BaseOpenmrsService implements Serializable
 	
 	private static final long serialVersionUID = 564561231321112365L;
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private AlertDAO dao;
 	

--- a/api/src/main/java/org/openmrs/notification/impl/MessageServiceImpl.java
+++ b/api/src/main/java/org/openmrs/notification/impl/MessageServiceImpl.java
@@ -14,8 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
@@ -27,12 +25,14 @@ import org.openmrs.notification.MessageSender;
 import org.openmrs.notification.MessageService;
 import org.openmrs.notification.Template;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public class MessageServiceImpl implements MessageService {
 	
-	private static final Log log = LogFactory.getLog(MessageServiceImpl.class);
+	private static final Logger log = LoggerFactory.getLogger(MessageServiceImpl.class);
 	
 	private TemplateDAO templateDAO;
 	

--- a/api/src/main/java/org/openmrs/notification/mail/MailMessageSender.java
+++ b/api/src/main/java/org/openmrs/notification/mail/MailMessageSender.java
@@ -16,17 +16,17 @@ import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.Message;
 import org.openmrs.notification.MessageException;
 import org.openmrs.notification.MessageSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 public class MailMessageSender implements MessageSender {
 	
-	protected static final Log log = LogFactory.getLog(MailMessageSender.class);
+	protected static final Logger log = LoggerFactory.getLogger(MailMessageSender.class);
 	
 	/**
 	 * JavaMail session

--- a/api/src/main/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparator.java
+++ b/api/src/main/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparator.java
@@ -11,21 +11,21 @@ package org.openmrs.notification.mail.velocity;
 
 import java.io.StringWriter;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.openmrs.notification.Message;
 import org.openmrs.notification.MessageException;
 import org.openmrs.notification.MessagePreparator;
 import org.openmrs.notification.Template;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class VelocityMessagePreparator implements MessagePreparator {
 	
 	/**
 	 * Logger
 	 */
-	private static final Log log = LogFactory.getLog(VelocityMessagePreparator.class);
+	private static final Logger log = LoggerFactory.getLogger(VelocityMessagePreparator.class);
 	
 	/**
 	 * Velocity template engine

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -17,13 +17,13 @@ import java.util.Arrays;
 import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract handler for some convenience methods Files are stored in the location specified by the
@@ -33,7 +33,7 @@ import org.openmrs.util.OpenmrsUtil;
  */
 public class AbstractHandler {
 	
-	public static final Log log = LogFactory.getLog(AbstractHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(AbstractHandler.class);
 	
 	protected NumberFormat nf;
 	

--- a/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
@@ -14,13 +14,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 /**
@@ -34,7 +34,7 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 	/** Views supported by this handler */
 	private static final String[] supportedViews = { ComplexObsHandler.RAW_VIEW, };
 	
-	public static final Log log = LogFactory.getLog(BinaryDataHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(BinaryDataHandler.class);
 	
 	/**
 	 * Constructor initializes formats for alternative file names to protect from unintentionally

--- a/api/src/main/java/org/openmrs/obs/handler/BinaryStreamHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryStreamHandler.java
@@ -15,14 +15,14 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 /**
@@ -36,7 +36,7 @@ public class BinaryStreamHandler extends AbstractHandler implements ComplexObsHa
 	/** Views supported by this handler */
 	private static final String[] supportedViews = { ComplexObsHandler.RAW_VIEW, };
 	
-	public static final Log log = LogFactory.getLog(BinaryStreamHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(BinaryStreamHandler.class);
 	
 	/**
 	 * Constructor initializes formats for alternative file names to protect from unintentionally

--- a/api/src/main/java/org/openmrs/obs/handler/ImageHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/ImageHandler.java
@@ -22,12 +22,12 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.FileImageInputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handler for storing basic images for complex obs to the file system. The image mime type used is
@@ -43,7 +43,7 @@ public class ImageHandler extends AbstractHandler implements ComplexObsHandler {
 	/** Views supported by this handler */
 	private static final String[] supportedViews = { ComplexObsHandler.RAW_VIEW };
 	
-	public static final Log log = LogFactory.getLog(ImageHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(ImageHandler.class);
 	
 	private Set<String> extensions;
 	

--- a/api/src/main/java/org/openmrs/obs/handler/MediaHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/MediaHandler.java
@@ -16,13 +16,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handler for storing audio and video for complex obs to the file system. The mime type used is
@@ -36,7 +36,7 @@ public class MediaHandler extends AbstractHandler implements ComplexObsHandler {
 	/** Views supported by this handler */
 	private static final String[] supportedViews = { ComplexObsHandler.RAW_VIEW, };
 	
-	public static final Log log = LogFactory.getLog(MediaHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(MediaHandler.class);
 	
 	public MediaHandler() {
 		super();

--- a/api/src/main/java/org/openmrs/obs/handler/TextHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/TextHandler.java
@@ -18,13 +18,13 @@ import java.io.InputStream;
 import java.io.Reader;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 /**
@@ -39,7 +39,7 @@ public class TextHandler extends AbstractHandler implements ComplexObsHandler {
 	private static final String[] supportedViews = { ComplexObsHandler.TEXT_VIEW, ComplexObsHandler.RAW_VIEW,
 	        ComplexObsHandler.URI_VIEW };
 	
-	public static final Log log = LogFactory.getLog(TextHandler.class);
+	public static final Logger log = LoggerFactory.getLogger(TextHandler.class);
 	
 	/**
 	 * Constructor initializes formats for alternative file names to protect from unintentionally

--- a/api/src/main/java/org/openmrs/order/OrderUtil.java
+++ b/api/src/main/java/org/openmrs/order/OrderUtil.java
@@ -9,18 +9,18 @@
  */
 package org.openmrs.order;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains convenience methods for working with Orders.
  */
 public class OrderUtil {
 	
-	private static final Log log = LogFactory.getLog(OrderUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(OrderUtil.class);
 	
 	/**
 	 * Checks whether orderType2 matches or is a sub type of orderType1

--- a/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
@@ -11,10 +11,10 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  */
 public class CohortEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public CohortEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptAnswerEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptAnswerEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswersEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswersEditor.java
@@ -15,13 +15,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptAnswersEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private Collection<ConceptAnswer> originalConceptAnswers = null;
 	

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptClass;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptClassEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptClassEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptDatatypeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptDatatypeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptMapTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptMapTypeEditor.java
@@ -11,15 +11,15 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptMapType;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 public class ConceptMapTypeEditor extends PropertyEditorSupport {
 	
-	private final static Log log = LogFactory.getLog(ConceptMapTypeEditor.class);
+	private final static Logger log = LoggerFactory.getLogger(ConceptMapTypeEditor.class);
 	
 	public ConceptMapTypeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptNameEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptNameEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptNumericEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptNumericEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
@@ -11,15 +11,15 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 public class ConceptReferenceTermEditor extends PropertyEditorSupport {
 	
-	private final static Log log = LogFactory.getLog(ConceptReferenceTermEditor.class);
+	private final static Logger log = LoggerFactory.getLogger(ConceptReferenceTermEditor.class);
 	
 	public ConceptReferenceTermEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptSetsEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptSetsEditor.java
@@ -15,11 +15,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptSet;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptSetsEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	private Collection<ConceptSet> originalConceptSets = null;
 	

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ConceptSourceEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ConceptSourceEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/DrugEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/DrugEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class DrugEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public DrugEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Encounter;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class EncounterEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public EncounterEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.EncounterType;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class EncounterTypeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public EncounterTypeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Form;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class FormEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public FormEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class LocationEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public LocationEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.LocationTag;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
  */
 public class LocationTagEditor extends PropertyEditorSupport {
 	
-	private static Log log = LogFactory.getLog(LocationTagEditor.class);
+	private static Logger log = LoggerFactory.getLogger(LocationTagEditor.class);
 	
 	public LocationTagEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Order;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class OrderEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @should set using id

--- a/api/src/main/java/org/openmrs/propertyeditor/PatientEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PatientEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Patient;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PatientEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @should set using id

--- a/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PatientIdentifierTypeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public PatientIdentifierTypeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PersonAttribute;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PersonAttributeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @should set using id

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PersonAttributeTypeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @should set using id

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Person;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PersonEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @should set using id

--- a/api/src/main/java/org/openmrs/propertyeditor/PrivilegeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PrivilegeEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Privilege;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class PrivilegeEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public PrivilegeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.Program;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -30,7 +30,7 @@ import org.springframework.util.StringUtils;
  */
 public class ProgramEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ProgramEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ProgramWorkflowEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ProgramWorkflowEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ProgramWorkflowState;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class ProgramWorkflowStateEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ProgramWorkflowStateEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/ProviderEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProviderEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Provider;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  */
 public class ProviderEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public ProviderEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/RoleEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/RoleEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Role;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class RoleEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public RoleEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
@@ -11,11 +11,11 @@ package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  */
 public class UserEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public UserEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/VisitEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/VisitEditor.java
@@ -12,11 +12,11 @@ package org.openmrs.propertyeditor;
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Visit;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
  */
 public class VisitEditor extends PropertyEditorSupport {
 	
-	private static final Log log = LogFactory.getLog(VisitEditor.class);
+	private static final Logger log = LoggerFactory.getLogger(VisitEditor.class);
 	
 	public VisitEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/VisitTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/VisitTypeEditor.java
@@ -12,11 +12,11 @@ package org.openmrs.propertyeditor;
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorSupport;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.VisitType;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
  */
 public class VisitTypeEditor extends PropertyEditorSupport {
 	
-	private static final Log log = LogFactory.getLog(VisitTypeEditor.class);
+	private static final Logger log = LoggerFactory.getLogger(VisitTypeEditor.class);
 	
 	public VisitTypeEditor() {
 	}

--- a/api/src/main/java/org/openmrs/propertyeditor/WorkflowCollectionEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/WorkflowCollectionEditor.java
@@ -14,13 +14,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Program;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
  */
 public class WorkflowCollectionEditor extends PropertyEditorSupport {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	public WorkflowCollectionEditor() {
 	}

--- a/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
@@ -15,14 +15,14 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.PrivilegeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SchedulerUtil {
 	
-	private static Log log = LogFactory.getLog(SchedulerUtil.class);
+	private static Logger log = LoggerFactory.getLogger(SchedulerUtil.class);
 	
 	/**
 	 * Start the scheduler given the following start up properties.

--- a/api/src/main/java/org/openmrs/scheduler/TaskDefinition.java
+++ b/api/src/main/java/org/openmrs/scheduler/TaskDefinition.java
@@ -13,16 +13,16 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.BaseOpenmrsMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents the metadata for a task that can be scheduled.
  */
 public class TaskDefinition extends BaseOpenmrsMetadata {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	// Task metadata
 	private Integer id;

--- a/api/src/main/java/org/openmrs/scheduler/TaskFactory.java
+++ b/api/src/main/java/org/openmrs/scheduler/TaskFactory.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.scheduler;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.scheduler.tasks.TaskThreadedInitializationWrapper;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  */
@@ -22,7 +22,7 @@ public class TaskFactory {
 	private static final TaskFactory factory = new TaskFactory();
 	
 	/** Logger */
-	private static Log log = LogFactory.getLog(TaskFactory.class);
+	private static Logger log = LoggerFactory.getLogger(TaskFactory.class);
 	
 	/** Private constructor */
 	private TaskFactory() {

--- a/api/src/main/java/org/openmrs/scheduler/db/hibernate/HibernateSchedulerDAO.java
+++ b/api/src/main/java/org/openmrs/scheduler/db/hibernate/HibernateSchedulerDAO.java
@@ -11,8 +11,6 @@ package org.openmrs.scheduler.db.hibernate;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
@@ -20,6 +18,8 @@ import org.openmrs.api.db.DAOException;
 import org.openmrs.scheduler.Schedule;
 import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.scheduler.db.SchedulerDAO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectRetrievalFailureException;
 
 /**
@@ -29,7 +29,7 @@ public class HibernateSchedulerDAO implements SchedulerDAO {
 	/**
 	 * Logger
 	 */
-	private static final Log log = LogFactory.getLog(HibernateSchedulerDAO.class);
+	private static final Logger log = LoggerFactory.getLogger(HibernateSchedulerDAO.class);
 	
 	/**
 	 * Hibernate session factory

--- a/api/src/main/java/org/openmrs/scheduler/tasks/AbstractTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AbstractTask.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.scheduler.tasks;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class for all other task classes.
@@ -20,7 +20,7 @@ import org.openmrs.scheduler.TaskDefinition;
 public abstract class AbstractTask implements Task {
 	
 	// Logger
-	private static final Log log = LogFactory.getLog(AbstractTask.class);
+	private static final Logger log = LoggerFactory.getLogger(AbstractTask.class);
 	
 	// Indicates whether the task is currently running
 	protected boolean isExecuting = false;

--- a/api/src/main/java/org/openmrs/scheduler/tasks/AlertReminderTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AlertReminderTask.java
@@ -12,14 +12,14 @@ package org.openmrs.scheduler.tasks;
 import java.util.Collection;
 import java.util.HashSet;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.Alert;
 import org.openmrs.notification.AlertRecipient;
 import org.openmrs.notification.Message;
 import org.openmrs.notification.MessageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sample implementation of task that shows how to send emails to users/roles via message service.
@@ -27,7 +27,7 @@ import org.openmrs.notification.MessageException;
 public class AlertReminderTask extends AbstractTask {
 	
 	// Logger 
-	private Log log = LogFactory.getLog(AlertReminderTask.class);
+	private Logger log = LoggerFactory.getLogger(AlertReminderTask.class);
 	
 	/**
 	 * Send alert reminder email to user(s) associated with the alert.
@@ -44,7 +44,7 @@ public class AlertReminderTask extends AbstractTask {
 			
 		}
 		catch (Exception e) {
-			log.error(e);
+			log.error("Failed to send alert notifications", e);
 		}
 	}
 	
@@ -69,7 +69,7 @@ public class AlertReminderTask extends AbstractTask {
 			
 		}
 		catch (MessageException e) {
-			log.error(e);
+			log.error("Failed to send message", e);
 		}
 	}
 	

--- a/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
@@ -11,10 +11,10 @@ package org.openmrs.scheduler.tasks;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A scheduled task that automatically closes all unvoided active visits that match the visit
@@ -25,7 +25,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class AutoCloseVisitsTask extends AbstractTask {
 	
-	private static final Log log = LogFactory.getLog(AutoCloseVisitsTask.class);
+	private static final Logger log = LoggerFactory.getLogger(AutoCloseVisitsTask.class);
 	
 	/**
 	 * @see org.openmrs.scheduler.tasks.AbstractTask#execute()

--- a/api/src/main/java/org/openmrs/scheduler/tasks/CheckInternetConnectivityTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/CheckInternetConnectivityTask.java
@@ -15,12 +15,12 @@ import java.net.URLConnection;
 import java.util.Collection;
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.Alert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple implementation to check if we have a connection to the internet.
@@ -30,7 +30,7 @@ public class CheckInternetConnectivityTask extends AbstractTask {
 	/**
 	 * Logger
 	 */
-	private Log log = LogFactory.getLog(getClass());
+	private Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * @see org.openmrs.scheduler.tasks.AbstractTask#execute()
@@ -55,7 +55,7 @@ public class CheckInternetConnectivityTask extends AbstractTask {
 			}
 			catch (Exception e) {
 				// Uh oh, just log it.
-				log.error(e);
+				log.error("Failed to check internet connectivity", e);
 			}
 		}
 	}

--- a/api/src/main/java/org/openmrs/scheduler/tasks/HelloWorldTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/HelloWorldTask.java
@@ -11,8 +11,8 @@ package org.openmrs.scheduler.tasks;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of a task that writes "Hello World" to a log file.
@@ -20,7 +20,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class HelloWorldTask extends AbstractTask {
 	
-	private static Log log = LogFactory.getLog(HelloWorldTask.class);
+	private static Logger log = LoggerFactory.getLogger(HelloWorldTask.class);
 	
 	/**
 	 * Public constructor.

--- a/api/src/main/java/org/openmrs/scheduler/tasks/ProcessHL7InQueueTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/ProcessHL7InQueueTask.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.scheduler.tasks;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.hl7.HL7InQueueProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.hl7v2.HL7Exception;
 
@@ -26,7 +26,7 @@ import ca.uhn.hl7v2.HL7Exception;
 public class ProcessHL7InQueueTask extends AbstractTask {
 	
 	// Logger
-	private static Log log = LogFactory.getLog(ProcessHL7InQueueTask.class);
+	private static Logger log = LoggerFactory.getLogger(ProcessHL7InQueueTask.class);
 	
 	// Instance of hl7 processor
 	private static HL7InQueueProcessor processor = null;

--- a/api/src/main/java/org/openmrs/scheduler/tasks/SendEmailTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/SendEmailTask.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.scheduler.tasks;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of the stateful task that sends an email.
@@ -19,7 +19,7 @@ import org.openmrs.api.context.Context;
 public class SendEmailTask extends AbstractTask {
 	
 	// Logger 
-	private Log log = LogFactory.getLog(SendEmailTask.class);
+	private Logger log = LoggerFactory.getLogger(SendEmailTask.class);
 	
 	/**
 	 * Process the next form entry in the database and then remove the form entry from the database.

--- a/api/src/main/java/org/openmrs/scheduler/tasks/TaskThreadedInitializationWrapper.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/TaskThreadedInitializationWrapper.java
@@ -13,10 +13,10 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class executes the Task.initialize method in a new thread. Extend this class if you want
@@ -26,7 +26,7 @@ import org.openmrs.scheduler.TaskDefinition;
 public class TaskThreadedInitializationWrapper implements Task {
 	
 	// Logger 
-	private Log log = LogFactory.getLog(TaskThreadedInitializationWrapper.class);
+	private Logger log = LoggerFactory.getLogger(TaskThreadedInitializationWrapper.class);
 	
 	private Task task;
 	

--- a/api/src/main/java/org/openmrs/scheduler/tasks/TestTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/TestTask.java
@@ -11,9 +11,9 @@ package org.openmrs.scheduler.tasks;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.scheduler.TaskDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of a simple task that throws an exception every 10 executions.
@@ -23,7 +23,7 @@ public class TestTask extends AbstractTask {
 	private static int executionCount = 0;
 	
 	// Logger 
-	private Log log = LogFactory.getLog(TestTask.class);
+	private Logger log = LoggerFactory.getLogger(TestTask.class);
 	
 	/**
 	 * @see org.openmrs.scheduler.tasks.AbstractTask#initialize(TaskDefinition)

--- a/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImpl.java
+++ b/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImpl.java
@@ -22,8 +22,6 @@ import java.util.Timer;
 import java.util.TreeMap;
 import java.util.WeakHashMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.scheduler.SchedulerConstants;
@@ -35,6 +33,8 @@ import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.scheduler.TaskFactory;
 import org.openmrs.scheduler.db.SchedulerDAO;
 import org.openmrs.util.OpenmrsMemento;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +47,7 @@ public class TimerSchedulerServiceImpl extends BaseOpenmrsService implements Sch
 	/**
 	 * Logger
 	 */
-	private Log log = LogFactory.getLog(getClass());
+	private Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Registered task list

--- a/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerTask.java
@@ -12,14 +12,14 @@ package org.openmrs.scheduler.timer;
 import java.util.Date;
 import java.util.TimerTask;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.Daemon;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.SchedulerUtil;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TimerSchedulerTask extends TimerTask {
 	
@@ -27,7 +27,7 @@ public class TimerSchedulerTask extends TimerTask {
 	private Task task;
 	
 	/** Logger */
-	private static Log log = LogFactory.getLog(TimerSchedulerTask.class);
+	private static Logger log = LoggerFactory.getLogger(TimerSchedulerTask.class);
 	
 	/** * Public constructor */
 	public TimerSchedulerTask(Task task) {

--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -30,10 +30,10 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.Liquibase;
 import liquibase.changelog.ChangeLogIterator;
@@ -66,7 +66,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class DatabaseUpdater {
 	
-	private static final Log log = LogFactory.getLog(DatabaseUpdater.class);
+	private static final Logger log = LoggerFactory.getLogger(DatabaseUpdater.class);
 	
 	private static final String CHANGE_LOG_FILE = "liquibase-update-to-latest.xml";
 	

--- a/api/src/main/java/org/openmrs/util/DatabaseUtil.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUtil.java
@@ -19,11 +19,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.Session;
 import org.hibernate.jdbc.Work;
 import org.openmrs.api.db.DAOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -33,7 +33,7 @@ import org.springframework.util.StringUtils;
  */
 public class DatabaseUtil {
 	
-	private final static Log log = LogFactory.getLog(DatabaseUtil.class);
+	private final static Logger log = LoggerFactory.getLogger(DatabaseUtil.class);
 
 	public final static String ORDER_ENTRY_UPGRADE_SETTINGS_FILENAME = "order_entry_upgrade_settings.txt";
 

--- a/api/src/main/java/org/openmrs/util/DrugsByNameComparator.java
+++ b/api/src/main/java/org/openmrs/util/DrugsByNameComparator.java
@@ -11,9 +11,9 @@ package org.openmrs.util;
 
 import java.util.Comparator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Drug;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The Class DrugsByNameComparator. An Util class which sorts drug names while ignoring any
@@ -23,7 +23,7 @@ import org.openmrs.Drug;
 public class DrugsByNameComparator implements Comparator<Drug> {
 	
 	/** The Constant log. */
-	private final static Log log = LogFactory.getLog(DrugsByNameComparator.class);
+	private final static Logger log = LoggerFactory.getLogger(DrugsByNameComparator.class);
 	
 	/* (non-Jsdoc)
 	 * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)

--- a/api/src/main/java/org/openmrs/util/Format.java
+++ b/api/src/main/java/org/openmrs/util/Format.java
@@ -15,13 +15,13 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Format {
 	
-	private static Log log = LogFactory.getLog(Format.class);
+	private static Logger log = LoggerFactory.getLogger(Format.class);
 	
 	public enum FORMAT_TYPE {
 		DATE,

--- a/api/src/main/java/org/openmrs/util/HandlerUtil.java
+++ b/api/src/main/java/org/openmrs/util/HandlerUtil.java
@@ -16,11 +16,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HandlerUtil implements ApplicationListener<ContextRefreshedEvent> {
 	
-	private static final Log log = LogFactory.getLog(HandlerUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(HandlerUtil.class);
 	
 	private static volatile Map<Key, List<?>> cachedHandlers = new WeakHashMap<HandlerUtil.Key, List<?>>();
 	

--- a/api/src/main/java/org/openmrs/util/HttpClient.java
+++ b/api/src/main/java/org/openmrs/util/HttpClient.java
@@ -17,8 +17,8 @@ import java.net.MalformedURLException;
 import java.net.URLEncoder;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class supports doing an HTTP post to a URL. (It replaces the OpenmrsUtil.postToUrl method, allowing us to
@@ -26,7 +26,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class HttpClient {
 	
-	private static Log log = LogFactory.getLog(HttpClient.class);
+	private static Logger log = LoggerFactory.getLogger(HttpClient.class);
 	
 	private HttpUrl url;
 	

--- a/api/src/main/java/org/openmrs/util/LocaleUtility.java
+++ b/api/src/main/java/org/openmrs/util/LocaleUtility.java
@@ -15,11 +15,11 @@ import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
  */
 public class LocaleUtility implements GlobalPropertyListener {
 	
-	private static Log log = LogFactory.getLog(LocaleUtility.class);
+	private static Logger log = LoggerFactory.getLogger(LocaleUtility.class);
 	
 	/**
 	 * Cached version of the default locale. This is cached so that we don't have to look it up in

--- a/api/src/main/java/org/openmrs/util/LocationUtility.java
+++ b/api/src/main/java/org/openmrs/util/LocationUtility.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Location;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utility class for working with locations
@@ -23,7 +23,7 @@ import org.openmrs.api.context.Context;
  */
 public class LocationUtility implements GlobalPropertyListener {
 	
-	private static Log log = LogFactory.getLog(LocationUtility.class);
+	private static Logger log = LoggerFactory.getLogger(LocationUtility.class);
 	
 	/**
 	 * Cached version of the system default location. This is cached so that we don't have to look

--- a/api/src/main/java/org/openmrs/util/MemoryLeakUtil.java
+++ b/api/src/main/java/org/openmrs/util/MemoryLeakUtil.java
@@ -12,8 +12,8 @@ package org.openmrs.util;
 import java.lang.reflect.Field;
 import java.util.Timer;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import sun.net.www.http.KeepAliveCache;
 
@@ -22,7 +22,7 @@ import sun.net.www.http.KeepAliveCache;
  */
 public class MemoryLeakUtil {
 	
-	private final static Log log = LogFactory.getLog(MemoryLeakUtil.class);
+	private final static Logger log = LoggerFactory.getLogger(MemoryLeakUtil.class);
 	
 	//http://bugs.mysql.com/bug.php?id=36565
 	public static void shutdownMysqlCancellationTimer() {

--- a/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
@@ -34,8 +34,6 @@ import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleClassLoader;
@@ -43,6 +41,8 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.scheduler.SchedulerException;
 import org.openmrs.scheduler.SchedulerService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.sf.ehcache.CacheManager;
 
@@ -52,7 +52,7 @@ import net.sf.ehcache.CacheManager;
  */
 public class OpenmrsClassLoader extends URLClassLoader {
 	
-	private static Log log = LogFactory.getLog(OpenmrsClassLoader.class);
+	private static Logger log = LoggerFactory.getLogger(OpenmrsClassLoader.class);
 	
 	private static File libCacheFolder;
 	

--- a/api/src/main/java/org/openmrs/util/OpenmrsClassScanner.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsClassScanner.java
@@ -15,8 +15,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -34,7 +34,7 @@ import org.springframework.core.type.filter.TypeFilter;
  */
 public class OpenmrsClassScanner {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private final MetadataReaderFactory metadataReaderFactory;
 	

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -20,8 +20,6 @@ import java.util.Properties;
 import java.util.Vector;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.handler.ExistingVisitAssignmentHandler;
 import org.openmrs.customdatatype.datatype.BooleanDatatype;
@@ -31,6 +29,8 @@ import org.openmrs.module.ModuleConstants;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.scheduler.SchedulerConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Constants used in OpenMRS. Contents built from build properties (version, version_short, and
@@ -40,7 +40,7 @@ import org.openmrs.scheduler.SchedulerConstants;
  */
 public final class OpenmrsConstants {
 	
-	private static final Log log = LogFactory.getLog(OpenmrsConstants.class);
+	private static final Logger log = LoggerFactory.getLogger(OpenmrsConstants.class);
 	
 	public static String KEY_OPENMRS_APPLICATION_DATA_DIRECTORY = "OPENMRS_APPLICATION_DATA_DIRECTORY";
 	

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -68,8 +68,6 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Appender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
@@ -108,6 +106,8 @@ import org.openmrs.propertyeditor.LocationEditor;
 import org.openmrs.propertyeditor.PersonAttributeTypeEditor;
 import org.openmrs.propertyeditor.ProgramEditor;
 import org.openmrs.propertyeditor.ProgramWorkflowStateEditor;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 import org.springframework.beans.propertyeditors.CustomDateEditor;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.context.NoSuchMessageException;
@@ -120,12 +120,12 @@ import org.w3c.dom.DocumentType;
  */
 public class OpenmrsUtil {
 	
-	private static Log log = LogFactory.getLog(OpenmrsUtil.class);
+	private static org.slf4j.Logger log = LoggerFactory.getLogger(OpenmrsUtil.class);
 	
 	private static Map<Locale, SimpleDateFormat> dateFormatCache = new HashMap<Locale, SimpleDateFormat>();
 	
 	private static Map<Locale, SimpleDateFormat> timeFormatCache = new HashMap<Locale, SimpleDateFormat>();
-
+	
 	/**
 	 * Compares origList to newList returning map of differences
 	 * 
@@ -276,20 +276,21 @@ public class OpenmrsUtil {
 	 * @should copy inputstream to outputstream and close the outputstream
 	 */
 	public static void copyFile(InputStream inputStream, OutputStream outputStream) throws IOException {
-
+		
 		if (inputStream == null || outputStream == null) {
 			if (outputStream != null) {
 				IOUtils.closeQuietly(outputStream);
 			}
 			return;
 		}
-
+		
 		try {
 			IOUtils.copy(inputStream, outputStream);
-		} finally {
+		}
+		finally {
 			IOUtils.closeQuietly(outputStream);
 		}
-
+		
 	}
 	
 	/**
@@ -454,8 +455,9 @@ public class OpenmrsUtil {
 					OpenmrsConstants.DATABASE_NAME = val;
 				}
 				catch (Exception e) {
-					log.fatal("Database name cannot be configured from 'connection.url' ."
-					        + "Either supply 'connection.database_name' or correct the url", e);
+					log.error(MarkerFactory.getMarker("FATAL"), "Database name cannot be configured from 'connection.url' ."
+					        + "Either supply 'connection.database_name' or correct the url",
+					    e);
 				}
 			}
 		}
@@ -573,8 +575,8 @@ public class OpenmrsUtil {
 	}
 	
 	/**
-	 * Takes a String like "size=compact|order=date" and returns a Map&lt;String,String&gt; from the keys
-	 * to the values.
+	 * Takes a String like "size=compact|order=date" and returns a Map&lt;String,String&gt; from the
+	 * keys to the values.
 	 * 
 	 * @param paramList <code>String</code> with a list of parameters
 	 * @return Map&lt;String, String&gt; of the parameters passed
@@ -586,8 +588,8 @@ public class OpenmrsUtil {
 			for (String s : args) {
 				int ind = s.indexOf('=');
 				if (ind <= 0) {
-					throw new IllegalArgumentException("Misformed argument in dynamic page specification string: '" + s
-					        + "' is not 'key=value'.");
+					throw new IllegalArgumentException(
+					        "Misformed argument in dynamic page specification string: '" + s + "' is not 'key=value'.");
 				}
 				String name = s.substring(0, ind);
 				String value = s.substring(ind + 1);
@@ -596,7 +598,7 @@ public class OpenmrsUtil {
 		}
 		return ret;
 	}
-
+	
 	public static <Arg1, Arg2 extends Arg1> boolean nullSafeEquals(Arg1 d1, Arg2 d2) {
 		if (d1 == null) {
 			return d2 == null;
@@ -1023,8 +1025,8 @@ public class OpenmrsUtil {
 		if (StringUtils.isNotBlank(systemProperty)) {
 			filepath = systemProperty;
 		} else {
-			String runtimeProperty = Context.getRuntimeProperties().getProperty(
-			    OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, null);
+			String runtimeProperty = Context.getRuntimeProperties()
+			        .getProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, null);
 			if (StringUtils.isNotBlank(runtimeProperty)) {
 				filepath = runtimeProperty;
 			}
@@ -1040,10 +1042,10 @@ public class OpenmrsUtil {
 				}
 			} else {
 				filepath = System.getProperty("user.home") + File.separator + "Application Data" + File.separator
-						+ "OpenMRS";
+				        + "OpenMRS";
 				if (!canWrite(new File(filepath))) {
 					log.warn("Unable to write to users home dir, fallback to: "
-							+ OpenmrsConstants.APPLICATION_DATA_DIRECTORY_FALLBACK_WIN);
+					        + OpenmrsConstants.APPLICATION_DATA_DIRECTORY_FALLBACK_WIN);
 					filepath = OpenmrsConstants.APPLICATION_DATA_DIRECTORY_FALLBACK_WIN + File.separator + openmrsDir;
 				}
 			}
@@ -1070,8 +1072,7 @@ public class OpenmrsUtil {
 	public static void setApplicationDataDirectory(String path) {
 		if (StringUtils.isBlank(path)) {
 			System.clearProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY);
-		}
-		else {
+		} else {
 			System.setProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY, path);
 		}
 	}
@@ -1336,8 +1337,8 @@ public class OpenmrsUtil {
 		}
 		
 		// note that we are using the custom OpenmrsDateFormat class here which prevents erroneous parsing of 2-digit years
-		SimpleDateFormat sdf = new OpenmrsDateFormat(
-		        (SimpleDateFormat) DateFormat.getDateInstance(DateFormat.SHORT, locale), locale);
+		SimpleDateFormat sdf = new OpenmrsDateFormat((SimpleDateFormat) DateFormat.getDateInstance(DateFormat.SHORT, locale),
+		        locale);
 		String pattern = sdf.toPattern();
 		
 		if (!pattern.contains("yyyy")) {
@@ -1608,7 +1609,7 @@ public class OpenmrsUtil {
 	public static String generateUid() {
 		return generateUid(20);
 	}
-		
+	
 	/**
 	 * Convenience method to replace Properties.store(), which isn't UTF-8 compliant <br>
 	 * NOTE: In Java 6, you will be able to pass the load() and store() methods a UTF-8
@@ -1754,8 +1755,7 @@ public class OpenmrsUtil {
 	 * </tr>
 	 * <tr>
 	 * <th>Require that it not match the {@link User}'s username or system id
-	 * <th>
-	 * {@link OpenmrsConstants#GP_PASSWORD_CANNOT_MATCH_USERNAME_OR_SYSTEMID}</th>
+	 * <th>{@link OpenmrsConstants#GP_PASSWORD_CANNOT_MATCH_USERNAME_OR_SYSTEMID}</th>
 	 * <th>true</th>
 	 * </tr>
 	 * <tr>
@@ -1861,9 +1861,8 @@ public class OpenmrsUtil {
 				}
 			}
 			catch (NumberFormatException nfe) {
-				log
-				        .warn("Error in global property <" + OpenmrsConstants.GP_PASSWORD_MINIMUM_LENGTH
-				                + "> must be an Integer");
+				log.warn(
+				    "Error in global property <" + OpenmrsConstants.GP_PASSWORD_MINIMUM_LENGTH + "> must be an Integer");
 			}
 		}
 		
@@ -2042,8 +2041,8 @@ public class OpenmrsUtil {
 		}
 		catch (Exception ex) {
 			log.info("Got an error while attempting to load the runtime properties", ex);
-			log
-			        .warn("Unable to find a runtime properties file. Initial setup is needed. View the webapp to run the setup wizard.");
+			log.warn(
+			    "Unable to find a runtime properties file. Initial setup is needed. View the webapp to run the setup wizard.");
 			return null;
 		}
 	}
@@ -2187,12 +2186,13 @@ public class OpenmrsUtil {
 		Calendar c2 = Calendar.getInstance();
 		c2.setTime(date);
 		
-		return (c1.get(Calendar.ERA) == c2.get(Calendar.ERA) && c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR) && c1
-		        .get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR));
+		return (c1.get(Calendar.ERA) == c2.get(Calendar.ERA) && c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR)
+		        && c1.get(Calendar.DAY_OF_YEAR) == c2.get(Calendar.DAY_OF_YEAR));
 	}
-
+	
 	/**
 	 * Get declared field names of a class
+	 * 
 	 * @param clazz
 	 * @return
 	 */

--- a/api/src/main/java/org/openmrs/util/Security.java
+++ b/api/src/main/java/org/openmrs/util/Security.java
@@ -22,11 +22,11 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.xerces.impl.dv.util.Base64;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 
 /**
@@ -42,7 +42,7 @@ public class Security {
 	/**
 	 * encryption settings
 	 */
-	public static Log log = LogFactory.getLog(Security.class);
+	public static Logger log = LoggerFactory.getLogger(Security.class);
 	
 	/**
 	 * Compare the given hash and the given string-to-hash to see if they are equal. The

--- a/api/src/main/java/org/openmrs/util/VelocityExceptionHandler.java
+++ b/api/src/main/java/org/openmrs/util/VelocityExceptionHandler.java
@@ -9,16 +9,16 @@
  */
 package org.openmrs.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.velocity.app.event.MethodExceptionEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to safely catch velocity exceptions
  */
 public class VelocityExceptionHandler implements MethodExceptionEventHandler {
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * When a user-supplied method throws an exception, the MethodExceptionEventHandler is invoked

--- a/api/src/main/java/org/openmrs/util/databasechange/AddConceptMapTypesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/AddConceptMapTypesChangeset.java
@@ -18,9 +18,9 @@ import java.sql.Statement;
 import java.util.Calendar;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -36,7 +36,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class AddConceptMapTypesChangeset implements CustomTaskChange {
 	
-	private static final Log log = LogFactory.getLog(AddConceptMapTypesChangeset.class);
+	private static final Logger log = LoggerFactory.getLogger(AddConceptMapTypesChangeset.class);
 	
 	/**
 	 * The "visibleConceptMapTypes" parameter defined in the liquibase xml changeSet element that is

--- a/api/src/main/java/org/openmrs/util/databasechange/BooleanConceptChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BooleanConceptChangeSet.java
@@ -17,9 +17,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -35,7 +35,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class BooleanConceptChangeSet implements CustomTaskChange {
 	
-	private static Log log = LogFactory.getLog(BooleanConceptChangeSet.class);
+	private static Logger log = LoggerFactory.getLogger(BooleanConceptChangeSet.class);
 	
 	private Integer trueConceptId;
 	

--- a/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
@@ -29,14 +29,14 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections.set.ListOrderedSet;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -54,7 +54,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class ConceptValidatorChangeSet implements CustomTaskChange {
 	
-	private final static Log log = LogFactory.getLog(ConceptValidatorChangeSet.class);
+	private final static Logger log = LoggerFactory.getLogger(ConceptValidatorChangeSet.class);
 	
 	//List to store warnings
 	private List<String> updateWarnings = new LinkedList<String>();

--- a/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterRoleNameChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterRoleNameChangeSet.java
@@ -24,10 +24,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -46,7 +46,7 @@ import liquibase.resource.ResourceAccessor;
 
 public class DuplicateEncounterRoleNameChangeSet implements CustomTaskChange {
 	
-	private static final Log log = LogFactory.getLog(DuplicateEncounterRoleNameChangeSet.class);
+	private static final Logger log = LoggerFactory.getLogger(DuplicateEncounterRoleNameChangeSet.class);
 	
 	@Override
 	public String getConfirmationMessage() {

--- a/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterTypeNameChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterTypeNameChangeSet.java
@@ -22,10 +22,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -44,7 +44,7 @@ import liquibase.resource.ResourceAccessor;
 
 public class DuplicateEncounterTypeNameChangeSet implements CustomTaskChange {
 	
-	private static final Log log = LogFactory.getLog(DuplicateEncounterTypeNameChangeSet.class);
+	private static final Logger log = LoggerFactory.getLogger(DuplicateEncounterTypeNameChangeSet.class);
 	
 	@Override
 	public String getConfirmationMessage() {

--- a/api/src/main/java/org/openmrs/util/databasechange/DuplicateLocationAttributeTypeNameChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/DuplicateLocationAttributeTypeNameChangeSet.java
@@ -24,10 +24,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -46,7 +46,7 @@ import liquibase.resource.ResourceAccessor;
 
 public class DuplicateLocationAttributeTypeNameChangeSet implements CustomTaskChange {
 	
-	private static final Log log = LogFactory.getLog(DuplicateLocationAttributeTypeNameChangeSet.class);
+	private static final Logger log = LoggerFactory.getLogger(DuplicateLocationAttributeTypeNameChangeSet.class);
 	
 	@Override
 	public String getConfirmationMessage() {

--- a/api/src/main/java/org/openmrs/util/databasechange/EncryptSecretAnswersChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/EncryptSecretAnswersChangeSet.java
@@ -14,9 +14,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.Security;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -32,7 +32,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class EncryptSecretAnswersChangeSet implements CustomTaskChange {
 	
-	private final static Log log = LogFactory.getLog(EncryptSecretAnswersChangeSet.class);
+	private final static Logger log = LoggerFactory.getLogger(EncryptSecretAnswersChangeSet.class);
 	
 	/**
 	 * @see CustomTaskChange#execute(Database)

--- a/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
@@ -17,9 +17,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -47,7 +47,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class GenerateUuid implements CustomTaskChange {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	public static final Integer TRANSACTION_BATCH_SIZE_LIMIT = 512;
 	
@@ -127,7 +127,7 @@ public class GenerateUuid implements CustomTaskChange {
 								statement.close();
 							}
 							catch (SQLException e) {
-								log.warn(e);
+								log.warn("Failed to close the statement", e);
 							}
 						}
 					}
@@ -175,7 +175,7 @@ public class GenerateUuid implements CustomTaskChange {
 									idStatement.close();
 								}
 								catch (SQLException e) {
-									log.warn(e);
+									log.warn("Failed to close statement", e);
 								}
 							}
 							if (updateStatement != null) {
@@ -183,7 +183,7 @@ public class GenerateUuid implements CustomTaskChange {
 									updateStatement.close();
 								}
 								catch (SQLException e) {
-									log.warn(e);
+									log.warn("Failed to close the statement", e);
 								}
 							}
 						}

--- a/api/src/main/java/org/openmrs/util/databasechange/MigrateConceptReferenceTermChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MigrateConceptReferenceTermChangeSet.java
@@ -18,8 +18,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -37,7 +37,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class MigrateConceptReferenceTermChangeSet implements CustomTaskChange {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	public static final String DEFAULT_CONCEPT_MAP_TYPE = "NARROWER-THAN";
 	

--- a/api/src/main/java/org/openmrs/util/databasechange/MoveDeletedHL7sChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MoveDeletedHL7sChangeSet.java
@@ -13,9 +13,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.hl7.HL7Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomChange;
 import liquibase.change.custom.CustomTaskChange;
@@ -32,7 +32,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class MoveDeletedHL7sChangeSet implements CustomTaskChange {
 	
-	protected final static Log log = LogFactory.getLog(MoveDeletedHL7sChangeSet.class);
+	protected final static Logger log = LoggerFactory.getLogger(MoveDeletedHL7sChangeSet.class);
 	
 	/**
 	 * @see CustomTaskChange#execute(Database)

--- a/api/src/main/java/org/openmrs/util/databasechange/ProgramValidatorChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/ProgramValidatorChangeSet.java
@@ -13,10 +13,10 @@ import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -34,7 +34,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class ProgramValidatorChangeSet implements CustomTaskChange {
 	
-	protected final static Log log = LogFactory.getLog(ProgramValidatorChangeSet.class);
+	protected final static Logger log = LoggerFactory.getLogger(ProgramValidatorChangeSet.class);
 	
 	/**
 	 * @see CustomTaskChange#execute(Database)

--- a/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
@@ -22,11 +22,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -48,7 +48,7 @@ public class SourceMySqldiffFile implements CustomTaskChange {
 	
 	public static final String CONNECTION_PASSWORD = "connection.password";
 	
-	private static Log log = LogFactory.getLog(SourceMySqldiffFile.class);
+	private static Logger log = LoggerFactory.getLogger(SourceMySqldiffFile.class);
 	
 	/**
 	 * Absolute path and name of file to source

--- a/api/src/main/java/org/openmrs/util/databasechange/UpdateCohortMemberIds.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/UpdateCohortMemberIds.java
@@ -14,8 +14,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -31,7 +31,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class UpdateCohortMemberIds implements CustomTaskChange {
 	
-	private final static Log log = LogFactory.getLog(UpdateCohortMemberIds.class);
+	private final static Logger log = LoggerFactory.getLogger(UpdateCohortMemberIds.class);
 	
 	/**
 	 * @see CustomTaskChange#execute(Database)

--- a/api/src/main/java/org/openmrs/util/databasechange/UpdateLayoutAddressFormatChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/UpdateLayoutAddressFormatChangeSet.java
@@ -14,8 +14,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -31,7 +31,7 @@ import liquibase.resource.ResourceAccessor;
  */
 public class UpdateLayoutAddressFormatChangeSet implements CustomTaskChange {
 	
-	private final static Log log = LogFactory.getLog(UpdateLayoutAddressFormatChangeSet.class);
+	private final static Logger log = LoggerFactory.getLogger(UpdateLayoutAddressFormatChangeSet.class);
 	
 	/**
 	 * @see CustomTaskChange#execute(Database)

--- a/api/src/main/java/org/openmrs/validator/AlertValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AlertValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.notification.Alert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Alert.class }, order = 50)
 public class AlertValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/BaseAttributeTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/BaseAttributeTypeValidator.java
@@ -10,13 +10,13 @@
 package org.openmrs.validator;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.attribute.AttributeType;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.CustomDatatypeHandler;
 import org.openmrs.customdatatype.CustomDatatypeUtil;
 import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -28,8 +28,8 @@ import org.springframework.validation.Validator;
  */
 public abstract class BaseAttributeTypeValidator<T extends AttributeType<?>> implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)

--- a/api/src/main/java/org/openmrs/validator/ConceptClassValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptClassValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptClass;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { ConceptClass.class }, order = 50)
 public class ConceptClassValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ConceptDatatypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptDatatypeValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { ConceptDatatype.class }, order = 50)
 public class ConceptDatatypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ConceptDrugValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptDrugValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Drug;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Drug.class }, order = 50)
 public class ConceptDrugValidator implements Validator {
 	
-	// Log for this class
-	private static final Log log = LogFactory.getLog(ConceptDrugValidator.class);
+	// Logger for this class
+	private static final Logger log = LoggerFactory.getLogger(ConceptDrugValidator.class);
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ConceptNameTagValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptNameTagValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptNameTag;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { ConceptNameTag.class }, order = 50)
 public class ConceptNameTagValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ConceptSourceValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptSourceValidator.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -22,8 +22,8 @@ import org.springframework.validation.Validator;
  */
 public class ConceptSourceValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ConceptValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptValidator.java
@@ -16,8 +16,6 @@ import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptMap;
@@ -26,6 +24,8 @@ import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
 import org.openmrs.api.DuplicateConceptNameException;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -39,8 +39,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Concept.class }, order = 50)
 public class ConceptValidator extends BaseCustomizableValidator implements Validator {
 	
-	// Log for this class
-	private static final Log log = LogFactory.getLog(ConceptValidator.class);
+	// Logger for this class
+	private static final Logger log = LoggerFactory.getLogger(ConceptValidator.class);
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -11,8 +11,6 @@ package org.openmrs.validator;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.CareSetting;
 import org.openmrs.Concept;
 import org.openmrs.DosingInstructions;
@@ -24,6 +22,8 @@ import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -36,8 +36,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { DrugOrder.class }, order = 50)
 public class DrugOrderValidator extends OrderValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/DrugValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugValidator.java
@@ -12,13 +12,13 @@ package org.openmrs.validator;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.Drug;
 import org.openmrs.DrugReferenceMap;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -31,8 +31,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Drug.class })
 public class DrugValidator implements Validator {
 	
-	// Log for this class
-	protected final Log log = LogFactory.getLog(getClass());
+	// Logger for this class
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/EncounterTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterTypeValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.EncounterType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { EncounterType.class }, order = 50)
 public class EncounterTypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/EncounterValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterValidator.java
@@ -12,12 +12,12 @@ package org.openmrs.validator;
 import java.util.Date;
 
 import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Encounter;
 import org.openmrs.Visit;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -30,7 +30,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Encounter.class }, order = 50)
 public class EncounterValidator implements Validator {
 	
-	private static final Log log = LogFactory.getLog(EncounterValidator.class);
+	private static final Logger log = LoggerFactory.getLogger(EncounterValidator.class);
 	
 	/**
 	 * Returns whether or not this validator supports validating a given class.

--- a/api/src/main/java/org/openmrs/validator/FieldTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/FieldTypeValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.FieldType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { FieldType.class }, order = 50)
 public class FieldTypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/FieldValidator.java
+++ b/api/src/main/java/org/openmrs/validator/FieldValidator.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Field;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -26,7 +26,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Field.class }, order = 50)
 public class FieldValidator implements Validator {
 	
-	private static final Log log = LogFactory.getLog(FieldValidator.class);
+	private static final Logger log = LoggerFactory.getLogger(FieldValidator.class);
 	
 	/**
 	 * Returns whether or not this validator supports validating a given class.

--- a/api/src/main/java/org/openmrs/validator/FormValidator.java
+++ b/api/src/main/java/org/openmrs/validator/FormValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Form;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -24,8 +24,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Form.class }, order = 50)
 public class FormValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/HL7SourceValidator.java
+++ b/api/src/main/java/org/openmrs/validator/HL7SourceValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.hl7.HL7Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { HL7Source.class }, order = 50)
 public class HL7SourceValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ImplementationIdValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ImplementationIdValidator.java
@@ -10,11 +10,11 @@
 package org.openmrs.validator;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ImplementationId;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -26,7 +26,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { ImplementationId.class }, order = 50)
 public class ImplementationIdValidator implements Validator {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	@Override
 	public boolean supports(Class<?> clazz) {

--- a/api/src/main/java/org/openmrs/validator/LocationValidator.java
+++ b/api/src/main/java/org/openmrs/validator/LocationValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
@@ -28,8 +28,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Location.class }, order = 50)
 public class LocationValidator extends BaseCustomizableValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/OrderFrequencyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/OrderFrequencyValidator.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.ConceptClass;
 import org.openmrs.OrderFrequency;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -28,8 +28,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { OrderFrequency.class })
 public class OrderFrequencyValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/OrderTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/OrderTypeValidator.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptClass;
 import org.openmrs.OrderType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.order.OrderUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -28,8 +28,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { OrderType.class })
 public class OrderTypeValidator implements Validator {
 	
-	// Log for this class
-	protected final Log log = LogFactory.getLog(getClass());
+	// Logger for this class
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/OrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/OrderValidator.java
@@ -11,13 +11,13 @@ package org.openmrs.validator;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.DrugOrder;
 import org.openmrs.Encounter;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -30,8 +30,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Order.class })
 public class OrderValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/PatientIdentifierTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientIdentifierTypeValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PatientIdentifierType.class }, order = 50)
 public class PatientIdentifierTypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/PatientIdentifierValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientIdentifierValidator.java
@@ -10,8 +10,6 @@
 package org.openmrs.validator;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PatientIdentifierType.LocationBehavior;
@@ -25,6 +23,8 @@ import org.openmrs.api.PatientIdentifierException;
 import org.openmrs.api.context.Context;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.UnallowedIdentifierException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -34,7 +34,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PatientIdentifier.class }, order = 50)
 public class PatientIdentifierValidator implements Validator {
 	
-	private static Log log = LogFactory.getLog(PatientIdentifierValidator.class);
+	private static Logger log = LoggerFactory.getLogger(PatientIdentifierValidator.class);
 	
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)

--- a/api/src/main/java/org/openmrs/validator/PatientProgramValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientProgramValidator.java
@@ -13,8 +13,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PatientProgram;
 import org.openmrs.PatientState;
 import org.openmrs.ProgramWorkflow;
@@ -22,6 +20,8 @@ import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -34,7 +34,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PatientProgram.class }, order = 50)
 public class PatientProgramValidator implements Validator {
 	
-	private static final Log log = LogFactory.getLog(PatientProgramValidator.class);
+	private static final Logger log = LoggerFactory.getLogger(PatientProgramValidator.class);
 	
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)

--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -11,11 +11,11 @@ package org.openmrs.validator;
 
 import java.util.Collection;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
@@ -26,7 +26,7 @@ import org.springframework.validation.ValidationUtils;
 @Handler(supports = { Patient.class }, order = 25)
 public class PatientValidator extends PersonValidator {
 	
-	private static Log log = LogFactory.getLog(PersonNameValidator.class);
+	private static Logger log = LoggerFactory.getLogger(PersonNameValidator.class);
 	
 	@Autowired
 	private PatientIdentifierValidator patientIdentifierValidator;

--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -14,13 +14,13 @@ import java.util.List;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PersonAddress;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.layout.address.AddressTemplate;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -32,7 +32,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PersonAddress.class }, order = 50)
 public class PersonAddressValidator implements Validator {
 	
-	private static Log log = LogFactory.getLog(PersonAddressValidator.class);
+	private static Logger log = LoggerFactory.getLogger(PersonAddressValidator.class);
 	
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)

--- a/api/src/main/java/org/openmrs/validator/PersonMergeLogValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonMergeLogValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.person.PersonMergeLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PersonMergeLog.class }, order = 50)
 public class PersonMergeLogValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
@@ -10,12 +10,12 @@
 package org.openmrs.validator;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.PersonName;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -27,7 +27,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { PersonName.class }, order = 50)
 public class PersonNameValidator implements Validator {
 	
-	private static Log log = LogFactory.getLog(PersonNameValidator.class);
+	private static Logger log = LoggerFactory.getLogger(PersonNameValidator.class);
 	
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)

--- a/api/src/main/java/org/openmrs/validator/PrivilegeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PrivilegeValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Privilege;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Privilege.class }, order = 50)
 public class PrivilegeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ProgramValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProgramValidator.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Program;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -26,7 +26,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Program.class }, order = 50)
 public class ProgramValidator implements Validator {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/ProviderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProviderValidator.java
@@ -10,13 +10,13 @@
 package org.openmrs.validator;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Encounter;
 import org.openmrs.Provider;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -28,7 +28,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Provider.class }, order = 50)
 public class ProviderValidator extends BaseCustomizableValidator implements Validator {
 	
-	private static final Log log = LogFactory.getLog(ProviderValidator.class);
+	private static final Logger log = LoggerFactory.getLogger(ProviderValidator.class);
 	
 	/**
 	 * Returns whether or not this validator supports validating a given class.

--- a/api/src/main/java/org/openmrs/validator/RelationshipTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/RelationshipTypeValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.RelationshipType;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -27,8 +27,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { RelationshipType.class }, order = 50)
 public class RelationshipTypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/RoleValidator.java
+++ b/api/src/main/java/org/openmrs/validator/RoleValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Role;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Role.class }, order = 50)
 public class RoleValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/SchedulerFormValidator.java
+++ b/api/src/main/java/org/openmrs/validator/SchedulerFormValidator.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.annotation.Handler;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -22,8 +22,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { TaskDefinition.class }, order = 50)
 public class SchedulerFormValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/StateConversionValidator.java
+++ b/api/src/main/java/org/openmrs/validator/StateConversionValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptStateConversion;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,7 +25,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { ConceptStateConversion.class }, order = 50)
 public class StateConversionValidator implements Validator {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/TestOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/TestOrderValidator.java
@@ -11,12 +11,12 @@ package org.openmrs.validator;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.TestOrder;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -30,8 +30,8 @@ import org.springframework.validation.Validator;
 @Component("testOrderValidator")
 public class TestOrderValidator extends OrderValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the object being submitted is a valid type

--- a/api/src/main/java/org/openmrs/validator/UserValidator.java
+++ b/api/src/main/java/org/openmrs/validator/UserValidator.java
@@ -14,8 +14,6 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Person;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;
@@ -23,6 +21,8 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -35,8 +35,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { User.class }, order = 50)
 public class UserValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private static final Pattern EMAIL_PATTERN = Pattern
 	        .compile("^.+@.+\\..+$");

--- a/api/src/main/java/org/openmrs/validator/VisitTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/VisitTypeValidator.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.VisitType;
 import org.openmrs.annotation.Handler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
@@ -25,8 +25,8 @@ import org.springframework.validation.Validator;
 @Handler(supports = { VisitType.class }, order = 50)
 public class VisitTypeValidator implements Validator {
 	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
+	/** Logger for this class and subclasses */
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * Determines if the command object being submitted is a valid type

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -39,8 +39,6 @@ import java.util.Vector;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -83,6 +81,8 @@ import org.openmrs.test.TestUtil;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class tests methods in the PatientService class TODO Add methods to test all methods in
@@ -91,7 +91,7 @@ import org.openmrs.util.OpenmrsUtil;
 public class PatientServiceTest extends BaseContextSensitiveTest {
 	
 	// Logger
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	// Datasets
 	protected static final String CREATE_PATIENT_XML = "org/openmrs/api/include/PatientServiceTest-createPatient.xml";
@@ -1085,7 +1085,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		
 		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
 		
-		log.info(patientIdentifierType.getRequired());
+		log.info(patientIdentifierType.getRequired().toString());
 		
 		// TODO Finish
 		

--- a/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/PatientDAOTest.java
@@ -25,8 +25,6 @@ import java.util.Random;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hibernate.SessionFactory;
@@ -54,11 +52,13 @@ import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.GlobalPropertiesTestHelper;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class PatientDAOTest extends BaseContextSensitiveTest {
 	
-	private final static Log log = LogFactory.getLog(PatientDAOTest.class);
+	private final static Logger log = LoggerFactory.getLogger(PatientDAOTest.class);
 	
 	private final static String PEOPLE_FROM_THE_SHIRE_XML = "org/openmrs/api/db/hibernate/include/HibernatePersonDAOTest-people.xml";
 	

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePersonDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePersonDAOTest.java
@@ -12,8 +12,6 @@ package org.openmrs.api.db.hibernate;
 import java.text.SimpleDateFormat;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Before;
@@ -23,10 +21,12 @@ import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.util.GlobalPropertiesTestHelper;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HibernatePersonDAOTest extends BaseContextSensitiveTest {
 	
-	private final static Log log = LogFactory.getLog(HibernatePersonDAOTest.class);
+	private final static Logger log = LoggerFactory.getLogger(HibernatePersonDAOTest.class);
 	
 	private final static String PEOPLE_FROM_THE_SHIRE_XML = "org/openmrs/api/db/hibernate/include/HibernatePersonDAOTest-people.xml";
 	

--- a/api/src/test/java/org/openmrs/api/db/hibernate/PersonAttributeHelperTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/PersonAttributeHelperTest.java
@@ -9,17 +9,17 @@
  */
 package org.openmrs.api.db.hibernate;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.hibernate.SessionFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.test.BaseContextSensitiveTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PersonAttributeHelperTest extends BaseContextSensitiveTest {
 	
-	private final static Log log = LogFactory.getLog(PersonAttributeHelperTest.class);
+	private final static Logger log = LoggerFactory.getLogger(PersonAttributeHelperTest.class);
 	
 	private final static String PEOPLE_FROM_THE_SHIRE_XML = "org/openmrs/api/db/hibernate/include/HibernatePersonDAOTest-people.xml";
 	

--- a/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
+++ b/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
@@ -18,8 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,6 +35,8 @@ import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.app.Application;
@@ -54,7 +54,7 @@ import ca.uhn.hl7v2.model.v25.segment.PV1;
  */
 public class HL7ServiceTest extends BaseContextSensitiveTest {
 	
-	private Log log = LogFactory.getLog(HL7ServiceTest.class);
+	private Logger log = LoggerFactory.getLogger(HL7ServiceTest.class);
 	
 	/**
 	 * @see HL7Service#saveHL7InQueue(HL7InQueue)

--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -45,8 +45,6 @@ import javax.swing.UIManager;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;
 import org.dbunit.database.DatabaseConnection;
@@ -86,6 +84,8 @@ import org.openmrs.module.ModuleConstants;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
@@ -109,7 +109,7 @@ import org.xml.sax.InputSource;
 @TransactionConfiguration(defaultRollback = true)
 public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringContextTests {
 	
-	private static Log log = LogFactory.getLog(BaseContextSensitiveTest.class);
+	private static Logger log = LoggerFactory.getLogger(BaseContextSensitiveTest.class);
 	
 	/**
 	 * Only the classpath/package path and filename of the initial dataset

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterTest.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.util;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.Verifies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests methods on the {@link DatabaseUpdater} class. This class expects /metadata/model to be on
@@ -21,7 +21,7 @@ import org.openmrs.test.Verifies;
  */
 public class DatabaseUpdaterTest extends BaseContextSensitiveTest {
 	
-	private static Log log = LogFactory.getLog(DatabaseUpdaterTest.class);
+	private static Logger log = LoggerFactory.getLogger(DatabaseUpdaterTest.class);
 	
 	/**
 	 * @see DatabaseUpdater#updatesRequired()

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -113,6 +113,7 @@
 			<property name="severity" value="error"/>
 		</module>
 		<module name="IllegalImport">
+			<property name="illegalPkgs" value="sun, org.apache.commons.logging" />
 			<property name="severity" value="error"/>
 		</module>
 		<module name="OneTopLevelClass">

--- a/web/src/main/java/org/openmrs/module/web/ModuleResourcesServlet.java
+++ b/web/src/main/java/org/openmrs/module/web/ModuleResourcesServlet.java
@@ -18,11 +18,11 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModuleResourcesServlet extends HttpServlet {
 	
@@ -30,7 +30,7 @@ public class ModuleResourcesServlet extends HttpServlet {
 	
 	private static final long serialVersionUID = 1239820102030344L;
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * Used for caching purposes

--- a/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
+++ b/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
@@ -19,16 +19,16 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ModuleServlet extends HttpServlet {
 	
 	private static final long serialVersionUID = 1239820102030303L;
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	@Override
 	protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {

--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -46,8 +46,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleException;
@@ -63,6 +61,8 @@ import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.DispatcherServlet;
 import org.openmrs.web.StaticDispatcherServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.support.WebApplicationContextUtils;
 import org.springframework.web.context.support.XmlWebApplicationContext;
 import org.w3c.dom.Document;
@@ -76,7 +76,7 @@ import org.xml.sax.SAXException;
 
 public class WebModuleUtil {
 	
-	private static Log log = LogFactory.getLog(WebModuleUtil.class);
+	private static Logger log = LoggerFactory.getLogger(WebModuleUtil.class);
 	
 	private static DispatcherServlet dispatcherServlet = null;
 	
@@ -971,10 +971,10 @@ public class WebModuleUtil {
 			
 		}
 		catch (ParserConfigurationException pce) {
-			log.error(pce);
+			log.error("Failed to parse document", pce);
 		}
 		catch (TransformerException tfe) {
-			log.error(tfe);
+			log.error("Failed to transorm xml source", tfe);
 		}
 	}
 	

--- a/web/src/main/java/org/openmrs/module/web/filter/ModuleFilter.java
+++ b/web/src/main/java/org/openmrs/module/web/filter/ModuleFilter.java
@@ -18,9 +18,9 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.web.WebModuleUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This filter provides a mechanism for modules to plug-in their own custom filters. It is started
@@ -28,7 +28,7 @@ import org.openmrs.module.web.WebModuleUtil;
  */
 public class ModuleFilter implements Filter {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * @see javax.servlet.Filter#init(javax.servlet.FilterConfig)

--- a/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterDefinition.java
+++ b/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterDefinition.java
@@ -15,10 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -43,7 +43,7 @@ public class ModuleFilterDefinition implements Serializable {
 	
 	public static final long serialVersionUID = 1;
 	
-	private static Log log = LogFactory.getLog(ModuleFilterDefinition.class);
+	private static Logger log = LoggerFactory.getLogger(ModuleFilterDefinition.class);
 	
 	// Properties
 	private Module module;

--- a/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterMapping.java
+++ b/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterMapping.java
@@ -14,11 +14,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleException;
 import org.openmrs.module.web.WebModuleUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -30,7 +30,7 @@ public class ModuleFilterMapping implements Serializable {
 	
 	public static final long serialVersionUID = 1;
 	
-	private static Log log = LogFactory.getLog(WebModuleUtil.class);
+	private static Logger log = LoggerFactory.getLogger(WebModuleUtil.class);
 	
 	// Properties
 	private Module module;

--- a/web/src/main/java/org/openmrs/web/DispatcherServlet.java
+++ b/web/src/main/java/org/openmrs/web/DispatcherServlet.java
@@ -12,8 +12,6 @@ package org.openmrs.web;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.web.WebModuleUtil;
@@ -21,6 +19,8 @@ import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.web.filter.initialization.InitializationFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.web.context.support.XmlWebApplicationContext;
 
@@ -36,7 +36,7 @@ public class DispatcherServlet extends org.springframework.web.servlet.Dispatche
 	
 	private static final long serialVersionUID = -6925172744402818729L;
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @see org.springframework.web.servlet.FrameworkServlet#initFrameworkServlet()

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -32,8 +32,6 @@ import javax.servlet.ServletException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -54,6 +52,8 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.web.filter.initialization.InitializationFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MarkerFactory;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ContextLoader;
@@ -72,15 +72,15 @@ import org.xml.sax.SAXException;
  * modules 2) Copy the custom look/images/messages over into the web layer
  */
 public final class Listener extends ContextLoader implements ServletContextListener { // extends ContextLoaderListener {
-
-	protected final Log log = LogFactory.getLog(getClass());
-
+	
+	protected final org.slf4j.Logger log = LoggerFactory.getLogger(getClass());
+	
 	private static boolean runtimePropertiesFound = false;
-
+	
 	private static Throwable errorAtStartup = null;
-
+	
 	private static boolean setupNeeded = false;
-
+	
 	/**
 	 * Boolean flag set on webapp startup marking whether there is a runtime properties file or not.
 	 * If there is not, then the {@link InitializationFilter} takes over any openmrs url and
@@ -91,7 +91,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	public static boolean runtimePropertiesFound() {
 		return runtimePropertiesFound;
 	}
-
+	
 	/**
 	 * Boolean flag set by the {@link #contextInitialized(ServletContextEvent)} method if an error
 	 * occurred when trying to start up. The StartupErrorFilter displays the error to the admin
@@ -101,7 +101,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	public static boolean errorOccurredAtStartup() {
 		return errorAtStartup != null;
 	}
-
+	
 	/**
 	 * Boolean flag that tells if we need to run the database setup wizard.
 	 *
@@ -110,7 +110,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	public static boolean isSetupNeeded() {
 		return setupNeeded;
 	}
-
+	
 	/**
 	 * Get the error thrown at startup
 	 *
@@ -119,15 +119,15 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	public static Throwable getErrorAtStartup() {
 		return errorAtStartup;
 	}
-
+	
 	public static void setRuntimePropertiesFound(boolean runtimePropertiesFound) {
 		Listener.runtimePropertiesFound = runtimePropertiesFound;
 	}
-
+	
 	public static void setErrorAtStartup(Throwable errorAtStartup) {
 		Listener.errorAtStartup = errorAtStartup;
 	}
-
+	
 	/**
 	 * This method is called when the servlet context is initialized(when the Web Application is
 	 * deployed). You can initialize servlet context related data here.
@@ -136,22 +136,22 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 */
 	@Override
 	public void contextInitialized(ServletContextEvent event) {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		log.debug("Starting the OpenMRS webapp");
-
+		
 		try {
 			// validate the current JVM version
 			OpenmrsUtil.validateJavaVersion();
-
+			
 			ServletContext servletContext = event.getServletContext();
-
+			
 			// pulled from web.xml.
 			loadConstants(servletContext);
-
+			
 			// erase things in the dwr file
 			clearDWRFile(servletContext);
-
+			
 			setApplicationDataDirectory(servletContext);
 			
 			// Try to get the runtime properties
@@ -163,7 +163,8 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				// used during sessionFactory creation
 				Context.setRuntimeProperties(props);
 				
-				String appDataRuntimeProperty = props.getProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, null);
+				String appDataRuntimeProperty = props
+				        .getProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, null);
 				if (StringUtils.hasLength(appDataRuntimeProperty)) {
 					OpenmrsUtil.setApplicationDataDirectory(null);
 				}
@@ -172,41 +173,40 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				//since openmrs is just booting, the log levels are not yet set. TRUNK-4835
 				Logger.getLogger(getClass()).setLevel(Level.INFO);
 				log.info("Using runtime properties file: "
-						+ OpenmrsUtil.getRuntimePropertiesFilePathName(WebConstants.WEBAPP_NAME));
+				        + OpenmrsUtil.getRuntimePropertiesFilePathName(WebConstants.WEBAPP_NAME));
 			}
 			
 			Thread.currentThread().setContextClassLoader(OpenmrsClassLoader.getInstance());
-
+			
 			if (!setupNeeded()) {
 				// must be done after the runtime properties are
 				// found but before the database update is done
 				copyCustomizationIntoWebapp(servletContext, props);
-
+				
 				//super.contextInitialized(event);
 				// also see commented out line in contextDestroyed
-
-				/** This logic is from ContextLoader.initWebApplicationContext.
-				 * Copied here instead of calling that so that the context is not cached
-				 * and hence not garbage collected
+				
+				/**
+				 * This logic is from ContextLoader.initWebApplicationContext. Copied here instead
+				 * of calling that so that the context is not cached and hence not garbage collected
 				 */
 				XmlWebApplicationContext context = (XmlWebApplicationContext) createWebApplicationContext(servletContext);
 				configureAndRefreshWebApplicationContext(context, servletContext);
 				servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
-
+				
 				WebDaemon.startOpenmrs(event.getServletContext());
-			}
-			else {
+			} else {
 				setupNeeded = true;
 			}
-
+			
 		}
 		catch (Exception e) {
 			setErrorAtStartup(e);
-			log.fatal("Got exception while starting up: ", e);
+			log.error(MarkerFactory.getMarker("FATAL"), "Failed to obtain JDBC connection", e);
 		}
-
+		
 	}
-
+	
 	/**
 	 * This method knows about all the filters that openmrs uses for setup. Currently those are the
 	 * {@link InitializationFilter} and the {@link UpdateFilter}. If either of these have to do
@@ -218,10 +218,10 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		if (!runtimePropertiesFound) {
 			return true;
 		}
-
+		
 		return DatabaseUpdater.updatesRequired() && !DatabaseUpdater.allowAutoUpdate();
 	}
-
+	
 	/**
 	 * Do the work of starting openmrs.
 	 *
@@ -229,18 +229,18 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 * @throws ServletException
 	 */
 	public static void startOpenmrs(ServletContext servletContext) throws ServletException {
-
+		
 		//Ensure that we are being called from WebDaemon
 		//TODO this did not work because callerClass was org.openmrs.web.WebDaemon$1 instead of org.openmrs.web.WebDaemon
 		/*Class<?> callerClass = new OpenmrsSecurityManager().getCallerClass(0);
 		if (!WebDaemon.class.isAssignableFrom(callerClass))
 			throw new APIException("This method can only be called from the WebDaemon class, not " + callerClass.getName());*/
-
+		
 		// start openmrs
 		try {
 			// load bundled modules that are packaged into the webapp
 			Listener.loadBundledModules(servletContext);
-
+			
 			Context.startup(getRuntimeProperties());
 		}
 		catch (DatabaseUpdateException updateEx) {
@@ -257,14 +257,14 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			// in the StartupErrorFilter class
 			throw coreModEx;
 		}
-
+		
 		// TODO catch openmrs errors here and drop the user back out to the setup screen
-
+		
 		try {
-
+			
 			// web load modules
 			Listener.performWebStartOfModules(servletContext);
-
+			
 			// start the scheduled tasks
 			SchedulerUtil.startup(getRuntimeProperties());
 		}
@@ -277,7 +277,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			Context.closeSession();
 		}
 	}
-
+	
 	/**
 	 * Load the openmrs constants with values from web.xml init parameters
 	 *
@@ -289,10 +289,11 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		WebConstants.MODULE_REPOSITORY_URL = servletContext.getInitParameter("module.repository.url");
 		
 		if (!"openmrs".equalsIgnoreCase(WebConstants.WEBAPP_NAME)) {
-			OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY = WebConstants.WEBAPP_NAME + "_APPLICATION_DATA_DIRECTORY";
+			OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY = WebConstants.WEBAPP_NAME
+			        + "_APPLICATION_DATA_DIRECTORY";
 		}
 	}
-
+	
 	private void setApplicationDataDirectory(ServletContext servletContext) {
 		// note: the below value will be overridden after reading the runtime properties if the
 		// "application_data_directory" runtime property is set
@@ -300,8 +301,8 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		if (StringUtils.hasLength(appDataDir)) {
 			OpenmrsUtil.setApplicationDataDirectory(appDataDir);
 		} else if (!"openmrs".equalsIgnoreCase(WebConstants.WEBAPP_NAME)) {
-			OpenmrsUtil.setApplicationDataDirectory(OpenmrsUtil.getApplicationDataDirectory() + File.separator
-			        + WebConstants.WEBAPP_NAME);
+			OpenmrsUtil.setApplicationDataDirectory(
+			    OpenmrsUtil.getApplicationDataDirectory() + File.separator + WebConstants.WEBAPP_NAME);
 		}
 	}
 	
@@ -328,21 +329,21 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				contextPath = contextPath.substring(contextPath.lastIndexOf("/"));
 			}
 			catch (Exception e) {
-				log.error(e);
+				log.error("Failed to get construct context path", e);
 			}
 		}
 		catch (Exception e) {
-			log.error(e);
+			log.error("Failed to get context path", e);
 		}
-
+		
 		// trim off initial slash if it exists
 		if (contextPath.indexOf("/") != -1) {
 			contextPath = contextPath.substring(1);
 		}
-
+		
 		return contextPath;
 	}
-
+	
 	/**
 	 * Convenience method to empty out the dwr-modules.xml file to fix any errors that might have
 	 * occurred in it when loading or unloading modules.
@@ -350,8 +351,8 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 * @param servletContext
 	 */
 	private void clearDWRFile(ServletContext servletContext) {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		String realPath = servletContext.getRealPath("");
 		String absPath = realPath + "/WEB-INF/dwr-modules.xml";
 		File dwrFile = new File(absPath.replace("/", File.separator));
@@ -359,7 +360,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder db = dbf.newDocumentBuilder();
 			db.setEntityResolver(new EntityResolver() {
-
+				
 				@Override
 				public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
 					// When asked to resolve external entities (such as a DTD) we return an InputSource
@@ -380,12 +381,13 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			FileWriter writer = null;
 			try {
 				writer = new FileWriter(dwrFile);
-				writer
-				        .write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE dwr PUBLIC \"-//GetAhead Limited//DTD Direct Web Remoting 2.0//EN\" \"http://directwebremoting.org/schema/dwr20.dtd\">\n<dwr></dwr>");
+				writer.write(
+				    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE dwr PUBLIC \"-//GetAhead Limited//DTD Direct Web Remoting 2.0//EN\" \"http://directwebremoting.org/schema/dwr20.dtd\">\n<dwr></dwr>");
 			}
 			catch (IOException io) {
-				log.error("Unable to clear out the " + dwrFile.getAbsolutePath()
-				        + " file.  Please redeploy the openmrs war file", io);
+				log.error(
+				    "Unable to clear out the " + dwrFile.getAbsolutePath() + " file.  Please redeploy the openmrs war file",
+				    io);
 			}
 			finally {
 				if (writer != null) {
@@ -399,15 +401,15 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			}
 		}
 	}
-
+	
 	/**
 	 * Copy the customization scripts over into the webapp
 	 *
 	 * @param servletContext
 	 */
 	private void copyCustomizationIntoWebapp(ServletContext servletContext, Properties props) {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		String realPath = servletContext.getRealPath("");
 		// TODO centralize map to WebConstants?
 		Map<String, String> custom = new HashMap<String, String>();
@@ -421,7 +423,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		custom.put("custom.messages_fr", "/WEB-INF/custom_messages_fr.properties");
 		custom.put("custom.messages_es", "/WEB-INF/custom_messages_es.properties");
 		custom.put("custom.messages_de", "/WEB-INF/custom_messages_de.properties");
-
+		
 		for (Map.Entry<String, String> entry : custom.entrySet()) {
 			String prop = entry.getKey();
 			String webappPath = entry.getValue();
@@ -430,7 +432,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			if (userOverridePath != null) {
 				String absolutePath = realPath + webappPath;
 				File file = new File(userOverridePath);
-
+				
 				// if they got the path correct
 				// also, if file does not start with a "." (hidden files, like SVN files)
 				if (file.exists() && !userOverridePath.startsWith(".")) {
@@ -458,10 +460,10 @@ public final class Listener extends ContextLoader implements ServletContextListe
 					}
 				}
 			}
-
+			
 		}
 	}
-
+	
 	/**
 	 * Copies file pointed to by <code>fromPath</code> to <code>toPath</code>
 	 *
@@ -470,8 +472,8 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 * @return true/false whether the copy was a success
 	 */
 	private boolean copyFile(String fromPath, String toPath) {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		FileInputStream inputStream = null;
 		FileOutputStream outputStream = null;
 		try {
@@ -502,7 +504,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		}
 		return true;
 	}
-
+	
 	/**
 	 * Load the pre-packaged modules from web/WEB-INF/bundledModules. <br>
 	 * <br>
@@ -512,12 +514,12 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 * @param servletContext the current servlet context for the webapp
 	 */
 	public static void loadBundledModules(ServletContext servletContext) {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		String path = servletContext.getRealPath("");
 		path += File.separator + "WEB-INF" + File.separator + "bundledModules";
 		File folder = new File(path);
-
+		
 		if (!folder.exists()) {
 			log.warn("Bundled module folder doesn't exist: " + folder.getAbsolutePath());
 			return;
@@ -526,7 +528,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			log.warn("Bundled module folder isn't really a directory: " + folder.getAbsolutePath());
 			return;
 		}
-
+		
 		// loop over the modules and load the modules that we can
 		for (File f : folder.listFiles()) {
 			if (!f.getName().startsWith(".")) { // ignore .svn folder and the like
@@ -540,7 +542,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			}
 		}
 	}
-
+	
 	/**
 	 * Called when the webapp is shut down properly Must call Context.shutdown() and then shutdown
 	 * all the web layers of the modules
@@ -550,21 +552,21 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	@SuppressWarnings("squid:S1215")
 	@Override
 	public void contextDestroyed(ServletContextEvent event) {
-
+		
 		try {
 			Context.openSession();
-
+			
 			Context.shutdown();
-
+			
 			WebModuleUtil.shutdownModules(event.getServletContext());
-
+			
 		}
 		catch (Exception e) {
 			// don't print the unhelpful "contextDAO is null" message
 			if (!"contextDAO is null".equals(e.getMessage())) {
 				// not using log.error here so it can be garbage collected
 				System.out.println("Listener.contextDestroyed: Error while shutting down openmrs: ");
-				log.error(e);
+				log.error("Listener.contextDestroyed: Error while shutting down openmrs: ", e);
 			}
 		}
 		finally {
@@ -578,10 +580,10 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			// remove the user context that we set earlier
 			Context.closeSession();
 		}
-
+		
 		// commented out because we are not init'ing it in the contextInitialization anymore
 		// super.contextDestroyed(event);
-
+		
 		try {
 			for (Enumeration<Driver> e = DriverManager.getDrivers(); e.hasMoreElements();) {
 				Driver driver = e.nextElement();
@@ -597,22 +599,22 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		}
 		catch (Exception e) {
 			System.err.println("Listener.contextDestroyed: Failed to cleanup drivers in webapp");
-			log.error(e);
+			log.error("Listener.contextDestroyed: Failed to cleanup drivers in webapp", e);
 		}
-
+		
 		MemoryLeakUtil.shutdownMysqlCancellationTimer();
 		MemoryLeakUtil.shutdownKeepAliveTimer();
-
+		
 		OpenmrsClassLoader.onShutdown();
-
+		
 		LogManager.shutdown();
-
+		
 		// just to make things nice and clean.
 		// Suppressing sonar issue squid:S1215
 		System.gc();
 		System.gc();
 	}
-
+	
 	/**
 	 * Finds and loads the runtime properties
 	 *
@@ -622,7 +624,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	public static Properties getRuntimeProperties() {
 		return OpenmrsUtil.getRuntimeProperties(WebConstants.WEBAPP_NAME);
 	}
-
+	
 	/**
 	 * Call WebModuleUtil.startModule on each started module
 	 *
@@ -635,23 +637,23 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		startedModules.addAll(ModuleFactory.getStartedModules());
 		performWebStartOfModules(startedModules, servletContext);
 	}
-
+	
 	public static void performWebStartOfModules(Collection<Module> startedModules, ServletContext servletContext)
 	        throws ModuleMustStartException, Exception {
-		Log log = LogFactory.getLog(Listener.class);
-
+		final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
+		
 		boolean someModuleNeedsARefresh = false;
 		for (Module mod : startedModules) {
 			try {
 				boolean thisModuleCausesRefresh = WebModuleUtil.startModule(mod, servletContext,
-				/* delayContextRefresh */true);
+				    /* delayContextRefresh */true);
 				someModuleNeedsARefresh = someModuleNeedsARefresh || thisModuleCausesRefresh;
 			}
 			catch (Exception e) {
 				mod.setStartupErrorMessage("Unable to start module", e);
 			}
 		}
-
+		
 		if (someModuleNeedsARefresh) {
 			try {
 				WebModuleUtil.refreshWAC(servletContext, true, null);
@@ -667,11 +669,13 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			catch (Exception e) {
 				Throwable rootCause = getActualRootCause(e, true);
 				if (rootCause != null) {
-					log.fatal("Unable to refresh the spring application context.  Root Cause was:", rootCause);
+					log.error(MarkerFactory.getMarker("FATAL"),
+					    "Unable to refresh the spring application context.  Root Cause was:", rootCause);
 				} else {
-					log.fatal("Unable to refresh the spring application context. Unloading all modules,  Error was:", e);
+					log.error(MarkerFactory.getMarker("FATAL"),
+					    "nable to refresh the spring application context. Unloading all modules,  Error was:", e);
 				}
-
+				
 				try {
 					WebModuleUtil.shutdownModules(servletContext);
 					for (Module mod : ModuleFactory.getLoadedModules()) {// use loadedModules to avoid a concurrentmodificationexception
@@ -701,7 +705,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				}
 			}
 		}
-
+		
 		// because we delayed the refresh, we need to load+start all servlets and filters now
 		// (this is to protect servlets/filters that depend on their module's spring xml config being available)
 		for (Module mod : ModuleFactory.getStartedModules()) {
@@ -709,7 +713,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			WebModuleUtil.loadFilters(mod, servletContext);
 		}
 	}
-
+	
 	/**
 	 * Convenience method that recursively attempts to pull the root case from a Throwable
 	 *
@@ -722,12 +726,12 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		if (t.getCause() != null) {
 			return getActualRootCause(t.getCause(), false);
 		}
-
+		
 		if (!isOriginalError) {
 			return t;
 		}
-
+		
 		return null;
 	}
-
+	
 }

--- a/web/src/main/java/org/openmrs/web/StaticDispatcherServlet.java
+++ b/web/src/main/java/org/openmrs/web/StaticDispatcherServlet.java
@@ -11,10 +11,10 @@ package org.openmrs.web;
 
 import javax.servlet.ServletException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.module.web.WebModuleUtil;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.web.context.support.XmlWebApplicationContext;
 
@@ -28,7 +28,7 @@ public class StaticDispatcherServlet extends org.springframework.web.servlet.Dis
 	
 	private static final long serialVersionUID = 1L;
 	
-	private Log log = LogFactory.getLog(this.getClass());
+	private Logger log = LoggerFactory.getLogger(this.getClass());
 	
 	/**
 	 * @see org.springframework.web.servlet.FrameworkServlet#initFrameworkServlet()

--- a/web/src/main/java/org/openmrs/web/WebUtil.java
+++ b/web/src/main/java/org/openmrs/web/WebUtil.java
@@ -16,8 +16,6 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;
@@ -26,10 +24,12 @@ import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsDateFormat;
 import org.owasp.encoder.Encode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class WebUtil implements GlobalPropertyListener {
 	
-	private static Log log = LogFactory.getLog(WebUtil.class);
+	private static Logger log = LoggerFactory.getLogger(WebUtil.class);
 	
 	private static String defaultDateCache = null;
 

--- a/web/src/main/java/org/openmrs/web/controller/PseudoStaticContentController.java
+++ b/web/src/main/java/org/openmrs/web/controller/PseudoStaticContentController.java
@@ -16,10 +16,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
 import org.springframework.web.servlet.mvc.LastModified;
@@ -35,7 +35,7 @@ import org.springframework.web.servlet.mvc.LastModified;
  */
 public class PseudoStaticContentController implements Controller, LastModified, GlobalPropertyListener {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	private Boolean interpretJstl = false;
 	

--- a/web/src/main/java/org/openmrs/web/filter/GZIPFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/GZIPFilter.java
@@ -16,11 +16,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -31,7 +31,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 public class GZIPFilter extends OncePerRequestFilter {
 	
-	private static final Log log = LogFactory.getLog(GZIPFilter.class);
+	private static final Logger log = LoggerFactory.getLogger(GZIPFilter.class);
 	
 	private Boolean cachedGZipEnabledFlag = null;
 	

--- a/web/src/main/java/org/openmrs/web/filter/GZIPResponseWrapper.java
+++ b/web/src/main/java/org/openmrs/web/filter/GZIPResponseWrapper.java
@@ -17,8 +17,8 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wraps Response for GZipFilter
@@ -27,7 +27,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public class GZIPResponseWrapper extends HttpServletResponseWrapper {
 	
-	private static final Log log = LogFactory.getLog(GZIPResponseWrapper.class);
+	private static final Logger log = LoggerFactory.getLogger(GZIPResponseWrapper.class);
 	
 	protected HttpServletResponse origResponse = null;
 	

--- a/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
@@ -17,13 +17,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.web.WebConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
@@ -36,7 +36,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
  */
 public class OpenmrsFilter extends OncePerRequestFilter {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * @see javax.servlet.Filter#destroy()

--- a/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
@@ -33,8 +33,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;
@@ -57,6 +55,8 @@ import org.openmrs.web.filter.initialization.InitializationFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
 import org.openmrs.web.filter.util.FilterUtil;
 import org.openmrs.web.filter.util.LocalizationTool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract class used when a small wizard is needed before Spring, jsp, etc has been started up.
@@ -66,7 +66,7 @@ import org.openmrs.web.filter.util.LocalizationTool;
  */
 public abstract class StartupFilter implements Filter {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	protected static VelocityEngine velocityEngine = null;
 	

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -40,8 +40,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
 import org.apache.xerces.impl.dv.util.Base64;
@@ -71,6 +69,7 @@ import org.openmrs.web.filter.update.UpdateFilter;
 import org.openmrs.web.filter.util.CustomResourceLoader;
 import org.openmrs.web.filter.util.ErrorMessageConstants;
 import org.openmrs.web.filter.util.FilterUtil;
+import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.ContextLoader;
 
@@ -83,7 +82,7 @@ import liquibase.changelog.ChangeSet;
  */
 public class InitializationFilter extends StartupFilter {
 	
-	private static final Log log = LogFactory.getLog(InitializationFilter.class);
+	private static final org.slf4j.Logger log = LoggerFactory.getLogger(InitializationFilter.class);
 	
 	private static final String LIQUIBASE_SCHEMA_DATA = "liquibase-schema-only.xml";
 	

--- a/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
@@ -29,8 +29,6 @@ import java.util.zip.ZipFile;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.xerces.impl.dv.util.Base64;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
@@ -39,6 +37,8 @@ import org.openmrs.module.ModuleConstants;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.web.filter.util.FilterUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains static methods to be used by the installation wizard when creating a testing
@@ -46,7 +46,7 @@ import org.openmrs.web.filter.util.FilterUtil;
  */
 public class TestInstallUtil {
 	
-	private static final Log log = LogFactory.getLog(TestInstallUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(TestInstallUtil.class);
 	
 	/**
 	 * Adds data to the test database from a sql dump file

--- a/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilter.java
@@ -29,13 +29,13 @@ import org.apache.commons.fileupload.RequestContext;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.servlet.ServletRequestContext;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.OpenmrsCoreModuleException;
 import org.openmrs.web.Listener;
 import org.openmrs.web.filter.StartupFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the second filter that is processed. It is only active when OpenMRS has some liquibase
@@ -44,7 +44,7 @@ import org.openmrs.web.filter.StartupFilter;
  */
 public class StartupErrorFilter extends StartupFilter {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * The velocity macro page to redirect to if an error occurs or on initial startup

--- a/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
@@ -10,10 +10,10 @@
 package org.openmrs.web.filter.startuperror;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.web.filter.StartupFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link UpdateFilter} uses this model object to hold all properties that are edited by the
@@ -22,7 +22,7 @@ import org.openmrs.web.filter.update.UpdateFilter;
  */
 public class StartupErrorFilterModel {
 	
-	protected static final Log log = LogFactory.getLog(StartupErrorFilterModel.class);
+	protected static final Logger log = LoggerFactory.getLogger(StartupErrorFilterModel.class);
 	
 	// automatically given to the .vm files and used there
 	public String headerTemplate = "org/openmrs/web/filter/startuperror/header.vm";

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -33,8 +33,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
 import org.openmrs.util.DatabaseUpdateException;
@@ -53,6 +51,7 @@ import org.openmrs.web.filter.initialization.InitializationFilter;
 import org.openmrs.web.filter.util.CustomResourceLoader;
 import org.openmrs.web.filter.util.ErrorMessageConstants;
 import org.openmrs.web.filter.util.FilterUtil;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.context.ContextLoader;
 
 import liquibase.changelog.ChangeSet;
@@ -65,7 +64,7 @@ import liquibase.exception.LockException;
  */
 public class UpdateFilter extends StartupFilter {
 	
-	protected final Log log = LogFactory.getLog(getClass());
+	protected final org.slf4j.Logger log = LoggerFactory.getLogger(getClass());
 	
 	/**
 	 * The velocity macro page to redirect to if an error occurs or on initial startup

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilterModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilterModel.java
@@ -11,14 +11,14 @@ package org.openmrs.web.filter.update;
 
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUpdater.OpenMRSChangeSet;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.RoleConstants;
 import org.openmrs.web.WebConstants;
 import org.openmrs.web.filter.StartupFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@link UpdateFilter} uses this model object to hold all properties that are edited by the
@@ -66,7 +66,7 @@ public class UpdateFilterModel {
 	 * that still need to be run.
 	 */
 	public void updateChanges() {
-		Log log = LogFactory.getLog(getClass());
+		Logger log = LoggerFactory.getLogger(getClass());
 		
 		try {
 			changes = DatabaseUpdater.getUnrunDatabaseChanges();

--- a/web/src/main/java/org/openmrs/web/filter/util/CustomResourceLoader.java
+++ b/web/src/main/java/org/openmrs/web/filter/util/CustomResourceLoader.java
@@ -21,9 +21,9 @@ import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.LocaleUtility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
@@ -32,7 +32,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
  */
 public class CustomResourceLoader {
 	
-	private static final Log log = LogFactory.getLog(CustomResourceLoader.class);
+	private static final Logger log = LoggerFactory.getLogger(CustomResourceLoader.class);
 	
 	/** */
 	public static final String PREFIX = "messages";

--- a/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
@@ -16,11 +16,11 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.OpenmrsConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class contains convenient methods for storing/retrieving locale parameters into/from DB as
@@ -28,7 +28,7 @@ import org.openmrs.util.OpenmrsConstants;
  */
 public class FilterUtil {
 	
-	private static final Log log = LogFactory.getLog(FilterUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(FilterUtil.class);
 	
 	public static final String LOCALE_ATTRIBUTE = "locale";
 	


### PR DESCRIPTION
## Description
we exclude the apache commons-logging dependency coming from springframework
and configure the slf4j facade with the log4j implementation but still
use commons-logging or log4j directly.

* replace usages by using the slf4j facade
* add "org.apache.commons.logging" to checkstyle's IllegalImport rule
so we get notified of anyone trying to use it
* replace log.fatal("message", exception)

with

log.error(MarkerFactory.getMarker("FATAL"), "message", e);

since slf4j does not provide the level FATAL and suggests the use of
markers instead

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->


<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5114


