### PR TITLE
TRUNK-5154 ProgramWorkflowStateEditor tries to get state by uuid twice

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
@@ -42,7 +42,7 @@ public class ProgramWorkflowStateEditor extends PropertyEditorSupport {
 		ProgramWorkflowService pws = Context.getProgramWorkflowService();
 		if (StringUtils.hasText(text)) {
 			try {
-				setValue(pws.getStateByUuid(text));
+				setValue(pws.getState(Integer.valueOf(text)));
 			}
 			catch (Exception ex) {
 				ProgramWorkflowState s = pws.getStateByUuid(text);

--- a/api/src/test/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditorTest.java
@@ -9,19 +9,24 @@
  */
 package org.openmrs.propertyeditor;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.ProgramWorkflowState;
+import org.openmrs.api.ProgramWorkflowService;
+import org.springframework.beans.factory.annotation.Autowired;
 
-public class ProgramWorkflowStateEditorTest extends BaseContextSensitiveTest {
+public class ProgramWorkflowStateEditorTest extends BasePropertyEditorTest<ProgramWorkflowState, ProgramWorkflowStateEditor> {
 
-	/**
-	 * @see ProgramWorkflowStateEditor#setAsText(String)
-	 */
-	@Test
-	public void setAsText_shouldSetUsingUuid() {
-		ProgramWorkflowStateEditor editor = new ProgramWorkflowStateEditor();
-		editor.setAsText("92584cdc-6a20-4c84-a659-e035e45d36b0");
-		Assert.assertNotNull(editor.getValue());
+	private static final String EXISTING_UUID = "92584cdc-6a20-4c84-a659-e035e45d36b0";
+	
+	@Autowired
+	ProgramWorkflowService programWorkflowService;
+	
+	@Override
+	protected ProgramWorkflowStateEditor getNewEditor() {
+		return new ProgramWorkflowStateEditor();
+	}
+	
+	@Override
+	protected ProgramWorkflowState getExistingObject() {
+		return programWorkflowService.getStateByUuid(EXISTING_UUID);
 	}
 }


### PR DESCRIPTION
the catch block will never be reached since getByUuid() just returns
null if nothing is found. The exception in the try block is normally
thrown by Integer.valueOf() if the text is a uuid and not a number

* use getState(Integer) first to try to get the ProgramWorkflowState by
its id
* is text is not an Integer, the exception in Integer.valueOf will lead
to the catch block being executed which then tries to fetch by the uuid
* added tests

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5154

