### PR TITLE
Clean and add tests to BaseAttributeTypeValidatorTest

### DIFF
--- a/api/src/test/java/org/openmrs/validator/BaseAttributeTypeValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/BaseAttributeTypeValidatorTest.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.validator;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,121 +19,224 @@ import org.openmrs.VisitAttributeType;
 import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.springframework.validation.BindException;
-import org.springframework.validation.Errors;
 
+/**
+ * Tests {@link BaseAttributeTypeValidator}.
+ */
 public class BaseAttributeTypeValidatorTest extends BaseContextSensitiveTest {
 	
-	VisitAttributeTypeValidator validator;
+	private CustomVisitAttributeTypeValidator validator;
 	
-	VisitAttributeType attributeType;
+	private VisitAttributeType attributeType;
 	
-	BindException errors;
+	private BindException errors;
 	
 	@Before
 	public void before() {
-		validator = new VisitAttributeTypeValidator();
+		validator = new CustomVisitAttributeTypeValidator();
 		attributeType = new VisitAttributeType();
 		errors = new BindException(attributeType, "attributeType");
 	}
 	
 	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
+	 * Needed so we can test the abstract {@link BaseAttributeTypeValidator} without interference of
+	 * an existing concrete implementation like a VisitAttributeTypeValidator.
 	 */
-	@Test
-	public void validate_shouldNotAllowMaxOccursLessThan1() {
-		attributeType.setMaxOccurs(0);
-		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("maxOccurs").size() > 0);
+	private class CustomVisitAttributeTypeValidator extends BaseAttributeTypeValidator<VisitAttributeType> {
+		
+		@Override
+		public boolean supports(Class<?> clazz) {
+			return clazz.equals(VisitAttributeType.class);
+		}
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
 	@Test
-	public void validate_shouldNotAllowMaxOccursLessThanMinOccurs() {
-		attributeType.setMinOccurs(3);
-		attributeType.setMaxOccurs(2);
-		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("maxOccurs").size() > 0);
+	public void shouldFailIfGivenNull() {
+		
+		validator.validate(null, errors);
+		
+		Assert.assertTrue(errors.hasErrors());
+		Assert.assertEquals("error.general", errors.getAllErrors().get(0).getCode());
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
 	@Test
-	public void validate_shouldRequireDatatypeClassname() {
+	public void shouldFailIfNameIsNull() {
+		
 		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("datatypeClassname").size() > 0);
+		
+		Assert.assertTrue(errors.hasFieldErrors("name"));
+		assertThat(errors.getFieldErrors("name").get(0).getCode(), is("error.name"));
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
+	@Test
+	public void shouldFailIfNameIsEmpty() {
+		
+		attributeType.setName("");
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("name"));
+		assertThat(errors.getFieldErrors("name").get(0).getCode(), is("error.name"));
+	}
+
+	@Test
+	public void shouldFailIfNameIsOnlyWhitespaces() {
+		
+		attributeType.setName("  ");
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("name"));
+		assertThat(errors.getFieldErrors("name").get(0).getCode(), is("error.name"));
+	}
+	
 	@Test
 	public void validate_shouldRequireMinOccurs() {
+		
 		attributeType.setMinOccurs(null);
+		
 		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("minOccurs").size() > 0);
+		
+		Assert.assertTrue(errors.hasFieldErrors("minOccurs"));
+		assertThat(errors.getFieldErrors("minOccurs").get(0).getCode(), is("error.null"));
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
 	@Test
-	public void validate_shouldRequireName() {
+	public void shouldFailIfMinOccursIsLessThanZero() {
+		
+		attributeType.setMinOccurs(-1);
+		
 		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("name").size() > 0);
+		
+		Assert.assertTrue(errors.hasFieldErrors("minOccurs"));
+		assertThat(errors.getFieldErrors("minOccurs").get(0).getCode(),
+		    is("AttributeType.minOccursShouldNotBeLessThanZero"));
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
 	@Test
-	public void validate_shouldRequireDatatypeConfigurationIfDatatypeEqualsRegexValidatedText() {
+	public void validate_shouldNotAllowMaxOccursLessThan1() {
+		
+		attributeType.setMaxOccurs(0);
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("maxOccurs"));
+		assertThat(errors.getFieldErrors("maxOccurs").get(0).getCode(), is("AttributeType.maxOccursShouldNotBeLessThanOne"));
+	}
+	
+	@Test
+	public void validate_shouldNotAllowMaxOccursLessThanMinOccurs() {
+		
+		attributeType.setMinOccurs(3);
+		attributeType.setMaxOccurs(2);
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("maxOccurs"));
+		assertThat(errors.getFieldErrors("maxOccurs").get(0).getCode(),
+		    is("AttributeType.maxOccursShouldNotBeLessThanMinOccurs"));
+	}
+	
+	@Test
+	public void validate_shouldRequireDatatypeClassname() {
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("datatypeClassname"));
+		assertThat(errors.getFieldErrors("datatypeClassname").get(0).getCode(), is("error.null"));
+	}
+	
+	@Test
+	public void shouldFailIfDatatypeConfigurationIsBlankIfDatatypeEqualsRegexValidatedText() {
+		
 		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
+		attributeType.setDatatypeConfig("");
+		
 		validator.validate(attributeType, errors);
-		Assert.assertTrue(errors.getFieldErrors("datatypeConfig").size() > 0);
+		
+		Assert.assertTrue(errors.hasFieldErrors("datatypeConfig"));
+		assertThat(errors.getFieldErrors("datatypeConfig").get(0).getCode(), is("error.null"));
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
 	@Test
-	public void validate_shouldPassValidationIfAllRequiredValuesAreSet() {
-		attributeType.setName("name");
-		attributeType.setMinOccurs(1);
+	public void shouldFailIfDatatypeConfigurationIsInvalidIfDatatypeEqualsRegexValidatedText() {
+		
 		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
-		attributeType.setDatatypeConfig("[a-z]+");
+		attributeType.setDatatypeConfig(null);
+		
 		validator.validate(attributeType, errors);
-		Assert.assertFalse(errors.hasErrors());
+		
+		Assert.assertTrue(errors.hasFieldErrors("datatypeConfig"));
+		assertThat(errors.getFieldErrors("datatypeConfig").get(0).getCode(), is("AttributeType.datatypeConfig.invalid"));
 	}
-	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
+
 	@Test
-	public void validate_shouldPassValidationIfFieldLengthsAreCorrect() {
-		attributeType.setName("name");
-		attributeType.setMinOccurs(1);
+	public void shouldFailIfPreferredHandlerClassIsOfWrongDatatype() {
+		
 		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
-		attributeType.setDatatypeConfig("[a-z]+");
-		attributeType.setHandlerConfig("HandlerConfig");
+		attributeType.setDatatypeConfig("some valid config");
+		attributeType.setPreferredHandlerClassname("org.openmrs.attribute.handler.DateDatatypeHandler");
+		
 		validator.validate(attributeType, errors);
-		Assert.assertFalse(errors.hasErrors());
+		
+		Assert.assertTrue(errors.hasFieldErrors("preferredHandlerClassname"));
+		assertThat(errors.getFieldErrors("preferredHandlerClassname").get(0).getCode(),
+		    is("AttributeType.preferredHandlerClassname.wrongDatatype"));
 	}
 	
-	/**
-	 * @see BaseAttributeTypeValidator#validate(Object,Errors)
-	 */
+	@Test
+	public void shouldFailIfPreferredHandlerClassIsInvalid() {
+		
+		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
+		attributeType.setDatatypeConfig("some valid config");
+		attributeType.setPreferredHandlerClassname("uncompatible class");
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertTrue(errors.hasFieldErrors("handlerConfig"));
+		assertThat(errors.getFieldErrors("handlerConfig").get(0).getCode(),
+		    is("AttributeType.handlerConfig.invalid"));
+	}
+	
 	@Test
 	public void validate_shouldFailValidationIfFieldLengthsAreNotCorrect() {
+		
 		attributeType.setName("name");
 		attributeType.setMinOccurs(1);
 		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
 		attributeType.setDatatypeConfig(new String(new char[66000]));
 		attributeType.setHandlerConfig(new String(new char[66000]));
+		
 		validator.validate(attributeType, errors);
+		
 		Assert.assertTrue(errors.hasFieldErrors("datatypeConfig"));
 		Assert.assertTrue(errors.hasFieldErrors("handlerConfig"));
+	}
+	
+	@Test
+	public void validate_shouldPassValidationIfFieldLengthsAreCorrect() {
+		
+		attributeType.setName("name");
+		attributeType.setMinOccurs(1);
+		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
+		attributeType.setDatatypeConfig("[a-z]+");
+		attributeType.setHandlerConfig("HandlerConfig");
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertFalse(errors.hasErrors());
+	}
+	
+	@Test
+	public void validate_shouldPassValidationIfAllRequiredValuesAreSet() {
+		
+		attributeType.setName("name");
+		attributeType.setMinOccurs(1);
+		attributeType.setDatatypeClassname(RegexValidatedTextDatatype.class.getName());
+		attributeType.setDatatypeConfig("[a-z]+");
+		
+		validator.validate(attributeType, errors);
+		
+		Assert.assertFalse(errors.hasErrors());
 	}
 }


### PR DESCRIPTION
* replace the VisitAttributeTypeValidator with an implementation added
to this test class. Reason is the VisitAttributeTypeValidator does some
things before calling super.validate which prevents us from testing
validate(null, errors)
* add test for validate(null, errors)
* add test for minOccurs < 0
* add test for datatypeConfig is blank when of type RegexValidatedTextDatatype
* rename test shouldRequireDatatypeConfigurationIfDatatypeEqualsRegexValidatedText
    which was actually testing the datatypeConfig.invalid path
* add test for wrong preferred handler type
* add test for invalid handlerConfig
* arrange tests to match code so reading code/test side by side is easy
* move happy path to the end
