### PR TITLE
 TRUNK-5114 Using different logging implementations instead of facade

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonValidator.java
@@ -12,12 +12,13 @@ package org.openmrs.validator;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.apache.log4j.Logger;
 import org.openmrs.Person;
 import org.openmrs.PersonAddress;
 import org.openmrs.PersonName;
 import org.openmrs.annotation.Handler;
 import org.openmrs.util.OpenmrsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
@@ -31,7 +32,7 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Person.class }, order = 50)
 public class PersonValidator implements Validator {
 	
-	private Logger log = Logger.getLogger(PersonValidator.class);
+	private Logger log = LoggerFactory.getLogger(PersonValidator.class);
 	
 	@Autowired
 	private PersonNameValidator personNameValidator;
@@ -59,9 +60,7 @@ public class PersonValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object target, Errors errors) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", this.getClass().getName());
 		
 		if (target == null) {
 			return;
@@ -169,7 +168,7 @@ public class PersonValidator implements Validator {
 			errors.rejectValue(dateField, "error.date.nonsensical");
 		}
 	}
-
+	
 	/**
 	 * Rejects a death date if it is before birth date
 	 * 
@@ -182,7 +181,5 @@ public class PersonValidator implements Validator {
 			errors.rejectValue("deathDate", "error.deathdate.before.birthdate");
 		}
 	}
-
-
 	
 }


### PR DESCRIPTION
* replace use of log4j with slf4j logging facade in PersonValidator
* use parametrized message with log.debug which avoids superfluous
object creation when the logger is disabled for the DEBUG level and
removes if clause which causes a double check for wether DEBUG level is
enabled

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5114


