### PR TITLE
TRUNK-5213: @OpenmrsProfile loads Spring resources conditionally based on missing module(s)

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -412,17 +412,23 @@ public class ModuleClassLoader extends URLClassLoader {
 				if (conditionalResource.getModules() != null) { //modules are optional
 					for (ModuleConditionalResource.ModuleAndVersion conditionalModuleResource : conditionalResource
 					        .getModules()) {
-						String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
-						if (moduleVersion != null) {
-							include = ModuleUtil
-							        .matchRequiredVersions(moduleVersion, conditionalModuleResource.getVersion());
-							
+						if ("!".equals(conditionalModuleResource.getVersion())) {
+							include = !ModuleFactory.isModuleStarted(conditionalModuleResource.getModuleId());
 							if (!include) {
 								return false;
 							}
+						} else {
+							String moduleVersion = startedRelatedModules.get(conditionalModuleResource.getModuleId());
+							if (moduleVersion != null) {
+								include = ModuleUtil.matchRequiredVersions(moduleVersion, conditionalModuleResource
+								        .getVersion());
+								
+								if (!include) {
+									return false;
+								}
+							}
 						}
 					}
-					
 				}
 			}
 		}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterTest.java
@@ -78,4 +78,14 @@ public class OpenmrsProfileExcludeFilterTest extends BaseContextSensitiveTest {
 	public void shouldNotBeIgnoredIfOpenmrsVersionDoesMatch() {
 		assumeOpenmrsPlatformVersion("1.9");
 	}
+	
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test
+	public void match_shouldIncludeBeanIfModuleMissing() {
+		OpenmrsProfileWithoutTest1Module bean = applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+		
+		assertThat(bean, is(notNullValue()));
+	}
 }

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileWithoutTest1Module.java
@@ -1,0 +1,13 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+@OpenmrsProfile(modules = { "!test1" })
+public class OpenmrsProfileWithoutTest1Module {}

--- a/api/src/test/java/org/openmrs/module/ModuleActivatorTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleActivatorTest.java
@@ -168,12 +168,8 @@ public class ModuleActivatorTest extends BaseModuleActivatorTest {
 	
 	@Test
 	public void shouldStartBeforeAnotherModule() {
-		//module 1 should start before module 5
 		//module 5 should start before module 4
 		assertTrue(moduleTestData.getWillStartCallTime(MODULE5_ID) <= moduleTestData.getWillStartCallTime(MODULE4_ID));
-		assertTrue(moduleTestData.getWillStartCallTime(MODULE1_ID) <= moduleTestData.getWillStartCallTime(MODULE5_ID));
-		
 		assertTrue(moduleTestData.getStartedCallTime(MODULE5_ID) <= moduleTestData.getStartedCallTime(MODULE4_ID));
-		assertTrue(moduleTestData.getStartedCallTime(MODULE1_ID) <= moduleTestData.getStartedCallTime(MODULE5_ID));
 	}
 }

--- a/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleAnnotationTest.java
@@ -9,12 +9,13 @@
  */
 package org.openmrs.test;
 
-import junit.framework.Assert;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
 
+import junit.framework.Assert;
+
 @StartModule( { "org/openmrs/module/include/dssmodule-1.44.omod", "org/openmrs/module/include/atdproducer-0.51.omod" })
-public class StartModuleAnnotatioTest extends BaseModuleContextSensitiveTest {
+public class StartModuleAnnotationTest extends BaseModuleContextSensitiveTest {
 	
 	@Test
 	public void shouldStartModules() throws Exception {

--- a/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
@@ -11,7 +11,11 @@ package org.openmrs.test;
 
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
@@ -22,7 +26,9 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleInteroperabilityTest;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.util.OpenmrsClassLoader;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.io.UrlResource;
 import org.springframework.test.context.TestContext;
@@ -41,6 +47,9 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 	// stores the last class that restarted the module system because we only 
 	// want it restarted once per class, not once per method
 	private static String lastClassRun = "";
+	
+	// storing the bean definitions that have been manually removed from the context
+	private Map<String, BeanDefinition> filteredDefinitions = new HashMap<String, BeanDefinition>();
 	
 	/**
 	 * called before @BeforeTransaction methods
@@ -87,6 +96,7 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 				 * loading beans from moduleApplicationContext into it and then calling ctx.refresh()
 				 * This approach ensures that the application context remains consistent
 				 */
+				removeFilteredBeanDefinitions(testContext.getApplicationContext());
 				GenericApplicationContext ctx = new GenericApplicationContext(testContext.getApplicationContext());
 				XmlBeanDefinitionReader xmlReader = new XmlBeanDefinitionReader(ctx);
 				
@@ -111,6 +121,37 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 		}
 	}
 	
+	/*
+	 * Starting modules may require to remove beans definitions that were initially loaded.
+	 */
+	protected void removeFilteredBeanDefinitions(ApplicationContext context) {
+		// first looking at a context loading the bean definitions "now"
+		GenericApplicationContext ctx = new GenericApplicationContext();
+		(new XmlBeanDefinitionReader(ctx)).loadBeanDefinitions("classpath:applicationContext-service.xml");
+		Set<String> filteredBeanNames = new HashSet<String>();
+		for (String beanName : ctx.getBeanDefinitionNames()) {
+			if (beanName.startsWith("openmrsProfile")) {
+				filteredBeanNames.add(beanName);
+			}
+		}
+		ctx.close();
+		
+		// looking at the context as it loaded the bean definitions before the module(s) were started
+		Set<String> originalBeanNames = new HashSet<String>();
+		for (String beanName : ((GenericApplicationContext) context).getBeanDefinitionNames()) {
+			if (beanName.startsWith("openmrsProfile")) {
+				originalBeanNames.add(beanName);
+			}
+		}
+		// removing the bean definitions that have been filtered out by starting the module(s)
+		for (String beanName : originalBeanNames) {
+			if (!filteredBeanNames.contains(beanName)) {
+				filteredDefinitions.put(beanName, ((GenericApplicationContext) context).getBeanDefinition(beanName));
+				((GenericApplicationContext) context).removeBeanDefinition(beanName);
+			}
+		}
+	}
+	
 	@Override
 	public void afterTestClass(TestContext testContext) throws Exception {
 		StartModule startModuleAnnotation = testContext.getTestClass().getAnnotation(StartModule.class);
@@ -123,6 +164,13 @@ public class StartModuleExecutionListener extends AbstractTestExecutionListener 
 			ModuleUtil.shutdown();
 			
 			Context.closeSession();
+			
+			// re-registering the bean definitions that we may have removed
+			for (String beanName : filteredDefinitions.keySet()) {
+				((GenericApplicationContext) testContext.getApplicationContext()).registerBeanDefinition(beanName,
+				    filteredDefinitions.get(beanName));
+			}
+			filteredDefinitions.clear();
 		}
 	}
 }

--- a/web/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
+++ b/web/src/test/java/org/openmrs/annotation/OpenmrsProfileExcludeFilterWithModulesTest.java
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+import org.junit.Test;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.test.StartModule;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+
+@StartModule( { "org/openmrs/module/include/test1-1.0-SNAPSHOT.omod" })
+public class OpenmrsProfileExcludeFilterWithModulesTest extends BaseContextSensitiveTest {
+	
+	/**
+	 * @see OpenmrsProfileExcludeFilter#match(org.springframework.core.type.classreading.MetadataReader, org.springframework.core.type.classreading.MetadataReaderFactory)
+	 */
+	@Test(expected = NoSuchBeanDefinitionException.class)
+	public void match_shouldNotIncludeBeanIfModuleIsStarted() {
+		applicationContext.getBean(OpenmrsProfileWithoutTest1Module.class);
+	}
+}


### PR DESCRIPTION
## Description
`@OpenmrsProfile` loads Spring resources conditionally based on missing module(s)
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://issues.openmrs.org/browse/TRUNK-5213

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ ] My pull request only contains one single commit.
@dkayiwa I have _exceptionally_ brought in two commits as I believe that I faced the same issue as what happened on 2.2 with `ModuleActivatorTest` failing. Therefore I first cherry-picked your commit that solved it before cherry-picking the actual change for TRUNK-5213.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream 1.11.x`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.