### PR TITLE
Trunk 5047 : Replace duplication in UserServiceImpl by StringUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
  - oraclejdk8
-script: mvn clean install --batch-mode
+script: mvn clean package --batch-mode
 matrix:
     - jdk: oraclejdk8
 branches:

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Person;
 import org.openmrs.Privilege;
 import org.openmrs.PrivilegeListener;
@@ -560,7 +561,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	@Transactional(readOnly = true)
 	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
 		if (name != null) {
-			name = name.replace(", ", " ");
+			name = StringUtils.replace(name,",","");
 		}
 		
 		// if the authenticated role is in the list of searched roles, then all
@@ -581,7 +582,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
 	        throws APIException {
 		if (name != null) {
-			name = name.replace(", ", " ");
+			name = StringUtils.replace(name,",","");
 		}
 		
 		if (roles == null) {

--- a/api/src/main/java/org/openmrs/scheduler/Schedule.java
+++ b/api/src/main/java/org/openmrs/scheduler/Schedule.java
@@ -189,7 +189,7 @@ public class Schedule {
 	public void setStartTime(Date startTime) {
 		this.startTime = startTime;
 	}
-
+	
 	/**
 	 * Gets the number of seconds until task is executed again.
 	 * 

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -36,6 +36,7 @@ import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.db.ProgramWorkflowDAO;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.TestUtil;
 
@@ -44,6 +45,7 @@ import org.openmrs.test.TestUtil;
  * PatientService class
  */
 public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
+	private ProgramWorkflowDAO dao = null;
 	
 	protected static final String CREATE_PATIENT_PROGRAMS_XML = "org/openmrs/api/include/ProgramWorkflowServiceTest-createPatientProgram.xml";
 	
@@ -67,8 +69,48 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 			encounterService = Context.getEncounterService();
 			cs = Context.getConceptService();
 		}
+
+		// fetch the dao from the spring application context
+		// this bean name matches the name in /metadata/spring/applicationContext-service.xml
+		dao = (ProgramWorkflowDAO) applicationContext.getBean("programWorkflowDAO");
 	}
-	
+
+	@Test
+	public void getProgramsByConceptTest(){
+
+		List<Program> actualProgramList = new ArrayList<Program>();
+		List<Program> expectedProgramList= new ArrayList<Program>();
+
+		Program program1 = new Program();
+
+		program1.setName("TEST PROGRAM1");
+		program1.setDescription("TEST PROGRAM DESCRIPTION1");
+		program1.setConcept(cs.getConcept(3));
+
+		Program program2 = new Program();
+
+		program2.setName("TEST PROGRAM2");
+		program2.setDescription("TEST PROGRAM DESCRIPTION2");
+		program2.setConcept(cs.getConcept(3));
+
+		Program program3 = new Program();
+
+		program3.setName("TEST PROGRAM3");
+		program3.setDescription("TEST PROGRAM DESCRIPTION3");
+		program3.setConcept(cs.getConcept(4));
+
+		expectedProgramList.add(0,program1);
+		expectedProgramList.add(1,program2);
+
+		dao.saveProgram(program1);
+		dao.saveProgram(program2);
+		dao.saveProgram(program3);
+
+		actualProgramList = dao.getProgramsByConcept(cs.getConcept(3));
+		assertEquals(expectedProgramList,actualProgramList);
+	}
+
+
 	/**
 	 * Tests fetching a PatientProgram, updating and saving it, and subsequently fetching the
 	 * updated value. To use in MySQL database: Uncomment method useInMemoryDatabase() and comment

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -70,45 +70,9 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 			cs = Context.getConceptService();
 		}
 
-		// fetch the dao from the spring application context
-		// this bean name matches the name in /metadata/spring/applicationContext-service.xml
-		dao = (ProgramWorkflowDAO) applicationContext.getBean("programWorkflowDAO");
+		
 	}
 
-	@Test
-	public void getProgramsByConceptTest_shouldReturnProgramsByConcept(){
-
-		List<Program> actualProgramList = new ArrayList<Program>();
-		List<Program> expectedProgramList= new ArrayList<Program>();
-
-		Program program1 = new Program();
-
-		program1.setName("TEST PROGRAM1");
-		program1.setDescription("TEST PROGRAM DESCRIPTION1");
-		program1.setConcept(cs.getConcept(3));
-
-		Program program2 = new Program();
-
-		program2.setName("TEST PROGRAM2");
-		program2.setDescription("TEST PROGRAM DESCRIPTION2");
-		program2.setConcept(cs.getConcept(3));
-
-		Program program3 = new Program();
-
-		program3.setName("TEST PROGRAM3");
-		program3.setDescription("TEST PROGRAM DESCRIPTION3");
-		program3.setConcept(cs.getConcept(4));
-
-		expectedProgramList.add(0,program1);
-		expectedProgramList.add(1,program2);
-
-		dao.saveProgram(program1);
-		dao.saveProgram(program2);
-		dao.saveProgram(program3);
-
-		actualProgramList = dao.getProgramsByConcept(cs.getConcept(3));
-		assertEquals(expectedProgramList,actualProgramList);
-	}
 
 
 	/**

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -76,7 +76,7 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void getProgramsByConceptTest(){
+	public void getProgramsByConceptTest_shouldReturnProgramsByConcept(){
 
 		List<Program> actualProgramList = new ArrayList<Program>();
 		List<Program> expectedProgramList= new ArrayList<Program>();


### PR DESCRIPTION

## Description of what I changed

The String.replace() method currently used takes two char values, so it only ever replaces one character with another (possibly multiple times, 'though).

The StringUtils.replace() method, on the other hand, takes String values as the search string and replacement, so it can replace longer substrings.

Hence, this can be replaced with StringUtils.replace as a solution to the above-mentioned bug.



## Issue I worked on
TRUNK-5047 Replace duplication in UserServiceImpl by StringUtils

## Checklist: I completed these to help reviewers :)

- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] Tested Changes with the already created userServiceTest test class

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.



