### PR TITLE
TRUNK-5158 PropertyEditors check for null primary key in getAsText

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptMapTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptMapTypeEditor.java
@@ -42,7 +42,7 @@ public class ConceptMapTypeEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		ConceptMapType mapType = (ConceptMapType) getValue();
-		if (mapType == null || mapType.getConceptMapTypeId() == null) {
+		if (mapType == null) {
 			return "";
 		}
 		

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
@@ -42,7 +42,7 @@ public class ConceptReferenceTermEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		ConceptReferenceTerm term = (ConceptReferenceTerm) getValue();
-		if (term == null || term.getConceptReferenceTermId() == null) {
+		if (term == null) {
 			return "";
 		}
 		

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
@@ -66,7 +66,7 @@ public class PersonEditor extends PropertyEditorSupport {
 		if (t == null) {
 			return "";
 		} else {
-			return (t.getPersonId() == null) ? "" : t.getPersonId().toString();
+			return t.getPersonId().toString();
 		}
 	}
 	


### PR DESCRIPTION
remove check if OpenmrsObject.id is null in getAsText() in case the object is not null
since its the PK and its guaranteed to be not null.

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5158


