### PR TITLE
moved scheduler password to property file

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/SchedulerConstants.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerConstants.java
@@ -9,7 +9,26 @@
  */
 package org.openmrs.scheduler;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.util.Properties;
+
 public class SchedulerConstants {
+	
+	static {
+		Properties prop = new Properties();
+		InputStream input = null;
+		
+		try {
+			input = new FileInputStream("/passwords.properties");
+			prop.load(input);
+			SCHEDULER_DEFAULT_PASSWORD = prop.getProperty("dbpassword");
+		}
+		catch (Exception e) {
+			System.out.println("Not able to fetch password from property file");
+		}
+		
+	}
 	
 	// Number of milliseconds per second (used for readability)
 	public static int SCHEDULER_MILLIS_PER_SECOND = 1000;
@@ -19,7 +38,7 @@ public class SchedulerConstants {
 	
 	public static String SCHEDULER_DEFAULT_USERNAME = "admin";
 	
-	public static String SCHEDULER_DEFAULT_PASSWORD = "test";
+	public static String SCHEDULER_DEFAULT_PASSWORD = "";
 	
 	/** The default 'from' address for emails send by the schedule */
 	public final static String SCHEDULER_DEFAULT_FROM = "scheduler@openmrs.org";

--- a/passwords.properties
+++ b/passwords.properties
@@ -1,0 +1,1 @@
+schedulerpassword:test


### PR DESCRIPTION
MOVED PASSWORD TO PROPERTY FILE
The SchedulerConstants.java file had a hardcoded password.
Moved the password to a newly created password file.

Done as part of CSC 515 Class Project for Fall 2017.

My Pull request contains one single commit.

My IDE is configured to follow Java Conventions

 I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

All existing tests passed

My pull request is based on the latest changes in the master branch


