### PR TITLE
TRUNK-5137 Add custom hamcrest matcher HasGlobalError

### DIFF
--- a/api/src/test/java/org/openmrs/test/matchers/HasGlobalErrors.java
+++ b/api/src/test/java/org/openmrs/test/matchers/HasGlobalErrors.java
@@ -1,0 +1,77 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.test.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.springframework.validation.Errors;
+
+/**
+ * Matcher to assert global errors in {@code Errors} used in Spring validation.
+ * <p>
+ * Usage example: <pre> {@code
+ * Errors item = new BindException(myObject, "myObject");
+ * item.reject("error.name");
+ * }
+ * </pre>
+ * <ul>
+ * <li>Has one or more global error: {@code assertThat(errors, hasGlobalErrors());}</li>
+ * <li>Has global error of specific code:
+ * {@code assertThat(errors, hasGlobalErrors("error.name"));}</li>
+ * </ul>
+ * </p>
+ * 
+ * @see org.springframework.validation.Errors;
+ * @since 2.2.0
+ */
+public final class HasGlobalErrors extends TypeSafeMatcher<Errors> {
+	
+	private final String code;
+	
+	private HasGlobalErrors() {
+		this(null);
+	}
+	
+	private HasGlobalErrors(String code) {
+		this.code = code;
+	}
+	
+	@Override
+	public void describeTo(Description description) {
+		if (code == null) {
+			description.appendText("to have global errors");
+		} else {
+			description.appendText("to have global error of code '" + code + "'");
+		}
+	}
+	
+	@Override
+	protected boolean matchesSafely(Errors item) {
+		if (code == null) {
+			return item.hasGlobalErrors();
+		} else {
+			return item.getGlobalErrors().stream().filter(c -> code.equals(c.getCode())).findFirst().isPresent();
+		}
+	}
+	
+	/**
+	 * Creates a matcher to assert global errors.
+	 */
+	public static HasGlobalErrors hasGlobalErrors() {
+		return new HasGlobalErrors();
+	}
+	
+	/**
+	 * Creates a matcher to assert global errors of a specific code.
+	 */
+	public static HasGlobalErrors hasGlobalErrors(String code) {
+		return new HasGlobalErrors(code);
+	}
+}

--- a/api/src/test/java/org/openmrs/test/matchers/HasGlobalErrorsTest.java
+++ b/api/src/test/java/org/openmrs/test/matchers/HasGlobalErrorsTest.java
@@ -1,0 +1,107 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.test.matchers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.hamcrest.Description;
+import org.hamcrest.StringDescription;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
+/**
+ * Tests {@link HasGlobalErrors}.
+ */
+public class HasGlobalErrorsTest {
+	
+	private HasGlobalErrors matcher;
+	
+	private Errors item;
+	
+	private Description description;
+	
+	@Before
+	public void setUp() {
+		
+		item = new BindException(new String(), "string");
+		description = new StringDescription();
+	}
+	
+	@Test
+	public void shouldAppendGlobalErrorsDescriptionIfCodeIsNull() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors();
+		
+		matcher.describeTo(description);
+		
+		assertThat(description.toString(), is("to have global errors"));
+	}
+	
+	@Test
+	public void shouldAppendGlobalErrorsDescriptionWithCodeIfCodeIsNonNull() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors("error.null");
+		
+		matcher.describeTo(description);
+		
+		assertThat(description.toString(), is("to have global error of code 'error.null'"));
+	}
+	
+	@Test
+	public void shouldNotMatchIfCodeIsNullAndGivenErrorHasNoGlobalErrors() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors();
+		
+		assertFalse("should not match", matcher.matchesSafely(item));
+	}
+	
+	@Test
+	public void shouldMatchIfCodeIsNullAndGivenErrorHasGlobalErrors() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors();
+		item.reject("error.name");
+		
+		assertTrue("should match", matcher.matchesSafely(item));
+	}
+	
+	@Test
+	public void shouldNotMatchIfCodeIsNonNullAndGivenErrorDoesNotHaveGlobalErrors() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors("error.name");
+		
+		assertFalse("should not match", matcher.matchesSafely(item));
+	}
+	
+	@Test
+	public void shouldNotMatchIfCodeIsNonNullButNotContainedInGivenErrors() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors("error.name");
+		item.reject("error.null");
+		item.reject("invalid.uuid");
+		
+		assertFalse("should not match", matcher.matchesSafely(item));
+	}
+	
+	@Test
+	public void shouldMatchIfCodeIsNonNullAndContainedInGivenErrors() {
+		
+		matcher = HasGlobalErrors.hasGlobalErrors("error.name");
+		item.reject("error.null");
+		item.reject("invalid.uuid");
+		item.reject("error.name");
+		
+		assertTrue("should match", matcher.matchesSafely(item));
+	}
+}

--- a/api/src/test/java/org/openmrs/validator/ConceptValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ConceptValidatorTest.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.validator;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.openmrs.test.matchers.HasGlobalErrors.hasGlobalErrors;
+
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -78,7 +81,8 @@ public class ConceptValidatorTest extends BaseContextSensitiveTest {
 		concept.addName(new ConceptName("", Context.getLocale()));
 		Errors errors = new BindException(concept, "concept");
 		new ConceptValidator().validate(concept, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+		
+		assertThat(errors, hasGlobalErrors("Concept.name.empty"));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/validator/PersonNameValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PersonNameValidatorTest.java
@@ -12,6 +12,7 @@ package org.openmrs.validator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.openmrs.test.matchers.HasFieldErrors.hasFieldErrors;
+import static org.openmrs.test.matchers.HasGlobalErrors.hasGlobalErrors;
 
 import java.util.HashMap;
 import java.util.stream.Stream;
@@ -60,7 +61,7 @@ public class PersonNameValidatorTest extends BaseContextSensitiveTest {
 		
 		validator.validate(null, errors);
 		
-		Assert.assertTrue(errors.hasErrors());
+		assertThat(errors, hasGlobalErrors("error.name"));
 	}
 	
 	/**


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Add a custom hamcrest matcher HasGlobalErrors which enables

assertThat(errors, hasGlobalErrors());
assertThat(errors, hasGlobalErrors("error.null"));

Provide factories which enables the above after static imports of
the matcher.

Show use of matcher in PersonNameValidatorTest and ConceptValidatorTest

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5137
