### PR TITLE
[GCI-142] Delete redundant Collection.addAll() call (replaced with constructor)

### DIFF
--- a/api/src/main/java/org/openmrs/Allergies.java
+++ b/api/src/main/java/org/openmrs/Allergies.java
@@ -297,8 +297,7 @@ public class Allergies implements List<Allergy> {
 	 * @param allergies the given allergies collection
 	 */
 	private void throwExceptionIfHasDuplicateAllergen(Collection<? extends Allergy> allergies) {
-		List<Allergy> allergiesCopy = new ArrayList<>();
-		allergiesCopy.addAll(allergies);
+		List<Allergy> allergiesCopy = new ArrayList<>(allergies);
 		
 		for (Allergy allergy : allergies) {
 			allergiesCopy.remove(allergy);

--- a/api/src/main/java/org/openmrs/Encounter.java
+++ b/api/src/main/java/org/openmrs/Encounter.java
@@ -705,8 +705,7 @@ public class Encounter extends BaseChangeableOpenmrsData {
 				order.getOrderGroup().addOrder(order, null);
 			}
 		}
-		List<OrderGroup> orderGroupList = new ArrayList<>();
-		orderGroupList.addAll(orderGroups.values());
+		List<OrderGroup> orderGroupList = new ArrayList<>(orderGroups.values());
 		return orderGroupList;
 	}
 	

--- a/api/src/main/java/org/openmrs/Form.java
+++ b/api/src/main/java/org/openmrs/Form.java
@@ -137,8 +137,7 @@ public class Form extends BaseChangeableOpenmrsMetadata {
 	public List<FormField> getOrderedFormFields() {
 		if (this.formFields != null) {
 			List<FormField> fieldList = new ArrayList<>();
-			Set<FormField> fieldSet = new HashSet<>();
-			fieldSet.addAll(this.formFields);
+			Set<FormField> fieldSet = new HashSet<>(this.formFields);
 			
 			int fieldSize = fieldSet.size();
 			

--- a/api/src/main/java/org/openmrs/Role.java
+++ b/api/src/main/java/org/openmrs/Role.java
@@ -211,12 +211,9 @@ public class Role extends BaseChangeableOpenmrsMetadata {
 		if (!this.inheritsRoles()) {
 			return total;
 		}
-		
-		Set<Role> allRoles = new HashSet<>(); // total roles (parents + children)
-		Set<Role> myRoles = new HashSet<>(); // new roles
-		allRoles.addAll(total);
-		
-		myRoles.addAll(this.getInheritedRoles());
+
+		Set<Role> allRoles = new HashSet<>(total);
+		Set<Role> myRoles = new HashSet<>(this.getInheritedRoles());
 		myRoles.removeAll(total);
 		myRoles.remove(this); // prevent an obvious looping problem
 		allRoles.addAll(myRoles);
@@ -307,12 +304,10 @@ public class Role extends BaseChangeableOpenmrsMetadata {
 		if (!this.hasChildRoles()) {
 			return total;
 		}
-		
-		Set<Role> allRoles = new HashSet<>(); // total roles (parents + children)
-		Set<Role> myRoles = new HashSet<>(); // new roles
-		allRoles.addAll(total);
-		
-		myRoles.addAll(this.getChildRoles());
+
+		Set<Role> allRoles = new HashSet<>(total);
+
+		Set<Role> myRoles = new HashSet<>(this.getChildRoles());
 		myRoles.removeAll(total);
 		myRoles.remove(this); // prevent an obvious looping problem
 		allRoles.addAll(myRoles);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -645,8 +645,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 	}
 	
 	private List<String> tokenizeConceptName(final String escapedName, final Set<Locale> locales) {
-		List<String> words = new ArrayList<>();
-		words.addAll(Arrays.asList(escapedName.trim().split(" ")));
+		List<String> words = new ArrayList<>(Arrays.asList(escapedName.trim().split(" ")));
 		
 		Set<String> stopWords = new HashSet<>();
 		for (Locale locale : locales) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
@@ -84,9 +84,7 @@ public class HibernatePersonDAO implements PersonDAO {
 		if (birthyear == null) {
 			birthyear = 0;
 		}
-		
-		Set<Person> people = new LinkedHashSet<>();
-		
+
 		name = name.replaceAll("  ", " ");
 		name = name.replace(", ", " ");
 		String[] names = name.split(" ");
@@ -189,8 +187,8 @@ public class HibernatePersonDAO implements PersonDAO {
 		if (qStr.contains(":gender")) {
 			query.setString("gender", gender);
 		}
-		
-		people.addAll(query.list());
+
+		Set<Person> people = new LinkedHashSet<Person>(query.list());
 		
 		return people;
 	}

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -499,9 +499,9 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 			ObsService obsService = Context.getObsService();
 			List<Encounter> justThisEncounter = new ArrayList<>();
 			justThisEncounter.add(encounter);
-			List<Obs> observations = new ArrayList<>();
-			observations.addAll(obsService.getObservations(null, justThisEncounter, null, null, null, null, null, null,
-			    null, null, null, true));
+			List<Obs> observations = new ArrayList<>(
+					obsService.getObservations(null, justThisEncounter, null, null, null, null, null, null,
+							null, null, null, true));
 			for (Obs o : observations) {
 				obsService.purgeObs(o);
 			}

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -416,8 +416,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService {
 		// search on patient identifier
 		PatientService ps = Context.getPatientService();
 		List<Patient> patients = ps.getPatients(searchString);
-		List<Person> persons = new ArrayList<>();
-		persons.addAll(patients);
+		List<Person> persons = new ArrayList<>(patients);
 		
 		// try to search on encounterId
 		EncounterService es = Context.getEncounterService();

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -985,8 +985,8 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	@Override
 	@Transactional(readOnly = true)
 	public List<Concept> getDrugDispensingUnits() {
-		List<Concept> dispensingUnits = new ArrayList<>();
-		dispensingUnits.addAll(getSetMembersOfConceptSetFromGP(OpenmrsConstants.GP_DRUG_DISPENSING_UNITS_CONCEPT_UUID));
+		List<Concept> dispensingUnits = new ArrayList<>(
+				getSetMembersOfConceptSetFromGP(OpenmrsConstants.GP_DRUG_DISPENSING_UNITS_CONCEPT_UUID));
 		for (Concept concept : getDrugDosingUnits()) {
 			if (!dispensingUnits.contains(concept)) {
 				dispensingUnits.add(concept);

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -282,8 +282,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 			throw new InsufficientIdentifiersException("At least one nonvoided Patient Identifier is required");
 		}
 
-		final List<PatientIdentifier> patientIdentifiers = new ArrayList<>();
-		patientIdentifiers.addAll(patient.getIdentifiers());
+		final List<PatientIdentifier> patientIdentifiers = new ArrayList<>(patient.getIdentifiers());
 
 		final Set<String> uniqueIdentifiers = new HashSet<>();
 

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -1145,8 +1145,7 @@ public class ModuleFactory {
 			
 			// stop all dependent modules
 			// copy modules to new list to avoid "concurrent modification exception"
-			List<Module> startedModulesCopy = new ArrayList<>();
-			startedModulesCopy.addAll(getStartedModules());
+			List<Module> startedModulesCopy = new ArrayList<>(getStartedModules());
 			for (Module dependentModule : startedModulesCopy) {
 				if (dependentModule != null && !dependentModule.equals(mod) && isModuleRequiredByAnother(dependentModule, modulePackage)) {
 					dependentModulesStopped.add(dependentModule);

--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -149,9 +149,8 @@ public class ModuleUtil {
 	 * Stops the module system by calling stopModule for all modules that are currently started
 	 */
 	public static void shutdown() {
-		
-		List<Module> modules = new ArrayList<>();
-		modules.addAll(ModuleFactory.getStartedModules());
+
+		List<Module> modules = new ArrayList<>(ModuleFactory.getStartedModules());
 		
 		for (Module mod : modules) {
 			if (log.isDebugEnabled()) {

--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -303,8 +303,8 @@ public class DatabaseUpdater {
 		
 		// loop over runtime properties and precede each with "hibernate" if
 		// it isn't already
-		Set<Object> runtimePropertyKeys = new HashSet<>();
-		runtimePropertyKeys.addAll(runtimeProperties.keySet()); // must do it this way to prevent concurrent mod errors
+		// must do it this way to prevent concurrent mod errors
+		Set<Object> runtimePropertyKeys = new HashSet<>(runtimeProperties.keySet());
 		for (Object key : runtimePropertyKeys) {
 			String prop = (String) key;
 			String value = (String) runtimeProperties.get(key);

--- a/api/src/main/java/org/openmrs/util/Graph.java
+++ b/api/src/main/java/org/openmrs/util/Graph.java
@@ -85,11 +85,10 @@ public class Graph<T> {
 	 */
 	private Set<T> getNodesWithNoIncomingEdges() {
 		Set<T> nodesWithIncomingEdges = new HashSet<>();
-		Set<T> nodesWithoutIncomingEdges = new HashSet<>();
 		for (Edge edge : edges) {
 			nodesWithIncomingEdges.add(edge.getToNode());
 		}
-		nodesWithoutIncomingEdges.addAll(nodes);
+		Set<T> nodesWithoutIncomingEdges = new HashSet<T>(nodes);
 		for (T node : nodesWithIncomingEdges) {
 			nodesWithoutIncomingEdges.remove(node);
 		}
@@ -152,8 +151,7 @@ public class Graph<T> {
 		List<T> result = new ArrayList<>();
 		
 		// The initial edges are stored.
-		List<Edge> initialEdges = new ArrayList<>();
-		initialEdges.addAll(edges);
+		List<Edge> initialEdges = new ArrayList<>(edges);
 		while (!queue.isEmpty()) {
 			T node = queue.iterator().next();
 			queue.remove(node);

--- a/api/src/test/java/org/openmrs/OrderTest.java
+++ b/api/src/test/java/org/openmrs/OrderTest.java
@@ -65,8 +65,7 @@ public class OrderTest extends BaseContextSensitiveTest {
 		if (methodName == null) {
 			methodName = "copy";
 		}
-		List<String> fieldsToExclude = new ArrayList<>();
-		fieldsToExclude.addAll(Arrays.asList("log", "serialVersionUID", "orderId", "uuid"));
+		List<String> fieldsToExclude = new ArrayList<>(Arrays.asList("log", "serialVersionUID", "orderId", "uuid"));
 		if (otherfieldsToExclude != null) {
 			fieldsToExclude.addAll(Arrays.asList(otherfieldsToExclude));
 		}

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -2910,9 +2910,9 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		Context.getEncounterService().saveEncounter(encounter);
 		
 		Context.flushSession();
-		
-		List<Order> orders = new ArrayList<>();
-		orders.addAll(Context.getEncounterService().getEncounterByUuid(encounter.getUuid()).getOrders());
+
+		List<Order> orders = new ArrayList<>(
+				Context.getEncounterService().getEncounterByUuid(encounter.getUuid()).getOrders());
 		
 		assertNotNull("OrderGroup is saved", orders.get(0).getOrderGroup());
 		assertEquals("OrderGroup isa same for both the orders ", true, orders.get(0).getOrderGroup().equals(
@@ -2979,9 +2979,9 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 		Context.getEncounterService().saveEncounter(encounter);
 		
 		Context.flushSession();
-		
-		List<Order> orders = new ArrayList<>();
-		orders.addAll(Context.getEncounterService().getEncounterByUuid(encounter.getUuid()).getOrders());
+
+		List<Order> orders = new ArrayList<>(
+				Context.getEncounterService().getEncounterByUuid(encounter.getUuid()).getOrders());
 		
 		HashMap<Integer, OrderGroup> orderGroups = new HashMap<>();
 		for (Order order : orders) {

--- a/api/src/test/java/org/openmrs/api/OrderSetServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderSetServiceTest.java
@@ -348,9 +348,8 @@ public class OrderSetServiceTest extends BaseContextSensitiveTest {
 		orderSetMember.setDateCreated(new Date());
 		orderSetMember.setRetired(orderSetMemberRetired);
 		orderSetMember.setOrderSet(orderSet);
-		
-		List<OrderSetMember> orderSetMembers = new ArrayList<>();
-		orderSetMembers.addAll(Collections.singletonList(orderSetMember));
+
+		List<OrderSetMember> orderSetMembers = new ArrayList<>(Collections.singletonList(orderSetMember));
 		orderSet.setOrderSetMembers(orderSetMembers);
 		orderSet.setCreator(new User(1));
 		orderSet.setDateCreated(new Date());

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -616,8 +616,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 *             {@link MandatoryModuleException} or {@link OpenmrsCoreModuleException}
 	 */
 	public static void performWebStartOfModules(ServletContext servletContext) throws ModuleMustStartException, Exception {
-		List<Module> startedModules = new ArrayList<>();
-		startedModules.addAll(ModuleFactory.getStartedModules());
+		List<Module> startedModules = new ArrayList<>(ModuleFactory.getStartedModules());
 		performWebStartOfModules(startedModules, servletContext);
 	}
 	


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-142
Related PR: #2366

I've replaced Collection.addAll() call with passing collection's content to it's constructor

I didn't find addresses Sonar issue, but IntelliJ Inspector gave me that hint.
I hope it's redundant to do this:
`List<> list = new ArrayList<>();
list.addAll(someCollection);`

Rather, I would do it just in List constructor