### PR TITLE
TRUNK-5167 PersonEditor does not throw if Person not found

### DIFF
--- a/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
@@ -45,11 +45,10 @@ public class PersonEditor extends PropertyEditorSupport {
 				setValue(ps.getPerson(personId));
 			}
 			catch (NumberFormatException e) {
-				// assume text entered is a uuid
 				Person person = ps.getPersonByUuid(text);
 				setValue(person);
 				if (person == null) {
-					log.trace("Unable to get Person by primary key or uuid using input: " + text);
+					throw new IllegalArgumentException("Failed to find person for value [" + text + "]");
 				}
 			}
 		} else {

--- a/api/src/test/java/org/openmrs/propertyeditor/PersonEditorTest.java
+++ b/api/src/test/java/org/openmrs/propertyeditor/PersonEditorTest.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.propertyeditor;
 
-import org.junit.Ignore;
-import org.junit.Test;
 import org.openmrs.Person;
 import org.openmrs.api.PersonService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,13 +28,5 @@ public class PersonEditorTest extends BasePropertyEditorTest<Person, PersonEdito
 	@Override
 	protected Person getExistingObject() {
 		return personService.getPerson(EXISTING_ID);
-	}
-	
-	@Override
-	@Ignore("to investigate, this behavior deviates from most openmrs propertyeditors")
-	@Test(expected = IllegalArgumentException.class)
-	public void shouldFailToSetTheEditorValueIfGivenUuidDoesNotExist() {
-		
-		editor.setAsText(getNonExistingObjectUuid());
 	}
 }


### PR DESCRIPTION
PersonEditor does not throw an IllegalArgumentException if Person
is not found given text which is different than ~30 PropertyEditors for OpenmrsObjects

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5167


