### PR TITLE
TRUNK-5213: @OpenmrsProfile loads Spring resources conditionally based on missing module(s)

### DIFF
--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs.annotation;
 
+import java.io.IOException;
+import java.util.Map;
+
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
@@ -17,9 +20,6 @@ import org.openmrs.util.OpenmrsConstants;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.core.type.classreading.MetadataReaderFactory;
 import org.springframework.core.type.filter.TypeFilter;
-
-import java.io.IOException;
-import java.util.Map;
 
 /**
  * Prevents creating a bean if profile is not matched. It returns true if a bean should not be created.
@@ -63,22 +63,27 @@ public class OpenmrsProfileExcludeFilter implements TypeFilter {
 		String[] modules = (String[]) openmrsProfile.get("modules");
 		
 		for (String moduleAndVersion : modules) {
-			String[] splitModuleAndVersion = moduleAndVersion.split(":");
-			String moduleId = splitModuleAndVersion[0];
-			String moduleVersion = splitModuleAndVersion[1];
-			
-			boolean moduleMatched = false;
-			for (Module module : ModuleFactory.getStartedModules()) {
-				if (module.getModuleId().equals(moduleId)) {
-					if (ModuleUtil.matchRequiredVersions(module.getVersion(), moduleVersion)) {
+			if ("!".equals(moduleAndVersion.substring(0, 1))) {
+				if (ModuleFactory.isModuleStarted(moduleAndVersion.substring(1, moduleAndVersion.length()))) {
+					return false;
+				}
+			} else {
+				String[] splitModuleAndVersion = moduleAndVersion.split(":");
+				String moduleId = splitModuleAndVersion[0];
+				String moduleVersion = splitModuleAndVersion[1];
+				
+				boolean moduleMatched = false;
+				for (Module module : ModuleFactory.getStartedModules()) {
+					if (module.getModuleId().equals(moduleId)
+					        && ModuleUtil.matchRequiredVersions(module.getVersion(), moduleVersion)) {
 						moduleMatched = true;
 						break;
 					}
 				}
-			}
-			
-			if (!moduleMatched) {
-				return false;
+				
+				if (!moduleMatched) {
+					return false;
+				}
 			}
 		}
 		

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -305,17 +305,23 @@ public class ModuleClassLoader extends URLClassLoader {
 				if (conditionalResource.getModules() != null) { //modules are optional
 					for (ModuleConditionalResource.ModuleAndVersion conditionalModuleResource : conditionalResource
 					        .getModules()) {
-						String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
-						if (moduleVersion != null) {
-							include = ModuleUtil
-							        .matchRequiredVersions(moduleVersion, conditionalModuleResource.getVersion());
-							
+						if ("!".equals(conditionalModuleResource.getVersion())) {
+							include = !ModuleFactory.isModuleStarted(conditionalModuleResource.getModuleId());
 							if (!include) {
 								return false;
 							}
+						} else {
+							String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
+							if (moduleVersion != null) {
+								include = ModuleUtil.matchRequiredVersions(moduleVersion, conditionalModuleResource
+								        .getVersion());
+								
+								if (!include) {
+									return false;
+								}
+							}
 						}
 					}
-					
 				}
 			}
 		}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
@@ -67,4 +67,14 @@ public class OpenmrsProfileExcludeFilterTest extends BaseContextSensitiveTest {
 	public void shouldNotBeIgnoredIfOpenmrsVersionDoesMatch() {
 		assumeOpenmrsPlatformVersion("1.9");
 	}
+	
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test
+	public void match_shouldIncludeBeanIfModuleMissing() {
+		OpenmrsProfileWithoutTest1Module bean = applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+		
+		assertThat(bean, is(notNullValue()));
+	}
 }

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
@@ -1,0 +1,13 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+@OpenmrsProfile(modules = { "!test1" })
+public class OpenmrsProfileWithoutTest1Module {}

--- a/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
@@ -9,12 +9,13 @@
  */
 package org.openmrs.test;
 
-import junit.framework.Assert;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 
+import junit.framework.Assert;
+
 @StartModule( { "org/openmrs/module/include/dssmodule-1.44.omod", "org/openmrs/module/include/atdproducer-0.51.omod" })
-public class StartModuleAnnotatioTest extends BaseModuleContextSensitiveTest {
+public class StartModuleAnnotationTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldStartModules() throws Exception {

--- a/web/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
+++ b/web/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+import org.junit.Test;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.test.StartModule;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+@StartModule( { "org/openmrs/module/include/test1-1.0-SNAPSHOT.omod" })
+public class OpenmrsProfileExcludeFilterWithModulesTest extends BaseContextSensitiveTest {
+	
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void match_shouldNotIncludeBeanIfModuleIsStarted() {
+		applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+	}
+}


### PR DESCRIPTION
## Description
`@OpenmrsProfile` loads Spring resources conditionally based on missing module(s)
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-5213

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream 1.10.x`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.