### PR TITLE
Extract setUp and fix tests in AllergyValidatorTest

### DIFF
--- a/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
@@ -9,13 +9,15 @@
  */
 package org.openmrs.validator;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -45,11 +47,25 @@ public class AllergyValidatorTest {
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
 	
+	private Allergy allergy;
+	
+	private Errors errors;
+	
 	@InjectMocks
 	private AllergyValidator validator;
 	
 	@Mock
 	private PatientService ps;
+	
+	@Before
+	public void setUp() {
+		allergy = new Allergy();
+		errors = new BindException(allergy, "allergy");
+	}
+	
+	private Concept createMockConcept() {
+		return createMockConcept(null);
+	}
 	
 	private Concept createMockConcept(String uuid) {
 		Concept concept = mock(Concept.class);
@@ -67,12 +83,10 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldFailForANullValue() {
+		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("Allergy should not be null");
-		Allergy allergy = new Allergy();
-		Errors errors = new BindException(allergy, "allergy");
-		allergy = null;
-		validator.validate(allergy, errors);
+		validator.validate(null, errors);
 	}
 	
 	/**
@@ -80,21 +94,11 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldFailIfPatientIsNull() {
-		Allergy allergy = new Allergy();
-		Errors errors = new BindException(allergy, "allergy");
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("patient"));
-	}
-	
-	/**
-	 * @see AllergyValidator#validate(Object, org.springframework.validation.Errors)
-	 */
-	@Test
-	public void validate_shouldFailIdAllergenTypeIsNull() {
-		Allergy allergy = new Allergy();
-		Errors errors = new BindException(allergy, "allergy");
-		validator.validate(allergy, errors);
-		assertTrue(errors.hasFieldErrors("allergen"));
+		assertThat(errors.getFieldError("patient").getCode(), is("allergyapi.patient.required"));
 	}
 	
 	/**
@@ -102,22 +106,40 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldFailIfAllergenIsNull() {
-		Allergy allergy = new Allergy();
-		Errors errors = new BindException(allergy, "allergy");
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("allergen"));
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.allergen.required"));
 	}
 	
 	/**
 	 * @see AllergyValidator#validate(Object, org.springframework.validation.Errors)
 	 */
 	@Test
-	public void validate_shouldFailIfCodedAllergenIsNull() {
-		Allergy allergy = new Allergy();
-		allergy.setAllergen(new Allergen(null, createMockConcept(null), null));
-		Errors errors = new BindException(allergy, "allergy");
+	public void validate_shouldFailIdAllergenTypeIsNull() {
+		
+		allergy.setAllergen(new Allergen());
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("allergen"));
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.allergenType.required"));
+	}
+	
+	/**
+	 * @see AllergyValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailIfCodedAndNonCodedAllergenAreNull() {
+		
+		Allergen allergen = new Allergen(AllergenType.DRUG, null, null);
+		allergy.setAllergen(allergen);
+		
+		validator.validate(allergy, errors);
+		
+		assertTrue(errors.hasFieldErrors("allergen"));
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.allergen.codedOrNonCodedAllergen.required"));
 	}
 	
 	/**
@@ -125,11 +147,19 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldFailIfNonCodedAllergenIsNullAndAllergenIsSetToOtherNonCoded() {
-		Allergy allergy = new Allergy();
-		allergy.setAllergen(new Allergen(null, createMockConcept(getOtherNonCodedConceptUuid()), null));
-		Errors errors = new BindException(allergy, "allergy");
+		
+		Allergen allergen = mock(Allergen.class);
+		when(allergen.getAllergenType()).thenReturn(AllergenType.DRUG);
+		Concept concept = createMockConcept(getOtherNonCodedConceptUuid());
+		when(allergen.getCodedAllergen()).thenReturn(concept);
+		when(allergen.getNonCodedAllergen()).thenReturn("");
+		when(allergen.isCoded()).thenReturn(false);
+		allergy.setAllergen(allergen);
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("allergen"));
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.allergen.nonCodedAllergen.required"));
 	}
 	
 	/**
@@ -137,12 +167,13 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldRejectADuplicateAllergen() {
+		
 		PowerMockito.mockStatic(Context.class);
 		MessageSourceService ms = mock(MessageSourceService.class);
 		when(Context.getMessageSourceService()).thenReturn(ms);
 		
 		Allergies allergies = new Allergies();
-		Concept aspirin = createMockConcept(null);
+		Concept aspirin = createMockConcept();
 		Allergen allergen1 = new Allergen(AllergenType.DRUG, aspirin, null);
 		allergies.add(new Allergy(null, allergen1, null, null, null));
 		when(ps.getAllergies(any(Patient.class))).thenReturn(allergies);
@@ -150,9 +181,11 @@ public class AllergyValidatorTest {
 		Allergen duplicateAllergen = new Allergen(AllergenType.FOOD, aspirin, null);
 		Allergy allergy = new Allergy(mock(Patient.class), duplicateAllergen, null, null, null);
 		Errors errors = new BindException(allergy, "allergy");
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("allergen"));
-		assertEquals("allergyapi.message.duplicateAllergen", errors.getFieldError("allergen").getCode());
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.message.duplicateAllergen"));
 	}
 	
 	/**
@@ -160,6 +193,7 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldRejectADuplicateNonCodedAllergen() {
+		
 		PowerMockito.mockStatic(Context.class);
 		MessageSourceService ms = mock(MessageSourceService.class);
 		when(Context.getMessageSourceService()).thenReturn(ms);
@@ -174,9 +208,11 @@ public class AllergyValidatorTest {
 		Allergen duplicateAllergen = new Allergen(AllergenType.FOOD, nonCodedConcept, freeText);
 		Allergy allergy = new Allergy(mock(Patient.class), duplicateAllergen, null, null, null);
 		Errors errors = new BindException(allergy, "allergy");
+		
 		validator.validate(allergy, errors);
+		
 		assertTrue(errors.hasFieldErrors("allergen"));
-		assertEquals("allergyapi.message.duplicateAllergen", errors.getFieldError("allergen").getCode());
+		assertThat(errors.getFieldError("allergen").getCode(), is("allergyapi.message.duplicateAllergen"));
 	}
 	
 	/**
@@ -184,6 +220,7 @@ public class AllergyValidatorTest {
 	 */
 	@Test
 	public void validate_shouldPassForAValidAllergy() {
+		
 		Allergies allergies = new Allergies();
 		Concept aspirin = new Concept();
 		Allergen allergen1 = new Allergen(AllergenType.DRUG, aspirin, null);
@@ -193,9 +230,9 @@ public class AllergyValidatorTest {
 		Allergen anotherAllergen = new Allergen(AllergenType.DRUG, new Concept(), null);
 		Allergy allergy = new Allergy(mock(Patient.class), anotherAllergen, null, null, null);
 		Errors errors = new BindException(allergy, "allergy");
-		validator.validate(allergy, errors);
 		
 		validator.validate(allergy, errors);
+		
 		assertFalse(errors.hasErrors());
 	}
 }


### PR DESCRIPTION
fixed errors in AllergyValidatorTest's, a few tests where just
asserting that the "allergen" field had an error but not the actual
code which lead to the fact that a few paths where not tested because the
Allergy passed in did not match the test expectations (either the
Allergen was null or the AllergenType of the Allergen not set)

* fixed test 'shouldFailIdAllergenTypeIsNull' which passed because
due to "allergyapi.allergen.required" coming from Allergen being null
not from the AllergenType
added assertion for the correct error code and passed in an Allergen to the
Allergy with no AllergenType

* add setUp method preparing variables needed for tests to remove
duplication in test setup
* arrange test implementations in a arrange, act, assert style (or what
we often called the given,when,then) so its clear to see whats been
tested and what the outcome should be
* move test 'validate_shouldFailIfAllergenIsNull' one up to match the
flow of the code. makes it easy to read code / test side by side
* removed one duplicate call to validate

