### PR TITLE
Add eclipse and intellij templates for unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -816,6 +816,7 @@
 						<exclude>**/license-header.txt</exclude>
 						<exclude>.git/**</exclude>
 						<exclude>**/NaturalStrings.java</exclude>
+						<exclude>src/main/resources/**/templates.xml</exclude>
 						<exclude>src/main/java/org/springframework/**</exclude>
 						<exclude>src/main/webapp/WEB-INF/view/scripts/dojo/**</exclude>
 						<exclude>src/main/webapp/WEB-INF/view/scripts/jquery/**</exclude>

--- a/tools/src/main/resources/eclipse/templates.xml
+++ b/tools/src/main/resources/eclipse/templates.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java-members" deleted="false" description="OpenMRS Style JUnit 4 Test Before" enabled="true" name="beforeTest">@${testType:newType(org.junit.Before)}
+public void setUp() {
+	${cursor}
+}</template><template autoinsert="true" context="java-statements" deleted="false" description="log a DEBUG message using slf4jlogger declared in this class" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.logdebug" name="logd">${log:field(org.slf4j.Logger)}.debug("${message}");
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log an ERROR message using slf4jlogger declared in this class" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.logerror" name="loge">${log:field(org.slf4j.Logger)}.error("${message}");
+</template><template autoinsert="true" context="java-members" deleted="false" description="static Logger field using slf4j" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.logger" name="logger">
+${:import(org.slf4j.Logger,org.slf4j.LoggerFactory)}
+private static final Logger log = LoggerFactory.getLogger(${enclosing_type}.class);
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log an INFO message using slf4jlogger declared in this class" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.loginfo" name="logi">${log:field(org.slf4j.Logger)}.info("${message}");
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log a parametrized DEBUG message using slf4j logger declared in this class" enabled="true" name="logpd">${log:field(org.slf4j.Logger)}.debug("${message}", ${param});
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log a parametrized ERROR message using slf4jlogger declared in this class" enabled="true" name="logpe">${log:field(org.slf4j.Logger)}.error("${message}", ${exception:var(java.lang.Throwable)});
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log a parametrized INFO message using slf4j logger declared in this class" enabled="true" name="logpi">${log:field(org.slf4j.Logger)}.info("${message}", ${param});
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log a parametrized WARN message using slf4j logger declared in this class" enabled="true" name="logpw">${log:field(org.slf4j.Logger)}.warn("${message}", ${param});
+</template><template autoinsert="true" context="java-statements" deleted="false" description="log a WARNING using slf4jlogger declared in this class" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.logwarn" name="logw">${log:field(org.slf4j.Logger)}.warn("${message}");
+</template><template autoinsert="true" context="java-members" deleted="false" description="OpenMRS Style JUnit 4 Test" enabled="true" name="test">@${testType:newType(org.junit.Test)}
+public void ${methodName}_${shouldSentence}() throws Exception {
+	${cursor}
+}</template><template autoinsert="true" context="java-members" deleted="false" description="OpenMRS Style JUnit 4 Test of exception" enabled="true" name="testException">@${testType:newType(org.junit.Test)}
+public void ${methodName}_${shouldFailGiven}() throws Exception {
+	${expectedException:var(org.junit.rules.ExpectedException)}.expect(${exception});
+	${expectedException:var(org.junit.rules.ExpectedException)}.expectMessage("${message}");
+	${methodThrowingException}
+}</template></templates>

--- a/tools/src/main/resources/intellij/templates.xml
+++ b/tools/src/main/resources/intellij/templates.xml
@@ -1,0 +1,92 @@
+<templateSet group="OpenMRS">
+  <template name="test" value="@Test&#10;public void $METHOD_NAME$_$SHOULD_SENTENCE$() throws Exception {&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="METHOD_NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SHOULD_SENTENCE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_DECLARATION" value="true" />
+    </context>
+  </template>
+  <template name="beforeTest" value="@Before&#10;public void setUp() {&#10;    $BODY$&#10;}" description="OpenMRS Style JUnit 4 Test Before" toReformat="true" toShortenFQNames="true">
+    <variable name="BODY" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_DECLARATION" value="true" />
+    </context>
+  </template>
+  <template name="logger" value="$ACCESS$ static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger($CLASS$.class);" description="declare static Logger field using slf4j" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="ACCESS" expression="" defaultValue="&quot;private&quot;" alwaysStopAt="true" />
+    <variable name="CLASS" expression="className()" defaultValue="" alwaysStopAt="false" />
+    <context>
+      <option name="JAVA_DECLARATION" value="true" />
+    </context>
+  </template>
+  <template name="logi" value="$LOGGER$.info(&quot;$MESSAGE$&quot;);" description="log an INFO message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logw" value="$LOGGER$.warn(&quot;$MESSAGE$&quot;);" description="log a WARN message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logd" value="$LOGGER$.debug(&quot;$MESSAGE$&quot;);" description="log a DEBUG message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="loge" value="$LOGGER$.error(&quot;$MESSAGE$&quot;);" description="log an ERROR message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logpe" value="$LOGGER$.error(&quot;$MESSAGE$&quot;, $ERROR$);" description="log a parametrized ERROR message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="ERROR" expression="variableOfType(&quot;java.lang.Throwable&quot;)" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logpi" value="$LOGGER$.info(&quot;$MESSAGE$&quot;, $PARAM$);" description="log a parametrized INFO message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="PARAM" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logpd" value="$LOGGER$.debug(&quot;$MESSAGE$&quot;, $PARAM$);" description="log a parametrized DEBUG message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="PARAM" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="logpw" value="$LOGGER$.warn(&quot;$MESSAGE$&quot;, $PARAM$);" description="log a parametrized WARN message using slf4j logger declared in this class" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="LOGGER" expression="variableOfType(&quot;org.slf4j.Logger&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="MESSAGE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="PARAM" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_STATEMENT" value="true" />
+    </context>
+  </template>
+  <template name="testException" value="@Test&#10;public void $METHOD_NAME$_$SHOULD_FAIL_SENTENCE$() throws Exception {&#10;&#9;$EXPECT$.expect($EXCEPTION$);&#10;&#9;$EXPECT$.expectMessage(&quot;$EXCEPTION_MESSAGE$&quot;);&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test for exception" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="METHOD_NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SHOULD_FAIL_SENTENCE" expression="" defaultValue="&quot;shouldFailGiven&quot;" alwaysStopAt="true" />
+    <variable name="EXPECT" expression="variableOfType(&quot;org.junit.rules.ExpectedException&quot;)" defaultValue="" alwaysStopAt="true" />
+    <variable name="EXCEPTION" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="EXCEPTION_MESSAGE" expression="" defaultValue="&quot;Fail Due To&quot;" alwaysStopAt="true" />
+    <context>
+      <option name="JAVA_DECLARATION" value="true" />
+    </context>
+  </template>
+</templateSet>


### PR DESCRIPTION
## Description

in preparation of the move away from the custom @should annotations and
the need for the test generator plugin add eclipse and intellij templates
to quickly create the scaffold for unit tests

* add template for creating @Before setUp()
* add template for creating @Test for standard unit test
* add template for creating @Test for unit test testing that a method
throws a certain exception with the org.junit.rules.ExpectedException

also added templates for logging to help get rid of the confusion
when logging. people use commons or log4j instead of the logging facade
slf4j
* add template for declaring slf4j Logger for a class
* add templates for standard log.info/debug/warn/error
* add templates for parametrized log.info/debug/warn/error
meaning log.info("some message {}", myParameter)

<!--- Provide PR Title above as: 'TRUNK-JiraIssueNumber JiraIssueTitle' -->

<!--- Describe your changes in detail -->


