### PR TITLE
TRUNK-5047: Replace duplication in UserServiceImpl class by StringUtils

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Person;
 import org.openmrs.Privilege;
 import org.openmrs.PrivilegeListener;
@@ -560,7 +561,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	@Transactional(readOnly = true)
 	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
 		if (name != null) {
-			name = name.replace(", ", " ");
+			name = StringUtils.replace(name,", ", " ");
 		}
 		
 		// if the authenticated role is in the list of searched roles, then all
@@ -581,7 +582,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
 	        throws APIException {
 		if (name != null) {
-			name = name.replace(", ", " ");
+			name = StringUtils.replace(name,", ", " ");
 		}
 		
 		if (roles == null) {


### PR DESCRIPTION

## Description of what I changed
The String.replace() method currently used takes two char values, so it only ever replaces one character with another (possibly multiple times, 'though).

The StringUtils.replace() method, on the other hand, takes String values as the search string and replacement, so it can replace longer substrings.

Hence, this can be replaced with StringUtils.replace as a solution to the above-mentioned bug.


## Issue I worked on
TRUNK-5047 Replace duplication in UserServiceImpl by StringUtils

## Checklist: I completed these to help reviewers :)

- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] Tested Changes with the already created userServiceTest test class

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

