### PR TITLE
TRUNK-5162 Few PropertyEditor getAsText return null if value is null

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditor.java
@@ -24,7 +24,7 @@ public class ConceptAttributeTypeEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		ConceptAttributeType conceptAttributeType = (ConceptAttributeType) getValue();
-		return conceptAttributeType == null ? null : conceptAttributeType.getId().toString();
+		return conceptAttributeType == null ? "" : conceptAttributeType.getId().toString();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationAttributeTypeEditor.java
@@ -29,7 +29,7 @@ public class LocationAttributeTypeEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		LocationAttributeType lat = (LocationAttributeType) getValue();
-		return lat == null ? null : lat.getId().toString();
+		return lat == null ? "" : lat.getId().toString();
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
@@ -60,7 +60,7 @@ public class LocationEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		Location t = (Location) getValue();
-		return t == null ? null : t.getLocationId().toString();
+		return t == null ? "" : t.getLocationId().toString();
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
@@ -62,7 +62,7 @@ public class LocationTagEditor extends PropertyEditorSupport {
 	@Override
 	public String getAsText() {
 		LocationTag t = (LocationTag) getValue();
-		return t == null ? null : t.getLocationTagId().toString();
+		return t == null ? "" : t.getLocationTagId().toString();
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditorTest.java
@@ -9,12 +9,7 @@
  */
 package org.openmrs.propertyeditor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import org.junit.Before;
-import org.junit.Test;
 import org.openmrs.ConceptAttributeType;
 import org.openmrs.api.ConceptService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,12 +36,5 @@ public class ConceptAttributeTypeEditorTest extends BasePropertyEditorTest<Conce
 	@Override
 	protected ConceptAttributeType getExistingObject() {
 		return conceptService.getConceptAttributeType(EXISTING_ID);
-	}
-	
-	@Override
-	@Test
-	public void shouldReturnEmptyStringIfValueIsNull() {
-		
-		assertThat(editor.getAsText(), is(nullValue()));
 	}
 }

--- a/api/src/test/java/org/openmrs/propertyeditor/LocationAttributeTypeEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/LocationAttributeTypeEditorTest.java
@@ -9,12 +9,7 @@
  */
 package org.openmrs.propertyeditor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import org.junit.Before;
-import org.junit.Test;
 import org.openmrs.LocationAttributeType;
 import org.openmrs.api.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,12 +34,5 @@ public class LocationAttributeTypeEditorTest extends BasePropertyEditorTest<Loca
 	@Override
 	protected LocationAttributeType getExistingObject() {
 		return locationService.getLocationAttributeType(EXISTING_ID);
-	}
-	
-	@Override
-	@Test
-	public void shouldReturnEmptyStringIfValueIsNull() {
-		
-		assertThat(editor.getAsText(), is(nullValue()));
 	}
 }

--- a/api/src/test/java/org/openmrs/propertyeditor/LocationEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/LocationEditorTest.java
@@ -9,11 +9,6 @@
  */
 package org.openmrs.propertyeditor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
 import org.openmrs.Location;
 import org.openmrs.api.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,12 +28,5 @@ public class LocationEditorTest extends BasePropertyEditorTest<Location, Locatio
 	@Override
 	protected Location getExistingObject() {
 		return locationService.getLocation(EXISTING_ID);
-	}
-	
-	@Override
-	@Test
-	public void shouldReturnEmptyStringIfValueIsNull() {
-		
-		assertThat(editor.getAsText(), is(nullValue()));
 	}
 }

--- a/api/src/test/java/org/openmrs/propertyeditor/LocationTagEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/LocationTagEditorTest.java
@@ -9,12 +9,7 @@
  */
 package org.openmrs.propertyeditor;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
 import org.junit.Before;
-import org.junit.Test;
 import org.openmrs.LocationTag;
 import org.openmrs.api.LocationService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,12 +36,5 @@ public class LocationTagEditorTest extends BasePropertyEditorTest<LocationTag, L
 	@Override
 	protected LocationTag getExistingObject() {
 		return locationService.getLocationTag(EXISTING_ID);
-	}
-	
-	@Override
-	@Test
-	public void shouldReturnEmptyStringIfValueIsNull() {
-		
-		assertThat(editor.getAsText(), is(nullValue()));
 	}
 }


### PR DESCRIPTION
ConceptAttributeTypeEditor.java
LocationAttributeTypeEditor.java
LocationEditor.java
LocationTagEditor.java

which where the only ones returning null, in ~37 PropertyEditors

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5162


