### PR TITLE
TRUNK-5166 ConceptReferenceTermEditorTest does not get object via uuid

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptReferenceTermEditor.java
@@ -32,7 +32,11 @@ public class ConceptReferenceTermEditor extends PropertyEditorSupport {
 				setValue(Context.getConceptService().getConceptReferenceTerm(Integer.valueOf(text)));
 			}
 			catch (Exception ex) {
-				throw new IllegalArgumentException("ConceptReferenceTerm not found: " + text, ex);
+				ConceptReferenceTerm value = Context.getConceptService().getConceptReferenceTermByUuid(text);
+				setValue(value);
+				if (value == null) {
+					throw new IllegalArgumentException("ConceptReferenceTerm not found: " + text, ex);
+				}
 			}
 		} else {
 			setValue(null);

--- a/api/src/test/java/org/openmrs/propertyeditor/ConceptReferenceTermEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/ConceptReferenceTermEditorTest.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.propertyeditor;
 
-import org.junit.Test;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.api.ConceptService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,12 +28,5 @@ public class ConceptReferenceTermEditorTest extends BasePropertyEditorTest<Conce
 	@Override
 	protected ConceptReferenceTerm getExistingObject() {
 		return conceptService.getConceptReferenceTerm(EXISTING_ID);
-	}
-	
-	@Override
-	@Test(expected = IllegalArgumentException.class)
-	public void shouldSetTheEditorValueToObjectAssociatedWithGivenUuid() {
-		
-		editor.setAsText(getExistingObject().getUuid());
 	}
 }


### PR DESCRIPTION
ConceptMapTypeEditor does not try getting the object via uuid after it failed to get it via its id
although the service provides the method. This is usually done (>30 editors for OpenmrsObjects).

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5166

