### PR TITLE
TRUNK-5164 Add abstract OpenmrsPropertyEditor

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
@@ -9,13 +9,8 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Cohort;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
@@ -25,44 +20,18 @@ import org.springframework.util.StringUtils;
  * 
  * @see Cohort
  */
-public class CohortEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class CohortEditor extends OpenmrsPropertyEditor<Cohort> {
 	
 	public CohortEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(Context.getCohortService().getCohort(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Cohort cohort = Context.getCohortService().getCohortByUuid(text);
-				setValue(cohort);
-				if (cohort == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Cohort not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Cohort getObjectById(Integer id) {
+		return Context.getCohortService().getCohort(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Cohort c = (Cohort) getValue();
-		if (c == null) {
-			return "";
-		} else {
-			return c.getCohortId().toString();
-		}
+	protected Cohort getObjectByUuid(String uuid) {
+		return Context.getCohortService().getCohortByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptAnswer;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptAnswer
  */
-public class ConceptAnswerEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptAnswerEditor extends OpenmrsPropertyEditor<ConceptAnswer> {
 	
 	public ConceptAnswerEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptAnswer(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptAnswer conceptAnswer = cs.getConceptAnswerByUuid(text);
-				setValue(conceptAnswer);
-				if (conceptAnswer == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("Concept not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptAnswer getObjectById(Integer id) {
+		return Context.getConceptService().getConceptAnswer(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ConceptAnswer c = (ConceptAnswer) getValue();
-		if (c == null) {
-			return "";
-		} else {
-			return c.getConceptAnswerId().toString();
-		}
+	protected ConceptAnswer getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptAnswerByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAttributeTypeEditor.java
@@ -9,47 +9,18 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptAttributeType;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.springframework.util.StringUtils;
 
-public class ConceptAttributeTypeEditor extends PropertyEditorSupport {
+public class ConceptAttributeTypeEditor extends OpenmrsPropertyEditor<ConceptAttributeType> {
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		ConceptAttributeType conceptAttributeType = (ConceptAttributeType) getValue();
-		return conceptAttributeType == null ? "" : conceptAttributeType.getId().toString();
+	protected ConceptAttributeType getObjectById(Integer id) {
+		return Context.getConceptService().getConceptAttributeType(id);
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 *
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService conceptService = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(conceptService.getConceptAttributeType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptAttributeType conceptAttributeType = conceptService.getConceptAttributeTypeByUuid(text);
-				setValue(conceptAttributeType);
-				if (conceptAttributeType == null) {
-					throw new IllegalArgumentException("ConceptAttributeType not found for " + text, ex);
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptAttributeType getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptAttributeTypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptClass;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptClass
  */
-public class ConceptClassEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptClassEditor extends OpenmrsPropertyEditor<ConceptClass> {
 	
 	public ConceptClassEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		log.debug("Setting text: " + text);
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptClass(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptClass conceptClass = cs.getConceptClassByUuid(text);
-				setValue(conceptClass);
-				if (conceptClass == null) {
-					throw new IllegalArgumentException("ConceptClass not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptClass getObjectById(Integer id) {
+		return Context.getConceptService().getConceptClass(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ConceptClass t = (ConceptClass) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getConceptClassId().toString();
-		}
+	protected ConceptClass getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptClassByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
@@ -9,63 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptDatatype;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptDatatype
  */
-public class ConceptDatatypeEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptDatatypeEditor extends OpenmrsPropertyEditor<ConceptDatatype> {
 	
 	public ConceptDatatypeEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		log.debug("setting text: " + text);
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptDatatype(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptDatatype conceptDatatype = cs.getConceptDatatypeByUuid(text);
-				setValue(conceptDatatype);
-				if (conceptDatatype == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("ConceptDatatype not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptDatatype getObjectById(Integer id) {
+		return Context.getConceptService().getConceptDatatype(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ConceptDatatype t = (ConceptDatatype) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getConceptDatatypeId().toString();
-		}
+	protected ConceptDatatype getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptDatatypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Concept;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see Concept
  */
-public class ConceptEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptEditor extends OpenmrsPropertyEditor<Concept> {
 	
 	public ConceptEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConcept(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Concept concept = cs.getConceptByUuid(text);
-				setValue(concept);
-				if (concept == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("Concept not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Concept getObjectById(Integer id) {
+		return Context.getConceptService().getConcept(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Concept c = (Concept) getValue();
-		if (c == null) {
-			return "";
-		} else {
-			return c.getConceptId().toString();
-		}
+	protected Concept getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
@@ -9,67 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptName;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptName
  */
-public class ConceptNameEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptNameEditor extends OpenmrsPropertyEditor<ConceptName> {
 	
 	public ConceptNameEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 * 
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptName(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptName conceptName = cs.getConceptNameByUuid(text);
-				setValue(conceptName);
-				if (conceptName == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("ConceptName not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptName getObjectById(Integer id) {
+		return Context.getConceptService().getConceptName(id);
 	}
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		ConceptName cn = (ConceptName) getValue();
-		if (cn == null) {
-			return "";
-		} else {
-			return cn.getConceptNameId().toString();
-		}
+	protected ConceptName getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptNameByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptNumeric;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptNumeric
  */
-public class ConceptNumericEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptNumericEditor extends OpenmrsPropertyEditor<ConceptNumeric> {
 	
 	public ConceptNumericEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptNumeric(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptNumeric conceptNumeric = cs.getConceptNumericByUuid(text);
-				setValue(conceptNumeric);
-				if (conceptNumeric == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("Concept not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptNumeric getObjectById(Integer id) {
+		return Context.getConceptService().getConceptNumeric(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ConceptNumeric c = (ConceptNumeric) getValue();
-		if (c == null) {
-			return "";
-		} else {
-			return c.getConceptId().toString();
-		}
+	protected ConceptNumeric getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptNumericByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
@@ -9,63 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ConceptSource;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ConceptSource
  */
-public class ConceptSourceEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ConceptSourceEditor extends OpenmrsPropertyEditor<ConceptSource> {
 	
 	public ConceptSourceEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		log.debug("Setting text: " + text);
-		ConceptService cs = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(cs.getConceptSource(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ConceptSource conceptSource = cs.getConceptSourceByUuid(text);
-				setValue(conceptSource);
-				if (conceptSource == null) {
-					log.trace("ConceptSource not found by ID or UUID");
-					throw new IllegalArgumentException("ConceptSource not found: " + text, ex);
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ConceptSource getObjectById(Integer id) {
+		return Context.getConceptService().getConceptSource(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ConceptSource t = (ConceptSource) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getConceptSourceId().toString();
-		}
+	protected ConceptSource getObjectByUuid(String uuid) {
+		return Context.getConceptService().getConceptSourceByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/DrugEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/DrugEditor.java
@@ -9,75 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Drug;
-import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see Drug
  */
-public class DrugEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class DrugEditor extends OpenmrsPropertyEditor<Drug> {
 	
 	public DrugEditor() {
 	}
 	
-	/**
-	 * Sets the value of the property editor given the drug identifier.
-	 * 
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 * @should set value to the drug with the specified identifier
-	 * @should set value to null if given empty string
-	 * @should set value to null if given null value
-	 * @should set using uuid
-	 * @should fail if drug does not exist with non-empty identifier
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ConceptService es = Context.getConceptService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(es.getDrug(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Drug drug = es.getDrugByUuid(text);
-				setValue(drug);
-				if (drug == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Drug not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Drug getObjectById(Integer id) {
+		return Context.getConceptService().getDrug(id);
 	}
 	
-	/**
-	 * Gets the drug identifier associated with this property editor.
-	 * 
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 * @should return drug identifier as string when editor has a value
-	 * @should return empty string when editor has a null value
-	 */
 	@Override
-	public String getAsText() {
-		Drug d = (Drug) getValue();
-		if (d == null) {
-			return "";
-		} else {
-			return d.getDrugId().toString();
-		}
+	protected Drug getObjectByUuid(String uuid) {
+		return Context.getConceptService().getDrugByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Encounter;
-import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see Encounter
  */
-public class EncounterEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class EncounterEditor extends OpenmrsPropertyEditor<Encounter> {
 	
 	public EncounterEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		EncounterService es = Context.getEncounterService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(es.getEncounter(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Encounter encounter = es.getEncounterByUuid(text);
-				setValue(encounter);
-				if (encounter == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Encounter not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Encounter getObjectById(Integer id) {
+		return Context.getEncounterService().getEncounter(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Encounter e = (Encounter) getValue();
-		if (e == null) {
-			return "";
-		} else {
-			return e.getEncounterId().toString();
-		}
+	protected Encounter getObjectByUuid(String uuid) {
+		return Context.getEncounterService().getEncounterByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.EncounterType;
-import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see EncounterType
  */
-public class EncounterTypeEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class EncounterTypeEditor extends OpenmrsPropertyEditor<EncounterType> {
 	
 	public EncounterTypeEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		EncounterService ps = Context.getEncounterService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getEncounterType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				EncounterType encounterType = ps.getEncounterTypeByUuid(text);
-				setValue(encounterType);
-				if (encounterType == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Encounter Type not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected EncounterType getObjectById(Integer id) {
+		return Context.getEncounterService().getEncounterType(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		EncounterType t = (EncounterType) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getEncounterTypeId().toString();
-		}
+	protected EncounterType getObjectByUuid(String uuid) {
+		return Context.getEncounterService().getEncounterTypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Form;
-import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see Form
  */
-public class FormEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class FormEditor extends OpenmrsPropertyEditor<Form> {
 	
 	public FormEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		FormService ps = Context.getFormService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getForm(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Form form = ps.getFormByUuid(text);
-				setValue(form);
-				if (form == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Form not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Form getObjectById(Integer id) {
+		return Context.getFormService().getForm(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Form t = (Form) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getFormId().toString();
-		}
+	protected Form getObjectByUuid(String uuid) {
+		return Context.getFormService().getFormByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationAttributeTypeEditor.java
@@ -9,52 +9,23 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.LocationAttributeType;
-import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
-import org.springframework.util.StringUtils;
 
 /**
  * Property editor for {@link LocationAttributeType}s
  * 
  * @since 1.9
  */
-public class LocationAttributeTypeEditor extends PropertyEditorSupport {
+public class LocationAttributeTypeEditor extends OpenmrsPropertyEditor<LocationAttributeType> {
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		LocationAttributeType lat = (LocationAttributeType) getValue();
-		return lat == null ? "" : lat.getId().toString();
+	protected LocationAttributeType getObjectById(Integer id) {
+		return Context.getLocationService().getLocationAttributeType(id);
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 * 
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		LocationService ls = Context.getLocationService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ls.getLocationAttributeType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				LocationAttributeType lat = ls.getLocationAttributeTypeByUuid(text);
-				setValue(lat);
-				if (lat == null) {
-					throw new IllegalArgumentException("LocationAttributeType not found for " + text, ex);
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected LocationAttributeType getObjectByUuid(String uuid) {
+		return Context.getLocationService().getLocationAttributeTypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
@@ -9,58 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Location;
-import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  *
  * @see Location
  */
-public class LocationEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class LocationEditor extends OpenmrsPropertyEditor<Location> {
 	
 	public LocationEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		LocationService ls = Context.getLocationService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ls.getLocation(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Location location = ls.getLocationByUuid(text);
-				setValue(location);
-				if (location == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Location not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Location getObjectById(Integer id) {
+		return Context.getLocationService().getLocation(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Location t = (Location) getValue();
-		return t == null ? "" : t.getLocationId().toString();
+	protected Location getObjectByUuid(String uuid) {
+		return Context.getLocationService().getLocationByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
@@ -9,14 +9,8 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.LocationTag;
-import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Property editor for {@link LocationTag}s In version 1.9, added ability for this to also retrieve
@@ -24,45 +18,18 @@ import org.springframework.util.StringUtils;
  * 
  * @since 1.7
  */
-public class LocationTagEditor extends PropertyEditorSupport {
-	
-	private static Logger log = LoggerFactory.getLogger(LocationTagEditor.class);
+public class LocationTagEditor extends OpenmrsPropertyEditor<LocationTag> {
 	
 	public LocationTagEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		LocationService ls = Context.getLocationService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ls.getLocationTag(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				LocationTag locationTag = ls.getLocationTagByUuid(text);
-				setValue(locationTag);
-				if (locationTag == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("LocationTag not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected LocationTag getObjectById(Integer id) {
+		return Context.getLocationService().getLocationTag(id);
 	}
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		LocationTag t = (LocationTag) getValue();
-		return t == null ? "" : t.getLocationTagId().toString();
+	protected LocationTag getObjectByUuid(String uuid) {
+		return Context.getLocationService().getLocationTagByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/OpenmrsPropertyEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/OpenmrsPropertyEditor.java
@@ -1,0 +1,61 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.propertyeditor;
+
+import java.beans.PropertyEditorSupport;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.OpenmrsObject;
+
+/**
+ * Base {@code PropertyEditor} for {@code OpenmrsObject}.
+ * <p>
+ * When setting the {@code value} from text it will try to get the {@code OpenmrsObject} via its id
+ * and if that fails using its uuid.
+ * </p>
+ * 
+ * @param <T> the openmrs object to convert to and from
+ * @since 2.2.0
+ * @see org.openmrs.OpenmrsObject
+ */
+public abstract class OpenmrsPropertyEditor<T extends OpenmrsObject> extends PropertyEditorSupport {
+	
+	protected abstract T getObjectById(Integer id);
+	
+	protected abstract T getObjectByUuid(String uuid);
+	
+	@Override
+	public void setAsText(String text) throws IllegalArgumentException {
+		if (StringUtils.isNotBlank(text)) {
+			try {
+				setValue(getObjectById(Integer.valueOf(text)));
+			}
+			catch (Exception ex) {
+				T o = getObjectByUuid(text);
+				setValue(o);
+				if (o == null) {
+					throw new IllegalArgumentException("Failed to find object for value [" + text + "]", ex);
+				}
+			}
+		} else {
+			setValue(null);
+		}
+	}
+	
+	@Override
+	public String getAsText() {
+		T t = (T) getValue();
+		if (t == null) {
+			return "";
+		} else {
+			return t.getId().toString();
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
@@ -9,64 +9,25 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Order;
-import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing a Order object to a string so that Spring knows how to pass
- * a Order back and forth through an html form or other medium
- * <br>
+ * a Order back and forth through an html form or other medium <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see Order
  */
-public class OrderEditor extends PropertyEditorSupport {
+public class OrderEditor extends OpenmrsPropertyEditor<Order> {
 	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 * 
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		OrderService ps = Context.getOrderService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getOrder(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Order order = ps.getOrderByUuid(text);
-				setValue(order);
-				if (order == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Order not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Order getObjectById(Integer id) {
+		return Context.getOrderService().getOrder(id);
 	}
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		Order t = (Order) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getOrderId().toString();
-		}
+	protected Order getObjectByUuid(String uuid) {
+		return Context.getOrderService().getOrderByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/PatientEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PatientEditor.java
@@ -9,14 +9,8 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.Patient;
-import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing a Patient object to a string so that Spring knows how to
@@ -26,47 +20,15 @@ import org.springframework.util.StringUtils;
  *
  * @see Patient
  */
-public class PatientEditor extends PropertyEditorSupport {
+public class PatientEditor extends OpenmrsPropertyEditor<Patient> {
 	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 * 
-	 * @see java.beans.PropertyEditorSupport#setAsText(java.lang.String)
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		PatientService ps = Context.getPatientService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getPatient(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Patient patient = ps.getPatientByUuid(text);
-				setValue(patient);
-				if (patient == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Patient not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Patient getObjectById(Integer id) {
+		return Context.getPatientService().getPatient(id);
 	}
 	
-	/**
-	 * @see java.beans.PropertyEditorSupport#getAsText()
-	 */
 	@Override
-	public String getAsText() {
-		Patient t = (Patient) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getPatientId().toString();
-		}
+	protected Patient getObjectByUuid(String uuid) {
+		return Context.getPatientService().getPatientByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.PatientIdentifierType;
-import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see PatientIdentifierType
  */
-public class PatientIdentifierTypeEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class PatientIdentifierTypeEditor extends OpenmrsPropertyEditor<PatientIdentifierType> {
 	
 	public PatientIdentifierTypeEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		PatientService ps = Context.getPatientService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getPatientIdentifierType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				PatientIdentifierType patientIdentifierType = ps.getPatientIdentifierTypeByUuid(text);
-				setValue(patientIdentifierType);
-				if (patientIdentifierType == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Identifier Type not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected PatientIdentifierType getObjectById(Integer id) {
+		return Context.getPatientService().getPatientIdentifierType(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		PatientIdentifierType t = (PatientIdentifierType) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getPatientIdentifierTypeId().toString();
-		}
+	protected PatientIdentifierType getObjectByUuid(String uuid) {
+		return Context.getPatientService().getPatientIdentifierTypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
@@ -9,59 +9,26 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.PersonAttribute;
-import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see PersonAttribute
  */
-public class PersonAttributeEditor extends PropertyEditorSupport {
+public class PersonAttributeEditor extends OpenmrsPropertyEditor<PersonAttribute> {
 	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		PersonService ps = Context.getPersonService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getPersonAttribute(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				PersonAttribute personAttribute = ps.getPersonAttributeByUuid(text);
-				setValue(personAttribute);
-				if (personAttribute == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Person Attribute Type not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected PersonAttribute getObjectById(Integer id) {
+		return Context.getPersonService().getPersonAttribute(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		PersonAttribute t = (PersonAttribute) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getPersonAttributeId().toString();
-		}
+	protected PersonAttribute getObjectByUuid(String uuid) {
+		return Context.getPersonService().getPersonAttributeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
@@ -9,59 +9,26 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.PersonAttributeType;
-import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see PersonAttributeType
  */
-public class PersonAttributeTypeEditor extends PropertyEditorSupport {
+public class PersonAttributeTypeEditor extends OpenmrsPropertyEditor<PersonAttributeType> {
 	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
-	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		PersonService ps = Context.getPersonService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getPersonAttributeType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				PersonAttributeType personAttributeType = ps.getPersonAttributeTypeByUuid(text);
-				setValue(personAttributeType);
-				if (personAttributeType == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("Person Attribute Type not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected PersonAttributeType getObjectById(Integer id) {
+		return Context.getPersonService().getPersonAttributeType(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		PersonAttributeType t = (PersonAttributeType) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getPersonAttributeTypeId().toString();
-		}
+	protected PersonAttributeType getObjectByUuid(String uuid) {
+		return Context.getPersonService().getPersonAttributeTypeByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ProgramWorkflow;
-import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ProgramWorkflow
  */
-public class ProgramWorkflowEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ProgramWorkflowEditor extends OpenmrsPropertyEditor<ProgramWorkflow> {
 	
 	public ProgramWorkflowEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ProgramWorkflowService pws = Context.getProgramWorkflowService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(pws.getWorkflow(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ProgramWorkflow pw = pws.getWorkflowByUuid(text);
-				setValue(pw);
-				if (pw == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("Program Workflow not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ProgramWorkflow getObjectById(Integer id) {
+		return Context.getProgramWorkflowService().getWorkflow(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ProgramWorkflow pw = (ProgramWorkflow) getValue();
-		if (pw == null) {
-			return "";
-		} else {
-			return pw.getProgramWorkflowId().toString();
-		}
+	protected ProgramWorkflow getObjectByUuid(String uuid) {
+		return Context.getProgramWorkflowService().getWorkflowByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.ProgramWorkflowState;
-import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see ProgramWorkflowState
  */
-public class ProgramWorkflowStateEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class ProgramWorkflowStateEditor extends OpenmrsPropertyEditor<ProgramWorkflowState> {
 	
 	public ProgramWorkflowStateEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		ProgramWorkflowService pws = Context.getProgramWorkflowService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(pws.getState(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				ProgramWorkflowState s = pws.getStateByUuid(text);
-				setValue(s);
-				if (s == null) {
-					log.error("Error setting text" + text, ex);
-					throw new IllegalArgumentException("Program Workflow State not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected ProgramWorkflowState getObjectById(Integer id) {
+		return Context.getProgramWorkflowService().getState(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		ProgramWorkflowState pws = (ProgramWorkflowState) getValue();
-		if (pws == null) {
-			return "";
-		} else {
-			return pws.getProgramWorkflowStateId().toString();
-		}
+	protected ProgramWorkflowState getObjectByUuid(String uuid) {
+		return Context.getProgramWorkflowService().getStateByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
@@ -9,62 +9,29 @@
  */
 package org.openmrs.propertyeditor;
 
-import java.beans.PropertyEditorSupport;
-
 import org.openmrs.User;
-import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
- * Allows for serializing/deserializing an object to a string so that Spring knows how to pass
- * an object back and forth through an html form or other medium. <br>
+ * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
+ * object back and forth through an html form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  * 
  * @see User
  */
-public class UserEditor extends PropertyEditorSupport {
-	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+public class UserEditor extends OpenmrsPropertyEditor<User> {
 	
 	public UserEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		UserService ps = Context.getUserService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(ps.getUser(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				User u = ps.getUserByUuid(text);
-				setValue(u);
-				if (u == null) {
-					log.error("Error setting text: " + text, ex);
-					throw new IllegalArgumentException("User not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected User getObjectById(Integer id) {
+		return Context.getUserService().getUser(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		User t = (User) getValue();
-		if (t == null) {
-			return "";
-		} else {
-			return t.getUserId().toString();
-		}
+	protected User getObjectByUuid(String uuid) {
+		return Context.getUserService().getUserByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/VisitEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/VisitEditor.java
@@ -10,58 +10,27 @@
 package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditor;
-import java.beans.PropertyEditorSupport;
 
 import org.openmrs.Visit;
-import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * {@link PropertyEditor} for {@link Visit}
  *
  * @since 1.9
  */
-public class VisitEditor extends PropertyEditorSupport {
-	
-	private static final Logger log = LoggerFactory.getLogger(VisitEditor.class);
+public class VisitEditor extends OpenmrsPropertyEditor<Visit> {
 	
 	public VisitEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		VisitService vs = Context.getVisitService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(vs.getVisit(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				Visit v = vs.getVisitByUuid(text);
-				setValue(v);
-				if (v == null) {
-					throw new IllegalArgumentException("Visit not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected Visit getObjectById(Integer id) {
+		return Context.getVisitService().getVisit(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		Visit v = (Visit) getValue();
-		if (v == null) {
-			return "";
-		} else {
-			return v.getVisitId().toString();
-		}
+	protected Visit getObjectByUuid(String uuid) {
+		return Context.getVisitService().getVisitByUuid(uuid);
 	}
-	
 }

--- a/api/src/main/java/org/openmrs/propertyeditor/VisitTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/VisitTypeEditor.java
@@ -10,58 +10,27 @@
 package org.openmrs.propertyeditor;
 
 import java.beans.PropertyEditor;
-import java.beans.PropertyEditorSupport;
 
 import org.openmrs.VisitType;
-import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StringUtils;
 
 /**
  * {@link PropertyEditor} for {@link VisitType}
  * 
  * @since 1.9
  */
-public class VisitTypeEditor extends PropertyEditorSupport {
-	
-	private static final Logger log = LoggerFactory.getLogger(VisitTypeEditor.class);
+public class VisitTypeEditor extends OpenmrsPropertyEditor<VisitType> {
 	
 	public VisitTypeEditor() {
 	}
 	
-	/**
-	 * @should set using id
-	 * @should set using uuid
-	 */
 	@Override
-	public void setAsText(String text) throws IllegalArgumentException {
-		VisitService vs = Context.getVisitService();
-		if (StringUtils.hasText(text)) {
-			try {
-				setValue(vs.getVisitType(Integer.valueOf(text)));
-			}
-			catch (Exception ex) {
-				VisitType v = vs.getVisitTypeByUuid(text);
-				setValue(v);
-				if (v == null) {
-					throw new IllegalArgumentException("Visit Type not found: " + ex.getMessage());
-				}
-			}
-		} else {
-			setValue(null);
-		}
+	protected VisitType getObjectById(Integer id) {
+		return Context.getVisitService().getVisitType(id);
 	}
 	
 	@Override
-	public String getAsText() {
-		VisitType vt = (VisitType) getValue();
-		if (vt == null) {
-			return "";
-		} else {
-			return vt.getVisitTypeId().toString();
-		}
+	protected VisitType getObjectByUuid(String uuid) {
+		return Context.getVisitService().getVisitTypeByUuid(uuid);
 	}
-	
 }


### PR DESCRIPTION
Add abstract OpenmrsPropertyEditor for OpenmrsObject's
which tries to get an object via its id and if that fails via its uuid

Let

CohortEditor.java
ConceptAnswerEditor.java
ConceptAttributeTypeEditor.java
ConceptClassEditor.java
ConceptDatatypeEditor.java
ConceptEditor.java
ConceptNameEditor.java
ConceptNumericEditor.java
ConceptSourceEditor.java
DrugEditor.java
EncounterEditor.java
EncounterTypeEditor.java
FormEditor.java
LocationAttributeTypeEditor.java
LocationEditor.java
LocationTagEditor.java
OpenmrsPropertyEditor.java
OrderEditor.java
PatientEditor.java
PatientIdentifierTypeEditor.java
PersonAttributeEditor.java
PersonAttributeTypeEditor.java
ProgramWorkflowEditor.java
ProgramWorkflowStateEditor.java
UserEditor.java
VisitEditor.java
VisitTypeEditor.java

extend OpenmrsPropertyEditor.

The current behavior is not changed as shown by existing tests which
were not changed.

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5164