### PR TITLE
TRUNK-5213: @OpenmrsProfile loads Spring resources conditionally based on missing module(s)

### DIFF
--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Prevents creating a bean if profile is not matched. It returns true if a bean should not be created.
  */
 public class OpenmrsProfileExcludeFilter implements TypeFilter {
-	
+
 	/**
 	 * @param metadataReader
 	 * @param metadataReaderFactory
@@ -40,7 +40,7 @@ public class OpenmrsProfileExcludeFilter implements TypeFilter {
 	@Override
 	public boolean match(MetadataReader metadataReader, MetadataReaderFactory metadataReaderFactory) throws IOException {
 		Map<String, Object> openmrsProfileAttributes = metadataReader.getAnnotationMetadata().getAnnotationAttributes(
-		    "org.openmrs.annotation.OpenmrsProfile");
+				"org.openmrs.annotation.OpenmrsProfile");
 		if (openmrsProfileAttributes != null) {
 			return !matchOpenmrsProfileAttributes(openmrsProfileAttributes);
 		} else {
@@ -48,40 +48,47 @@ public class OpenmrsProfileExcludeFilter implements TypeFilter {
 			return false;
 		}
 	}
-	
+
 	public boolean matchOpenmrsProfileAttributes(Map<String, Object> openmrsProfile) {
 		Object openmrsPlatformVersion = openmrsProfile.get("openmrsPlatformVersion");
 		if (StringUtils.isBlank((String) openmrsPlatformVersion)) {
 			//Left for backwards compatibility
 			openmrsPlatformVersion = openmrsProfile.get("openmrsVersion");
 		}
-		
+
 		if (StringUtils.isNotBlank((String) openmrsPlatformVersion)
-		        && !ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, (String) openmrsPlatformVersion)) {
+				&& !ModuleUtil.matchRequiredVersions(OpenmrsConstants.OPENMRS_VERSION_SHORT, (String) openmrsPlatformVersion)) {
 			return false;
 		}
-		
+
 		String[] modules = (String[]) openmrsProfile.get("modules");
-		
+
 		for (String moduleAndVersion : modules) {
-			String[] splitModuleAndVersion = moduleAndVersion.split(":");
-			String moduleId = splitModuleAndVersion[0];
-			String moduleVersion = splitModuleAndVersion[1];
-			
-			boolean moduleMatched = false;
-			for (Module module : ModuleFactory.getStartedModules()) {
-				if (module.getModuleId().equals(moduleId)
-				        && ModuleUtil.matchRequiredVersions(module.getVersion(), moduleVersion)) {
-					moduleMatched = true;
-					break;
+			if ("!".equals(moduleAndVersion.substring(0, 1))) {
+				if (ModuleFactory.isModuleStarted(moduleAndVersion.substring(1, moduleAndVersion.length()))) {
+					return false;
 				}
 			}
-			
-			if (!moduleMatched) {
-				return false;
+			else {
+				String[] splitModuleAndVersion = moduleAndVersion.split(":");
+				String moduleId = splitModuleAndVersion[0];
+				String moduleVersion = splitModuleAndVersion[1];
+
+				boolean moduleMatched = false;
+				for (Module module : ModuleFactory.getStartedModules()) {
+					if (module.getModuleId().equals(moduleId)
+							&& ModuleUtil.matchRequiredVersions(module.getVersion(), moduleVersion)) {
+						moduleMatched = true;
+						break;
+					}
+				}
+
+				if (!moduleMatched) {
+					return false;
+				}
 			}
 		}
-		
+
 		return true;
 	}
 }

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -382,13 +382,21 @@ public class ModuleClassLoader extends URLClassLoader {
 				if (conditionalResource.getModules() != null) { //modules are optional
 					for (ModuleConditionalResource.ModuleAndVersion conditionalModuleResource : conditionalResource
 					        .getModules()) {
-						String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
-						if (moduleVersion != null) {
-							include = ModuleUtil
-							        .matchRequiredVersions(moduleVersion, conditionalModuleResource.getVersion());
-							
+						if ("!".equals(conditionalModuleResource.getVersion())) {
+							include = !ModuleFactory.isModuleStarted(conditionalModuleResource.getModuleId());
 							if (!include) {
 								return false;
+							}
+						}
+						else {
+							String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
+							if (moduleVersion != null) {
+								include = ModuleUtil
+								        .matchRequiredVersions(moduleVersion, conditionalModuleResource.getVersion());
+								
+								if (!include) {
+									return false;
+								}
 							}
 						}
 					}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
@@ -78,4 +78,14 @@ public class OpenmrsProfileExcludeFilterTest extends BaseContextSensitiveTest {
 	public void shouldNotBeIgnoredIfOpenmrsVersionDoesMatch() {
 		assumeOpenmrsPlatformVersion("1.9");
 	}
+	
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test
+	public void match_shouldIncludeBeanIfModuleMissing() {
+		OpenmrsProfileWithoutTest1Module bean = applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+		
+		assertThat(bean, is(notNullValue()));
+	}
 }

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+import org.junit.Test;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.test.StartModule;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+@StartModule({"org/openmrs/module/include/test1-1.0-SNAPSHOT.omod"})
+public class OpenmrsProfileExcludeFilterWithModulesTest extends BaseContextSensitiveTest {
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void match_shouldNotIncludeBeanIfModuleIsStarted() {
+		applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+	}
+}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
@@ -1,0 +1,16 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+/**
+ * Test bean which should be only loaded when module 'test1' is missing
+ */
+@OpenmrsProfile(modules = { "!test1" })
+public class OpenmrsProfileWithoutTest1Module {}

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -12,6 +12,7 @@ package org.openmrs.module;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
@@ -108,6 +109,57 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
+	}
+	
+	/**
+	 * @throws MalformedURLException
+	 * @see ModuleClassLoader#shouldResourceBeIncluded(Module, java.net.URL, String, java.util.Map)
+	 */
+	@Test
+	public void shouldResourceBeIncluded_shouldReturnTrueIfFileMatchesAndModuleIsMissing()
+	        throws MalformedURLException {
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath("lib/mockmodule-api-1.10.jar");
+		
+		ModuleConditionalResource.ModuleAndVersion module = new ModuleConditionalResource.ModuleAndVersion();
+		module.setModuleId("module");
+		module.setVersion("!");
+		resource.getModules().add(module);
+		
+		mockModule.getConditionalResources().add(resource);
+		
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
+		
+		assertThat(result, is(true));
+	}
+	
+	/**
+	 * @throws MalformedURLException
+	 * @see ModuleClassLoader#shouldResourceBeIncluded(Module, java.net.URL, String, java.util.Map)
+	 */
+	@Test
+	public void shouldResourceBeIncluded_shouldReturnFalseIfFileMatchesAndModuleIsNotMissing()
+	        throws MalformedURLException {
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath("lib/mockmodule-api-1.10.jar");
+		
+		ModuleConditionalResource.ModuleAndVersion module = new ModuleConditionalResource.ModuleAndVersion();
+		module.setModuleId("module");
+		module.setVersion("!");
+		resource.getModules().add(module);
+		
+		mockModule.getConditionalResources().add(resource);
+		
+		ModuleFactory.getStartedModulesMap().put("module", new Module("", "module", "", "", "", "3.0"));
+		mockModules.put("module", "3.0");
+		
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
+		
+		assertThat(result, is(false));
+		
+		ModuleFactory.getStartedModulesMap().clear();
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.openmrs.api.context.Context;
 
 @StartModule( { "org/openmrs/module/include/dssmodule-1.44.omod", "org/openmrs/module/include/atdproducer-0.51.omod" })
-public class StartModuleAnnotatioTest extends BaseModuleContextSensitiveTest {
+public class StartModuleAnnotationTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldStartModules() throws Exception {

--- a/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
@@ -11,7 +11,11 @@ package org.openmrs.test;
 
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
@@ -22,7 +26,11 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleInteroperabilityTest;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.context.TestContext;
@@ -38,9 +46,14 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
  */
 public class StartModuleExecutionListener extends AbstractTestExecutionListener {
 	
+	private Logger log = LoggerFactory.getLogger(getClass());
+	
 	// stores the last class that restarted the module system because we only 
 	// want it restarted once per class, not once per method
 	private static String lastClassRun = "";
+	
+	// storing the bean definitions that have been manually removed from the context
+	private Map<String, BeanDefinition> filteredDefinitions = new HashMap<String, BeanDefinition>();
 	
 	/**
 	 * called before @BeforeTransaction methods
@@ -72,8 +85,7 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 					ModuleUtil.startup(props);
 				}
 				catch (Exception e) {
-					System.out.println("Error while starting modules: ");
-					e.printStackTrace(System.out);
+					log.error("Error while starting modules: ", e);
 					throw e;
 				}
 				Assert.assertTrue("Some of the modules did not start successfully for "
@@ -87,13 +99,45 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 				 * loading beans from moduleApplicationContext into it and then calling ctx.refresh()
 				 * This approach ensures that the application context remains consistent
 				 */
+				removeFilteredBeanDefinitions(testContext.getApplicationContext());
 				GenericApplicationContext ctx = new GenericApplicationContext(testContext.getApplicationContext());
-				XmlBeanDefinitionReader xmlReader = new XmlBeanDefinitionReader(ctx);
 				
+				XmlBeanDefinitionReader xmlReader = new XmlBeanDefinitionReader(ctx);
 				Enumeration<URL> list = OpenmrsClassLoader.getInstance().getResources("moduleApplicationContext.xml");
 				while (list.hasMoreElements()) {
 					xmlReader.loadBeanDefinitions(new UrlResource(list.nextElement()));
 				}
+			}
+		}
+	}
+	
+	/*
+	 * Starting modules may require to remove beans definitions that were initially loaded.
+	 */
+	protected void removeFilteredBeanDefinitions(ApplicationContext context) {
+		// first looking at a context loading the bean definitions "now"
+		GenericApplicationContext ctx = new GenericApplicationContext();
+		(new XmlBeanDefinitionReader(ctx)).loadBeanDefinitions("classpath:applicationContext-service.xml");
+		Set<String> filteredBeanNames = new HashSet<String>();
+		for (String beanName : ctx.getBeanDefinitionNames()) {
+			if (beanName.startsWith("openmrsProfile")) {
+				filteredBeanNames.add(beanName);
+			}
+		}
+		ctx.close();
+		
+		// then looking at the context as it loaded the bean definitions before the module(s) were started
+		Set<String> originalBeanNames = new HashSet<String>();
+		for (String beanName : ((GenericApplicationContext) context).getBeanDefinitionNames()) {
+			if (beanName.startsWith("openmrsProfile")) {
+				originalBeanNames.add(beanName);
+			}
+		}
+		// removing the bean definitions that have been filtered out by starting the module(s)
+		for (String beanName : originalBeanNames) {
+			if (!filteredBeanNames.contains(beanName)) {
+				filteredDefinitions.put(beanName, ((GenericApplicationContext) context).getBeanDefinition(beanName));
+				((GenericApplicationContext) context).removeBeanDefinition(beanName);
 			}
 		}
 	}
@@ -106,6 +150,13 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 			if (!Context.isSessionOpen()) {
 				Context.openSession();
 			}
+			
+			// re-registering the bean definitions that we may have removed
+			for (String beanName : filteredDefinitions.keySet()) {
+				((GenericApplicationContext) testContext.getApplicationContext())
+					.registerBeanDefinition(beanName, filteredDefinitions.get(beanName));
+			}
+			filteredDefinitions.clear();
 			
 			ModuleUtil.shutdown();
 			


### PR DESCRIPTION
## Description
`@OpenmrsProfile` loads Spring resources conditionally based on missing module(s)
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-5213

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream 2.1.x`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.