### PR TITLE
TRUNK-5174 Deprecate PersonNameValidator.validatePersonName

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
@@ -58,6 +58,7 @@ public class PersonNameValidator implements Validator {
 			if (personName == null) {
 				errors.reject("error.name");
 			} else if (!personName.getVoided()) {
+				// TODO - the following method should be made private in a major release
 				validatePersonName(personName, errors, false, true);
 			}
 		}
@@ -118,7 +119,9 @@ public class PersonNameValidator implements Validator {
 	 * @should pass validation if regex string is null
 	 * @should pass validation if regex string is empty
 	 * @should not validate against regex for blank names
+	 * @deprecated as of 2.2.0, use {@link #validate(Object, Errors)}
 	 */
+	@Deprecated
 	public void validatePersonName(PersonName personName, Errors errors, boolean arrayInd, boolean testInd) {
 		
 		if (personName == null) {


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
PersonNameValidator implements Validator so client code can call
validate to get the same behavior as calling validatePersonName which
should be made private in a major release


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5174
