### PR TITLE
Update IDE test code templates to match conventions

### DIFF
--- a/tools/src/main/resources/eclipse/templates.xml
+++ b/tools/src/main/resources/eclipse/templates.xml
@@ -13,10 +13,10 @@ private static final Logger log = LoggerFactory.getLogger(${enclosing_type}.clas
 </template><template autoinsert="true" context="java-statements" deleted="false" description="log a parametrized WARN message using slf4j logger declared in this class" enabled="true" name="logpw">${log:field(org.slf4j.Logger)}.warn("${message}", ${param});
 </template><template autoinsert="true" context="java-statements" deleted="false" description="log a WARNING using slf4jlogger declared in this class" enabled="true" id="org.springframework.ide.eclipse.boot.templates.slf4j.logwarn" name="logw">${log:field(org.slf4j.Logger)}.warn("${message}");
 </template><template autoinsert="true" context="java-members" deleted="false" description="OpenMRS Style JUnit 4 Test" enabled="true" name="test">@${testType:newType(org.junit.Test)}
-public void ${methodName}_${shouldSentence}() throws Exception {
+public void ${shouldSentence}() throws Exception {
 	${cursor}
 }</template><template autoinsert="true" context="java-members" deleted="false" description="OpenMRS Style JUnit 4 Test of exception" enabled="true" name="testException">@${testType:newType(org.junit.Test)}
-public void ${methodName}_${shouldFailGiven}() throws Exception {
+public void ${shouldFailGiven}() throws Exception {
 	${expectedException:var(org.junit.rules.ExpectedException)}.expect(${exception});
 	${expectedException:var(org.junit.rules.ExpectedException)}.expectMessage("${message}");
 	${methodThrowingException}

--- a/tools/src/main/resources/intellij/templates.xml
+++ b/tools/src/main/resources/intellij/templates.xml
@@ -1,6 +1,5 @@
 <templateSet group="OpenMRS">
-  <template name="test" value="@Test&#10;public void $METHOD_NAME$_$SHOULD_SENTENCE$() throws Exception {&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test" toReformat="true" toShortenFQNames="true" useStaticImport="true">
-    <variable name="METHOD_NAME" expression="" defaultValue="" alwaysStopAt="true" />
+  <template name="test" value="@Test&#10;public void $SHOULD_SENTENCE$() throws Exception {&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test" toReformat="true" toShortenFQNames="true" useStaticImport="true">
     <variable name="SHOULD_SENTENCE" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="JAVA_DECLARATION" value="true" />
@@ -79,9 +78,8 @@
       <option name="JAVA_STATEMENT" value="true" />
     </context>
   </template>
-  <template name="testException" value="@Test&#10;public void $METHOD_NAME$_$SHOULD_FAIL_SENTENCE$() throws Exception {&#10;&#9;$EXPECT$.expect($EXCEPTION$);&#10;&#9;$EXPECT$.expectMessage(&quot;$EXCEPTION_MESSAGE$&quot;);&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test for exception" toReformat="true" toShortenFQNames="true" useStaticImport="true">
-    <variable name="METHOD_NAME" expression="" defaultValue="" alwaysStopAt="true" />
-    <variable name="SHOULD_FAIL_SENTENCE" expression="" defaultValue="&quot;shouldFailGiven&quot;" alwaysStopAt="true" />
+  <template name="testException" value="@Test&#10;public void $SHOULD_FAIL_SENTENCE$() throws Exception {&#10;&#9;$EXPECT$.expect($EXCEPTION$);&#10;&#9;$EXPECT$.expectMessage(&quot;$EXCEPTION_MESSAGE$&quot;);&#10;    $END$&#10;}" description="OpenMRS Style JUnit 4 Test for exception" toReformat="true" toShortenFQNames="true" useStaticImport="true">
+    <variable name="SHOULD_FAIL_SENTENCE" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="EXPECT" expression="variableOfType(&quot;org.junit.rules.ExpectedException&quot;)" defaultValue="" alwaysStopAt="true" />
     <variable name="EXCEPTION" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="EXCEPTION_MESSAGE" expression="" defaultValue="&quot;Fail Due To&quot;" alwaysStopAt="true" />


### PR DESCRIPTION
remove the 'methodName_' part of the test and testException
code templates for Intellij and Eclipse

