### PR TITLE
TRUNK-4868: Set dead flag depending on deathDate presence

### DIFF
--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -303,9 +303,11 @@ public class Person extends BaseOpenmrsData {
 	
 	/**
 	 * @param deathDate date of person's death
+	 * @should set dead flag depending on deathDate presence
 	 */
 	public void setDeathDate(Date deathDate) {
 		this.deathDate = deathDate;
+		this.setDead(deathDate != null);
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/PersonTest.java
+++ b/api/src/test/java/org/openmrs/PersonTest.java
@@ -880,4 +880,22 @@ public class PersonTest extends BaseContextSensitiveTest {
 			return personAddress;
 		}
 	}
+
+	/**
+	 * @see Person#setDeathDate(Date)
+	 * @verifies set dead flag depending on deathDate presence
+	 */
+	@Test
+	public void setDeathDate_shouldSetDeadFlagDependingOnDeathDatePresence() {
+		Calendar birthdate = Calendar.getInstance();
+		birthdate.set(1990, Calendar.JUNE, 2);
+		Calendar deathDate = Calendar.getInstance();
+		deathDate.set(2000, Calendar.JUNE, 3);
+		Person person = new Person();
+		person.setBirthdate(birthdate.getTime());
+		person.setDeathDate(deathDate.getTime());
+		assertTrue(person.getDead());
+		person.setDeathDate(null);
+		assertFalse(person.getDead());
+	}
 }

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -22,6 +22,22 @@ import static org.junit.Assert.fail;
 import static org.openmrs.test.TestUtil.assertCollectionContentsEquals;
 import static org.openmrs.util.AddressMatcher.containsAddress;
 import static org.openmrs.util.NameMatcher.containsFullName;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,21 +81,6 @@ import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Vector;
-import java.util.stream.Collectors;
 
 /**
  * This class tests methods in the PatientService class TODO Add methods to test all methods in
@@ -217,8 +218,8 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// patient.removeAddress(pAddress);
 		
 		patient.setDeathDate(new Date());
-		// patient.setCauseOfDeath("air");
-		patient.setBirthdate(new Date());
+		patient.setCauseOfDeath(Context.getConceptService().getConcept(3));
+		patient.setBirthdate(new Date(0));
 		patient.setBirthdateEstimated(true);
 		patient.setGender("male");
 		patient.setDeathdateEstimated(true);
@@ -250,9 +251,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// patient.removeAddress(pAddress);
 		
 		patient.setDeathDate(new Date());
+		patient.setCauseOfDeath(Context.getConceptService().getConcept(3));
 		patient.setBirthdateEstimated(true);
-		// patient.setCauseOfDeath("air");
-		patient.setBirthdate(new Date());
+		patient.setBirthdate(new Date(0));
 		patient.setBirthdateEstimated(true);
 		patient.setGender("male");
 		
@@ -2549,6 +2550,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		cDate.setTime(new Date());
 		Patient preferred = patientService.getPatient(999);
 		preferred.setDeathDate(cDate.getTime());
+		preferred.setCauseOfDeath(Context.getConceptService().getConcept(3));
 		preferred.setDeathdateEstimated(true);
 		preferred.addName(new PersonName("givenName", "middleName", "familyName"));
 		patientService.savePatient(preferred);

--- a/api/src/test/java/org/openmrs/api/PersonServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PersonServiceTest.java
@@ -197,6 +197,7 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		patient.setBirthdate(new Date());
 		patient.setBirthdateEstimated(true);
 		patient.setDeathDate(new Date());
+		patient.setCauseOfDeath(Context.getConceptService().getConcept(3));
 		patient.setGender("male");
 		List<PatientIdentifierType> patientIdTypes = ps.getAllPatientIdentifierTypes();
 		assertNotNull(patientIdTypes);

--- a/api/src/test/resources/org/openmrs/api/db/hibernate/include/HibernatePersonDAOTest-people.xml
+++ b/api/src/test/resources/org/openmrs/api/db/hibernate/include/HibernatePersonDAOTest-people.xml
@@ -61,8 +61,8 @@
     <!--
         Dead people with non-voided name
     -->
-    <person person_id="51" gender="M" birthdate="1998-09-30 12:34:56.7" birthdate_estimated="0" dead="true" creator="1" date_created="2013-04-25 12:34:56.7" voided="false" uuid="A10595DC-B782-4F19-8693-0F6963A67DB6"/>
-    <person person_id="52" gender="M" birthdate="1998-09-30 12:34:56.7" birthdate_estimated="0" dead="true"  creator="1" date_created="2013-04-25 12:34:56.7" voided="false" uuid="1A1108EB-D6F6-4676-BF33-DF7BF7B1C882"/>
+    <person person_id="51" gender="M" birthdate="1998-09-30 12:34:56.7" birthdate_estimated="0" dead="true" creator="1" date_created="2013-04-25 12:34:56.7" voided="false" uuid="A10595DC-B782-4F19-8693-0F6963A67DB6" death_date="2008-09-30 12:34:56.7"/>
+    <person person_id="52" gender="M" birthdate="1998-09-30 12:34:56.7" birthdate_estimated="0" dead="true"  creator="1" date_created="2013-04-25 12:34:56.7" voided="false" uuid="1A1108EB-D6F6-4676-BF33-DF7BF7B1C882" death_date="2008-09-30 12:34:56.7"/>
 
     <person_name person_name_id="51" preferred="true" person_id="51" prefix="Mr." given_name="dead-charlie" middle_name="dead-golf"  family_name="dead-kilo" family_name2="dead-papa" creator="1" date_created="2013-04-18 12:34:56.7" voided="false" void_reason="" uuid="C9495BF5-6082-4A17-8D3C-AFD3DFA5FD65"/>
     <person_name person_name_id="52" preferred="true" person_id="52" prefix="Mr." given_name="dead-delta"   middle_name="dead-hotel" family_name="dead-lima" family_name2="dead-papa" creator="1" date_created="2013-04-18 12:34:56.7" voided="false" void_reason="" uuid="00337604-57E0-4E75-B358-27A7A464FF62"/>


### PR DESCRIPTION
TRUNK-4868: Set dead flag depending on deathDate presence

Made setting of dead flag depending on deathDate presence.
Fixed failing tests. Added setting causeOfDeath to pass validations. Changed birth dates to be less than death dates. 
Added death dates to people.xml.

See https://issues.openmrs.org/browse/TRUNK-4868

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

