### PR TITLE
TRUNK-5123 Change signature of transformNamesToConcepts to LinkedHashSet

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -560,14 +561,12 @@ public class HibernateConceptDAO implements ConceptDAO {
 		    false, false, classes, null, datatypes, null, null);
 		
 		List<ConceptName> names = conceptNameQuery.list();
-		
-		List<Concept> concepts = transformNamesToConcepts(names);
-		
-		return concepts;
+
+		return new ArrayList<>(transformNamesToConcepts(names));
 	}
 	
-	private List<Concept> transformNamesToConcepts(List<ConceptName> names) {
-		List<Concept> concepts = new ArrayList<Concept>();
+	private LinkedHashSet<Concept> transformNamesToConcepts(List<ConceptName> names) {
+		LinkedHashSet<Concept> concepts = new LinkedHashSet<>();
 		
 		for (ConceptName name : names) {
 			concepts.add(name.getConcept());
@@ -1778,7 +1777,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 		
 		List<ConceptName> names = conceptNameQuery.list();
 		
-		final List<Concept> concepts = transformNamesToConcepts(names);
+		final List<Concept> concepts = new ArrayList<>(transformNamesToConcepts(names));
 		
 		return concepts;
 	}
@@ -1807,15 +1806,15 @@ public class HibernateConceptDAO implements ConceptDAO {
 		
 		@SuppressWarnings("unchecked")
 		List<ConceptName> list = criteria.list();
-		
-		if (list.size() == 1) {
-			return list.get(0).getConcept();
+		LinkedHashSet<Concept> concepts = transformNamesToConcepts(list);
+
+		if (concepts.size() == 1) {
+			return concepts.iterator().next();
 		} else if (list.size() == 0) {
 			log.warn("No concept found for '" + name + "'");
 		} else {
 			log.warn("Multiple concepts found for '" + name + "'");
 			
-			List<Concept> concepts = transformNamesToConcepts(list);
 			for (Concept concept : concepts) {
 				for (ConceptName conceptName : concept.getNames(locale)) {
 					if (conceptName.getName().equalsIgnoreCase(name)) {


### PR DESCRIPTION
TRUNK-5123 getConceptByName should immediately return concept if only one matching concept

## Description of what I changed
transformNamesToConcept now returns a LinkedHashSet to remove duplicate concepts,
and use this fact that every element is indeed unique in getConceptByName.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5123

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
