### PR TITLE
TRUNK-5205 Use java8 Base64 instead of xerces

### DIFF
--- a/api/src/main/java/org/openmrs/util/Security.java
+++ b/api/src/main/java/org/openmrs/util/Security.java
@@ -14,6 +14,7 @@ import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Random;
 
 import javax.crypto.Cipher;
@@ -22,7 +23,6 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.xerces.impl.dv.util.Base64;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
@@ -227,11 +227,13 @@ public class Security {
 		IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
 		SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
 		byte[] encrypted;
+		String result;
 		
 		try {
 			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
 			cipher.init(Cipher.ENCRYPT_MODE, secret, initVectorSpec);
 			encrypted = cipher.doFinal(text.getBytes(encoding));
+			result = new String(Base64.getEncoder().encode(encrypted), encoding);
 		}
 		catch (GeneralSecurityException e) {
 			throw new APIException("could.not.encrypt.text", null, e);
@@ -240,7 +242,7 @@ public class Security {
 			throw new APIException("system.cannot.find.encoding", new Object[] { encoding }, e);
 		}
 		
-		return Base64.encode(encrypted);
+		return result;
 	}
 	
 	/**
@@ -275,7 +277,7 @@ public class Security {
 		try {
 			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
 			cipher.init(Cipher.DECRYPT_MODE, secret, initVectorSpec);
-			byte[] original = cipher.doFinal(Base64.decode(text));
+			byte[] original = cipher.doFinal(Base64.getDecoder().decode(text));
 			decrypted = new String(original, encoding);
 		}
 		catch (GeneralSecurityException e) {
@@ -311,7 +313,7 @@ public class Security {
 		    OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, OpenmrsConstants.ENCRYPTION_VECTOR_DEFAULT);
 		
 		if (StringUtils.hasText(initVectorText)) {
-			return Base64.decode(initVectorText);
+			return Base64.getDecoder().decode(initVectorText);
 		}
 		
 		throw new APIException("no.encryption.initialization.vector.found", (Object[]) null);
@@ -343,7 +345,7 @@ public class Security {
 		    OpenmrsConstants.ENCRYPTION_KEY_DEFAULT);
 		
 		if (StringUtils.hasText(keyText)) {
-			return Base64.decode(keyText);
+			return Base64.getDecoder().decode(keyText);
 		}
 		
 		throw new APIException("no.encryption.secret.key.found", (Object[]) null);

--- a/api/src/test/java/org/openmrs/util/SecurityTest.java
+++ b/api/src/test/java/org/openmrs/util/SecurityTest.java
@@ -9,7 +9,9 @@
  */
 package org.openmrs.util;
 
-import org.apache.xerces.impl.dv.util.Base64;
+import java.util.Base64;
+import java.util.Base64.Decoder;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.util.StringUtils;
@@ -73,9 +75,10 @@ public class SecurityTest {
 	 */
 	@Test
 	public void decrypt_shouldDecryptShortAndLongText() {
+		final Decoder base64 = Base64.getDecoder();
 		// use specific IV and Key
-		byte[] initVector = Base64.decode("9wyBUNglFCRVSUhMfsTa3Q==");
-		byte[] secretKey = Base64.decode("dTfyELRrAICGDwzjHDjuhw==");
+		byte[] initVector = base64.decode("9wyBUNglFCRVSUhMfsTa3Q==");
+		byte[] secretKey = base64.decode("dTfyELRrAICGDwzjHDjuhw==");
 		
 		// perform decryption
 		String expected = "this is fantasmic";

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -113,7 +113,7 @@
 			<property name="severity" value="error"/>
 		</module>
 		<module name="IllegalImport">
-			<property name="illegalPkgs" value="sun, org.apache.commons.logging, org.openmrs.test.Verifies" />
+			<property name="illegalPkgs" value="sun, org.apache.commons.logging, org.openmrs.test.Verifies, org.apache.xerces" />
 			<property name="severity" value="error"/>
 		</module>
 		<module name="OneTopLevelClass">

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -23,6 +23,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Base64.Encoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -42,7 +44,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
-import org.apache.xerces.impl.dv.util.Base64;
 import org.openmrs.ImplementationId;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.PasswordException;
@@ -1508,10 +1509,11 @@ public class InitializationFilter extends StartupFilter {
 						}
 						runtimeProperties.put("module.allow_web_admin", wizardModel.moduleWebAdmin.toString());
 						runtimeProperties.put("auto_update_database", wizardModel.autoUpdateDatabase.toString());
-						runtimeProperties.put(OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, Base64.encode(Security
-						        .generateNewInitVector()));
-						runtimeProperties.put(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY, Base64.encode(Security
-						        .generateNewSecretKey()));
+						final Encoder base64 = Base64.getEncoder();
+						runtimeProperties.put(OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY,
+						    new String(base64.encode(Security.generateNewInitVector())));
+						runtimeProperties.put(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY,
+						    new String(base64.encode(Security.generateNewSecretKey())));
 						
 						Properties properties = Context.getRuntimeProperties();
 						properties.putAll(runtimeProperties);


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
replaced use of org.apache.xerces.impl.dv.util.Base64
with java8 Base64

added small refactorings TestInstallUtil.getResourceInputStream
* extracted private methods to improve readability
* renamed parameter
* use parametrized log message style and remove if since log.info
already checks for the log level

set checkstyle rule: Import from illegal package - org.apache.xerces


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5205

