### PR TITLE
TRUNK-5135 Deprecate @Verifies

### DIFF
--- a/api/src/test/java/org/openmrs/test/Verifies.java
+++ b/api/src/test/java/org/openmrs/test/Verifies.java
@@ -20,7 +20,11 @@ import java.lang.annotation.Target;
  * <br>
  * This allows a unit test to be linked back to a specific behavior being tested on a specific
  * method. The class being tested is implied from the name of the parent test class.
+ * 
+ * @deprecated as of release 2.2.0 in favor of standard testing best practices, see
+ *             https://issues.openmrs.org/browse/TRUNK-5122
  */
+@Deprecated
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Verifies {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -113,7 +113,7 @@
 			<property name="severity" value="error"/>
 		</module>
 		<module name="IllegalImport">
-			<property name="illegalPkgs" value="sun, org.apache.commons.logging" />
+			<property name="illegalPkgs" value="sun, org.apache.commons.logging, org.openmrs.test.Verifies" />
 			<property name="severity" value="error"/>
 		</module>
 		<module name="OneTopLevelClass">


### PR DESCRIPTION


<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
all usages of @Verifies and @verifies were removed in TRUNK-5122
and thus @Verifies is deprecated and flagged using checkstyle

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5135
