### PR TITLE
GCI-178: Remove unused log from StartupErrorFilter

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilter.java
@@ -34,8 +34,6 @@ import org.openmrs.module.ModuleUtil;
 import org.openmrs.module.OpenmrsCoreModuleException;
 import org.openmrs.web.Listener;
 import org.openmrs.web.filter.StartupFilter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is the second filter that is processed. It is only active when OpenMRS has some liquibase
@@ -43,9 +41,7 @@ import org.slf4j.LoggerFactory;
  * authenticate and review the updates before continuing.
  */
 public class StartupErrorFilter extends StartupFilter {
-	
-	protected final Logger log = LoggerFactory.getLogger(getClass());
-	
+
 	/**
 	 * The velocity macro page to redirect to if an error occurs or on initial startup
 	 */


### PR DESCRIPTION
## Description of what I changed
Remove unused log from StartupErrorFilter

## Issue I worked on
see https://issues.openmrs.org/browse/GCI-178

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [X] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

