### PR TITLE
Extract setUp and clean AlertValidatorTest

### DIFF
--- a/api/src/test/java/org/openmrs/validator/AlertValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/AlertValidatorTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.validator;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.notification.Alert;
 import org.openmrs.test.BaseContextSensitiveTest;
@@ -22,69 +23,71 @@ import org.springframework.validation.Errors;
  */
 public class AlertValidatorTest extends BaseContextSensitiveTest {
 	
-	/**
-	 * @see AlertValidator#validate(Object,Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfAlertTextIsNullOrEmptyOrWhitespace() {
-		Alert alert = new Alert();
-		Assert.assertNull(alert.getText());
+	private AlertValidator validator;
+	
+	private Alert alert;
+	
+	private Errors errors;
+	
+	@Before
+	public void setUp() {
+		validator = new AlertValidator();
 		
-		Errors errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
-		Assert.assertTrue(errors.hasFieldErrors("text"));
+		alert = new Alert();
+		
+		errors = new BindException(alert, "alert");
+	}
+	
+	@Test
+	public void shouldFailValidationIfAlertTextIsNull() {
+		
+		validator.validate(alert, errors);
+		
+		assertThatFieldTextHasError();
+	}
+
+	@Test
+	public void shouldFailValidationIfAlertTextIsEmpty() {
 		
 		alert.setText("");
-		errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
-		Assert.assertTrue(errors.hasFieldErrors("text"));
+		
+		validator.validate(alert, errors);
+		
+		assertThatFieldTextHasError();
+	}
+	
+	@Test
+	public void shouldFailValidationIfAlertTextIsOnlyWhitespaces() {
 		
 		alert.setText(" ");
-		errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
-		Assert.assertTrue(errors.hasFieldErrors("text"));
+		
+		validator.validate(alert, errors);
+		
+		assertThatFieldTextHasError();
 	}
 	
-	/**
-	 * Test for all the values being set
-	 * @see AlertValidator#validate(Object,Errors)
-	 */
 	@Test
 	public void validate_shouldPassValidationIfAllRequiredValuesAreSet() {
-		Alert alert = new Alert();
+		
 		alert.setText("Alert Text");
 		
-		Errors errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
-		Assert.assertFalse(errors.hasErrors());
-	}
-	
-	/**
-	 * Test for all the values being set
-	 * @see AlertValidator#validate(Object,Errors)
-	 */
-	@Test
-	public void validate_shouldPassValidationIfFieldLengthsAreCorrect() {
-		Alert alert = new Alert();
-		alert.setText("text");
+		validator.validate(alert, errors);
 		
-		Errors errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
 		Assert.assertFalse(errors.hasErrors());
 	}
 	
-	/**
-	 * Test for all the values being set
-	 * @see AlertValidator#validate(Object,Errors)
-	 */
 	@Test
 	public void validate_shouldFailValidationIfFieldLengthsAreNotCorrect() {
-		Alert alert = new Alert();
+		
 		alert
 		        .setText("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
 		
-		Errors errors = new BindException(alert, "alert");
-		new AlertValidator().validate(alert, errors);
+		validator.validate(alert, errors);
+		
+		assertThatFieldTextHasError();
+	}
+	
+	private void assertThatFieldTextHasError() {
 		Assert.assertTrue(errors.hasFieldErrors("text"));
 	}
 }


### PR DESCRIPTION
* add setUp method preparing variables needed for tests to remove
duplication in test setup
* arrange test implementations in a arrange, act, assert style (or what
we often called the given,when,then) so its clear to see whats been
tested and what the outcome should be
* split test that tested null/empty/whitespace of alert text in a
single test as these are independent

