### PR TITLE
GCI-182 ModuleServlet Logger should be "private static final"

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
+++ b/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
@@ -28,7 +28,7 @@ public class ModuleServlet extends HttpServlet {
 	
 	private static final long serialVersionUID = 1239820102030303L;
 	
-	private Logger log = LoggerFactory.getLogger(this.getClass());
+	private static final Logger log = LoggerFactory.getLogger(ModuleServlet.class);
 	
 	@Override
 	protected void service(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {


### PR DESCRIPTION
Changed ModuleServlet Logger to private static final

Issue: https://issues.openmrs.org/browse/GCI-182
