### PR TITLE
TRUNK-5111 Replace refs to deprecated isVoided in javadocs

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -146,11 +146,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	}
 	
 	/**
-	 * This method delegates to {@link #isVoided()}. This is only needed for jstl syntax like
-	 * ${person.voided} because the return type is a Boolean object instead of a boolean primitive
-	 * type.
-	 * 
-	 * @see org.openmrs.Voidable#isVoided()
+	 * @see org.openmrs.Voidable#getVoided()
 	 */
 	@Override
 	public Boolean getVoided() {

--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -154,9 +154,6 @@ public class Encounter extends BaseOpenmrsData {
 			for (Obs o : this.obs) {
 				ret.addAll(getObsLeaves(o));
 			}
-			// this should be all that is needed unless the encounter has been built by hand
-			//if (o.isVoided() == false && o.isObsGrouping() == false)
-			//	ret.add(o);
 		}
 		
 		return ret;

--- a/api/src/main/java/org/openmrs/Voidable.java
+++ b/api/src/main/java/org/openmrs/Voidable.java
@@ -37,6 +37,9 @@ public interface Voidable extends OpenmrsObject {
 	@JsonIgnore
 	public Boolean isVoided();
 	
+	/**
+	 * @return true if this object is voided and otherwise false
+	 */
 	public Boolean getVoided();
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/handler/UnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/UnvoidHandler.java
@@ -19,7 +19,7 @@ import org.openmrs.aop.RequiredDataAdvice;
  * This is the super interface for all unvoid* actions that take place on all services. The
  * {@link RequiredDataAdvice} class uses AOP around each method in every service to check to see if
  * its a unvoid* method. If it is a unvoid* method, this class is called to handle setting the
- * {@link Voidable#isVoided()}, {@link Voidable#setVoidReason(String)},
+ * {@link Voidable#getVoided()}, {@link Voidable#setVoidReason(String)},
  * {@link Voidable#setVoidedBy(User)}, and {@link Voidable#setDateVoided(Date)} all to null. <br>
  * <br>
  * Child collections on this {@link Voidable} that are themselves a {@link Voidable} are looped over

--- a/api/src/main/java/org/openmrs/api/handler/VoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/VoidHandler.java
@@ -19,7 +19,7 @@ import org.openmrs.aop.RequiredDataAdvice;
  * This is the super interface for all void* actions that take place on all services. The
  * {@link RequiredDataAdvice} class uses AOP around each method in every service to check to see if
  * its a void* method. If it is a void* method, this class is called to handle setting the
- * {@link Voidable#isVoided()}, {@link Voidable#setVoidReason(String)},
+ * {@link Voidable#getVoided()}, {@link Voidable#setVoidReason(String)},
  * {@link Voidable#setVoidedBy(User)}, and {@link Voidable#setDateVoided(Date)}. <br>
  * <br>
  * Child collections on this {@link Voidable} that are themselves a {@link Voidable} are looped over

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -569,7 +569,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 		
 		UserService userService = Context.getUserService();
 		User voidedUser = userService.getUser(501);
-		// assertTrue(voidedUser.isVoided());
+		// assertTrue(voidedUser.getVoided());
 		// this generates an error:
 		// org.hibernate.QueryException: illegal attempt to dereference 
 		// collection [user0_.user_id.names] with element property reference [givenName]
@@ -588,7 +588,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 		
 		UserService userService = Context.getUserService();
 		User voidedUser = userService.getUser(501);
-		// assertTrue(voidedUser.isVoided());
+		// assertTrue(voidedUser.getVoided());
 		// this generates an error:
 		// org.hibernate.QueryException: illegal attempt to dereference 
 		// collection [user0_.user_id.names] with element property reference [givenName]

--- a/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
@@ -31,7 +31,7 @@ public class BaseUnvoidHandlerTest {
 	public void handle_shouldUnsetTheVoidedBit() throws Exception {
 		UnvoidHandler<Voidable> handler = new BaseUnvoidHandler();
 		Voidable voidable = new Person();
-		voidable.setVoided(true); // make sure isVoided is set
+		voidable.setVoided(true);
 		handler.handle(voidable, null, null, null);
 		Assert.assertFalse(voidable.getVoided());
 	}

--- a/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
@@ -31,7 +31,7 @@ public class BaseVoidHandlerTest {
 	public void handle_shouldSetTheVoidedBit() throws Exception {
 		VoidHandler<Voidable> handler = new BaseVoidHandler();
 		Voidable voidable = new Person();
-		voidable.setVoided(false); // make sure isVoided is false
+		voidable.setVoided(false);
 		handler.handle(voidable, null, null, " ");
 		Assert.assertTrue(voidable.getVoided());
 	}


### PR DESCRIPTION


<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
some javadocs, comments were still referencing the deprecated isVoided

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/TRUNK-5111

