### PR TITLE
TRUNK-5096 Remove MemoryLeakUtil.shutdownKeepAliveTimer

### DIFF
--- a/api/src/main/java/org/openmrs/util/MemoryLeakUtil.java
+++ b/api/src/main/java/org/openmrs/util/MemoryLeakUtil.java
@@ -15,8 +15,6 @@ import java.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.net.www.http.KeepAliveCache;
-
 /**
  * Utility functions to clean up causes of memory leakages.
  */
@@ -56,27 +54,6 @@ public class MemoryLeakUtil {
 		}
 		catch (IllegalAccessException iae) {
 			log.info("Failed to shut-down MySQL Statement Cancellation Timer due to an IllegalAccessException", iae);
-		}
-	}
-	
-	public static void shutdownKeepAliveTimer() {
-		try {
-			final Field kac = HttpClient.class.getDeclaredField("kac");
-			
-			kac.setAccessible(true);
-			final Field keepAliveTimer = KeepAliveCache.class.getDeclaredField("keepAliveTimer");
-			
-			keepAliveTimer.setAccessible(true);
-			
-			final Thread thread = (Thread) keepAliveTimer.get(kac.get(null));
-			
-			if (thread.getContextClassLoader() == OpenmrsClassLoader.getInstance()) {
-				//Set to system class loader such that we can be garbage collected.
-				thread.setContextClassLoader(ClassLoader.getSystemClassLoader());
-			}
-		}
-		catch (final Exception e) {
-			log.error(e.getMessage(), e);
 		}
 	}
 }

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -603,7 +603,6 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		}
 		
 		MemoryLeakUtil.shutdownMysqlCancellationTimer();
-		MemoryLeakUtil.shutdownKeepAliveTimer();
 		
 		OpenmrsClassLoader.onShutdown();
 		


### PR DESCRIPTION


<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Remove MemoryLeakUtil.shutdownKeepAliveTimer since its implementation
is based on a non-existing field and throws an exception on its first
line; also thereby remove a dependency on a sun package

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5096

