### PR TITLE
TRUNK-5183 Not able to save data of java.sql.Time data type

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptor.java
@@ -10,6 +10,7 @@
 package org.openmrs.api.db.hibernate;
 
 import java.io.Serializable;
+import java.sql.Time;
 import java.util.Date;
 
 import org.hibernate.EmptyInterceptor;
@@ -65,7 +66,7 @@ public class DropMillisecondsHibernateInterceptor extends EmptyInterceptor {
 		boolean anyChanges = false;
 		for (int i = fieldValues.length - 1; i >= 0; --i) {
 			Object candidate = fieldValues[i];
-			if (candidate instanceof Date) {
+			if (!(candidate instanceof Time) && candidate instanceof Date) {
 				Date noMilliseconds = DateUtil.truncateToSeconds((Date) candidate);
 				if (!noMilliseconds.equals(candidate)) {
 					fieldValues[i] = noMilliseconds;

--- a/api/src/test/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptorTest.java
@@ -10,8 +10,10 @@
 package org.openmrs.api.db.hibernate;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.sql.Time;
 import java.util.Date;
 
 import org.junit.Test;
@@ -30,6 +32,9 @@ public class DropMillisecondsHibernateInterceptorTest extends BaseContextSensiti
 
 	@Autowired
 	PersonService personService;
+
+	@Autowired
+	DropMillisecondsHibernateInterceptor dropMillisecondsHibernateInterceptor;
 
 	@Test
 	public void shouldClearMillisecondsWhenSavingANewObject() throws Exception {
@@ -59,5 +64,12 @@ public class DropMillisecondsHibernateInterceptorTest extends BaseContextSensiti
 		Context.flushSession();
 
 		assertThat(person.getBirthdate(), is(dateWithoutMillisecond));
+	}
+
+	@Test
+	public void shouldNotChangeWhenInstanceOfTime() throws Exception {
+		Time[] time = { Time.valueOf("17:00:00") };
+		boolean anyChanges = dropMillisecondsHibernateInterceptor.onSave(null, null, time, null, null);
+		assertEquals(false, anyChanges);
 	}
 }


### PR DESCRIPTION
Truncate milliseconds on if its a instance of Date and not Time



## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5183

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

