### PR TITLE
TRUNK-248: Remove TODO from deprecated and unused code

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -311,8 +311,6 @@ public class PatientSearchCriteria {
 			}
 		}
 		
-		// TODO add a junit test for patientIdentifierType restrictions	
-		
 		// do the type restriction
 		if (!CollectionUtils.isEmpty(identifierTypes)) {
 			criteria.add(Restrictions.in("ids.identifierType", identifierTypes));


### PR DESCRIPTION
## Description of what I changed

The `PatientSearchCriteria` class is deprecated. This TODO is on a private method, called by another private method, called by the helper method `prepareCriteria`. This method is only called in one place, `HibernateEnounterDAO` which doesn't pass in the parameter that would lead to this line of code being executed.

Therefore, we think the code is not used and the test is not required.

@annashipman @davbo @TheDoubleK

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-248

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

