### PR TITLE
GCI-190: ModuleFilterMapping Logger should be "private static final"

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterMapping.java
+++ b/web/src/main/java/org/openmrs/module/web/filter/ModuleFilterMapping.java
@@ -30,7 +30,7 @@ public class ModuleFilterMapping implements Serializable {
 	
 	public static final long serialVersionUID = 1;
 	
-	private static Logger log = LoggerFactory.getLogger(WebModuleUtil.class);
+	private static final Logger log = LoggerFactory.getLogger(ModuleFilterMapping.class);
 	
 	// Properties
 	private Module module;


### PR DESCRIPTION
https://issues.openmrs.org/browse/GCI-190

GCI-190 ModuleFilterMapping Logger should be "private static final"
