### PR TITLE
TRUNK-5195 Do not use nullSafeEquals in ConceptName enum comparisons 

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -1022,7 +1022,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			}
 			if (!names.contains(conceptName)) {
 				if (getNames().isEmpty()
-				        && !OpenmrsUtil.nullSafeEquals(conceptName.getConceptNameType(), ConceptNameType.FULLY_SPECIFIED)) {
+				        && !ConceptNameType.FULLY_SPECIFIED.equals(conceptName.getConceptNameType())) {
 					conceptName.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
 				} else {
 					if (conceptName.isPreferred() && !conceptName.isIndexTerm() && conceptName.getLocale() != null) {

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -31,7 +31,6 @@ import org.hibernate.search.annotations.TokenFilterDef;
 import org.hibernate.search.annotations.TokenizerDef;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.db.hibernate.search.bridge.LocaleFieldBridge;
-import org.openmrs.util.OpenmrsUtil;
 
 /**
  * ConceptName is the real world term used to express a Concept within the idiom of a particular
@@ -498,7 +497,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @since Version 1.7
 	 */
 	public Boolean isFullySpecifiedName() {
-		return OpenmrsUtil.nullSafeEquals(getConceptNameType(), ConceptNameType.FULLY_SPECIFIED);
+		return ConceptNameType.FULLY_SPECIFIED.equals(getConceptNameType());
 	}
 	
 	/**
@@ -507,7 +506,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @return true if the name is marked as a short name, otherwise false
 	 */
 	public Boolean isShort() {
-		return OpenmrsUtil.nullSafeEquals(getConceptNameType(), ConceptNameType.SHORT);
+		return ConceptNameType.SHORT.equals(getConceptNameType());
 	}
 	
 	/**
@@ -517,7 +516,7 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	 * @since Version 1.7
 	 */
 	public Boolean isIndexTerm() {
-		return OpenmrsUtil.nullSafeEquals(getConceptNameType(), ConceptNameType.INDEX_TERM);
+		return ConceptNameType.INDEX_TERM.equals(getConceptNameType());
 	}
 	
 	/**


### PR DESCRIPTION
Replaced nullSafeEquals with equals for enums

see https://issues.openmrs.org/browse/TRUNK-5195

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

