### PR TITLE
[GCI-142] Delete unnecessary interface methods identifiers

### DIFF
--- a/api/src/main/java/org/openmrs/Address.java
+++ b/api/src/main/java/org/openmrs/Address.java
@@ -15,57 +15,57 @@ package org.openmrs;
  */
 public interface Address {
 	
-	public String getAddress1();
+	String getAddress1();
 	
-	public void setAddress1(String address1);
+	void setAddress1(String address1);
 	
-	public String getAddress2();
+	String getAddress2();
 	
-	public void setAddress2(String address2);
+	void setAddress2(String address2);
 	
-	public String getAddress3();
+	String getAddress3();
 	
-	public void setAddress3(String address3);
+	void setAddress3(String address3);
 	
-	public String getAddress4();
+	String getAddress4();
 	
-	public void setAddress4(String address4);
+	void setAddress4(String address4);
 	
-	public String getAddress5();
+	String getAddress5();
 	
-	public void setAddress5(String address5);
+	void setAddress5(String address5);
 	
-	public String getAddress6();
+	String getAddress6();
 	
-	public void setAddress6(String address6);
+	void setAddress6(String address6);
 	
-	public String getCityVillage();
+	String getCityVillage();
 	
-	public void setCityVillage(String cityVillage);
+	void setCityVillage(String cityVillage);
 	
-	public String getStateProvince();
+	String getStateProvince();
 	
-	public void setStateProvince(String stateProvince);
+	void setStateProvince(String stateProvince);
 	
-	public String getCountyDistrict();
+	String getCountyDistrict();
 	
-	public void setCountyDistrict(String countyDistrict);
+	void setCountyDistrict(String countyDistrict);
 	
-	public String getPostalCode();
+	String getPostalCode();
 	
-	public void setPostalCode(String postalCode);
+	void setPostalCode(String postalCode);
 	
-	public String getCountry();
+	String getCountry();
 	
-	public void setCountry(String country);
+	void setCountry(String country);
 	
-	public String getLatitude();
+	String getLatitude();
 	
-	public void setLatitude(String latitude);
+	void setLatitude(String latitude);
 	
-	public String getLongitude();
+	String getLongitude();
 	
-	public void setLongitude(String longitude);
+	void setLongitude(String longitude);
 	
 	/**
 	 * @since 2.0

--- a/api/src/main/java/org/openmrs/Attributable.java
+++ b/api/src/main/java/org/openmrs/Attributable.java
@@ -22,14 +22,14 @@ public interface Attributable<E> {
 	 * @param s String to deserialize
 	 * @return hydrated object
 	 */
-	public E hydrate(String s);
+	E hydrate(String s);
 	
 	/**
 	 * Turn the current object into an identifying string that can be retrieved later
 	 * 
 	 * @return String representing this object (Usually an identifier or primary key)
 	 */
-	public String serialize();
+	String serialize();
 	
 	/**
 	 * Find all possible values of this object. For example, if this object is a Location, the
@@ -37,7 +37,7 @@ public interface Attributable<E> {
 	 * 
 	 * @return List of objects that can be assigned
 	 */
-	public List<E> getPossibleValues();
+	List<E> getPossibleValues();
 	
 	/**
 	 * Search for possible values of this object using the given search string
@@ -45,7 +45,7 @@ public interface Attributable<E> {
 	 * @param searchText String to search on
 	 * @return List of possible objects that can be assigned
 	 */
-	public List<E> findPossibleValues(String searchText);
+	List<E> findPossibleValues(String searchText);
 	
 	/**
 	 * Gets a descriptive String used for display purposes This is meant as an alternative to using
@@ -53,6 +53,6 @@ public interface Attributable<E> {
 	 * 
 	 * @return String acceptable to display on a page
 	 */
-	public String getDisplayString();
+	String getDisplayString();
 	
 }

--- a/api/src/main/java/org/openmrs/DosingInstructions.java
+++ b/api/src/main/java/org/openmrs/DosingInstructions.java
@@ -39,14 +39,14 @@ public interface DosingInstructions {
 	 * 
 	 * @return localized drug instructions string
 	 */
-	public String getDosingInstructionsAsString(Locale locale);
+	String getDosingInstructionsAsString(Locale locale);
 	
 	/**
 	 * Serialize dosing instructions into order
 	 * 
 	 * @param order DrugOrder to set dosing instructions
 	 */
-	public void setDosingInstructions(DrugOrder order);
+	void setDosingInstructions(DrugOrder order);
 	
 	/**
 	 * Get dosing instructions from order
@@ -56,9 +56,9 @@ public interface DosingInstructions {
 	 * @throws APIException if dosing type of passing order is not matched with dosing type of
 	 *             implementing dosing instruction
 	 */
-	public DosingInstructions getDosingInstructions(DrugOrder order) throws APIException;
+	DosingInstructions getDosingInstructions(DrugOrder order) throws APIException;
 	
-	public void validate(DrugOrder order, Errors errors);
+	void validate(DrugOrder order, Errors errors);
 	
 	/**
 	 * Implementations of this interface may be able to infer the auto-expiration date from other
@@ -67,5 +67,5 @@ public interface DosingInstructions {
 	 * has non-zero refills, the auto-expiration date should <em>not</em> be set (even if it has
 	 * a known duration).
 	 */
-	public Date getAutoExpireDate(DrugOrder order);
+	Date getAutoExpireDate(DrugOrder order);
 }

--- a/api/src/main/java/org/openmrs/OpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/OpenmrsMetadata.java
@@ -26,22 +26,22 @@ public interface OpenmrsMetadata extends Auditable, Retireable {
 	/**
 	 * @return the name
 	 */
-	public String getName();
+	String getName();
 	
 	/**
 	 * @param name the name to set
 	 */
-	public void setName(String name);
+	void setName(String name);
 	
 	/**
 	 * @return the description
 	 */
-	public String getDescription();
+	String getDescription();
 	
 	/**
 	 * @param description the description to set
 	 */
-	public void setDescription(String description);
+	void setDescription(String description);
 	
 	/**
 	 * @deprecated As of version 2.2 OpenmrsMetadata is immutable by default, it's up to the

--- a/api/src/main/java/org/openmrs/OpenmrsObject.java
+++ b/api/src/main/java/org/openmrs/OpenmrsObject.java
@@ -19,21 +19,21 @@ public interface OpenmrsObject {
 	/**
 	 * @return id - The unique Identifier for the object
 	 */
-	public Integer getId();
+	Integer getId();
 	
 	/**
 	 * @param id - The unique Identifier for the object
 	 */
-	public void setId(Integer id);
+	void setId(Integer id);
 	
 	/**
 	 * @return the universally unique id for this object
 	 */
-	public String getUuid();
+	String getUuid();
 	
 	/**
 	 * @param uuid a universally unique id for this object
 	 */
-	public void setUuid(String uuid);
+	void setUuid(String uuid);
 	
 }

--- a/api/src/main/java/org/openmrs/PrivilegeListener.java
+++ b/api/src/main/java/org/openmrs/PrivilegeListener.java
@@ -30,5 +30,5 @@ public interface PrivilegeListener {
 	 * @param hasPrivilege <code>true</code> if the authenticated user has the required privilege or if it is a proxy privilege
 	 * @since 1.8.4, 1.9.1, 1.10
 	 */
-	public void privilegeChecked(User user, String privilege, boolean hasPrivilege);
+	void privilegeChecked(User user, String privilege, boolean hasPrivilege);
 }

--- a/api/src/main/java/org/openmrs/Retireable.java
+++ b/api/src/main/java/org/openmrs/Retireable.java
@@ -35,42 +35,42 @@ public interface Retireable extends OpenmrsObject {
 	 */
 	@Deprecated
 	@JsonIgnore
-	public Boolean isRetired();
+	Boolean isRetired();
 	
-	public Boolean getRetired();
+	Boolean getRetired();
 	
 	/**
 	 * @param retired - whether of not this object is retired
 	 */
-	public void setRetired(Boolean retired);
+	void setRetired(Boolean retired);
 	
 	/**
 	 * @return User - the user who retired the object
 	 */
-	public User getRetiredBy();
+	User getRetiredBy();
 	
 	/**
 	 * @param retiredBy - the user who retired the object
 	 */
-	public void setRetiredBy(User retiredBy);
+	void setRetiredBy(User retiredBy);
 	
 	/**
 	 * @return Date - the date the object was retired
 	 */
-	public Date getDateRetired();
+	Date getDateRetired();
 	
 	/**
 	 * @param dateRetired - the date the object was retired
 	 */
-	public void setDateRetired(Date dateRetired);
+	void setDateRetired(Date dateRetired);
 	
 	/**
 	 * @return String - the reason the object was retired
 	 */
-	public String getRetireReason();
+	String getRetireReason();
 	
 	/**
 	 * @param retireReason - the reason the object was retired
 	 */
-	public void setRetireReason(String retireReason);
+	void setRetireReason(String retireReason);
 }

--- a/api/src/main/java/org/openmrs/Voidable.java
+++ b/api/src/main/java/org/openmrs/Voidable.java
@@ -35,45 +35,45 @@ public interface Voidable extends OpenmrsObject {
 	 */
 	@Deprecated
 	@JsonIgnore
-	public Boolean isVoided();
+	Boolean isVoided();
 	
 	/**
 	 * @return true if this object is voided and otherwise false
 	 */
-	public Boolean getVoided();
+	Boolean getVoided();
 	
 	/**
 	 * @param voided - whether of not this object is voided
 	 */
-	public void setVoided(Boolean voided);
+	void setVoided(Boolean voided);
 	
 	/**
 	 * @return User - the user who voided the object
 	 */
-	public User getVoidedBy();
+	User getVoidedBy();
 	
 	/**
 	 * @param voidedBy - the user who voided the object
 	 */
-	public void setVoidedBy(User voidedBy);
+	void setVoidedBy(User voidedBy);
 	
 	/**
 	 * @return Date - the date the object was voided
 	 */
-	public Date getDateVoided();
+	Date getDateVoided();
 	
 	/**
 	 * @param dateVoided - the date the object was voided
 	 */
-	public void setDateVoided(Date dateVoided);
+	void setDateVoided(Date dateVoided);
 	
 	/**
 	 * @return String - the reason the object was voided
 	 */
-	public String getVoidReason();
+	String getVoidReason();
 	
 	/**
 	 * @param voidReason - the reason the object was voided
 	 */
-	public void setVoidReason(String voidReason);
+	void setVoidReason(String voidReason);
 }

--- a/api/src/main/java/org/openmrs/annotation/AddOnStartup.java
+++ b/api/src/main/java/org/openmrs/annotation/AddOnStartup.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
 @Documented
 public @interface AddOnStartup {
 	
-	public String description() default "";
+	String description() default "";
 	
-	public boolean core() default true;
+	boolean core() default true;
 }

--- a/api/src/main/java/org/openmrs/annotation/Authorized.java
+++ b/api/src/main/java/org/openmrs/annotation/Authorized.java
@@ -50,7 +50,7 @@ public @interface Authorized {
 	 * 
 	 * @return String[] The secure method attributes
 	 */
-	public String[] value() default {};
+	String[] value() default {};
 	
 	/**
 	 * If set to true, will require that the user have <i>all</i> privileges listed in
@@ -58,6 +58,6 @@ public @interface Authorized {
 	 * 
 	 * @return boolean true/false whether the privileges should be "and"ed together
 	 */
-	public boolean requireAll() default false;
+	boolean requireAll() default false;
 	
 }

--- a/api/src/main/java/org/openmrs/annotation/DisableHandlers.java
+++ b/api/src/main/java/org/openmrs/annotation/DisableHandlers.java
@@ -41,6 +41,6 @@ public @interface DisableHandlers {
 	/**
 	 * The set of handlers to be be disabled
 	 */
-	public Class<? extends RequiredDataHandler>[] handlerTypes() default {};
+	Class<? extends RequiredDataHandler>[] handlerTypes() default {};
 	
 }

--- a/api/src/main/java/org/openmrs/annotation/Handler.java
+++ b/api/src/main/java/org/openmrs/annotation/Handler.java
@@ -57,7 +57,7 @@ public @interface Handler {
 	 * 
 	 * @return list of classes
 	 */
-	public Class<?>[] supports() default {};
+	Class<?>[] supports() default {};
 	
 	/**
 	 * Provides a means for specifying the relative order of this Handler against another Handler of
@@ -69,6 +69,6 @@ public @interface Handler {
 	 * 
 	 * @return an int specifying the relative order of this Handler
 	 */
-	public int order() default Integer.MAX_VALUE;
+	int order() default Integer.MAX_VALUE;
 	
 }

--- a/api/src/main/java/org/openmrs/annotation/Logging.java
+++ b/api/src/main/java/org/openmrs/annotation/Logging.java
@@ -49,7 +49,7 @@ public @interface Logging {
 	 * @return boolean true/false to suppress OpenMRS's automatic logging of this method
 	 * @since 1.8
 	 */
-	public boolean ignore() default false;
+	boolean ignore() default false;
 	
 	/**
 	 * If set to true, the annotated method will not print out the contents of the arguments every
@@ -57,7 +57,7 @@ public @interface Logging {
 	 * 
 	 * @return boolean true/false to ignore the argument content when logging
 	 */
-	public boolean ignoreAllArgumentValues() default false;
+	boolean ignoreAllArgumentValues() default false;
 	
 	/**
 	 * This list should set the argument indexes that should not be printed. This is useful if one
@@ -67,6 +67,6 @@ public @interface Logging {
 	 * 
 	 * @return list of argument indexes to ignore. (first argument is 0, second is 1, etc)
 	 */
-	public int[] ignoredArgumentIndexes() default {};
+	int[] ignoredArgumentIndexes() default {};
 	
 }

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
@@ -29,7 +29,7 @@ public @interface OpenmrsProfile {
 	/**
 	 * @since 1.11.3, 1.10.2, 1.9.9
 	 */
-	public String openmrsPlatformVersion() default "";
+	String openmrsPlatformVersion() default "";
 	
-	public String[] modules() default {};
+	String[] modules() default {};
 }

--- a/api/src/main/java/org/openmrs/api/AdministrationService.java
+++ b/api/src/main/java/org/openmrs/api/AdministrationService.java
@@ -46,7 +46,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * 
 	 * @param dao The dao implementation to use
 	 */
-	public void setAdministrationDAO(AdministrationDAO dao);
+	void setAdministrationDAO(AdministrationDAO dao);
 										
 	/**
 	 * Get a global property by its uuid. There should be only one of these in the database (well,
@@ -56,7 +56,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public GlobalProperty getGlobalPropertyByUuid(String uuid) throws APIException;
+	GlobalProperty getGlobalPropertyByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get a listing or important variables used in openmrs
@@ -66,7 +66,7 @@ public interface AdministrationService extends OpenmrsService {
 	 */
 	
 	@Authorized(PrivilegeConstants.VIEW_ADMIN_FUNCTIONS)
-	public SortedMap<String, String> getSystemVariables() throws APIException;
+	SortedMap<String, String> getSystemVariables() throws APIException;
 	
 	/**
 	 * Get a map of all the System Information. Java, user, time, runtime properties, etc
@@ -75,7 +75,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should return all system information
 	 */
 	@Authorized(PrivilegeConstants.VIEW_ADMIN_FUNCTIONS)
-	public Map<String, Map<String, String>> getSystemInformation() throws APIException;
+	Map<String, Map<String, String>> getSystemInformation() throws APIException;
 	
 	/**
 	 * Gets the global property that has the given <code>propertyName</code>.
@@ -90,7 +90,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should get property value given valid property name
 	 * @should get property in case insensitive way
 	 */
-	public String getGlobalProperty(String propertyName) throws APIException;
+	String getGlobalProperty(String propertyName) throws APIException;
 	
 	/**
 	 * Gets the global property that has the given <code>propertyName</code>
@@ -106,7 +106,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should return default value if property name does not exist
 	 * @should not fail with null default value
 	 */
-	public String getGlobalProperty(String propertyName, String defaultValue) throws APIException;
+	String getGlobalProperty(String propertyName, String defaultValue) throws APIException;
 	
 	/**
 	 * Gets the global property that has the given <code>propertyName</code>
@@ -115,7 +115,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @return the global property that matches the given <code>propertyName</code>
 	 * @should return null when no global property match given property name
 	 */
-	public GlobalProperty getGlobalPropertyObject(String propertyName);
+	GlobalProperty getGlobalPropertyObject(String propertyName);
 	
 	/**
 	 * Gets all global properties that begin with <code>prefix</code>.
@@ -125,7 +125,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @since 1.5
 	 * @should return all relevant global properties in the database
 	 */
-	public List<GlobalProperty> getGlobalPropertiesByPrefix(String prefix);
+	List<GlobalProperty> getGlobalPropertiesByPrefix(String prefix);
 	
 	/**
 	 * Gets all global properties that end with <code>suffix</code>.
@@ -135,7 +135,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @since 1.6
 	 * @should return all relevant global properties in the database
 	 */
-	public List<GlobalProperty> getGlobalPropertiesBySuffix(String suffix);
+	List<GlobalProperty> getGlobalPropertiesBySuffix(String suffix);
 	
 	/**
 	 * Get a list of all global properties in the system
@@ -144,7 +144,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should return all global properties in the database
 	 */
 	@Authorized(PrivilegeConstants.GET_GLOBAL_PROPERTIES)
-	public List<GlobalProperty> getAllGlobalProperties() throws APIException;
+	List<GlobalProperty> getAllGlobalProperties() throws APIException;
 	
 	/**
 	 * Save the given list of global properties to the database.
@@ -157,7 +157,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should save properties with case difference only
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
-	public List<GlobalProperty> saveGlobalProperties(List<GlobalProperty> props) throws APIException;
+	List<GlobalProperty> saveGlobalProperties(List<GlobalProperty> props) throws APIException;
 	
 	/**
 	 * Completely remove the given global property from the database
@@ -167,7 +167,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should delete global property from database
 	 */
 	@Authorized(PrivilegeConstants.PURGE_GLOBAL_PROPERTIES)
-	public void purgeGlobalProperty(GlobalProperty globalProperty) throws APIException;
+	void purgeGlobalProperty(GlobalProperty globalProperty) throws APIException;
 	
 	/**
 	 * Completely remove the given global properties from the database
@@ -177,7 +177,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should delete global properties from database
 	 */
 	@Authorized(PrivilegeConstants.PURGE_GLOBAL_PROPERTIES)
-	public void purgeGlobalProperties(List<GlobalProperty> globalProperties) throws APIException;
+	void purgeGlobalProperties(List<GlobalProperty> globalProperties) throws APIException;
 	
 	/**
 	 * Save the given global property to the database. If the global property already exists,
@@ -189,7 +189,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should overwrite global property if exists
 	 * @should save a global property whose typed value is handled by a custom datatype
 	 */
-	public void setGlobalProperty(String propertyName, String propertyValue);
+	void setGlobalProperty(String propertyName, String propertyValue);
 	
 	/**
 	 * Overwrites the value of the global property if it already exists. If the global property does
@@ -202,7 +202,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should fail if global property being updated does not already exist
 	 * @should update a global property whose typed value is handled by a custom datatype
 	 */
-	public void updateGlobalProperty(String propertyName, String propertyValue) throws IllegalStateException;
+	void updateGlobalProperty(String propertyName, String propertyValue) throws IllegalStateException;
 	
 	/**
 	 * Save the given global property to the database
@@ -217,7 +217,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should evict all entries of search locale cache
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
-	public GlobalProperty saveGlobalProperty(GlobalProperty gp) throws APIException;
+	GlobalProperty saveGlobalProperty(GlobalProperty gp) throws APIException;
 	
 	/**
 	 * Allows code to be notified when a global property is created/edited/deleted.
@@ -225,7 +225,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @see GlobalPropertyListener
 	 * @param listener The listener to register
 	 */
-	public void addGlobalPropertyListener(GlobalPropertyListener listener);
+	void addGlobalPropertyListener(GlobalPropertyListener listener);
 	
 	/**
 	 * Removes a GlobalPropertyListener previously registered by
@@ -233,7 +233,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * 
 	 * @param listener
 	 */
-	public void removeGlobalPropertyListener(GlobalPropertyListener listener);
+	void removeGlobalPropertyListener(GlobalPropertyListener listener);
 	
 	/**
 	 * Runs the <code>sql</code> on the database. If <code>selectOnly</code> is flagged then any
@@ -246,7 +246,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should execute sql containing group by
 	 */
 	@Authorized(PrivilegeConstants.SQL_LEVEL_ACCESS)
-	public List<List<Object>> executeSQL(String sql, boolean selectOnly) throws APIException;
+	List<List<Object>> executeSQL(String sql, boolean selectOnly) throws APIException;
 	
 	/**
 	 * Get the implementation id stored for this server Returns null if no implementation id has
@@ -256,7 +256,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should return null if no implementation id is defined yet
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_IMPLEMENTATION_ID)
-	public ImplementationId getImplementationId() throws APIException;
+	ImplementationId getImplementationId() throws APIException;
 	
 	/**
 	 * Set the given <code>implementationId</code> as this implementation's unique id
@@ -273,7 +273,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should set uuid on implementation id global property
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_IMPLEMENTATION_ID)
-	public void setImplementationId(ImplementationId implementationId) throws APIException;
+	void setImplementationId(ImplementationId implementationId) throws APIException;
 	
 	/**
 	 * Gets the list of locales which the administrator has allowed for use on the system. This is
@@ -285,7 +285,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should not fail if not global property for locales allowed defined yet
 	 * @should not return duplicates even if the global property has them
 	 */
-	public List<Locale> getAllowedLocales();
+	List<Locale> getAllowedLocales();
 	
 	/**
 	 * Gets the list of locales for which localized messages are available for the user interface
@@ -301,7 +301,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should return language locale if country locale is specified in allowed list but country locale message file is missing
 	 * @should return language locale if it is specified in allowed list and there are no country locale message files available
 	 */
-	public Set<Locale> getPresentationLocales();
+	Set<Locale> getPresentationLocales();
 	
 	/**
 	 * Returns a global property according to the type specified
@@ -313,14 +313,14 @@ public interface AdministrationService extends OpenmrsService {
 	 * @return property value in the type of the default value
 	 * @since 1.7
 	 */
-	public <T> T getGlobalPropertyValue(String propertyName, T defaultValue) throws APIException;
+	<T> T getGlobalPropertyValue(String propertyName, T defaultValue) throws APIException;
 	
 	/**
 	 * @param aClass class of object getting length for
 	 * @param fieldName name of the field to get the length for
 	 * @return the max field length of a property
 	 */
-	public int getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName);
+	int getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName);
 	
 	/**
 	 * Performs validation in the manual flush mode to prevent any premature flushes.
@@ -334,7 +334,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should fail for an invalid object
 	 * @should throw throw APIException if the input is null
 	 */
-	public void validate(Object object, Errors errors) throws APIException;
+	void validate(Object object, Errors errors) throws APIException;
 
 	/**
 	 * Returns a list of locales used by the user when searching.
@@ -344,7 +344,7 @@ public interface AdministrationService extends OpenmrsService {
 	 * @return
 	 * @throws APIException
      */
-	public List<Locale> getSearchLocales(Locale currentLocale, User user) throws APIException;
+	List<Locale> getSearchLocales(Locale currentLocale, User user) throws APIException;
 
 	/**
 	 * Returns a list of locales used by the user when searching.
@@ -359,14 +359,14 @@ public interface AdministrationService extends OpenmrsService {
 	 * @should exclude not allowed locales
 	 * @should cache results for a user
 	 */
-	public List<Locale> getSearchLocales() throws APIException;
+	List<Locale> getSearchLocales() throws APIException;
 	
 	/**
 	 * Used by Spring to set the http client for accessing the openmrs implementation service
 	 *
 	 * @param implementationHttpClient The implementation http client
 	 */
-	public void setImplementationIdHttpClient(HttpClient implementationHttpClient);
+	void setImplementationIdHttpClient(HttpClient implementationHttpClient);
 	
 	/**
 	 * Reads a GP which specifies if database string comparison is case sensitive.
@@ -379,5 +379,5 @@ public interface AdministrationService extends OpenmrsService {
 	 * @return true if database string comparison is case sensitive
 	 * @since 1.9.9, 1.10.2, 1.11
 	 */
-	public boolean isDatabaseStringComparisonCaseSensitive();
+	boolean isDatabaseStringComparisonCaseSensitive();
 }

--- a/api/src/main/java/org/openmrs/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/api/CohortService.java
@@ -38,7 +38,7 @@ public interface CohortService extends OpenmrsService {
 	 * 
 	 * @param dao
 	 */
-	public void setCohortDAO(CohortDAO dao);
+	void setCohortDAO(CohortDAO dao);
 	
 	/**
 	 * Save a cohort to the database (create if new, or update if changed) This method will throw an
@@ -51,7 +51,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should update an existing cohort
 	 */
 	@Authorized({ PrivilegeConstants.ADD_COHORTS, PrivilegeConstants.EDIT_COHORTS })
-	public Cohort saveCohort(Cohort cohort) throws APIException;
+	Cohort saveCohort(Cohort cohort) throws APIException;
 	
 	/**
 	 * Voids the given cohort, deleting it from the perspective of the typical end user.
@@ -66,7 +66,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should not change an already voided cohort
 	 */
 	@Authorized({ PrivilegeConstants.DELETE_COHORTS })
-	public Cohort voidCohort(Cohort cohort, String reason) throws APIException;
+	Cohort voidCohort(Cohort cohort, String reason) throws APIException;
 	
 	/**
 	 * Completely removes a Cohort from the database (not reversible)
@@ -75,7 +75,7 @@ public interface CohortService extends OpenmrsService {
 	 * @throws APIException
 	 * @should delete cohort from database
 	 */
-	public Cohort purgeCohort(Cohort cohort) throws APIException;
+	Cohort purgeCohort(Cohort cohort) throws APIException;
 	
 	/**
 	 * Gets a Cohort by its database primary key
@@ -86,7 +86,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should get cohort by id
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public Cohort getCohort(Integer id) throws APIException;
+	Cohort getCohort(Integer id) throws APIException;
 	
 	/**
 	 * Gets a non voided Cohort by its name
@@ -100,14 +100,14 @@ public interface CohortService extends OpenmrsService {
 	 * @since 2.1.0
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public Cohort getCohortByName(String name) throws APIException;
+	Cohort getCohortByName(String name) throws APIException;
 	
 	/**
 	 * @deprecated use {@link #getCohortByName(String)}
 	 */
 	@Deprecated
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public Cohort getCohort(String name) throws APIException;
+	Cohort getCohort(String name) throws APIException;
 	
 	/**
 	 * Gets all Cohorts (not including voided ones)
@@ -118,7 +118,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should not return any voided cohorts
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public List<Cohort> getAllCohorts() throws APIException;
+	List<Cohort> getAllCohorts() throws APIException;
 	
 	/**
 	 * Gets all Cohorts, possibly including the voided ones
@@ -129,7 +129,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should return all cohorts and voided
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public List<Cohort> getAllCohorts(boolean includeVoided) throws APIException;
+	List<Cohort> getAllCohorts(boolean includeVoided) throws APIException;
 	
 	/**
 	 * Returns Cohorts whose names match the given string. Returns an empty list in the case of no
@@ -141,7 +141,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should never return null
 	 * @should match cohorts by partial name
 	 */
-	public List<Cohort> getCohorts(String nameFragment) throws APIException;
+	List<Cohort> getCohorts(String nameFragment) throws APIException;
 	
 	/**
 	 * @deprecated use {@link #getCohortsContainingPatientId(Integer)}
@@ -156,7 +156,7 @@ public interface CohortService extends OpenmrsService {
 	 */
 	@Deprecated
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public List<Cohort> getCohortsContainingPatient(Patient patient) throws APIException;
+	List<Cohort> getCohortsContainingPatient(Patient patient) throws APIException;
 	
 	/**
 	 * Find all Cohorts that contain the given patientId right now. (Not including voided Cohorts, or ended memberships)
@@ -166,7 +166,7 @@ public interface CohortService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public List<Cohort> getCohortsContainingPatientId(Integer patientId) throws APIException;
+	List<Cohort> getCohortsContainingPatientId(Integer patientId) throws APIException;
 	
 	/**
 	 * Adds a new patient to a Cohort. If the patient is not already in the Cohort, then they are
@@ -181,7 +181,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should not fail if cohort already contains patient
 	 */
 	@Authorized({ PrivilegeConstants.EDIT_COHORTS })
-	public Cohort addPatientToCohort(Cohort cohort, Patient patient) throws APIException;
+	Cohort addPatientToCohort(Cohort cohort, Patient patient) throws APIException;
 	
 	/**
 	 * Removes a patient from a Cohort, by voiding their membership. (Has no effect if the patient is not in the cohort.)
@@ -198,7 +198,7 @@ public interface CohortService extends OpenmrsService {
 	 */
 	@Deprecated
 	@Authorized({ PrivilegeConstants.EDIT_COHORTS })
-	public Cohort removePatientFromCohort(Cohort cohort, Patient patient) throws APIException;
+	Cohort removePatientFromCohort(Cohort cohort, Patient patient) throws APIException;
 	
 	/**
 	 * Get Cohort by its UUID
@@ -209,7 +209,7 @@ public interface CohortService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public Cohort getCohortByUuid(String uuid);
+	Cohort getCohortByUuid(String uuid);
 	
 	/**
 	 * Get CohortMembership by its UUID
@@ -218,7 +218,7 @@ public interface CohortService extends OpenmrsService {
 	 * @since 2.1.0
 	 */
 	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
-	public CohortMembership getCohortMembershipByUuid(String uuid);
+	CohortMembership getCohortMembershipByUuid(String uuid);
 	
 	/**
 	 * Removes a CohortMembership from its parent Cohort

--- a/api/src/main/java/org/openmrs/api/ConceptNameType.java
+++ b/api/src/main/java/org/openmrs/api/ConceptNameType.java
@@ -36,6 +36,6 @@ public enum ConceptNameType {
 	
 	FULLY_SPECIFIED,
 	SHORT,
-	INDEX_TERM;
-	
+	INDEX_TERM
+
 }

--- a/api/src/main/java/org/openmrs/api/ConceptService.java
+++ b/api/src/main/java/org/openmrs/api/ConceptService.java
@@ -79,7 +79,7 @@ public interface ConceptService extends OpenmrsService {
 	 * 
 	 * @param dao The data access object to use
 	 */
-	public void setConceptDAO(ConceptDAO dao);
+	void setConceptDAO(ConceptDAO dao);
 	
 	/**
 	 * Get Concept by its UUID
@@ -90,7 +90,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConceptByUuid(String uuid);
+	Concept getConceptByUuid(String uuid);
 	
 	/**
 	 * Save or update the given <code>Concept</code> or <code>ConceptNumeric</code> in the database
@@ -128,7 +128,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should save a conceptNumeric with allowDecimal value
 	 */
 	@Authorized({ PrivilegeConstants.MANAGE_CONCEPTS })
-	public Concept saveConcept(Concept concept) throws APIException;
+	Concept saveConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Save or update the given <code>Drug</code> in the database. If this is a new drug, the
@@ -143,7 +143,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should update drug already existing in database
 	 */
 	@Authorized({ PrivilegeConstants.MANAGE_CONCEPTS })
-	public Drug saveDrug(Drug drug) throws APIException;
+	Drug saveDrug(Drug drug) throws APIException;
 	
 	/**
 	 * Completely purge a <code>Concept</code> or <code>ConceptNumeric</code> from the database.
@@ -157,7 +157,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if any of the conceptNames of the concept is being used by an obs
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPTS)
-	public void purgeConcept(Concept conceptOrConceptNumeric) throws APIException;
+	void purgeConcept(Concept conceptOrConceptNumeric) throws APIException;
 	
 	/**
 	 * Retiring a concept essentially removes it from circulation
@@ -171,7 +171,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should retire the given concept
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
-	public Concept retireConcept(Concept conceptOrConceptNumeric, String reason) throws APIException;
+	Concept retireConcept(Concept conceptOrConceptNumeric, String reason) throws APIException;
 	
 	/**
 	 * Retiring a Drug essentially removes it from circulation
@@ -183,7 +183,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should retire the given Drug
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
-	public Drug retireDrug(Drug drug, String reason) throws APIException;
+	Drug retireDrug(Drug drug, String reason) throws APIException;
 	
 	/**
 	 * Marks a drug that is currently retired as not retired.
@@ -195,7 +195,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not change attributes of drug that is already not retired
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
-	public Drug unretireDrug(Drug drug) throws APIException;
+	Drug unretireDrug(Drug drug) throws APIException;
 	
 	/**
 	 * Completely purge a Drug from the database. This should not typically be used unless
@@ -206,7 +206,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should purge the given drug
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPTS)
-	public void purgeDrug(Drug drug) throws APIException;
+	void purgeDrug(Drug drug) throws APIException;
 	
 	/**
 	 * Gets the concept with the given id
@@ -216,7 +216,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConcept(Integer conceptId) throws APIException;
+	Concept getConcept(Integer conceptId) throws APIException;
 	
 	/**
 	 * Gets the concept-name with the given id
@@ -226,7 +226,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptName getConceptName(Integer conceptNameId) throws APIException;
+	ConceptName getConceptName(Integer conceptNameId) throws APIException;
 	
 	/**
 	 * Gets the ConceptAnswer with the given id
@@ -236,7 +236,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptAnswer getConceptAnswer(Integer conceptAnswerId) throws APIException;
+	ConceptAnswer getConceptAnswer(Integer conceptAnswerId) throws APIException;
 	
 	/**
 	 * Get the Drug with the given id
@@ -246,7 +246,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Drug getDrug(Integer drugId) throws APIException;
+	Drug getDrug(Integer drugId) throws APIException;
 	
 	/**
 	 * Get the ConceptNumeric with the given id
@@ -256,7 +256,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptNumeric getConceptNumeric(Integer conceptId) throws APIException;
+	ConceptNumeric getConceptNumeric(Integer conceptId) throws APIException;
 	
 	/**
 	 * Return a Concept class matching the given identifier
@@ -266,7 +266,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return the matching ConceptClass
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptClass getConceptClass(Integer conceptClassId) throws APIException;
+	ConceptClass getConceptClass(Integer conceptClassId) throws APIException;
 	
 	/**
 	 * Return a list of unretired concepts sorted by concept id ascending and
@@ -275,7 +275,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getAllConcepts() throws APIException;
+	List<Concept> getAllConcepts() throws APIException;
 	
 	/**
 	 * Return a list of concepts sorted on sortBy in dir direction (asc/desc)
@@ -292,7 +292,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should order by a concept field
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getAllConcepts(String sortBy, boolean asc, boolean includeRetired) throws APIException;
+	List<Concept> getAllConcepts(String sortBy, boolean asc, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Returns a list of concepts matching any part of a concept name, this method is case
@@ -304,7 +304,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should pass irrespective of the case of the passed parameter
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByName(String name) throws APIException;
+	List<Concept> getConceptsByName(String name) throws APIException;
 	
 	/**
 	 * Return a Concept that matches the name exactly
@@ -320,7 +320,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null given blank string
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConceptByName(String name) throws APIException;
+	Concept getConceptByName(String name) throws APIException;
 	
 	/**
 	 * Get Concept by id or name convenience method
@@ -331,7 +331,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null given null parameter
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConcept(String conceptIdOrName) throws APIException;
+	Concept getConcept(String conceptIdOrName) throws APIException;
 	
 	/**
 	 * Get Drug by its UUID
@@ -342,7 +342,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Drug getDrugByUuid(String uuid);
+	Drug getDrugByUuid(String uuid);
 	
 	/**
 	 * Get Drug Ingredient by its UUID
@@ -353,7 +353,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public DrugIngredient getDrugIngredientByUuid(String uuid);
+	DrugIngredient getDrugIngredientByUuid(String uuid);
 	
 	/**
 	 * Return the drug object corresponding to the given name or drugId
@@ -365,7 +365,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no matching drug is found
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Drug getDrug(String drugNameOrId) throws APIException;
+	Drug getDrug(String drugNameOrId) throws APIException;
 	
 	/**
 	 * Return a list of drugs currently in the database that are not retired
@@ -375,7 +375,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a list of all drugs
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getAllDrugs() throws APIException;
+	List<Drug> getAllDrugs() throws APIException;
 	
 	/**
 	 * Return a list of drugs associated with the given concept
@@ -385,7 +385,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return a List&lt;Drug&gt; object containing all matching drugs
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getDrugsByConcept(Concept concept) throws APIException;
+	List<Drug> getDrugsByConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Get drugs by concept. This method is the utility method that should be used to generically
@@ -397,7 +397,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all drugs excluding retired ones if given false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getAllDrugs(boolean includeRetired);
+	List<Drug> getAllDrugs(boolean includeRetired);
 	
 	/**
 	 * Find drugs in the system. The string search can match either drug.name or drug.concept.name,
@@ -412,7 +412,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not fail if there is no drug by given id
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getDrugs(String phrase) throws APIException;
+	List<Drug> getDrugs(String phrase) throws APIException;
 	
 	/**
 	 * @param cc ConceptClass
@@ -421,7 +421,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not fail due to no name in search
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByClass(ConceptClass cc) throws APIException;
+	List<Concept> getConceptsByClass(ConceptClass cc) throws APIException;
 	
 	/**
 	 * Return a Concept class matching the given name
@@ -431,7 +431,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_CLASSES)
-	public ConceptClass getConceptClassByName(String name) throws APIException;
+	ConceptClass getConceptClassByName(String name) throws APIException;
 	
 	/**
 	 * Return a list of concept classes currently in the database
@@ -441,7 +441,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a list of all concept classes
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_CLASSES)
-	public List<ConceptClass> getAllConceptClasses() throws APIException;
+	List<ConceptClass> getAllConceptClasses() throws APIException;
 	
 	/**
 	 * Return a list of concept classes currently in the database
@@ -453,7 +453,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept classes excluding retired ones when given false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_CLASSES)
-	public List<ConceptClass> getAllConceptClasses(boolean includeRetired) throws APIException;
+	List<ConceptClass> getAllConceptClasses(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get ConceptClass by its UUID
@@ -464,7 +464,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_CLASSES)
-	public ConceptClass getConceptClassByUuid(String uuid);
+	ConceptClass getConceptClassByUuid(String uuid);
 	
 	/**
 	 * Get ConceptAnswer by its UUID
@@ -475,7 +475,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptAnswer getConceptAnswerByUuid(String uuid);
+	ConceptAnswer getConceptAnswerByUuid(String uuid);
 	
 	/**
 	 * Get ConceptName by its UUID
@@ -486,7 +486,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptName getConceptNameByUuid(String uuid);
+	ConceptName getConceptNameByUuid(String uuid);
 	
 	/**
 	 * Get ConceptSet by its UUID
@@ -497,7 +497,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptSet getConceptSetByUuid(String uuid);
+	ConceptSet getConceptSetByUuid(String uuid);
 	
 	/**
 	 * Get ConceptSource by its UUID
@@ -508,7 +508,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public ConceptSource getConceptSourceByUuid(String uuid);
+	ConceptSource getConceptSourceByUuid(String uuid);
 	
 	/**
 	 * Creates or updates a concept class
@@ -518,7 +518,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should save the the given ConceptClass
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_CLASSES)
-	public ConceptClass saveConceptClass(ConceptClass cc) throws APIException;
+	ConceptClass saveConceptClass(ConceptClass cc) throws APIException;
 	
 	/**
 	 * Purge a ConceptClass
@@ -528,7 +528,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should delete the given ConceptClass
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_CLASSES)
-	public void purgeConceptClass(ConceptClass cc) throws APIException;
+	void purgeConceptClass(ConceptClass cc) throws APIException;
 	
 	/**
 	 * Purge a ConceptNameTag
@@ -539,7 +539,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should delete the specified conceptNameTag from the database
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_NAME_TAGS)
-	public void purgeConceptNameTag(ConceptNameTag cnt) throws APIException;
+	void purgeConceptNameTag(ConceptNameTag cnt) throws APIException;
 	
 	/**
 	 * Return a list of all concept datatypes currently in the database
@@ -549,7 +549,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should give a list of all concept datatypes
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_DATATYPES)
-	public List<ConceptDatatype> getAllConceptDatatypes() throws APIException;
+	List<ConceptDatatype> getAllConceptDatatypes() throws APIException;
 	
 	/**
 	 * Return a list of concept datatypes currently in the database
@@ -561,7 +561,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept datatypes excluding retired ones when given false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_DATATYPES)
-	public List<ConceptDatatype> getAllConceptDatatypes(boolean includeRetired) throws APIException;
+	List<ConceptDatatype> getAllConceptDatatypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Return a ConceptDatatype matching the given identifier
@@ -571,7 +571,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_DATATYPES)
-	public ConceptDatatype getConceptDatatype(Integer i) throws APIException;
+	ConceptDatatype getConceptDatatype(Integer i) throws APIException;
 	
 	/**
 	 * Get ConceptDatatype by its UUID
@@ -582,7 +582,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_DATATYPES)
-	public ConceptDatatype getConceptDatatypeByUuid(String uuid);
+	ConceptDatatype getConceptDatatypeByUuid(String uuid);
 	
 	/**
 	 * Return a Concept datatype matching the given name
@@ -594,7 +594,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not return a fuzzy match on name
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_DATATYPES)
-	public ConceptDatatype getConceptDatatypeByName(String name) throws APIException;
+	ConceptDatatype getConceptDatatypeByName(String name) throws APIException;
 	
 	/**
 	 * Return a list of the concept sets with concept_set matching concept
@@ -608,7 +608,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptSet> getConceptSetsByConcept(Concept concept) throws APIException;
+	List<ConceptSet> getConceptSetsByConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Return a List of all concepts within a concept set
@@ -618,7 +618,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByConceptSet(Concept concept) throws APIException;
+	List<Concept> getConceptsByConceptSet(Concept concept) throws APIException;
 	
 	/**
 	 * Find all sets that the given concept is a member of
@@ -631,7 +631,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should give an empty list if concept id is null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptSet> getSetsContainingConcept(Concept concept) throws APIException;
+	List<ConceptSet> getSetsContainingConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Get a List of all concept proposals
@@ -643,7 +643,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept proposals excluding retired ones when given false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
-	public List<ConceptProposal> getAllConceptProposals(boolean includeCompleted) throws APIException;
+	List<ConceptProposal> getAllConceptProposals(boolean includeCompleted) throws APIException;
 	
 	/**
 	 * Get ConceptNumeric by its UUID
@@ -654,7 +654,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptNumeric getConceptNumericByUuid(String uuid);
+	ConceptNumeric getConceptNumericByUuid(String uuid);
 	
 	/**
 	 * Get a ConceptProposal by conceptProposalId
@@ -664,7 +664,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
-	public ConceptProposal getConceptProposal(Integer conceptProposalId) throws APIException;
+	ConceptProposal getConceptProposal(Integer conceptProposalId) throws APIException;
 	
 	/**
 	 * Find matching concept proposals
@@ -674,7 +674,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
-	public List<ConceptProposal> getConceptProposals(String text) throws APIException;
+	List<ConceptProposal> getConceptProposals(String text) throws APIException;
 	
 	/**
 	 * Find matching proposed concepts
@@ -684,7 +684,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
-	public List<Concept> getProposedConcepts(String text) throws APIException;
+	List<Concept> getProposedConcepts(String text) throws APIException;
 	
 	/**
 	 * Saves/updates/proposes a concept proposal
@@ -694,7 +694,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return the saved/updated ConceptProposal object
 	 */
 	@Authorized({ PrivilegeConstants.ADD_CONCEPT_PROPOSALS, PrivilegeConstants.EDIT_CONCEPT_PROPOSALS })
-	public ConceptProposal saveConceptProposal(ConceptProposal conceptProposal) throws APIException;
+	ConceptProposal saveConceptProposal(ConceptProposal conceptProposal) throws APIException;
 	
 	/**
 	 * Removes a concept proposal from the database entirely.
@@ -704,7 +704,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should purge the given concept proposal
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_PROPOSALS)
-	public void purgeConceptProposal(ConceptProposal cp) throws APIException;
+	void purgeConceptProposal(ConceptProposal cp) throws APIException;
 	
 	/**
 	 * Maps a concept proposal to a concept
@@ -718,7 +718,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should throw APIException when mapping to null concept
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
-	public Concept mapConceptProposalToConcept(ConceptProposal cp, Concept mappedConcept) throws APIException;
+	Concept mapConceptProposalToConcept(ConceptProposal cp, Concept mappedConcept) throws APIException;
 	
 	/**
 	 * Maps a concept proposal to a concept
@@ -736,7 +736,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail when adding a duplicate synonym
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPTS)
-	public Concept mapConceptProposalToConcept(ConceptProposal cp, Concept mappedConcept, Locale locale) throws APIException;
+	Concept mapConceptProposalToConcept(ConceptProposal cp, Concept mappedConcept, Locale locale) throws APIException;
 	
 	/**
 	 * Returns all possible Concepts to which this concept is a value-coded answer. To navigate in
@@ -749,7 +749,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return an empty list if concept id is null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByAnswer(Concept concept) throws APIException;
+	List<Concept> getConceptsByAnswer(Concept concept) throws APIException;
 	
 	/**
 	 * Finds the previous concept in the dictionary that has the next lowest concept id
@@ -760,7 +760,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return the concept previous to the given concept
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getPrevConcept(Concept concept) throws APIException;
+	Concept getPrevConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Finds the next concept in the dictionary that has the next largest concept id
@@ -771,14 +771,14 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return the concept next to the given concept
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getNextConcept(Concept concept) throws APIException;
+	Concept getNextConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Check if the concepts are locked and if so, throw exception during manipulation of concept
 	 * 
 	 * @throws ConceptsLockedException
 	 */
-	public void checkIfLocked() throws ConceptsLockedException;
+	void checkIfLocked() throws ConceptsLockedException;
 	
 	/**
 	 * Get ConceptProposal by its UUID
@@ -789,7 +789,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
-	public ConceptProposal getConceptProposalByUuid(String uuid);
+	ConceptProposal getConceptProposalByUuid(String uuid);
 	
 	/**
 	 * Convenience method for finding concepts associated with drugs in formulary.
@@ -799,7 +799,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should give a list of all matching concepts
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsWithDrugsInFormulary() throws APIException;
+	List<Concept> getConceptsWithDrugsInFormulary() throws APIException;
 	
 	/**
 	 * Get ConceptNameTag by its UUID
@@ -813,7 +813,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptNameTag getConceptNameTagByUuid(String uuid);
+	ConceptNameTag getConceptNameTagByUuid(String uuid);
 	
 	/**
 	 * Get a ComplexConcept with the given conceptId
@@ -824,7 +824,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a concept complex object
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptComplex getConceptComplex(Integer conceptId);
+	ConceptComplex getConceptComplex(Integer conceptId);
 	
 	/**
 	 * Search for a ConceptNameTag by name
@@ -837,7 +837,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @see Concept#getShortestName(Locale, Boolean)
 	 */
 	@Authorized({ PrivilegeConstants.GET_CONCEPTS })
-	public ConceptNameTag getConceptNameTagByName(String tag);
+	ConceptNameTag getConceptNameTagByName(String tag);
 	
 	/**
 	 * Gets the set of unique Locales used by existing concept names.
@@ -845,7 +845,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return set of used Locales
 	 * @should return a list of matching locales
 	 */
-	public Set<Locale> getLocalesOfConceptNames();
+	Set<Locale> getLocalesOfConceptNames();
 	
 	/**
 	 * Return a list of concept sources currently in the database Whether or not to return retired
@@ -857,7 +857,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept sources excluding retired ones when given false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public List<ConceptSource> getAllConceptSources(boolean includeRetired) throws APIException;
+	List<ConceptSource> getAllConceptSources(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Return a Concept source matching the given concept source id
@@ -866,7 +866,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return ConceptSource
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public ConceptSource getConceptSource(Integer i) throws APIException;
+	ConceptSource getConceptSource(Integer i) throws APIException;
 	
 	/**
 	 * Create a new ConceptSource
@@ -879,7 +879,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not save a ConceptSource if voided is null
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_SOURCES)
-	public ConceptSource saveConceptSource(ConceptSource conceptSource) throws APIException;
+	ConceptSource saveConceptSource(ConceptSource conceptSource) throws APIException;
 	
 	/**
 	 * Delete ConceptSource
@@ -889,7 +889,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should purge the given concept source
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_SOURCES)
-	public ConceptSource purgeConceptSource(ConceptSource cs) throws APIException;
+	ConceptSource purgeConceptSource(ConceptSource cs) throws APIException;
 	
 	/**
 	 * This effectively removes a concept source from the database. The source can still be
@@ -902,7 +902,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should retire concept source
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_SOURCES)
-	public ConceptSource retireConceptSource(ConceptSource cs, String reason) throws APIException;
+	ConceptSource retireConceptSource(ConceptSource cs, String reason) throws APIException;
 	
 	/**
 	 * Creates a new Concept name tag if none exists. If a tag exists with the same name then that
@@ -917,7 +917,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should save an edited concept name tag
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_NAME_TAGS)
-	public ConceptNameTag saveConceptNameTag(ConceptNameTag nameTag);
+	ConceptNameTag saveConceptNameTag(ConceptNameTag nameTag);
 	
 	/**
 	 * Gets the highest concept-id used by a concept.
@@ -925,7 +925,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return highest concept-id
 	 * @should give the maximum concept-id
 	 */
-	public Integer getMaxConceptId();
+	Integer getMaxConceptId();
 	
 	/**
 	 * Returns an iterator for all concepts, including retired and expired.
@@ -935,7 +935,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should iterate over all concepts
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Iterator<Concept> conceptIterator();
+	Iterator<Concept> conceptIterator();
 	
 	/**
 	 * Looks up a concept via {@link ConceptMap} This will return the {@link Concept} which contains
@@ -954,7 +954,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if mapping does not exist
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConceptByMapping(String code, String sourceName) throws APIException;
+	Concept getConceptByMapping(String code, String sourceName) throws APIException;
 	
 	/**
 	 * Looks up a concept via {@link ConceptMap} This will return the {@link Concept} which contains
@@ -980,7 +980,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if mapping does not exist
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getConceptByMapping(String code, String sourceName, Boolean includeRetired) throws APIException;
+	Concept getConceptByMapping(String code, String sourceName, Boolean includeRetired) throws APIException;
 	
 	/**
 	 * Looks up a concept via {@link ConceptMap} This will return the list of concepts
@@ -1002,7 +1002,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByMapping(String code, String sourceName) throws APIException;
+	List<Concept> getConceptsByMapping(String code, String sourceName) throws APIException;
 	
 	/**
 	 * Looks up a concept via {@link ConceptMap} This will return the list of {@link Concept}s which
@@ -1024,7 +1024,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired) throws APIException;
+	List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get all the concept name tags defined in the database, included voided ones
@@ -1033,7 +1033,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return a list of the concept name tags stored in the dataset
 	 * @should return a list of all concept name tags
 	 */
-	public List<ConceptNameTag> getAllConceptNameTags();
+	List<ConceptNameTag> getAllConceptNameTags();
 	
 	/**
 	 * Gets the {@link ConceptNameTag} with the given database primary key
@@ -1043,7 +1043,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public ConceptNameTag getConceptNameTag(Integer id);
+	ConceptNameTag getConceptNameTag(Integer id);
 	
 	/**
 	 * Get ConceptDescription by its UUID
@@ -1054,7 +1054,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized({ PrivilegeConstants.GET_CONCEPTS })
-	public ConceptDescription getConceptDescriptionByUuid(String uuid);
+	ConceptDescription getConceptDescriptionByUuid(String uuid);
 	
 	/**
 	 * Lookup a ConceptSource by its name property
@@ -1066,7 +1066,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no ConceptSource with that name is found
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public ConceptSource getConceptSourceByName(String conceptSourceName) throws APIException;
+	ConceptSource getConceptSourceByName(String conceptSourceName) throws APIException;
 	
 	/**
 	 * Get a ConceptSource by its unique id.
@@ -1080,7 +1080,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if given null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public ConceptSource getConceptSourceByUniqueId(String uniqueId) throws APIException;
+	ConceptSource getConceptSourceByUniqueId(String uniqueId) throws APIException;
 	
 	/**
 	 * Get a ConceptSource by its hl7Code.
@@ -1094,7 +1094,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if given null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_SOURCES)
-	public ConceptSource getConceptSourceByHL7Code(String hl7Code) throws APIException;
+	ConceptSource getConceptSourceByHL7Code(String hl7Code) throws APIException;
 	
 	/**
 	 * Checks if there are any observations (including voided observations) for a concept.
@@ -1104,7 +1104,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public boolean hasAnyObservation(Concept concept);
+	boolean hasAnyObservation(Concept concept);
 	
 	/**
 	 * Returns the TRUE concept
@@ -1112,7 +1112,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return true concept
 	 * @should return the true concept
 	 */
-	public Concept getTrueConcept();
+	Concept getTrueConcept();
 	
 	/**
 	 * Returns the FALSE concept
@@ -1120,7 +1120,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return false concept
 	 * @should return the false concept
 	 */
-	public Concept getFalseConcept();
+	Concept getFalseConcept();
 	
 	/**
 	 * Returns the UNKNOWN concept
@@ -1128,7 +1128,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return unknown concept
 	 * @should return the unknown concept
 	 */
-	public Concept getUnknownConcept();
+	Concept getUnknownConcept();
 	
 	/**
 	 * Changes the datatype of a concept from boolean to coded when it has observations it is
@@ -1142,7 +1142,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should explicitly add false concept as a value_Coded answer
 	 */
 	@Authorized({ PrivilegeConstants.MANAGE_CONCEPTS })
-	public void convertBooleanConceptToCoded(Concept conceptToChange) throws APIException;
+	void convertBooleanConceptToCoded(Concept conceptToChange) throws APIException;
 	
 	/**
 	 * Checks if there are any observations (including voided observations) using a conceptName.
@@ -1153,7 +1153,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since Version 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public boolean hasAnyObservation(ConceptName conceptName) throws APIException;
+	boolean hasAnyObservation(ConceptName conceptName) throws APIException;
 	
 	/**
 	 * Searches for concepts by the given parameters.
@@ -1181,9 +1181,9 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptSearchResult> getConcepts(String phrase, List<Locale> locales, boolean includeRetired,
-	        List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
-	        List<ConceptDatatype> excludeDatatypes, Concept answersToConcept, Integer start, Integer size)
+	List<ConceptSearchResult> getConcepts(String phrase, List<Locale> locales, boolean includeRetired,
+			List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
+			List<ConceptDatatype> excludeDatatypes, Concept answersToConcept, Integer start, Integer size)
 	                throws APIException;
 					
 	/**
@@ -1198,7 +1198,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptSearchResult> findConceptAnswers(String phrase, Locale locale, Concept concept) throws APIException;
+	List<ConceptSearchResult> findConceptAnswers(String phrase, Locale locale, Concept concept) throws APIException;
 	
 	/**
 	 * Iterates over the words in names and synonyms (for each locale) and updates the concept
@@ -1210,7 +1210,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized({ PrivilegeConstants.MANAGE_CONCEPTS })
-	public void updateConceptIndex(Concept concept) throws APIException;
+	void updateConceptIndex(Concept concept) throws APIException;
 	
 	/**
 	 * Iterates over all concepts and calls updateConceptIndexes(Concept concept)
@@ -1219,7 +1219,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized({ PrivilegeConstants.MANAGE_CONCEPTS })
-	public void updateConceptIndexes() throws APIException;
+	void updateConceptIndexes() throws APIException;
 	
 	/**
 	 * Searches for concepts with the given parameters
@@ -1233,7 +1233,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptSearchResult> getConcepts(String phrase, Locale locale, boolean includeRetired) throws APIException;
+	List<ConceptSearchResult> getConcepts(String phrase, Locale locale, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Return the number of concepts matching a search phrase and the specified arguments
@@ -1252,9 +1252,9 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a count of unique concepts
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Integer getCountOfConcepts(String phrase, List<Locale> locales, boolean includeRetired,
-	        List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
-	        List<ConceptDatatype> excludeDatatypes, Concept answersToConcept);
+	Integer getCountOfConcepts(String phrase, List<Locale> locales, boolean includeRetired,
+			List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
+			List<ConceptDatatype> excludeDatatypes, Concept answersToConcept);
 			
 	/**
 	 * Return the number of drugs with matching names or concept drug names
@@ -1272,8 +1272,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Integer getCountOfDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
-	        boolean includeRetired) throws APIException;
+	Integer getCountOfDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
+			boolean includeRetired) throws APIException;
 			
 	/**
 	 * Returns a list of drugs with matching names or concept drug names and returns a specific
@@ -1295,8 +1295,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a list of matching drugs
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getDrugs(String drugName, Concept concept, boolean searchKeywords, boolean searchDrugConceptNames,
-	        boolean includeRetired, Integer start, Integer length) throws APIException;
+	List<Drug> getDrugs(String drugName, Concept concept, boolean searchKeywords, boolean searchDrugConceptNames,
+			boolean includeRetired, Integer start, Integer length) throws APIException;
 			
 	/**
 	 * Gets the list of <code>ConceptStopWord</code> for given locale
@@ -1308,7 +1308,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return default Locale <code>ConceptStopWord</code> if Locale is null
 	 * @since 1.8
 	 */
-	public List<String> getConceptStopWords(Locale locale);
+	List<String> getConceptStopWords(Locale locale);
 	
 	/**
 	 * Save the given <code>ConceptStopWord</code> in the database
@@ -1329,7 +1329,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_STOP_WORDS)
-	public ConceptStopWord saveConceptStopWord(ConceptStopWord conceptStopWord) throws APIException;
+	ConceptStopWord saveConceptStopWord(ConceptStopWord conceptStopWord) throws APIException;
 	
 	/**
 	 * Delete the given <code>ConceptStopWord</code> in the database
@@ -1340,7 +1340,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_STOP_WORDS)
-	public void deleteConceptStopWord(Integer conceptStopWordId) throws APIException;
+	void deleteConceptStopWord(Integer conceptStopWordId) throws APIException;
 	
 	/**
 	 * Get all the concept stop words
@@ -1350,7 +1350,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return empty list if nothing found
 	 * @since 1.8
 	 */
-	public List<ConceptStopWord> getAllConceptStopWords();
+	List<ConceptStopWord> getAllConceptStopWords();
 	
 	/**
 	 * Gets drugs by the given ingredient, which can be either the drug itself or any ingredient.
@@ -1362,7 +1362,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should raise exception if no concept is given
 	 * @since 1.10
 	 */
-	public List<Drug> getDrugsByIngredient(Concept ingredient);
+	List<Drug> getDrugsByIngredient(Concept ingredient);
 	
 	/**
 	 * Returns a list of concept map types currently in the database excluding hidden ones
@@ -1373,7 +1373,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all the concept map types excluding hidden ones
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public List<ConceptMapType> getActiveConceptMapTypes() throws APIException;
+	List<ConceptMapType> getActiveConceptMapTypes() throws APIException;
 	
 	/**
 	 * Returns a list of concept map types currently in the database including or excluding retired
@@ -1388,7 +1388,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not include hidden concept map types if includeHidden is set to false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public List<ConceptMapType> getConceptMapTypes(boolean includeRetired, boolean includeHidden) throws APIException;
+	List<ConceptMapType> getConceptMapTypes(boolean includeRetired, boolean includeHidden) throws APIException;
 	
 	/**
 	 * Return a concept map type matching the given concept map type id
@@ -1399,7 +1399,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public ConceptMapType getConceptMapType(Integer conceptMapTypeId) throws APIException;
+	ConceptMapType getConceptMapType(Integer conceptMapTypeId) throws APIException;
 	
 	/**
 	 * Return a concept map type matching the given uuid
@@ -1411,7 +1411,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a conceptMapType matching the specified uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public ConceptMapType getConceptMapTypeByUuid(String uuid) throws APIException;
+	ConceptMapType getConceptMapTypeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Return a concept map type matching the given name
@@ -1424,7 +1424,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should be case insensitive
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public ConceptMapType getConceptMapTypeByName(String name) throws APIException;
+	ConceptMapType getConceptMapTypeByName(String name) throws APIException;
 	
 	/**
 	 * Saves or updates the specified concept map type in the database
@@ -1437,7 +1437,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should update an existing concept map type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_MAP_TYPES)
-	public ConceptMapType saveConceptMapType(ConceptMapType conceptMapType) throws APIException;
+	ConceptMapType saveConceptMapType(ConceptMapType conceptMapType) throws APIException;
 	
 	/**
 	 * Retiring a concept map type essentially removes it from circulation
@@ -1451,7 +1451,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should should set the default retire reason if none is given
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_MAP_TYPES)
-	public ConceptMapType retireConceptMapType(ConceptMapType conceptMapType, String retireReason) throws APIException;
+	ConceptMapType retireConceptMapType(ConceptMapType conceptMapType, String retireReason) throws APIException;
 	
 	/**
 	 * Marks a concept map type that is currently retired as not retired.
@@ -1463,7 +1463,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should unretire the specified concept map type and drop all retire related fields
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_MAP_TYPES)
-	public ConceptMapType unretireConceptMapType(ConceptMapType conceptMapType) throws APIException;
+	ConceptMapType unretireConceptMapType(ConceptMapType conceptMapType) throws APIException;
 	
 	/**
 	 * Completely purges a concept map type from the database
@@ -1474,7 +1474,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should delete the specified conceptMapType from the database
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_MAP_TYPES)
-	public void purgeConceptMapType(ConceptMapType conceptMapType) throws APIException;
+	void purgeConceptMapType(ConceptMapType conceptMapType) throws APIException;
 	
 	/**
 	 * Returns a list of mappings from concepts to terms in the given reference terminology
@@ -1486,7 +1486,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a List of ConceptMaps from the given source
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<ConceptMap> getConceptMappingsToSource(ConceptSource conceptSource) throws APIException;
+	List<ConceptMap> getConceptMappingsToSource(ConceptSource conceptSource) throws APIException;
 	
 	/**
 	 * Gets a list of all concept reference terms saved in the database
@@ -1497,7 +1497,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept reference terms in the database
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public List<ConceptReferenceTerm> getAllConceptReferenceTerms() throws APIException;
+	List<ConceptReferenceTerm> getAllConceptReferenceTerms() throws APIException;
 	
 	/**
 	 * Gets a list of concept reference terms saved in the database
@@ -1510,7 +1510,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return only un retired concept reference terms if includeRetired is set to false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public List<ConceptReferenceTerm> getConceptReferenceTerms(boolean includeRetired) throws APIException;
+	List<ConceptReferenceTerm> getConceptReferenceTerms(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Gets the concept reference term with the specified concept reference term id
@@ -1521,7 +1521,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm getConceptReferenceTerm(Integer conceptReferenceTermId) throws APIException;
+	ConceptReferenceTerm getConceptReferenceTerm(Integer conceptReferenceTermId) throws APIException;
 	
 	/**
 	 * Gets the concept reference term with the specified uuid
@@ -1533,7 +1533,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return the concept reference term that matches the given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm getConceptReferenceTermByUuid(String uuid) throws APIException;
+	ConceptReferenceTerm getConceptReferenceTermByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Gets a concept reference term with the specified name from the specified concept source
@@ -1549,7 +1549,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no concept reference term is found
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm getConceptReferenceTermByName(String name, ConceptSource conceptSource) throws APIException;
+	ConceptReferenceTerm getConceptReferenceTermByName(String name, ConceptSource conceptSource) throws APIException;
 	
 	/**
 	 * Gets a concept reference term with the specified code from the specified concept source
@@ -1562,7 +1562,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return a concept reference term that matches the given code from the given source
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm getConceptReferenceTermByCode(String code, ConceptSource conceptSource) throws APIException;
+	ConceptReferenceTerm getConceptReferenceTermByCode(String code, ConceptSource conceptSource) throws APIException;
 	
 	/**
 	 * Stores the specified concept reference term to the database
@@ -1575,7 +1575,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should update changes to the concept reference term in the database
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm saveConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
+	ConceptReferenceTerm saveConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
 	
 	/**
 	 * Retiring a concept reference term essentially removes it from circulation
@@ -1589,7 +1589,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should should set the default retire reason if none is given
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm retireConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm, String retireReason)
+	ConceptReferenceTerm retireConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm, String retireReason)
 	        throws APIException;
 			
 	/**
@@ -1602,7 +1602,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should unretire the specified concept reference term and drop all retire related fields
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_REFERENCE_TERMS)
-	public ConceptReferenceTerm unretireConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
+	ConceptReferenceTerm unretireConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
 	
 	/**
 	 * Purges the specified concept reference term from the database
@@ -1614,7 +1614,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if given concept reference term is in use
 	 */
 	@Authorized(PrivilegeConstants.PURGE_CONCEPT_REFERENCE_TERMS)
-	public void purgeConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
+	void purgeConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws APIException;
 	
 	/**
 	 * Finds the concept reference term in the database that have a code or name that contains the
@@ -1632,8 +1632,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return only the concept reference terms from the given concept source
 	 */
 	@Authorized({ PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS })
-	public List<ConceptReferenceTerm> getConceptReferenceTerms(String query, ConceptSource conceptSource, Integer start,
-	        Integer length, boolean includeRetired) throws APIException;
+	List<ConceptReferenceTerm> getConceptReferenceTerms(String query, ConceptSource conceptSource, Integer start,
+			Integer length, boolean includeRetired) throws APIException;
 			
 	/**
 	 * Returns the count of concept reference terms that match the specified arguments
@@ -1648,7 +1648,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should not include retired terms if includeRetired is set to false
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public Integer getCountOfConceptReferenceTerms(String query, ConceptSource conceptSource, boolean includeRetired)
+	Integer getCountOfConceptReferenceTerms(String query, ConceptSource conceptSource, boolean includeRetired)
 	        throws APIException;
 			
 	/**
@@ -1662,7 +1662,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept reference term maps where the specified term is the termB
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
-	public List<ConceptReferenceTermMap> getReferenceTermMappingsTo(ConceptReferenceTerm term) throws APIException;
+	List<ConceptReferenceTermMap> getReferenceTermMappingsTo(ConceptReferenceTerm term) throws APIException;
 	
 	/**
 	 * Returns a list of concepts with the same name in the given locale.
@@ -1682,7 +1682,7 @@ public interface ConceptService extends OpenmrsService {
 	 *         locale
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getConceptsByName(String name, Locale locale, Boolean exactLocale) throws APIException;
+	List<Concept> getConceptsByName(String name, Locale locale, Boolean exactLocale) throws APIException;
 	
 	/**
 	 * Gets the concept map type to be used as the default. It is specified by the
@@ -1695,7 +1695,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return type as set in gp
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_MAP_TYPES)
-	public ConceptMapType getDefaultConceptMapType() throws APIException;
+	ConceptMapType getDefaultConceptMapType() throws APIException;
 	
 	/**
 	 * Determines if the given concept name is a duplicate.
@@ -1714,7 +1714,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @return true if it is a duplicate name
 	 * @since 1.11
 	 */
-	public boolean isConceptNameDuplicate(ConceptName name);
+	boolean isConceptNameDuplicate(ConceptName name);
 	
 	/**
 	 * Fetches un retired drugs that match the specified search phrase. The logic matches on drug
@@ -1739,7 +1739,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should reject a null search phrase
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getDrugs(String searchPhrase, Locale locale, boolean exactLocale, boolean includeRetired);
+	List<Drug> getDrugs(String searchPhrase, Locale locale, boolean exactLocale, boolean includeRetired);
 	
 	/**
 	 * Fetches all drugs with reference mappings to the specified concept source that match the
@@ -1763,8 +1763,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if source is null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Drug> getDrugsByMapping(String code, ConceptSource conceptSource,
-	        Collection<ConceptMapType> withAnyOfTheseTypes, boolean includeRetired) throws APIException;
+	List<Drug> getDrugsByMapping(String code, ConceptSource conceptSource,
+			Collection<ConceptMapType> withAnyOfTheseTypes, boolean includeRetired) throws APIException;
 			
 	/**
 	 * Gets the "best" matching drug, i.e. matching the earliest ConceptMapType passed in e.g.
@@ -1785,8 +1785,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @should fail if source is null
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Drug getDrugByMapping(String code, ConceptSource conceptSource,
-	        Collection<ConceptMapType> withAnyOfTheseTypesOrOrderOfPreference) throws APIException;
+	Drug getDrugByMapping(String code, ConceptSource conceptSource,
+			Collection<ConceptMapType> withAnyOfTheseTypesOrOrderOfPreference) throws APIException;
 			
 	/**
 	 * An Orderable concept is one where its conceptClass has a mapping in the order_type_class_map
@@ -1802,8 +1802,8 @@ public interface ConceptService extends OpenmrsService {
 	 * @should get orderable concepts
 	 * @should return an empty list if no concept search result is found
 	 */
-	public List<ConceptSearchResult> getOrderableConcepts(String phrase, List<Locale> locales, boolean includeRetired,
-	        Integer start, Integer length);
+	List<ConceptSearchResult> getOrderableConcepts(String phrase, List<Locale> locales, boolean includeRetired,
+			Integer start, Integer length);
 			
 	/**
 	 * @return all {@link ConceptAttributeType}s
@@ -1811,7 +1811,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return all concept attribute types including retired ones
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_ATTRIBUTE_TYPES)
-	public List<ConceptAttributeType> getAllConceptAttributeTypes();
+	List<ConceptAttributeType> getAllConceptAttributeTypes();
 	
 	/**
 	 * Creates or updates the given concept attribute type in the database
@@ -1823,7 +1823,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should edit an existing concept attribute type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_ATTRIBUTE_TYPES)
-	public ConceptAttributeType saveConceptAttributeType(ConceptAttributeType conceptAttributeType);
+	ConceptAttributeType saveConceptAttributeType(ConceptAttributeType conceptAttributeType);
 	
 	/**
 	 * @param id
@@ -1833,7 +1833,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no concept attribute type exists with the given id
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_ATTRIBUTE_TYPES)
-	public ConceptAttributeType getConceptAttributeType(Integer id);
+	ConceptAttributeType getConceptAttributeType(Integer id);
 	
 	/**
 	 * @param uuid
@@ -1843,7 +1843,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no concept attribute type exists with the given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPT_ATTRIBUTE_TYPES)
-	public ConceptAttributeType getConceptAttributeTypeByUuid(String uuid);
+	ConceptAttributeType getConceptAttributeTypeByUuid(String uuid);
 	
 	/**
 	 * Completely removes a concept attribute type from the database
@@ -1867,7 +1867,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return empty list when no concept attribute types match given name
 	 */
 	@Authorized({ PrivilegeConstants.GET_CONCEPT_ATTRIBUTE_TYPES })
-	public List<ConceptAttributeType> getConceptAttributeTypes(String name) throws APIException;
+	List<ConceptAttributeType> getConceptAttributeTypes(String name) throws APIException;
 	
 	/**
 	 * Retrieves a ConceptAttributeType object based on the name provided
@@ -1879,7 +1879,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should return null if no concept attribute type exists with the exact specified name
 	 */
 	@Authorized({ PrivilegeConstants.GET_CONCEPT_ATTRIBUTE_TYPES })
-	public ConceptAttributeType getConceptAttributeTypeByName(String exactName);
+	ConceptAttributeType getConceptAttributeTypeByName(String exactName);
 	
 	/**
 	 * Retire a concept attribute type
@@ -1891,7 +1891,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should retire concept type attribute
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_ATTRIBUTE_TYPES)
-	public ConceptAttributeType retireConceptAttributeType(ConceptAttributeType conceptAttributeType, String reason);
+	ConceptAttributeType retireConceptAttributeType(ConceptAttributeType conceptAttributeType, String reason);
 	
 	/**
 	 * Un-Retire a concept attribute type
@@ -1902,7 +1902,7 @@ public interface ConceptService extends OpenmrsService {
 	 * @should unretire a concept attribute type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_CONCEPT_ATTRIBUTE_TYPES)
-	public ConceptAttributeType unretireConceptAttributeType(ConceptAttributeType conceptAttributeType);
+	ConceptAttributeType unretireConceptAttributeType(ConceptAttributeType conceptAttributeType);
 	
 	/**
 	 * @param uuid

--- a/api/src/main/java/org/openmrs/api/EncounterService.java
+++ b/api/src/main/java/org/openmrs/api/EncounterService.java
@@ -44,7 +44,7 @@ public interface EncounterService extends OpenmrsService {
 	 * 
 	 * @param dao
 	 */
-	public void setEncounterDAO(EncounterDAO dao);
+	void setEncounterDAO(EncounterDAO dao);
 	
 	/**
 	 * Saves a new encounter or updates an existing encounter. If an existing encounter, this method
@@ -72,7 +72,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should fail if user is not supposed to edit encounters of type of given encounter
 	 */
 	@Authorized( { PrivilegeConstants.ADD_ENCOUNTERS, PrivilegeConstants.EDIT_ENCOUNTERS })
-	public Encounter saveEncounter(Encounter encounter) throws APIException;
+	Encounter saveEncounter(Encounter encounter) throws APIException;
 	
 	/**
 	 * Get encounter by internal identifier
@@ -85,7 +85,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return encounter if user is allowed to view it
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public Encounter getEncounter(Integer encounterId) throws APIException;
+	Encounter getEncounter(Integer encounterId) throws APIException;
 	
 	/**
 	 * Get Encounter by its UUID
@@ -96,7 +96,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public Encounter getEncounterByUuid(String uuid) throws APIException;
+	Encounter getEncounterByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get all encounters (not voided) for a patient, sorted by encounterDatetime ascending.
@@ -107,7 +107,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error when given null parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersByPatient(Patient patient);
+	List<Encounter> getEncountersByPatient(Patient patient);
 	
 	/**
 	 * Get encounters for a patientId
@@ -119,7 +119,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error if given a null parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersByPatientId(Integer patientId) throws APIException;
+	List<Encounter> getEncountersByPatientId(Integer patientId) throws APIException;
 	
 	/**
 	 * Get encounters (not voided) for a patient identifier
@@ -131,7 +131,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error if given null parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersByPatientIdentifier(String identifier) throws APIException;
+	List<Encounter> getEncountersByPatientIdentifier(String identifier) throws APIException;
 		
 	/**
 	 * Get all encounters that match a variety of (nullable) criteria. Each extra value for a
@@ -164,9 +164,9 @@ public interface EncounterService extends OpenmrsService {
 	 */
 	@Deprecated
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncounters(Patient who, Location loc, Date fromDate, Date toDate,
-	        Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
-	        Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided);
+	List<Encounter> getEncounters(Patient who, Location loc, Date fromDate, Date toDate,
+			Collection<Form> enteredViaForms, Collection<EncounterType> encounterTypes, Collection<Provider> providers,
+			Collection<VisitType> visitTypes, Collection<Visit> visits, boolean includeVoided);
 	
 	/**
 	 * Get all encounters that match a variety of (nullable) criteria contained in the parameter object.
@@ -178,7 +178,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get encounters modified after specified date
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
+	List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
 	
 	/**
 	 * Voiding a encounter essentially removes it from circulation
@@ -193,7 +193,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should fail if user is not supposed to edit encounters of type of given encounter
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_ENCOUNTERS })
-	public Encounter voidEncounter(Encounter encounter, String reason);
+	Encounter voidEncounter(Encounter encounter, String reason);
 	
 	/**
 	 * Unvoid encounter record
@@ -205,7 +205,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should fail if user is not supposed to edit encounters of type of given encounter
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_ENCOUNTERS })
-	public Encounter unvoidEncounter(Encounter encounter) throws APIException;
+	Encounter unvoidEncounter(Encounter encounter) throws APIException;
 	
 	/**
 	 * Completely remove an encounter from database. For super users only. If dereferencing
@@ -216,7 +216,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should fail if user is not supposed to edit encounters of type of given encounter
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ENCOUNTERS })
-	public void purgeEncounter(Encounter encounter) throws APIException;
+	void purgeEncounter(Encounter encounter) throws APIException;
 	
 	/**
 	 * Completely remove an encounter from database. For super users only. If dereferencing
@@ -228,7 +228,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should fail if user is not supposed to edit encounters of type of given encounter
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ENCOUNTERS })
-	public void purgeEncounter(Encounter encounter, boolean cascade) throws APIException;
+	void purgeEncounter(Encounter encounter, boolean cascade) throws APIException;
 	
 	/**
 	 * Save a new Encounter Type or update an existing Encounter Type.
@@ -242,7 +242,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error when trying to save encounter type when encounter types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_TYPES })
-	public EncounterType saveEncounterType(EncounterType encounterType) throws APIException;
+	EncounterType saveEncounterType(EncounterType encounterType) throws APIException;
 	
 	/**
 	 * Get encounterType by internal identifier
@@ -253,7 +253,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error if given null parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public EncounterType getEncounterType(Integer encounterTypeId) throws APIException;
+	EncounterType getEncounterType(Integer encounterTypeId) throws APIException;
 	
 	/**
 	 * Get EncounterType by its UUID
@@ -264,7 +264,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public EncounterType getEncounterTypeByUuid(String uuid) throws APIException;
+	EncounterType getEncounterTypeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get encounterType by exact name
@@ -278,7 +278,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return null with null name parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public EncounterType getEncounterType(String name) throws APIException;
+	EncounterType getEncounterType(String name) throws APIException;
 	
 	/**
 	 * Get all encounter types (including retired)
@@ -288,7 +288,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should not return retired types
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public List<EncounterType> getAllEncounterTypes() throws APIException;
+	List<EncounterType> getAllEncounterTypes() throws APIException;
 	
 	/**
 	 * Get all encounter types. If includeRetired is true, also get retired encounter types.
@@ -300,7 +300,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should include retired types with true includeRetired parameter
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public List<EncounterType> getAllEncounterTypes(boolean includeRetired) throws APIException;
+	List<EncounterType> getAllEncounterTypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Find Encounter Types with name matching the beginning of the search string. Search strings
@@ -316,7 +316,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return types ordered on name and nonretired first
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_TYPES })
-	public List<EncounterType> findEncounterTypes(String name) throws APIException;
+	List<EncounterType> findEncounterTypes(String name) throws APIException;
 	
 	/**
 	 * Retire an EncounterType. This essentially marks the given encounter type as a non-current
@@ -331,7 +331,7 @@ public interface EncounterService extends OpenmrsService {
 	 *         locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_TYPES })
-	public EncounterType retireEncounterType(EncounterType encounterType, String reason) throws APIException;
+	EncounterType retireEncounterType(EncounterType encounterType, String reason) throws APIException;
 	
 	/**
 	 * Unretire an EncounterType. This brings back the given encounter type and says that it can be
@@ -344,7 +344,7 @@ public interface EncounterService extends OpenmrsService {
 	 *         locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_TYPES })
-	public EncounterType unretireEncounterType(EncounterType encounterType) throws APIException;
+	EncounterType unretireEncounterType(EncounterType encounterType) throws APIException;
 	
 	/**
 	 * Completely remove an encounter type from database.
@@ -356,7 +356,7 @@ public interface EncounterService extends OpenmrsService {
 	 *         locked
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ENCOUNTER_TYPES })
-	public void purgeEncounterType(EncounterType encounterType) throws APIException;
+	void purgeEncounterType(EncounterType encounterType) throws APIException;
 		
 	/**
 	 * Search for encounters by patient name or patient identifier.
@@ -368,7 +368,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersByPatient(String query) throws APIException;
+	List<Encounter> getEncountersByPatient(String query) throws APIException;
 	
 	/**
 	 * Search for encounters by patient name or patient identifier.
@@ -384,7 +384,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersByPatient(String query, boolean includeVoided) throws APIException;
+	List<Encounter> getEncountersByPatient(String query, boolean includeVoided) throws APIException;
 	
 	/**
 	 * Search for encounters by patient name or patient identifier and returns a specific number of
@@ -403,7 +403,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return empty list for empty query
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncounters(String query, Integer start, Integer length, boolean includeVoided)
+	List<Encounter> getEncounters(String query, Integer start, Integer length, boolean includeVoided)
 	        throws APIException;
 	
 	/**
@@ -429,8 +429,8 @@ public interface EncounterService extends OpenmrsService {
 	 * @should match on the form name
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncounters(String query, Integer patientId, Integer start, Integer length,
-	        boolean includeVoided) throws APIException;
+	List<Encounter> getEncounters(String query, Integer patientId, Integer start, Integer length,
+			boolean includeVoided) throws APIException;
 	
 	/**
 	 * Get all encounters for a cohort of patients
@@ -440,7 +440,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get all encounters for a cohort of patients
 	 * @since 1.8
 	 */
-	public Map<Integer, List<Encounter>> getAllEncounters(Cohort patients);
+	Map<Integer, List<Encounter>> getAllEncounters(Cohort patients);
 	
 	/**
 	 * Return the number of encounters matching a patient name or patient identifier
@@ -452,7 +452,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get the correct count of unique encounters
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public Integer getCountOfEncounters(String query, boolean includeVoided);
+	Integer getCountOfEncounters(String query, boolean includeVoided);
 	
 	/**
 	 * Gets all encounters grouped within a given visit.
@@ -476,7 +476,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return the existing visit only assignment handler
 	 * @should return the existing or new visit assignment handler
 	 */
-	public List<EncounterVisitHandler> getEncounterVisitHandlers();
+	List<EncounterVisitHandler> getEncounterVisitHandlers();
 	
 	/**
 	 * Gets the active handler for assigning visits to encounters.
@@ -486,7 +486,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @return the active handler class.
 	 * @throws APIException thrown if something goes wrong during the retrieval of the handler.
 	 */
-	public EncounterVisitHandler getActiveEncounterVisitHandler() throws APIException;
+	EncounterVisitHandler getActiveEncounterVisitHandler() throws APIException;
 	
 	/**
 	 * Saves a new encounter role or updates an existing encounter role.
@@ -499,7 +499,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should update encounter role successfully
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_ROLES })
-	public EncounterRole saveEncounterRole(EncounterRole encounterRole) throws APIException;
+	EncounterRole saveEncounterRole(EncounterRole encounterRole) throws APIException;
 	
 	/**
 	 * Gets an encounter role when and internal encounter role id is provided.
@@ -510,7 +510,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_ROLES })
-	public EncounterRole getEncounterRole(Integer encounterRoleId) throws APIException;
+	EncounterRole getEncounterRole(Integer encounterRoleId) throws APIException;
 	
 	/**
 	 * Completely remove an encounter role from database. For super users only. If dereferencing
@@ -522,7 +522,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should purge Encounter Role
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ENCOUNTER_ROLES })
-	public void purgeEncounterRole(EncounterRole encounterRole) throws APIException;
+	void purgeEncounterRole(EncounterRole encounterRole) throws APIException;
 	
 	/**
 	 * Get all encounter roles based on includeRetired flag
@@ -533,7 +533,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should get all encounter roles based on include retired flag.
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_ROLES })
-	public List<EncounterRole> getAllEncounterRoles(boolean includeRetired);
+	List<EncounterRole> getAllEncounterRoles(boolean includeRetired);
 	
 	/**
 	 * Get EncounterRole by its UUID
@@ -544,7 +544,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should find encounter role based on uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_ROLES })
-	public EncounterRole getEncounterRoleByUuid(String uuid) throws APIException;
+	EncounterRole getEncounterRoleByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get EncounterRole by name
@@ -555,7 +555,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should find an encounter role identified by its name
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_ROLES })
-	public EncounterRole getEncounterRoleByName(String name);
+	EncounterRole getEncounterRoleByName(String name);
 	
 	/**
 	 * Retire an EncounterRole. This essentially marks the given encounter role as a non-current
@@ -569,7 +569,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should throw error if given null reason parameter
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_ROLES })
-	public EncounterRole retireEncounterRole(EncounterRole encounterRole, String reason) throws APIException;
+	EncounterRole retireEncounterRole(EncounterRole encounterRole, String reason) throws APIException;
 	
 	/**
 	 * Unretire an EncounterRole. This brings back the given encounter role and says that it can be
@@ -581,7 +581,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should unretire type and unmark attributes
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ENCOUNTER_ROLES })
-	public EncounterRole unretireEncounterRole(EncounterRole encounterType) throws APIException;
+	EncounterRole unretireEncounterRole(EncounterRole encounterType) throws APIException;
 	
 	/**
 	 * Gets the unvoided encounters for the specified patient that are not assigned to any visit.
@@ -594,7 +594,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> getEncountersNotAssignedToAnyVisit(Patient patient) throws APIException;
+	List<Encounter> getEncountersNotAssignedToAnyVisit(Patient patient) throws APIException;
 	
 	/**
 	 * Gets encounters for the given patient. It populates results with empty encounters to include
@@ -612,8 +612,8 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_VISITS })
-	public List<Encounter> getEncountersByVisitsAndPatient(Patient patient, boolean includeVoided, String query,
-	        Integer start, Integer length) throws APIException;
+	List<Encounter> getEncountersByVisitsAndPatient(Patient patient, boolean includeVoided, String query,
+			Integer start, Integer length) throws APIException;
 	
 	/**
 	 * Returns result count for
@@ -627,7 +627,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_VISITS })
-	public Integer getEncountersByVisitsAndPatientCount(Patient patient, boolean includeVoided, String query)
+	Integer getEncountersByVisitsAndPatientCount(Patient patient, boolean includeVoided, String query)
 	        throws APIException;
 	
 	/**
@@ -642,7 +642,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should not filter all encounters when the encounter type's view privilege column is null
 	 */
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTERS })
-	public List<Encounter> filterEncountersByViewPermissions(List<Encounter> encounters, User user);
+	List<Encounter> filterEncountersByViewPermissions(List<Encounter> encounters, User user);
 	
 	/**
 	 * Determines whether given user is granted to view all encounter types or not
@@ -652,7 +652,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return true if user is granted to view all encounters
 	 * @should return true when the encounter type's view privilege column is null
 	 */
-	public boolean canViewAllEncounterTypes(User subject);
+	boolean canViewAllEncounterTypes(User subject);
 	
 	/**
 	 * Determines whether given user is granted to edit all encounter types or not
@@ -662,7 +662,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return true if user is granted to edit all encounters
 	 * @should return true when the encounter type's edit privilege column is null
 	 */
-	public boolean canEditAllEncounterTypes(User subject);
+	boolean canEditAllEncounterTypes(User subject);
 	
 	/**
 	 * Checks if passed in user can edit given encounter. If user is not specified, then
@@ -675,7 +675,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return false if user can not edit encounter
 	 * @should fail if encounter is null
 	 */
-	public boolean canEditEncounter(Encounter encounter, User subject);
+	boolean canEditEncounter(Encounter encounter, User subject);
 	
 	/**
 	 * Checks if passed in user can view given encounter. If user is not specified, then
@@ -688,7 +688,7 @@ public interface EncounterService extends OpenmrsService {
 	 * @should return false if user can not view encounter
 	 * @should fail if encounter is null
 	 */
-	public boolean canViewEncounter(Encounter encounter, User subject);
+	boolean canViewEncounter(Encounter encounter, User subject);
 	
 	/**
 	 * Check if the encounter types are locked, and if so, throw exception during manipulation of
@@ -696,7 +696,7 @@ public interface EncounterService extends OpenmrsService {
 	 * 
 	 * @throws EncounterTypeLockedException
 	 */
-	public void checkIfEncounterTypesAreLocked() throws EncounterTypeLockedException;
+	void checkIfEncounterTypesAreLocked() throws EncounterTypeLockedException;
 	
 	/**
 	 * Get EncounterRoles by name
@@ -708,7 +708,7 @@ public interface EncounterService extends OpenmrsService {
 	 */
 	
 	@Authorized( { PrivilegeConstants.GET_ENCOUNTER_ROLES })
-	public List<EncounterRole> getEncounterRolesByName(String name);
+	List<EncounterRole> getEncounterRolesByName(String name);
 	
 	/**
 	 *Transfer encounter to another patient
@@ -723,5 +723,5 @@ public interface EncounterService extends OpenmrsService {
 	 * @should void given encounter visit if given encounter is the only encounter
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_ENCOUNTERS })
-	public Encounter transferEncounter(Encounter encounter, Patient patient);
+	Encounter transferEncounter(Encounter encounter, Patient patient);
 }

--- a/api/src/main/java/org/openmrs/api/FormService.java
+++ b/api/src/main/java/org/openmrs/api/FormService.java
@@ -41,7 +41,7 @@ public interface FormService extends OpenmrsService {
 	 * @should throw an error when trying to save a new form while forms are locked
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public Form saveForm(Form form) throws APIException;
+	Form saveForm(Form form) throws APIException;
 	
 	/**
 	 * Get form by internal form identifier
@@ -53,7 +53,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return the requested form
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public Form getForm(Integer formId) throws APIException;
+	Form getForm(Integer formId) throws APIException;
 	
 	/**
 	 * Get form by exact name match. If there are multiple forms with this name, then this returns
@@ -65,7 +65,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return null if no form has the exact form name
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public Form getForm(String name) throws APIException;
+	Form getForm(String name) throws APIException;
 	
 	/**
 	 * Get Form by its UUID
@@ -75,7 +75,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public Form getFormByUuid(String uuid) throws APIException;
+	Form getFormByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get form by exact name &amp; version match. If version is null, then this method behaves like
@@ -88,7 +88,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get the specific version of the form with the given name
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public Form getForm(String name, String version) throws APIException;
+	Form getForm(String name, String version) throws APIException;
 	
 	/**
 	 * Gets all Forms, including retired ones.
@@ -98,7 +98,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return all forms including retired
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getAllForms() throws APIException;
+	List<Form> getAllForms() throws APIException;
 	
 	/**
 	 * Gets all forms, possibly including retired ones
@@ -110,7 +110,7 @@ public interface FormService extends OpenmrsService {
 	 * @should not return retired forms if includeRetired is false
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getAllForms(boolean includeRetired) throws APIException;
+	List<Form> getAllForms(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Gets all forms with name similar to the given name. (The precise fuzzy matching algorithm is
@@ -124,7 +124,7 @@ public interface FormService extends OpenmrsService {
 	 * @should only return one form per name if onlyLatestVersion is true
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getForms(String fuzzyName, boolean onlyLatestVersion);
+	List<Form> getForms(String fuzzyName, boolean onlyLatestVersion);
 	
 	/**
 	 * Gets all forms that match all the (nullable) criteria
@@ -151,9 +151,9 @@ public interface FormService extends OpenmrsService {
 	 * @should return forms that have any matching formFields in containingAnyFormField
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getForms(String partialNameSearch, Boolean published, Collection<EncounterType> encounterTypes,
-	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
-	        Collection<Field> fields);
+	List<Form> getForms(String partialNameSearch, Boolean published, Collection<EncounterType> encounterTypes,
+			Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
+			Collection<Field> fields);
 	
 	/**
 	 * Same as
@@ -163,9 +163,9 @@ public interface FormService extends OpenmrsService {
 	 * @see #getForms(String, Boolean, Collection, Boolean, Collection, Collection, Collection)
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public Integer getFormCount(String partialNameSearch, Boolean published, Collection<EncounterType> encounterTypes,
-	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
-	        Collection<Field> fields);
+	Integer getFormCount(String partialNameSearch, Boolean published, Collection<EncounterType> encounterTypes,
+			Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
+			Collection<Field> fields);
 	
 	/**
 	 * Returns all published forms (not including retired ones)
@@ -175,7 +175,7 @@ public interface FormService extends OpenmrsService {
 	 * @should only return published forms that are not retired
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getPublishedForms() throws APIException;
+	List<Form> getPublishedForms() throws APIException;
 		
 	/**
 	 * Audit form, consolidate similar fields
@@ -184,7 +184,7 @@ public interface FormService extends OpenmrsService {
 	 * @should should merge fields with similar attributes
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public int mergeDuplicateFields() throws APIException;
+	int mergeDuplicateFields() throws APIException;
 	
 	/**
 	 * Duplicate this form and form_fields associated with this form
@@ -198,7 +198,7 @@ public interface FormService extends OpenmrsService {
 	 * @should throw an error when trying to duplicate a form while forms are locked
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public Form duplicateForm(Form form) throws APIException;
+	Form duplicateForm(Form form) throws APIException;
 	
 	/**
 	 * Retires the Form, leaving it in the database, but removing it from data entry screens
@@ -209,7 +209,7 @@ public interface FormService extends OpenmrsService {
 	 * @should set the retired bit before saving
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void retireForm(Form form, String reason) throws APIException;
+	void retireForm(Form form, String reason) throws APIException;
 	
 	/**
 	 * Unretires a Form that had previous been retired.
@@ -219,7 +219,7 @@ public interface FormService extends OpenmrsService {
 	 * @should unset the retired bit before saving
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void unretireForm(Form form) throws APIException;
+	void unretireForm(Form form) throws APIException;
 	
 	/**
 	 * Completely remove a Form from the database. This is not reversible. It will fail if this form
@@ -232,7 +232,7 @@ public interface FormService extends OpenmrsService {
 	 * @should throw an error when trying to delete a form while forms are locked
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void purgeForm(Form form) throws APIException;
+	void purgeForm(Form form) throws APIException;
 	
 	/**
 	 * Completely remove a Form from the database. This is not reversible. !! WARNING: Calling this
@@ -244,7 +244,7 @@ public interface FormService extends OpenmrsService {
 	 * @should throw APIException if cascade is true
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void purgeForm(Form form, boolean cascade) throws APIException;
+	void purgeForm(Form form, boolean cascade) throws APIException;
 		
 	/**
 	 * Get all field types in the database including the retired ones
@@ -254,7 +254,7 @@ public interface FormService extends OpenmrsService {
 	 * @should also get retired field types
 	 */
 	@Authorized(PrivilegeConstants.GET_FIELD_TYPES)
-	public List<FieldType> getAllFieldTypes() throws APIException;
+	List<FieldType> getAllFieldTypes() throws APIException;
 	
 	/**
 	 * Get all field types in the database with or without retired ones
@@ -266,7 +266,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get all field types excluding retired when includeRetired equals false
 	 */
 	@Authorized(PrivilegeConstants.GET_FIELD_TYPES)
-	public List<FieldType> getAllFieldTypes(boolean includeRetired) throws APIException;
+	List<FieldType> getAllFieldTypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get fieldType by internal identifier
@@ -277,7 +277,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return null when no field type matching given id
 	 */
 	@Authorized(PrivilegeConstants.GET_FIELD_TYPES)
-	public FieldType getFieldType(Integer fieldTypeId) throws APIException;
+	FieldType getFieldType(Integer fieldTypeId) throws APIException;
 	
 	/**
 	 * Get FieldType by its UUID
@@ -287,7 +287,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public FieldType getFieldTypeByUuid(String uuid) throws APIException;
+	FieldType getFieldTypeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get FieldType by its name
@@ -297,7 +297,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid name
 	 * @should return null if no object found with given name
 	 */
-	public FieldType getFieldTypeByName(String name) throws APIException;
+	FieldType getFieldTypeByName(String name) throws APIException;
 	
 	/**
 	 * Returns all forms that contain the given concept as a field in their schema. (includes
@@ -310,7 +310,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get all forms for concept
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Form> getFormsContainingConcept(Concept concept) throws APIException;
+	List<Form> getFormsContainingConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Returns all FormFields in the database
@@ -320,7 +320,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get all form fields including retired
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<FormField> getAllFormFields() throws APIException;
+	List<FormField> getAllFormFields() throws APIException;
 	
 	/**
 	 * Find all Fields whose names are similar to or contain the given phrase. (The exact similarity
@@ -335,7 +335,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return fields in alphabetical order by name
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Field> getFields(String fuzzySearchPhrase) throws APIException;
+	List<Field> getFields(String fuzzySearchPhrase) throws APIException;
 	
 	/**
 	 * Finds all Fields that point to the given concept, including retired ones.
@@ -346,7 +346,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get fields with concept matching given concept
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Field> getFieldsByConcept(Concept concept) throws APIException;
+	List<Field> getFieldsByConcept(Concept concept) throws APIException;
 	
 	/**
 	 * Fetches all Fields in the database, including retired ones
@@ -356,7 +356,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get all fields including retired
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Field> getAllFields() throws APIException;
+	List<Field> getAllFields() throws APIException;
 	
 	/**
 	 * Fetches all Fields in the database, possibly including retired ones
@@ -368,7 +368,7 @@ public interface FormService extends OpenmrsService {
 	 * @should get all fields excluding retired when includeRetired is false
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Field> getAllFields(boolean includeRetired) throws APIException;
+	List<Field> getAllFields(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Returns all Fields that match these (nullable) criteria
@@ -392,9 +392,9 @@ public interface FormService extends OpenmrsService {
 	 * @should get fields with selectMultiple equals true when given selectMultiple equals true
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public List<Field> getFields(Collection<Form> forms, Collection<FieldType> fieldTypes, Collection<Concept> concepts,
-	        Collection<String> tableNames, Collection<String> attributeNames, Boolean selectMultiple,
-	        Collection<FieldAnswer> containsAllAnswers, Collection<FieldAnswer> containsAnyAnswer, Boolean retired)
+	List<Field> getFields(Collection<Form> forms, Collection<FieldType> fieldTypes, Collection<Concept> concepts,
+			Collection<String> tableNames, Collection<String> attributeNames, Boolean selectMultiple,
+			Collection<FieldAnswer> containsAllAnswers, Collection<FieldAnswer> containsAnyAnswer, Boolean retired)
 	        throws APIException;
 	
 	/**
@@ -406,7 +406,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return null if no field exists with given fieldId
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public Field getField(Integer fieldId) throws APIException;
+	Field getField(Integer fieldId) throws APIException;
 	
 	/**
 	 * Get Field by its UUID
@@ -416,7 +416,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public Field getFieldByUuid(String uuid) throws APIException;
+	Field getFieldByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get FieldAnswer by its UUID
@@ -426,7 +426,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public FieldAnswer getFieldAnswerByUuid(String uuid) throws APIException;
+	FieldAnswer getFieldAnswerByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Creates or updates the given Field
@@ -438,7 +438,7 @@ public interface FormService extends OpenmrsService {
 	 * @should update an existing field
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public Field saveField(Field field) throws APIException;
+	Field saveField(Field field) throws APIException;
 	
 	/**
 	 * Completely removes a Field from the database. Not reversible.
@@ -448,7 +448,7 @@ public interface FormService extends OpenmrsService {
 	 * @should delete given field successfully
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void purgeField(Field field) throws APIException;
+	void purgeField(Field field) throws APIException;
 	
 	/**
 	 * Completely removes a Field from the database. Not reversible. !! WARNING: calling this with
@@ -460,7 +460,7 @@ public interface FormService extends OpenmrsService {
 	 * @should throw APIException if cascade is true
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void purgeField(Field field, boolean cascade) throws APIException;
+	void purgeField(Field field, boolean cascade) throws APIException;
 	
 	/**
 	 * Gets a FormField by internal database id
@@ -471,7 +471,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return null if no formField exists with given id
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public FormField getFormField(Integer formFieldId) throws APIException;
+	FormField getFormField(Integer formFieldId) throws APIException;
 	
 	/**
 	 * Get FormField by its UUID
@@ -481,7 +481,7 @@ public interface FormService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public FormField getFormFieldByUuid(String uuid) throws APIException;
+	FormField getFormFieldByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Finds the FormField defined for this form/concept combination while discounting any form
@@ -506,7 +506,7 @@ public interface FormService extends OpenmrsService {
 	 * @should ignore formFields passed to ignoreFormFields
 	 */
 	@Authorized(PrivilegeConstants.GET_FORMS)
-	public FormField getFormField(Form form, Concept concept, Collection<FormField> ignoreFormFields, boolean force)
+	FormField getFormField(Form form, Concept concept, Collection<FormField> ignoreFormFields, boolean force)
 	        throws APIException;
 	
 	/**
@@ -520,7 +520,7 @@ public interface FormService extends OpenmrsService {
 	 * @should inject form fields from serializable complex obs handlers
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public FormField saveFormField(FormField formField) throws APIException;
+	FormField saveFormField(FormField formField) throws APIException;
 	
 	/**
 	 * Completely removes the given FormField from the database. This is not reversible
@@ -530,7 +530,7 @@ public interface FormService extends OpenmrsService {
 	 * @should delete the given form field successfully
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public void purgeFormField(FormField formField) throws APIException;
+	void purgeFormField(FormField formField) throws APIException;
 	
 	/**
 	 * Retires field
@@ -541,7 +541,7 @@ public interface FormService extends OpenmrsService {
 	 * @should set the retired bit before saving
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public Field retireField(Field field) throws APIException;
+	Field retireField(Field field) throws APIException;
 	
 	/**
 	 * Unretires field
@@ -552,7 +552,7 @@ public interface FormService extends OpenmrsService {
 	 * @should unset the retired bit before saving
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FORMS)
-	public Field unretireField(Field field) throws APIException;
+	Field unretireField(Field field) throws APIException;
 	
 	/**
 	 * Saves the given field type to the database
@@ -564,7 +564,7 @@ public interface FormService extends OpenmrsService {
 	 * @should update existing field type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_FIELD_TYPES)
-	public FieldType saveFieldType(FieldType fieldType) throws APIException;
+	FieldType saveFieldType(FieldType fieldType) throws APIException;
 	
 	/**
 	 * Deletes the given field type from the database. This should not be done. It is preferred to
@@ -575,7 +575,7 @@ public interface FormService extends OpenmrsService {
 	 * @should delete the given field type successfully
 	 */
 	@Authorized(PrivilegeConstants.PURGE_FIELD_TYPES)
-	public void purgeFieldType(FieldType fieldType) throws APIException;
+	void purgeFieldType(FieldType fieldType) throws APIException;
 	
 	/**
 	 * Finds a FormResource by its id
@@ -585,7 +585,7 @@ public interface FormService extends OpenmrsService {
 	 * @should return null if no FormResource found
 	 * @since 1.9
 	 */
-	public FormResource getFormResource(Integer formResourceId) throws APIException;
+	FormResource getFormResource(Integer formResourceId) throws APIException;
 	
 	/**
 	 * Finds a FormResource by its uuid
@@ -593,7 +593,7 @@ public interface FormService extends OpenmrsService {
 	 * @param uuid the uuid of the resource
 	 * @since 1.9
 	 */
-	public FormResource getFormResourceByUuid(String uuid) throws APIException;
+	FormResource getFormResourceByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Finds a FormResource based on a given Form and name
@@ -602,7 +602,7 @@ public interface FormService extends OpenmrsService {
 	 * @param name the name of the resource
 	 * @since 1.9
 	 */
-	public FormResource getFormResource(Form form, String name) throws APIException;
+	FormResource getFormResource(Form form, String name) throws APIException;
 	
 	/**
 	 * Finds all FormResources tied to a given form
@@ -612,7 +612,7 @@ public interface FormService extends OpenmrsService {
 	 * @throws APIException
 	 * @since 1.9
 	 */
-	public Collection<FormResource> getFormResourcesForForm(Form form) throws APIException;
+	Collection<FormResource> getFormResourcesForForm(Form form) throws APIException;
 	
 	/**
 	 * Saves or updates the given form resource
@@ -623,7 +623,7 @@ public interface FormService extends OpenmrsService {
 	 * @should be able to save an XSLT
 	 * @since 1.9
 	 */
-	public FormResource saveFormResource(FormResource formResource) throws APIException;
+	FormResource saveFormResource(FormResource formResource) throws APIException;
 	
 	/**
 	 * Purges a form resource
@@ -632,12 +632,12 @@ public interface FormService extends OpenmrsService {
 	 * @should delete a form resource
 	 * @since 1.9
 	 */
-	public void purgeFormResource(FormResource formResource) throws APIException;
+	void purgeFormResource(FormResource formResource) throws APIException;
 	
 	/**
 	 * Checks if the forms are locked, and if they are throws an exception when saving or deleting a form
 	 * 
 	 * @throws FormsLockedException
 	 */
-	public void checkIfFormsAreLocked() throws FormsLockedException;
+	void checkIfFormsAreLocked() throws FormsLockedException;
 }

--- a/api/src/main/java/org/openmrs/api/GlobalPropertyListener.java
+++ b/api/src/main/java/org/openmrs/api/GlobalPropertyListener.java
@@ -25,20 +25,20 @@ public interface GlobalPropertyListener {
 	 * @return whether this listener wants its action methods to be notified of properties with the
 	 *         given name
 	 */
-	public boolean supportsPropertyName(String propertyName);
+	boolean supportsPropertyName(String propertyName);
 	
 	/**
 	 * Called after a global property is created or updated
 	 * 
 	 * @param newValue the new value of the property that was just saved
 	 */
-	public void globalPropertyChanged(GlobalProperty newValue);
+	void globalPropertyChanged(GlobalProperty newValue);
 	
 	/**
 	 * Called after a global property is deleted
 	 * 
 	 * @param propertyName the name of the property that was just deleted
 	 */
-	public void globalPropertyDeleted(String propertyName);
+	void globalPropertyDeleted(String propertyName);
 	
 }

--- a/api/src/main/java/org/openmrs/api/LocationService.java
+++ b/api/src/main/java/org/openmrs/api/LocationService.java
@@ -41,7 +41,7 @@ public interface LocationService extends OpenmrsService {
 	 * 
 	 * @param dao
 	 */
-	public void setLocationDAO(LocationDAO dao);
+	void setLocationDAO(LocationDAO dao);
 	
 	/**
 	 * Save location to database (create if new or update if changed)
@@ -59,7 +59,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should create location successfully
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATIONS })
-	public Location saveLocation(Location location) throws APIException;
+	Location saveLocation(Location location) throws APIException;
 	
 	/**
 	 * Returns a location given that locations primary key <code>locationId</code> A null value is
@@ -70,7 +70,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return null when no location match given location id
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public Location getLocation(Integer locationId) throws APIException;
+	Location getLocation(Integer locationId) throws APIException;
 	
 	/**
 	 * Returns a location given the location's exact <code>name</code> A null value is returned if
@@ -81,7 +81,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return null when no location match given location name
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public Location getLocation(String name) throws APIException;
+	Location getLocation(String name) throws APIException;
 	
 	/**
 	 * Returns the default location for this implementation.
@@ -91,7 +91,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return Unknown Location if the global property is something else that doesnot exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public Location getDefaultLocation() throws APIException;
+	Location getDefaultLocation() throws APIException;
 	
 	/**
 	 * Returns a location by uuid
@@ -102,7 +102,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public Location getLocationByUuid(String uuid) throws APIException;
+	Location getLocationByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns a location tag by uuid
@@ -113,7 +113,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public LocationTag getLocationTagByUuid(String uuid) throws APIException;
+	LocationTag getLocationTagByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns all locations, includes retired locations. This method delegates to the
@@ -123,7 +123,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return all locations including retired
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getAllLocations() throws APIException;
+	List<Location> getAllLocations() throws APIException;
 	
 	/**
 	 * Returns all locations.
@@ -133,7 +133,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return only unretired locations when includeRetires is false
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getAllLocations(boolean includeRetired) throws APIException;
+	List<Location> getAllLocations(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Returns locations that match the beginning of the given string. A null list will never be
@@ -144,7 +144,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return empty list when no location match the name fragment
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getLocations(String nameFragment) throws APIException;
+	List<Location> getLocations(String nameFragment) throws APIException;
 	
 	/**
 	 * Gets the locations matching the specified arguments. A null list will never be returned. An empty list will be
@@ -163,8 +163,8 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getLocations(String nameFragment, Location parent,
-	        Map<LocationAttributeType, Object> attributeValues, boolean includeRetired, Integer start, Integer length)
+	List<Location> getLocations(String nameFragment, Location parent,
+			Map<LocationAttributeType, Object> attributeValues, boolean includeRetired, Integer start, Integer length)
 	        throws APIException;
 	
 	/**
@@ -176,7 +176,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getLocationsByTag(LocationTag tag) throws APIException;
+	List<Location> getLocationsByTag(LocationTag tag) throws APIException;
 	
 	/**
 	 * Returns locations that are mapped to all given tags.
@@ -187,7 +187,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getLocationsHavingAllTags(List<LocationTag> tags) throws APIException;
+	List<Location> getLocationsHavingAllTags(List<LocationTag> tags) throws APIException;
 	
 	/**
 	 * Returns locations that are mapped to any of the given tags.
@@ -199,7 +199,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getLocationsHavingAnyTag(List<LocationTag> tags) throws APIException;
+	List<Location> getLocationsHavingAnyTag(List<LocationTag> tags) throws APIException;
 	
 	/**
 	 * Retires the given location. This effectively removes the location from circulation or use.
@@ -209,7 +209,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should retire location successfully
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATIONS })
-	public Location retireLocation(Location location, String reason) throws APIException;
+	Location retireLocation(Location location, String reason) throws APIException;
 	
 	/**
 	 * Unretire the given location. This restores a previously retired location back into
@@ -221,7 +221,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should unretire retired location
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATIONS })
-	public Location unretireLocation(Location location) throws APIException;
+	Location unretireLocation(Location location) throws APIException;
 	
 	/**
 	 * Completely remove a location from the database (not reversible) This method delegates to
@@ -231,7 +231,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should delete location successfully
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_LOCATIONS })
-	public void purgeLocation(Location location) throws APIException;
+	void purgeLocation(Location location) throws APIException;
 	
 	/**
 	 * Save location tag to database (create if new or update if changed)
@@ -245,7 +245,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATION_TAGS })
-	public LocationTag saveLocationTag(LocationTag tag) throws APIException;
+	LocationTag saveLocationTag(LocationTag tag) throws APIException;
 	
 	/**
 	 * Returns a location tag given that locations primary key <code>locationTagId</code>. A null
@@ -258,7 +258,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public LocationTag getLocationTag(Integer locationTagId) throws APIException;
+	LocationTag getLocationTag(Integer locationTagId) throws APIException;
 	
 	/**
 	 * Returns a location tag given the location's exact name (tag). A null value is returned if
@@ -271,7 +271,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public LocationTag getLocationTagByName(String tag) throws APIException;
+	LocationTag getLocationTagByName(String tag) throws APIException;
 	
 	/**
 	 * Returns all location tags, includes retired location tags. This method delegates to the
@@ -282,7 +282,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<LocationTag> getAllLocationTags() throws APIException;
+	List<LocationTag> getAllLocationTags() throws APIException;
 	
 	/**
 	 * Returns all location tags.
@@ -293,7 +293,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<LocationTag> getAllLocationTags(boolean includeRetired) throws APIException;
+	List<LocationTag> getAllLocationTags(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Returns location tags that match the beginning of the given string. A null list will never be
@@ -305,7 +305,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<LocationTag> getLocationTags(String search) throws APIException;
+	List<LocationTag> getLocationTags(String search) throws APIException;
 	
 	/**
 	 * Retire the given location tag. This effectively removes the tag from circulation or use.
@@ -317,7 +317,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATION_TAGS })
-	public LocationTag retireLocationTag(LocationTag tag, String reason) throws APIException;
+	LocationTag retireLocationTag(LocationTag tag, String reason) throws APIException;
 	
 	/**
 	 * Unretire the given location tag. This restores a previously retired tag back into circulation
@@ -330,7 +330,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_LOCATION_TAGS })
-	public LocationTag unretireLocationTag(LocationTag tag) throws APIException;
+	LocationTag unretireLocationTag(LocationTag tag) throws APIException;
 	
 	/**
 	 * Completely remove a location tag from the database (not reversible).
@@ -340,7 +340,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_LOCATION_TAGS })
-	public void purgeLocationTag(LocationTag tag) throws APIException;
+	void purgeLocationTag(LocationTag tag) throws APIException;
 	
 	/**
 	 * Return the number of all locations that start with the given name fragment, if the name
@@ -352,7 +352,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public Integer getCountOfLocations(String nameFragment, Boolean includeRetired);
+	Integer getCountOfLocations(String nameFragment, Boolean includeRetired);
 	
 	/**
 	 * Returns all root locations (i.e. those who have no parentLocation), optionally including
@@ -365,7 +365,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public List<Location> getRootLocations(boolean includeRetired);
+	List<Location> getRootLocations(boolean includeRetired);
 	
 	/**
 	 * Given an Address object, returns all the possible values for the specified AddressField. This
@@ -380,7 +380,7 @@ public interface LocationService extends OpenmrsService {
 	 * @should return null by default
 	 * @since 1.7.2
 	 */
-	public List<String> getPossibleAddressValues(Address incomplete, String fieldName) throws APIException;
+	List<String> getPossibleAddressValues(Address incomplete, String fieldName) throws APIException;
 	
 	/**
 	 * Returns the xml of default address template.
@@ -392,7 +392,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.GET_LOCATIONS })
-	public String getAddressTemplate() throws APIException;
+	String getAddressTemplate() throws APIException;
 	
 	/**
 	 * Saved default address template to global properties
@@ -404,7 +404,7 @@ public interface LocationService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ADDRESS_TEMPLATES })
-	public void saveAddressTemplate(String xml) throws APIException;
+	void saveAddressTemplate(String xml) throws APIException;
 	
 	/**
 	 * @return all {@link LocationAttributeType}s

--- a/api/src/main/java/org/openmrs/api/ObsService.java
+++ b/api/src/main/java/org/openmrs/api/ObsService.java
@@ -50,7 +50,7 @@ public interface ObsService extends OpenmrsService {
 	 * 
 	 * @param dao specific ObsDAO to use for this service
 	 */
-	public void setObsDAO(ObsDAO dao);
+	void setObsDAO(ObsDAO dao);
 	
 	/**
 	 * Get an observation
@@ -61,7 +61,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should get obs matching given obsId
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Obs getObs(Integer obsId) throws APIException;
+	Obs getObs(Integer obsId) throws APIException;
 	
 	/**
 	 * Get Obs by its UUID
@@ -72,7 +72,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Obs getObsByUuid(String uuid) throws APIException;
+	Obs getObsByUuid(String uuid) throws APIException;
 
 	/**
 	 * Get Revision Obs for initial Obs
@@ -84,7 +84,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should return null if no revision obs found for given obs
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Obs getRevisionObs(Obs initialObs);
+	Obs getRevisionObs(Obs initialObs);
 
 	/**
 	 * <p>Save the given obs to the database. The behavior differs for first-time save, and edit.</p>
@@ -126,7 +126,7 @@ public interface ObsService extends OpenmrsService {
      * @should not void an Obs with no changes
 	 */
 	@Authorized( { PrivilegeConstants.ADD_OBS, PrivilegeConstants.EDIT_OBS })
-	public Obs saveObs(Obs obs, String changeMessage) throws APIException;
+	Obs saveObs(Obs obs, String changeMessage) throws APIException;
 	
 	/**
 	 * Equivalent to deleting an observation
@@ -138,7 +138,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should fail if reason parameter is empty
 	 */
 	@Authorized(PrivilegeConstants.EDIT_OBS)
-	public Obs voidObs(Obs obs, String reason) throws APIException;
+	Obs voidObs(Obs obs, String reason) throws APIException;
 	
 	/**
 	 * Revive an observation (pull a Lazarus)
@@ -149,7 +149,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should cascade unvoid to child grouped obs
 	 */
 	@Authorized(PrivilegeConstants.EDIT_OBS)
-	public Obs unvoidObs(Obs obs) throws APIException;
+	Obs unvoidObs(Obs obs) throws APIException;
 	
 	/**
 	 * Completely remove an observation from the database. This should typically not be called
@@ -163,7 +163,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should delete the given obs from the database
 	 */
 	@Authorized(PrivilegeConstants.DELETE_OBS)
-	public void purgeObs(Obs obs) throws APIException;
+	void purgeObs(Obs obs) throws APIException;
 	
 	/**
 	 * Completely remove an observation from the database. This should typically not be called
@@ -181,7 +181,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should not delete referenced orders when purging obs
 	 */
 	@Authorized(PrivilegeConstants.DELETE_OBS)
-	public void purgeObs(Obs obs, boolean cascade) throws APIException;
+	void purgeObs(Obs obs, boolean cascade) throws APIException;
 
 	/**
 	 * Get all Observations for the given person, sorted by obsDatetime ascending. Does not return
@@ -194,7 +194,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should get all observations assigned to given person
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public List<Obs> getObservationsByPerson(Person who);
+	List<Obs> getObservationsByPerson(Person who);
 	
 	/**
 	 * This method fetches observations according to the criteria in the given arguments. All
@@ -228,9 +228,9 @@ public interface ObsService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
-	        Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs)
+	List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
+			Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs)
 	        throws APIException;
 	
 	/**
@@ -277,10 +277,10 @@ public interface ObsService extends OpenmrsService {
 	 * @should only return observations with matching accession number
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
-	        Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs,
-	        String accessionNumber) throws APIException;
+	List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
+			Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs,
+			String accessionNumber) throws APIException;
 	
 	/**
 	 * This method fetches the count of observations according to the criteria in the given
@@ -312,9 +312,9 @@ public interface ObsService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Integer getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
-	        Date fromDate, Date toDate, boolean includeVoidedObs) throws APIException;
+	Integer getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
+			Date fromDate, Date toDate, boolean includeVoidedObs) throws APIException;
 	
 	/**
 	 * @see org.openmrs.api.ObsService#getObservationCount(java.util.List, java.util.List,
@@ -355,9 +355,9 @@ public interface ObsService extends OpenmrsService {
 	 * @should return count of obs with matching accession number
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Integer getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
-	        Date fromDate, Date toDate, boolean includeVoidedObs, String accessionNumber) throws APIException;
+	Integer getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
+			Date fromDate, Date toDate, boolean includeVoidedObs, String accessionNumber) throws APIException;
 	
 	/**
 	 * This method searches the obs table based on the given <code>searchString</code>.
@@ -370,7 +370,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should get obs matching obsId in searchString
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public List<Obs> getObservations(String searchString) throws APIException;
+	List<Obs> getObservations(String searchString) throws APIException;
 	
 	/**
 	 * Get all nonvoided observations for the given patient with the given concept as the question
@@ -386,7 +386,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should not fail with null person parameter
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public List<Obs> getObservationsByPersonAndConcept(Person who, Concept question) throws APIException;
+	List<Obs> getObservationsByPersonAndConcept(Person who, Concept question) throws APIException;
 	
 	/**
 	 * Get a complex observation. If obs.isComplex() is true, then returns an Obs with its
@@ -401,7 +401,7 @@ public interface ObsService extends OpenmrsService {
 	 */
 	@Deprecated
 	@Authorized( { PrivilegeConstants.GET_OBS })
-	public Obs getComplexObs(Integer obsId, String view) throws APIException;
+	Obs getComplexObs(Integer obsId, String view) throws APIException;
 	
 	/**
 	 * Get the ComplexObsHandler that has been registered with the given key
@@ -412,7 +412,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should get handler with matching key
 	 * @should have default image and text handlers registered by spring
 	 */
-	public ComplexObsHandler getHandler(String key) throws APIException;
+	ComplexObsHandler getHandler(String key) throws APIException;
 	
 	/**
 	 * Get the ComplexObsHandler associated with a complex observation
@@ -425,7 +425,7 @@ public interface ObsService extends OpenmrsService {
 	 * @since 1.12
 	 * @should get handler associated with complex observation
 	 */
-	public ComplexObsHandler getHandler(Obs obs) throws APIException;
+	ComplexObsHandler getHandler(Obs obs) throws APIException;
 	
 	/**
 	 * <u>Add</u> the given map to this service's handlers. This method registers each
@@ -439,7 +439,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should override handlers with same key
 	 * @should add new handlers with new keys
 	 */
-	public void setHandlers(Map<String, ComplexObsHandler> handlers) throws APIException;
+	void setHandlers(Map<String, ComplexObsHandler> handlers) throws APIException;
 	
 	/**
 	 * Gets the handlers map registered
@@ -449,7 +449,7 @@ public interface ObsService extends OpenmrsService {
 	 * @throws APIException
 	 * @should never return null
 	 */
-	public Map<String, ComplexObsHandler> getHandlers() throws APIException;
+	Map<String, ComplexObsHandler> getHandlers() throws APIException;
 	
 	/**
 	 * Registers the given handler with the given key If the given String key exists, that handler
@@ -461,7 +461,7 @@ public interface ObsService extends OpenmrsService {
 	 * @since 1.5
 	 * @should register handler with the given key
 	 */
-	public void registerHandler(String key, ComplexObsHandler handler) throws APIException;
+	void registerHandler(String key, ComplexObsHandler handler) throws APIException;
 	
 	/**
 	 * Convenience method for {@link #registerHandler(String, ComplexObsHandler)}
@@ -472,7 +472,7 @@ public interface ObsService extends OpenmrsService {
 	 * @since 1.5
 	 * @should load handler and register key
 	 */
-	public void registerHandler(String key, String handlerClass) throws APIException;
+	void registerHandler(String key, String handlerClass) throws APIException;
 	
 	/**
 	 * Remove the handler associated with the key from list of available handlers
@@ -482,7 +482,7 @@ public interface ObsService extends OpenmrsService {
 	 * @should remove handler with matching key
 	 * @should not fail with invalid key
 	 */
-	public void removeHandler(String key) throws APIException;
+	void removeHandler(String key) throws APIException;
 	
 	/**
 	 * Gets the number of observations(including voided ones) that are using the specified
@@ -497,6 +497,6 @@ public interface ObsService extends OpenmrsService {
 	 * @since Version 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_OBS)
-	public Integer getObservationCount(List<ConceptName> conceptNames, boolean includeVoided);
+	Integer getObservationCount(List<ConceptName> conceptNames, boolean includeVoided);
 	
 }

--- a/api/src/main/java/org/openmrs/api/OpenmrsService.java
+++ b/api/src/main/java/org/openmrs/api/OpenmrsService.java
@@ -25,11 +25,11 @@ public interface OpenmrsService {
 	 * Called when the OpenMRS service layer is initializing. This occurs when a new module is
 	 * loaded or during the initial server/api start
 	 */
-	public void onStartup();
+	void onStartup();
 	
 	/**
 	 * Called when the OpenMRS service layer is shutting down
 	 */
-	public void onShutdown();
+	void onShutdown();
 	
 }

--- a/api/src/main/java/org/openmrs/api/OrderNumberGenerator.java
+++ b/api/src/main/java/org/openmrs/api/OrderNumberGenerator.java
@@ -23,5 +23,5 @@ public interface OrderNumberGenerator {
 	 * @should always return unique orderNumbers when called multiple times without saving orders
 	 * @param orderContext
 	 */
-	public String getNewOrderNumber(OrderContext orderContext);
+	String getNewOrderNumber(OrderContext orderContext);
 }

--- a/api/src/main/java/org/openmrs/api/OrderService.java
+++ b/api/src/main/java/org/openmrs/api/OrderService.java
@@ -34,7 +34,7 @@ import org.openmrs.util.PrivilegeConstants;
 public interface OrderService extends OpenmrsService {
 	
 	
-	public static final String PARALLEL_ORDERS = "PARALLEL_ORDERS";
+	String PARALLEL_ORDERS = "PARALLEL_ORDERS";
 	
 	/**
 	 * Setter for the Order data access object. The dao is used for saving and getting orders
@@ -42,7 +42,7 @@ public interface OrderService extends OpenmrsService {
 	 * 
 	 * @param dao The data access object to use
 	 */
-	public void setOrderDAO(OrderDAO dao);
+	void setOrderDAO(OrderDAO dao);
 	
 	/**
 	 * Save or update the given <code>order</code> in the database. If the OrderType for the order
@@ -105,7 +105,7 @@ public interface OrderService extends OpenmrsService {
 	 *         same drug
 	 */
 	@Authorized({ PrivilegeConstants.EDIT_ORDERS, PrivilegeConstants.ADD_ORDERS })
-	public Order saveOrder(Order order, OrderContext orderContext) throws APIException;
+	Order saveOrder(Order order, OrderContext orderContext) throws APIException;
 	
 	/**
 	 * Save or update the given retrospective <code>order</code> in the database. If the OrderType
@@ -124,7 +124,7 @@ public interface OrderService extends OpenmrsService {
 	 * @see #saveOrder(Order, OrderContext)
 	 */
 	@Authorized({ PrivilegeConstants.EDIT_ORDERS, PrivilegeConstants.ADD_ORDERS })
-	public Order saveRetrospectiveOrder(Order order, OrderContext orderContext);
+	Order saveRetrospectiveOrder(Order order, OrderContext orderContext);
 	
 	/**
 	 * Completely delete an order from the database. This should not typically be used unless
@@ -135,7 +135,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should delete order from the database
 	 */
 	@Authorized(PrivilegeConstants.PURGE_ORDERS)
-	public void purgeOrder(Order order) throws APIException;
+	void purgeOrder(Order order) throws APIException;
 	
 	/**
 	 * Completely delete an order from the database. This should not typically be used unless
@@ -151,7 +151,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should delete any Obs associated to the order when cascade is true
 	 */
 	@Authorized(PrivilegeConstants.PURGE_ORDERS)
-	public void purgeOrder(Order order, boolean cascade) throws APIException;
+	void purgeOrder(Order order, boolean cascade) throws APIException;
 	
 	/**
 	 * Mark an order as voided. This functionally removes the Order from the system while keeping a
@@ -166,7 +166,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should unset dateStopped of the previous order if the specified order is a revision
 	 */
 	@Authorized(PrivilegeConstants.DELETE_ORDERS)
-	public Order voidOrder(Order order, String voidReason) throws APIException;
+	Order voidOrder(Order order, String voidReason) throws APIException;
 	
 	/**
 	 * Get order by internal primary key identifier
@@ -176,7 +176,7 @@ public interface OrderService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public Order getOrder(Integer orderId) throws APIException;
+	Order getOrder(Integer orderId) throws APIException;
 	
 	/**
 	 * Get Order by its UUID
@@ -187,7 +187,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public Order getOrderByUuid(String uuid) throws APIException;
+	Order getOrderByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get discontinuation order for the given order, it is the un voided discontinuation order with
@@ -202,7 +202,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return null if dc order is voided
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public Order getDiscontinuationOrder(Order order) throws APIException;
+	Order getDiscontinuationOrder(Order order) throws APIException;
 	
 	/**
 	 * Get revision order for the given order, it is the order with the changes that was created as
@@ -218,7 +218,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should not return a voided revision order
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public Order getRevisionOrder(Order order) throws APIException;
+	Order getRevisionOrder(Order order) throws APIException;
 	
 	/**
 	 * Gets all Orders that match the specified parameters excluding discontinuation orders
@@ -237,7 +237,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should include orders for sub types if order type is specified
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public List<Order> getOrders(Patient patient, CareSetting careSetting, OrderType orderType, boolean includeVoided);
+	List<Order> getOrders(Patient patient, CareSetting careSetting, OrderType orderType, boolean includeVoided);
 	
 	/**
 	 * Gets all orders for the specified patient including discontinuation orders
@@ -249,7 +249,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should get all the orders for the specified patient
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public List<Order> getAllOrdersByPatient(Patient patient);
+	List<Order> getAllOrdersByPatient(Patient patient);
 	
 	/**
 	 * Unvoid order record. Reverse a previous call to {@link #voidOrder(Order, String)}
@@ -263,7 +263,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should fail for a revise order if the previousOrder is inactive
 	 */
 	@Authorized(PrivilegeConstants.DELETE_ORDERS)
-	public Order unvoidOrder(Order order) throws APIException;
+	Order unvoidOrder(Order order) throws APIException;
 	
 	/**
 	 * Gets the order identified by a given order number
@@ -274,7 +274,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return null if no object found with given order number
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public Order getOrderByOrderNumber(String orderNumber);
+	Order getOrderByOrderNumber(String orderNumber);
 	
 	/**
 	 * Gets all Order objects that use this Concept for a given patient. Orders will be returned in
@@ -289,7 +289,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should reject a null concept
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public List<Order> getOrderHistoryByConcept(Patient patient, Concept concept);
+	List<Order> getOrderHistoryByConcept(Patient patient, Concept concept);
 	
 	/**
 	 * Gets the next available order number seed
@@ -297,7 +297,7 @@ public interface OrderService extends OpenmrsService {
 	 * @return the order number seed
 	 */
 	@Authorized(PrivilegeConstants.ADD_ORDERS)
-	public Long getNextOrderNumberSeedSequenceValue();
+	Long getNextOrderNumberSeedSequenceValue();
 	
 	/**
 	 * Gets the order matching the specified order number and its previous orders in the ordering
@@ -309,7 +309,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return all order history for given order number
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public List<Order> getOrderHistoryByOrderNumber(String orderNumber);
+	List<Order> getOrderHistoryByOrderNumber(String orderNumber);
 	
 	/**
 	 * Gets all active orders for the specified patient matching the specified CareSetting,
@@ -340,7 +340,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should include orders for sub types if order type is specified
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public List<Order> getActiveOrders(Patient patient, OrderType orderType, CareSetting careSetting, Date asOfDate);
+	List<Order> getActiveOrders(Patient patient, OrderType orderType, CareSetting careSetting, Date asOfDate);
 	
 	/**
 	 * Retrieve care setting
@@ -350,7 +350,7 @@ public interface OrderService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized(PrivilegeConstants.GET_CARE_SETTINGS)
-	public CareSetting getCareSetting(Integer careSettingId);
+	CareSetting getCareSetting(Integer careSettingId);
 	
 	/**
 	 * Gets the CareSetting with the specified uuid
@@ -360,7 +360,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the care setting with the specified uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_CARE_SETTINGS)
-	public CareSetting getCareSettingByUuid(String uuid);
+	CareSetting getCareSettingByUuid(String uuid);
 	
 	/**
 	 * Gets the CareSetting with the specified name
@@ -370,7 +370,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the care setting with the specified name
 	 */
 	@Authorized(PrivilegeConstants.GET_CARE_SETTINGS)
-	public CareSetting getCareSettingByName(String name);
+	CareSetting getCareSettingByName(String name);
 	
 	/**
 	 * Gets all non retired CareSettings if includeRetired is set to true otherwise retired ones are
@@ -382,7 +382,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return retired care settings if includeRetired is set to true
 	 */
 	@Authorized(PrivilegeConstants.GET_CARE_SETTINGS)
-	public List<CareSetting> getCareSettings(boolean includeRetired);
+	List<CareSetting> getCareSettings(boolean includeRetired);
 	
 	/**
 	 * Gets OrderType that matches the specified name
@@ -393,7 +393,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the order type that matches the specified name
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public OrderType getOrderTypeByName(String orderTypeName);
+	OrderType getOrderTypeByName(String orderTypeName);
 	
 	/**
 	 * Gets OrderFrequency that matches the specified orderFrequencyId
@@ -404,7 +404,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the order frequency that matches the specified id
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_FREQUENCIES)
-	public OrderFrequency getOrderFrequency(Integer orderFrequencyId);
+	OrderFrequency getOrderFrequency(Integer orderFrequencyId);
 	
 	/**
 	 * Gets OrderFrequency that matches the specified uuid
@@ -415,7 +415,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the order frequency that matches the specified uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_FREQUENCIES)
-	public OrderFrequency getOrderFrequencyByUuid(String uuid);
+	OrderFrequency getOrderFrequencyByUuid(String uuid);
 	
 	/**
 	 * Gets an OrderFrequency that matches the specified concept
@@ -426,7 +426,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the order frequency that matches the specified concept
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_FREQUENCIES)
-	public OrderFrequency getOrderFrequencyByConcept(Concept concept);
+	OrderFrequency getOrderFrequencyByConcept(Concept concept);
 	
 	/**
 	 * Gets all order frequencies
@@ -438,7 +438,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return all the order frequencies if includeRetired is set to true
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_FREQUENCIES)
-	public List<OrderFrequency> getOrderFrequencies(boolean includeRetired);
+	List<OrderFrequency> getOrderFrequencies(boolean includeRetired);
 	
 	/**
 	 * Gets all non retired order frequencies associated to concepts that match the specified search
@@ -461,8 +461,8 @@ public interface OrderService extends OpenmrsService {
 	 * @should reject a null search phrase
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_FREQUENCIES)
-	public List<OrderFrequency> getOrderFrequencies(String searchPhrase, Locale locale, boolean exactLocale,
-	        boolean includeRetired);
+	List<OrderFrequency> getOrderFrequencies(String searchPhrase, Locale locale, boolean exactLocale,
+			boolean includeRetired);
 	
 	/**
 	 * Discontinues an order. Creates a new order that discontinues the orderToDiscontinue
@@ -485,8 +485,8 @@ public interface OrderService extends OpenmrsService {
 	 * @should not pass for a discontinued order
 	 */
 	@Authorized({ PrivilegeConstants.ADD_ORDERS, PrivilegeConstants.EDIT_ORDERS })
-	public Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate, Provider orderer,
-	        Encounter encounter);
+	Order discontinueOrder(Order orderToDiscontinue, Concept reasonCoded, Date discontinueDate, Provider orderer,
+			Encounter encounter);
 	
 	/**
 	 * Discontinues an order. Creates a new order that discontinues the orderToDiscontinue.
@@ -508,8 +508,8 @@ public interface OrderService extends OpenmrsService {
 	 * @should fail for a discontinued order
 	 */
 	@Authorized({ PrivilegeConstants.ADD_ORDERS, PrivilegeConstants.EDIT_ORDERS })
-	public Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate, Provider orderer,
-	        Encounter encounter);
+	Order discontinueOrder(Order orderToDiscontinue, String reasonNonCoded, Date discontinueDate, Provider orderer,
+			Encounter encounter);
 	
 	/**
 	 * Creates or updates the given order frequency in the database
@@ -522,7 +522,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should not allow editing an existing order frequency that is in use
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_FREQUENCIES)
-	public OrderFrequency saveOrderFrequency(OrderFrequency orderFrequency) throws APIException;
+	OrderFrequency saveOrderFrequency(OrderFrequency orderFrequency) throws APIException;
 	
 	/**
 	 * Retires the given order frequency in the database
@@ -534,7 +534,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should retire given order frequency
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_FREQUENCIES)
-	public OrderFrequency retireOrderFrequency(OrderFrequency orderFrequency, String reason);
+	OrderFrequency retireOrderFrequency(OrderFrequency orderFrequency, String reason);
 	
 	/**
 	 * Restores an order frequency that was previously retired in the database
@@ -545,7 +545,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should unretire given order frequency
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_FREQUENCIES)
-	public OrderFrequency unretireOrderFrequency(OrderFrequency orderFrequency);
+	OrderFrequency unretireOrderFrequency(OrderFrequency orderFrequency);
 	
 	/**
 	 * Completely removes an order frequency from the database
@@ -556,7 +556,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should not allow deleting an order frequency that is in use
 	 */
 	@Authorized(PrivilegeConstants.PURGE_ORDER_FREQUENCIES)
-	public void purgeOrderFrequency(OrderFrequency orderFrequency) throws APIException;
+	void purgeOrderFrequency(OrderFrequency orderFrequency) throws APIException;
 	
 	/**
 	 * Get OrderType by orderTypeId
@@ -568,7 +568,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return null if no order type object found with given id
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public OrderType getOrderType(Integer orderTypeId);
+	OrderType getOrderType(Integer orderTypeId);
 	
 	/**
 	 * Get OrderType by uuid
@@ -580,7 +580,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return null if no order type object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public OrderType getOrderTypeByUuid(String uuid);
+	OrderType getOrderTypeByUuid(String uuid);
 	
 	/**
 	 * Get all order types, if includeRetired is set to true then retired ones will be included
@@ -594,7 +594,7 @@ public interface OrderService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public List<OrderType> getOrderTypes(boolean includeRetired);
+	List<OrderType> getOrderTypes(boolean includeRetired);
 	
 	/**
 	 * Creates or updates the given order type in the database
@@ -606,7 +606,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should edit an existing order type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_TYPES)
-	public OrderType saveOrderType(OrderType orderType);
+	OrderType saveOrderType(OrderType orderType);
 	
 	/**
 	 * Completely removes an order type from the database
@@ -617,7 +617,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should not allow deleting an order type that is in use
 	 */
 	@Authorized(PrivilegeConstants.PURGE_ORDER_TYPES)
-	public void purgeOrderType(OrderType orderType) throws APIException;
+	void purgeOrderType(OrderType orderType) throws APIException;
 	
 	/**
 	 * Retires the given order type in the database
@@ -629,7 +629,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should retire order type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_TYPES)
-	public OrderType retireOrderType(OrderType orderType, String reason);
+	OrderType retireOrderType(OrderType orderType, String reason);
 	
 	/**
 	 * Restores an order type that was previously retired in the database
@@ -640,7 +640,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should unretire order type
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ORDER_TYPES)
-	public OrderType unretireOrderType(OrderType orderType);
+	OrderType unretireOrderType(OrderType orderType);
 	
 	/**
 	 * Returns all descendants of a given order type for example Given TEST will get back LAB TEST
@@ -652,7 +652,7 @@ public interface OrderService extends OpenmrsService {
 	 * @return list of order type which matches the given order type
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public List<OrderType> getSubtypes(OrderType orderType, boolean includeRetired);
+	List<OrderType> getSubtypes(OrderType orderType, boolean includeRetired);
 	
 	/**
 	 * Gets the order type mapped to a given concept class
@@ -663,7 +663,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should get order type mapped to the given concept class
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public OrderType getOrderTypeByConceptClass(ConceptClass conceptClass);
+	OrderType getOrderTypeByConceptClass(ConceptClass conceptClass);
 	
 	/**
 	 * Gets the order type mapped to a given concept
@@ -674,7 +674,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should get order type mapped to the given concept
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDER_TYPES)
-	public OrderType getOrderTypeByConcept(Concept concept);
+	OrderType getOrderTypeByConcept(Concept concept);
 	
 	/**
 	 * Gets the possible drug routes, i.e the set members for the concept that matches the uuid
@@ -686,7 +686,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return an empty list if nothing is configured
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getDrugRoutes();
+	List<Concept> getDrugRoutes();
 	
 	/**
 	 * Gets the possible drug dosing units, i.e the set members for the concept that matches the
@@ -699,7 +699,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return a list if GP is set
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getDrugDosingUnits();
+	List<Concept> getDrugDosingUnits();
 	
 	/**
 	 * Gets the possible units of dispensing, i.e the set members for the concept that matches the
@@ -713,7 +713,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return the union of the dosing and dispensing units
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getDrugDispensingUnits();
+	List<Concept> getDrugDispensingUnits();
 	
 	/**
 	 * Gets the possible units of duration, i.e the set members for the concept that matches the
@@ -726,7 +726,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return a list if GP is set
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getDurationUnits();
+	List<Concept> getDurationUnits();
 	
 	/**
 	 * Gets the possible test specimen sources, i.e the set members for the concept that matches the
@@ -739,7 +739,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return a list if GP is set
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public List<Concept> getTestSpecimenSources();
+	List<Concept> getTestSpecimenSources();
 	
 	/**
 	 * Gets the non coded drug concept, i.e the concept that matches the uuid specified as the value
@@ -751,7 +751,7 @@ public interface OrderService extends OpenmrsService {
 	 * @should return a concept if GP is set
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
-	public Concept getNonCodedDrugConcept();
+	Concept getNonCodedDrugConcept();
 	
 	/**
 	 * Fetches the OrderGroup By Uuid.
@@ -762,7 +762,7 @@ public interface OrderService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public OrderGroup getOrderGroupByUuid(String uuid) throws APIException;
+	OrderGroup getOrderGroupByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Fetches the OrderGroup by Id.
@@ -773,7 +773,7 @@ public interface OrderService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_ORDERS)
-	public OrderGroup getOrderGroup(Integer orderGroupId) throws APIException;
+	OrderGroup getOrderGroup(Integer orderGroupId) throws APIException;
 	
 	/**
 	 * Saves the orderGroup. It also saves the list of orders that are present within the
@@ -784,5 +784,5 @@ public interface OrderService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized({ PrivilegeConstants.EDIT_ORDERS, PrivilegeConstants.ADD_ORDERS })
-	public OrderGroup saveOrderGroup(OrderGroup orderGroup) throws APIException;
+	OrderGroup saveOrderGroup(OrderGroup orderGroup) throws APIException;
 }

--- a/api/src/main/java/org/openmrs/api/PatientService.java
+++ b/api/src/main/java/org/openmrs/api/PatientService.java
@@ -47,7 +47,7 @@ public interface PatientService extends OpenmrsService {
 	 * 
 	 * @param dao DAO for this service
 	 */
-	public void setPatientDAO(PatientDAO dao);
+	void setPatientDAO(PatientDAO dao);
 		
 	/**
 	 * Saved the given <code>patient</code> to the database
@@ -67,7 +67,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should not set a voided name or address or identifier as preferred
 	 */
 	@Authorized( { PrivilegeConstants.ADD_PATIENTS, PrivilegeConstants.EDIT_PATIENTS })
-	public Patient savePatient(Patient patient) throws APIException;
+	Patient savePatient(Patient patient) throws APIException;
 	
 	/**
 	 * Get patient by internal identifier
@@ -80,7 +80,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null when patient with given patient id does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public Patient getPatient(Integer patientId) throws APIException;
+	Patient getPatient(Integer patientId) throws APIException;
 	
 	/**
 	 * Get patient by internal identifier. If this id is for an existing person then instantiates a
@@ -103,7 +103,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null if patient not found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public Patient getPatientByUuid(String uuid) throws APIException;
+	Patient getPatientByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get patient identifier by universally unique identifier.
@@ -115,7 +115,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null if patient identifier not found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_IDENTIFIERS })
-	public PatientIdentifier getPatientIdentifierByUuid(String uuid) throws APIException;
+	PatientIdentifier getPatientIdentifierByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns all non voided patients in the system
@@ -126,7 +126,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should fetch all non voided patients
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getAllPatients() throws APIException;
+	List<Patient> getAllPatients() throws APIException;
 	
 	/**
 	 * Returns patients in the system
@@ -138,7 +138,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should fetch non voided patients when given include voided is false
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getAllPatients(boolean includeVoided) throws APIException;
+	List<Patient> getAllPatients(boolean includeVoided) throws APIException;
 		
 	/**
 	 * Get patients based on given criteria The identifier is matched with the regex
@@ -169,8 +169,8 @@ public interface PatientService extends OpenmrsService {
 	 * @should return empty list if name and identifier is empty
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getPatients(String name, String identifier, List<PatientIdentifierType> identifierTypes,
-	        boolean matchIdentifierExactly) throws APIException;
+	List<Patient> getPatients(String name, String identifier, List<PatientIdentifierType> identifierTypes,
+			boolean matchIdentifierExactly) throws APIException;
 	
 	/**
 	 * Void patient record (functionally delete patient from system). Voids Person and retires
@@ -187,7 +187,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should retire users
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_PATIENTS })
-	public Patient voidPatient(Patient patient, String reason) throws APIException;
+	Patient voidPatient(Patient patient, String reason) throws APIException;
 	
 	/**
 	 * Unvoid patient record. Unvoids Person as well.
@@ -200,7 +200,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should not unretire users
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_PATIENTS })
-	public Patient unvoidPatient(Patient patient) throws APIException;
+	Patient unvoidPatient(Patient patient) throws APIException;
 		
 	/**
 	 * Delete patient from database. This <b>should not be called</b> except for testing and
@@ -212,7 +212,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should delete patient from database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PATIENTS })
-	public void purgePatient(Patient patient) throws APIException;
+	void purgePatient(Patient patient) throws APIException;
 		
 	/**
 	 * Get all patientIdentifiers that match all of the given criteria Voided identifiers are not
@@ -237,9 +237,9 @@ public interface PatientService extends OpenmrsService {
 	 * @should fetch preferred and non preferred patient identifiers when given is preferred is null
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_IDENTIFIERS })
-	public List<PatientIdentifier> getPatientIdentifiers(String identifier,
-	        List<PatientIdentifierType> patientIdentifierTypes, List<Location> locations, List<Patient> patients,
-	        Boolean isPreferred) throws APIException;
+	List<PatientIdentifier> getPatientIdentifiers(String identifier,
+			List<PatientIdentifierType> patientIdentifierTypes, List<Location> locations, List<Patient> patients,
+			Boolean isPreferred) throws APIException;
 		
 	/**
 	 * Create or update a PatientIdentifierType
@@ -253,7 +253,7 @@ public interface PatientService extends OpenmrsService {
 	 *         types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_IDENTIFIER_TYPES })
-	public PatientIdentifierType savePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws APIException;
+	PatientIdentifierType savePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws APIException;
 		
 	/**
 	 * Get all patientIdentifier types
@@ -266,7 +266,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should order as default comparator
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public List<PatientIdentifierType> getAllPatientIdentifierTypes() throws APIException;
+	List<PatientIdentifierType> getAllPatientIdentifierTypes() throws APIException;
 	
 	/**
 	 * Get all patientIdentifier types.
@@ -281,7 +281,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should order as default comparator
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public List<PatientIdentifierType> getAllPatientIdentifierTypes(boolean includeRetired) throws APIException;
+	List<PatientIdentifierType> getAllPatientIdentifierTypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get all patientIdentifier types that match the given criteria
@@ -307,8 +307,8 @@ public interface PatientService extends OpenmrsService {
 	 * @should order as default comparator
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public List<PatientIdentifierType> getPatientIdentifierTypes(String name, String format, Boolean required,
-	        Boolean hasCheckDigit) throws APIException;
+	List<PatientIdentifierType> getPatientIdentifierTypes(String name, String format, Boolean required,
+			Boolean hasCheckDigit) throws APIException;
 	
 	/**
 	 * Get patientIdentifierType by internal identifier
@@ -320,7 +320,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null when patient identifier identifier does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public PatientIdentifierType getPatientIdentifierType(Integer patientIdentifierTypeId) throws APIException;
+	PatientIdentifierType getPatientIdentifierType(Integer patientIdentifierTypeId) throws APIException;
 	
 	/**
 	 * Get patient identifierType by universally unique identifier
@@ -332,7 +332,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null when patient identifier type with given uuid does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public PatientIdentifierType getPatientIdentifierTypeByUuid(String uuid) throws APIException;
+	PatientIdentifierType getPatientIdentifierTypeByUuid(String uuid) throws APIException;
 		
 	/**
 	 * Get patientIdentifierType by exact name
@@ -345,7 +345,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null when patient identifier type with given name does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_IDENTIFIER_TYPES })
-	public PatientIdentifierType getPatientIdentifierTypeByName(String name) throws APIException;
+	PatientIdentifierType getPatientIdentifierTypeByName(String name) throws APIException;
 	
 	/**
 	 * Retire a type of patient identifier
@@ -360,7 +360,7 @@ public interface PatientService extends OpenmrsService {
 	 *         types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_IDENTIFIER_TYPES })
-	public PatientIdentifierType retirePatientIdentifierType(PatientIdentifierType patientIdentifierType, String reason)
+	PatientIdentifierType retirePatientIdentifierType(PatientIdentifierType patientIdentifierType, String reason)
 	        throws APIException;
 	
 	/**
@@ -375,7 +375,7 @@ public interface PatientService extends OpenmrsService {
 	 *         identifier types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_IDENTIFIER_TYPES })
-	public PatientIdentifierType unretirePatientIdentifierType(PatientIdentifierType patientIdentifierType)
+	PatientIdentifierType unretirePatientIdentifierType(PatientIdentifierType patientIdentifierType)
 	        throws APIException;
 	
 	/**
@@ -389,7 +389,7 @@ public interface PatientService extends OpenmrsService {
 	 *         types are locked
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_IDENTIFIER_TYPES })
-	public void purgePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws APIException;
+	void purgePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws APIException;
 		
 	/**
 	 * Convenience method to validate all identifiers for a given patient
@@ -408,7 +408,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should require one non voided patient identifier
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_IDENTIFIERS })
-	public void checkPatientIdentifiers(Patient patient) throws PatientIdentifierException;
+	void checkPatientIdentifiers(Patient patient) throws PatientIdentifierException;
 		
 	/**
 	 * Generic search on patients based on the given string. Implementations can use this string to
@@ -425,7 +425,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should not fail when minimum search characters is invalid integer
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getPatients(String query) throws APIException;
+	List<Patient> getPatients(String query) throws APIException;
 	
 	/**
 	 * Generic search on patients based on the given string and returns a specific number of them
@@ -442,7 +442,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should find a patients with a matching identifier with no digits
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getPatients(String query, Integer start, Integer length) throws APIException;
+	List<Patient> getPatients(String query, Integer start, Integer length) throws APIException;
 	
 	/**
 	 * @param query the string to search on
@@ -454,7 +454,7 @@ public interface PatientService extends OpenmrsService {
 	 * @since 1.11
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getPatients(String query, boolean includeVoided, Integer start, Integer length) throws APIException;
+	List<Patient> getPatients(String query, boolean includeVoided, Integer start, Integer length) throws APIException;
 		
 	/**
 	 * This method tries to find a patient in the database given the attributes on the given
@@ -469,7 +469,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return null when no patient matches given patient to match
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public Patient getPatientByExample(Patient patientToMatch) throws APIException;
+	Patient getPatientByExample(Patient patientToMatch) throws APIException;
 		
 	/**
 	 * Search the database for patients that both share the given attributes. Each attribute that is
@@ -484,7 +484,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should not return patients that exactly match on some but not all given attributes
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getDuplicatePatientsByAttributes(List<String> attributes) throws APIException;
+	List<Patient> getDuplicatePatientsByAttributes(List<String> attributes) throws APIException;
 	
 	/**
 	 * Convenience method to join two patients' information into one record.
@@ -547,7 +547,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should fail if not preferred patient has unvoided orders
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PATIENTS })
-	public void mergePatients(Patient preferred, Patient notPreferred) throws APIException, SerializationException;
+	void mergePatients(Patient preferred, Patient notPreferred) throws APIException, SerializationException;
 	
 	/**
 	 * Convenience method to join multiple patients' information into one record.
@@ -558,7 +558,7 @@ public interface PatientService extends OpenmrsService {
 	 * @throws SerializationException
 	 * @should merge all non Preferred patients in the the notPreferred list to preferred patient
 	 */
-	public void mergePatients(Patient preferred, List<Patient> notPreferred) throws APIException, SerializationException;
+	void mergePatients(Patient preferred, List<Patient> notPreferred) throws APIException, SerializationException;
 		
 	/**
 	 * Convenience method to establish that a patient has died. In addition to exiting the patient
@@ -574,7 +574,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should throw API exception if patient is null 
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PATIENTS })
-	public void processDeath(Patient patient, Date dateDied, Concept causeOfDeath, String otherReason) throws APIException;
+	void processDeath(Patient patient, Date dateDied, Concept causeOfDeath, String otherReason) throws APIException;
 	
 	/**
 	 * Convenience method that saves the Obs that indicates when and why the patient died (including
@@ -596,7 +596,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should be tested more thoroughly
 	 */
 	@Authorized(value = { PrivilegeConstants.GET_PATIENTS, PrivilegeConstants.EDIT_OBS }, requireAll = true)
-	public void saveCauseOfDeathObs(Patient patient, Date dateDied, Concept causeOfDeath, String otherReason)
+	void saveCauseOfDeathObs(Patient patient, Date dateDied, Concept causeOfDeath, String otherReason)
 	        throws APIException;
 	
 	/**
@@ -605,25 +605,25 @@ public interface PatientService extends OpenmrsService {
 	 * @param clazz identifierValidator which validator to get.
 	 * @should return patient identifier validator given class
 	 */
-	public IdentifierValidator getIdentifierValidator(Class<IdentifierValidator> clazz);
+	IdentifierValidator getIdentifierValidator(Class<IdentifierValidator> clazz);
 	
 	/**
 	 * @should return patient identifier validator given class name
 	 * @should treat empty strings like a null entry
 	 */
-	public IdentifierValidator getIdentifierValidator(String pivClassName);
+	IdentifierValidator getIdentifierValidator(String pivClassName);
 	
 	/**
 	 * @return the default IdentifierValidator
 	 * @should return default patient identifier validator
 	 */
-	public IdentifierValidator getDefaultIdentifierValidator();
+	IdentifierValidator getDefaultIdentifierValidator();
 	
 	/**
 	 * @return All registered PatientIdentifierValidators
 	 * @should return all registered patient identifier validators
 	 */
-	public Collection<IdentifierValidator> getAllIdentifierValidators();
+	Collection<IdentifierValidator> getAllIdentifierValidators();
 	
 	/**
 	 * Checks whether the given patient identifier is already assigned to a patient other than
@@ -647,7 +647,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return true if in use and id type uniqueness is null
 	 */
 	@Authorized(PrivilegeConstants.GET_PATIENTS)
-	public boolean isIdentifierInUseByAnotherPatient(PatientIdentifier patientIdentifier);
+	boolean isIdentifierInUseByAnotherPatient(PatientIdentifier patientIdentifier);
 	
 	/**
 	 * Returns a patient identifier that matches the given patientIndentifier id
@@ -658,7 +658,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return the patientIdentifier with the given id
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_IDENTIFIERS })
-	public PatientIdentifier getPatientIdentifier(Integer patientIdentifierId) throws APIException;
+	PatientIdentifier getPatientIdentifier(Integer patientIdentifierId) throws APIException;
 	
 	/**
 	 * Void patient identifier (functionally delete patient identifier from system)
@@ -673,7 +673,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should throw an APIException if the reason is a white space character
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_PATIENT_IDENTIFIERS })
-	public PatientIdentifier voidPatientIdentifier(PatientIdentifier patientIdentifier, String reason) throws APIException;
+	PatientIdentifier voidPatientIdentifier(PatientIdentifier patientIdentifier, String reason) throws APIException;
 	
 	/**
 	 * Saved the given <code>patientIndentifier</code> to the database
@@ -689,7 +689,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should throw an APIException if the patientIdentifier string is an empty string
 	 */
 	@Authorized( { PrivilegeConstants.ADD_PATIENT_IDENTIFIERS, PrivilegeConstants.EDIT_PATIENT_IDENTIFIERS })
-	public PatientIdentifier savePatientIdentifier(PatientIdentifier patientIdentifier) throws APIException;
+	PatientIdentifier savePatientIdentifier(PatientIdentifier patientIdentifier) throws APIException;
 	
 	/**
 	 * Purge PatientIdentifier (cannot be undone)
@@ -699,7 +699,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should delete patient identifier from database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PATIENT_IDENTIFIERS })
-	public void purgePatientIdentifier(PatientIdentifier patientIdentifier) throws APIException;
+	void purgePatientIdentifier(PatientIdentifier patientIdentifier) throws APIException;
 	
 	/**
 	 * Gets allergies for a given patient
@@ -741,7 +741,7 @@ public interface PatientService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.GET_ALLERGIES })
-	public Allergy getAllergy(Integer allergyListId) throws APIException;
+	Allergy getAllergy(Integer allergyListId) throws APIException;
 	
 	/**
 	 * Returns the Allergy identified by uuid
@@ -754,7 +754,7 @@ public interface PatientService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.GET_ALLERGIES })
-	public Allergy getAllergyByUuid(String uuid) throws APIException;
+	Allergy getAllergyByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Creates an AllergyListItem to the Patient's Allergy Active List. Sets the start date to now,
@@ -765,7 +765,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should save the allergy
 	 */
 	@Authorized( { PrivilegeConstants.ADD_ALLERGIES, PrivilegeConstants.EDIT_ALLERGIES })
-	public void saveAllergy(Allergy allergy) throws APIException;
+	void saveAllergy(Allergy allergy) throws APIException;
 	
 	/**
 	 * Resolving the allergy, effectively removes the Allergy from the Patient's Active List by
@@ -777,7 +777,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should set the end date for the allergy
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_ALLERGIES })
-	public void removeAllergy(Allergy allergy, String reason) throws APIException;
+	void removeAllergy(Allergy allergy, String reason) throws APIException;
 	
 	/**
 	 * Used only in cases where the Allergy was entered by error
@@ -787,7 +787,7 @@ public interface PatientService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_ALLERGIES })
-	public void voidAllergy(Allergy allergy, String reason) throws APIException;
+	void voidAllergy(Allergy allergy, String reason) throws APIException;
 	
 	/**
 	 * Return the number of unvoided patients with names or patient identifiers or searchable person
@@ -800,7 +800,7 @@ public interface PatientService extends OpenmrsService {
 	 * @should return the right count of patients with a matching identifier with no digits
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public Integer getCountOfPatients(String query);
+	Integer getCountOfPatients(String query);
 	
 	/**
 	 * @param query the string to search on
@@ -808,7 +808,7 @@ public interface PatientService extends OpenmrsService {
 	 * @return the number of patients matching the given search phrase
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public Integer getCountOfPatients(String query, boolean includeVoided);
+	Integer getCountOfPatients(String query, boolean includeVoided);
 	
 	/**
 	 * Get a limited size of patients from a given start index based on given criteria The
@@ -830,8 +830,8 @@ public interface PatientService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENTS })
-	public List<Patient> getPatients(String name, String identifier, List<PatientIdentifierType> identifierTypes,
-	        boolean matchIdentifierExactly, Integer start, Integer length) throws APIException;
+	List<Patient> getPatients(String name, String identifier, List<PatientIdentifierType> identifierTypes,
+			boolean matchIdentifierExactly, Integer start, Integer length) throws APIException;
 	
 	/**
 	 * Check if patient identifier types are locked, and if they are, throws an exception during
@@ -839,5 +839,5 @@ public interface PatientService extends OpenmrsService {
 	 * 
 	 * @throws PatientIdentifierTypeLockedException
 	 */
-	public void checkIfPatientIdentifierTypesAreLocked() throws PatientIdentifierTypeLockedException;
+	void checkIfPatientIdentifierTypesAreLocked() throws PatientIdentifierTypeLockedException;
 }

--- a/api/src/main/java/org/openmrs/api/PersonService.java
+++ b/api/src/main/java/org/openmrs/api/PersonService.java
@@ -50,7 +50,7 @@ public interface PersonService extends OpenmrsService {
 	 * off a lot of patients/users, one set of types are shown. When only displaying one
 	 * patient/user, another type is shown.
 	 */
-	public static enum ATTR_VIEW_TYPE {
+	enum ATTR_VIEW_TYPE {
 		/**
 		 * Attributes to be shown when listing off multiple patients or users
 		 */
@@ -73,7 +73,7 @@ public interface PersonService extends OpenmrsService {
 	 * 
 	 * @param dao DAO for this service
 	 */
-	public void setPersonDAO(PersonDAO dao);
+	void setPersonDAO(PersonDAO dao);
 	
 	/**
 	 * Find a similar person given the attributes. This does a very loose lookup with the
@@ -94,7 +94,7 @@ public interface PersonService extends OpenmrsService {
 	 */
 	// TODO: make gender a (definable?) constant
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public Set<Person> getSimilarPeople(String nameSearch, Integer birthyear, String gender) throws APIException;
+	Set<Person> getSimilarPeople(String nameSearch, Integer birthyear, String gender) throws APIException;
 		
 	/**
 	 * Find a person matching the <tt>searchPhrase</tt> search string
@@ -106,10 +106,10 @@ public interface PersonService extends OpenmrsService {
 	 * @should match search to familyName2
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public List<Person> getPeople(String searchPhrase, Boolean dead) throws APIException;
+	List<Person> getPeople(String searchPhrase, Boolean dead) throws APIException;
 	
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public List<Person> getPeople(String searchPhrase, Boolean dead, Boolean voided) throws APIException;
+	List<Person> getPeople(String searchPhrase, Boolean dead, Boolean voided) throws APIException;
 		
 	/**
 	 * Save the given person attribute type in the database. <br>
@@ -126,7 +126,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should throw an error when trying to save person attribute type while person attribute types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttributeType savePersonAttributeType(PersonAttributeType type) throws APIException;
+	PersonAttributeType savePersonAttributeType(PersonAttributeType type) throws APIException;
 	
 	/**
 	 * Retire a Person Attribute Type
@@ -136,7 +136,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should throw an error when trying to retire person attribute type while person attribute types are locked
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttributeType retirePersonAttributeType(PersonAttributeType type, String retiredReason) throws APIException;
+	PersonAttributeType retirePersonAttributeType(PersonAttributeType type, String retiredReason) throws APIException;
 	
 	/**
 	 * Retire a Person Relationship Type
@@ -145,7 +145,7 @@ public interface PersonService extends OpenmrsService {
 	 * @param retiredReason
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES })
-	public RelationshipType retireRelationshipType(RelationshipType type, String retiredReason) throws APIException;
+	RelationshipType retireRelationshipType(RelationshipType type, String retiredReason) throws APIException;
 	
 	/**
 	 * Unretire a Person Relationship Type
@@ -154,7 +154,7 @@ public interface PersonService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES })
-	public RelationshipType unretireRelationshipType(RelationshipType relationshipType);
+	RelationshipType unretireRelationshipType(RelationshipType relationshipType);
 	
 	/**
 	 * Purges a PersonAttribute type from the database (cannot be undone)
@@ -165,7 +165,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should throw an error when trying to delete person attribute type while person attribute types are locked
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PERSON_ATTRIBUTE_TYPES })
-	public void purgePersonAttributeType(PersonAttributeType type) throws APIException;
+	void purgePersonAttributeType(PersonAttributeType type) throws APIException;
 	
 	/**
 	 * Unretires a PersonAttribute type from the database (can be undone)
@@ -177,7 +177,7 @@ public interface PersonService extends OpenmrsService {
 	 */
 	
 	@Authorized( { PrivilegeConstants.MANAGE_PERSON_ATTRIBUTE_TYPES })
-	public void unretirePersonAttributeType(PersonAttributeType type) throws APIException;
+	void unretirePersonAttributeType(PersonAttributeType type) throws APIException;
 	
 	/**
 	 * Effectively removes this person from the system. Voids Patient and retires Users as well.
@@ -190,7 +190,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should retire users
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public Person voidPerson(Person person, String reason) throws APIException;
+	Person voidPerson(Person person, String reason) throws APIException;
 	
 	/**
 	 * Effectively resurrects this person in the db. Unvoids Patient as well.
@@ -202,7 +202,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should not unretire users
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public Person unvoidPerson(Person person) throws APIException;
+	Person unvoidPerson(Person person) throws APIException;
 		
 	/**
 	 * Get all PersonAttributeTypes in the database
@@ -212,7 +212,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return all person attribute types including retired
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public List<PersonAttributeType> getAllPersonAttributeTypes() throws APIException;
+	List<PersonAttributeType> getAllPersonAttributeTypes() throws APIException;
 	
 	/**
 	 * Get all PersonAttributeTypes in the database with the option of including the retired types
@@ -224,7 +224,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return all person attribute types excluding retired when include retired is false
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public List<PersonAttributeType> getAllPersonAttributeTypes(boolean includeRetired) throws APIException;
+	List<PersonAttributeType> getAllPersonAttributeTypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Find person attribute types matching the given parameters. Retired types are included in the
@@ -241,8 +241,8 @@ public interface PersonService extends OpenmrsService {
 	 * @should return empty list when no person attribute types match given parameters
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public List<PersonAttributeType> getPersonAttributeTypes(String exactName, String format, Integer foreignKey,
-	        Boolean searchable) throws APIException;
+	List<PersonAttributeType> getPersonAttributeTypes(String exactName, String format, Integer foreignKey,
+			Boolean searchable) throws APIException;
 	
 	/**
 	 * Get the PersonAttributeType given the type's PersonAttributeTypeId
@@ -252,7 +252,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when no person attribute with the given id exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttributeType getPersonAttributeType(Integer typeId) throws APIException;
+	PersonAttributeType getPersonAttributeType(Integer typeId) throws APIException;
 	
 	/**
 	 * Gets a person attribute type with the given uuid.
@@ -263,7 +263,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttributeType getPersonAttributeTypeByUuid(String uuid);
+	PersonAttributeType getPersonAttributeTypeByUuid(String uuid);
 	
 	/**
 	 * Get a PersonAttribute from the database with the given PersonAttributeid
@@ -275,7 +275,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return person attribute when PersonAttribute with given id does exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttribute getPersonAttribute(Integer id) throws APIException;
+	PersonAttribute getPersonAttribute(Integer id) throws APIException;
 	
 	/**
 	 * Get the PersonAttributeType given the type's name
@@ -286,7 +286,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when no person attribute type match given typeName
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSON_ATTRIBUTE_TYPES })
-	public PersonAttributeType getPersonAttributeTypeByName(String typeName) throws APIException;
+	PersonAttributeType getPersonAttributeTypeByName(String typeName) throws APIException;
 	
 	/**
 	 * Get relationship by internal relationship identifier
@@ -298,7 +298,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when relationship with given id does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public Relationship getRelationship(Integer relationshipId) throws APIException;
+	Relationship getRelationship(Integer relationshipId) throws APIException;
 	
 	/**
 	 * Get Relationship by its UUID
@@ -309,7 +309,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public Relationship getRelationshipByUuid(String uuid) throws APIException;
+	Relationship getRelationshipByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get list of relationships that are not voided
@@ -320,7 +320,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return all unvoided relationships
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getAllRelationships() throws APIException;
+	List<Relationship> getAllRelationships() throws APIException;
 	
 	/**
 	 * Get list of relationships optionally including the voided ones or not
@@ -332,7 +332,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return all relationship excluding voided when include voided equals false
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getAllRelationships(boolean includeVoided) throws APIException;
+	List<Relationship> getAllRelationships(boolean includeVoided) throws APIException;
 		
 	/**
 	 * Get list of relationships that include Person in person_id or relative_id Does not include
@@ -346,7 +346,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should fetch unvoided relationships only
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getRelationshipsByPerson(Person p) throws APIException;
+	List<Relationship> getRelationshipsByPerson(Person p) throws APIException;
 	
 	/**
 	 * Get list of relationships that include Person in person_id or relative_id. Does not include
@@ -365,7 +365,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should fetch relationships that were active during effectiveDate
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getRelationshipsByPerson(Person p, Date effectiveDate) throws APIException;
+	List<Relationship> getRelationshipsByPerson(Person p, Date effectiveDate) throws APIException;
 		
 	/**
 	 * Get relationships stored in the database that
@@ -381,7 +381,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return empty list when no relationship matching given parameters exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType)
+	List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType)
 	        throws APIException;
 	
 	/**
@@ -400,8 +400,8 @@ public interface PersonService extends OpenmrsService {
 	 * @should fetch relationships that were active during effectiveDate
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
-	        Date effectiveDate) throws APIException;
+	List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
+			Date effectiveDate) throws APIException;
 	
 	/**
 	 * Get relationships stored in the database that were active during the specified date range
@@ -422,8 +422,8 @@ public interface PersonService extends OpenmrsService {
 	 * @should fetch relationships that were active during the specified date range
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
-	        Date startEffectiveDate, Date endEffectiveDate) throws APIException;
+	List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
+			Date startEffectiveDate, Date endEffectiveDate) throws APIException;
 	
 	/**
 	 * Get all relationshipTypes Includes retired relationship types
@@ -433,7 +433,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return all relationship types
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public List<RelationshipType> getAllRelationshipTypes() throws APIException;
+	List<RelationshipType> getAllRelationshipTypes() throws APIException;
 	
 	/**
 	 * Get all relationshipTypes with the option of including the retired types
@@ -443,7 +443,7 @@ public interface PersonService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public List<RelationshipType> getAllRelationshipTypes(boolean includeRetired) throws APIException;
+	List<RelationshipType> getAllRelationshipTypes(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get relationshipType by internal identifier
@@ -455,7 +455,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when no relationship type matches given relationship type id
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public RelationshipType getRelationshipType(Integer relationshipTypeId) throws APIException;
+	RelationshipType getRelationshipType(Integer relationshipTypeId) throws APIException;
 	
 	/**
 	 * Gets the relationship type with the given uuid.
@@ -467,7 +467,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public RelationshipType getRelationshipTypeByUuid(String uuid) throws APIException;
+	RelationshipType getRelationshipTypeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Find relationshipType by exact name match
@@ -478,7 +478,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when no relationship type match the given name
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public RelationshipType getRelationshipTypeByName(String relationshipTypeName) throws APIException;
+	RelationshipType getRelationshipTypeByName(String relationshipTypeName) throws APIException;
 	
 	/**
 	 * Find relationshipTypes by exact name match and/or preferred status
@@ -492,7 +492,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return empty list when no preferred relationship type match the given name
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public List<RelationshipType> getRelationshipTypes(String relationshipTypeName, Boolean preferred) throws APIException;
+	List<RelationshipType> getRelationshipTypes(String relationshipTypeName, Boolean preferred) throws APIException;
 	
 	/**
 	 * Get relationshipTypes by searching through the names and loosely matching to the given
@@ -504,7 +504,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return empty list when no relationship type match the search string
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIP_TYPES })
-	public List<RelationshipType> getRelationshipTypes(String searchString) throws APIException;
+	List<RelationshipType> getRelationshipTypes(String searchString) throws APIException;
 	
 	/**
 	 * Create or update a relationship between people. Saves the given <code>relationship</code> to
@@ -517,7 +517,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should update existing object when relationship id is not null
 	 */
 	@Authorized( { PrivilegeConstants.ADD_RELATIONSHIPS, PrivilegeConstants.EDIT_RELATIONSHIPS })
-	public Relationship saveRelationship(Relationship relationship) throws APIException;
+	Relationship saveRelationship(Relationship relationship) throws APIException;
 	
 	/**
 	 * Purges a relationship from the database (cannot be undone)
@@ -527,7 +527,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should delete relationship from the database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_RELATIONSHIPS })
-	public void purgeRelationship(Relationship relationship) throws APIException;
+	void purgeRelationship(Relationship relationship) throws APIException;
 	
 	/**
 	 * Voids the given Relationship, effectively removing it from openmrs.
@@ -539,7 +539,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should void relationship with the given reason
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_RELATIONSHIPS })
-	public Relationship voidRelationship(Relationship relationship, String voidReason) throws APIException;
+	Relationship voidRelationship(Relationship relationship, String voidReason) throws APIException;
 	
 	/**
 	 * Unvoid Relationship in the database, effectively marking this as a valid relationship again
@@ -550,7 +550,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should unvoid voided relationship
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_RELATIONSHIPS })
-	public Relationship unvoidRelationship(Relationship relationship) throws APIException;
+	Relationship unvoidRelationship(Relationship relationship) throws APIException;
 	
 	/**
 	 * Creates or updates a Person in the database
@@ -565,7 +565,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should not set a voided name or address as preferred
 	 */
 	@Authorized( { PrivilegeConstants.ADD_PERSONS, PrivilegeConstants.EDIT_PERSONS })
-	public Person savePerson(Person person) throws APIException;
+	Person savePerson(Person person) throws APIException;
 	
 	/**
 	 * Purges a person from the database (cannot be undone)
@@ -575,7 +575,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should delete person from the database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PERSONS })
-	public void purgePerson(Person person) throws APIException;
+	void purgePerson(Person person) throws APIException;
 	
 	/**
 	 * Get Person by its UUID
@@ -586,7 +586,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public Person getPersonByUuid(String uuid) throws APIException;
+	Person getPersonByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get PersonAddress by its UUID
@@ -597,7 +597,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public PersonAddress getPersonAddressByUuid(String uuid) throws APIException;
+	PersonAddress getPersonAddressByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get PersonAttribute by its UUID
@@ -608,7 +608,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public PersonAttribute getPersonAttributeByUuid(String uuid) throws APIException;
+	PersonAttribute getPersonAttributeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get PersonName by its personNameId
@@ -630,7 +630,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public PersonName getPersonNameByUuid(String uuid) throws APIException;
+	PersonName getPersonNameByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Gets a person by internal id
@@ -641,7 +641,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return null when no person has the given id
 	 */
 	@Authorized( { PrivilegeConstants.GET_PERSONS })
-	public Person getPerson(Integer personId) throws APIException;
+	Person getPerson(Integer personId) throws APIException;
 	
 	/**
 	 * Inserts or updates the given relationship type object in the database
@@ -654,7 +654,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should fail if the description is not specified
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES })
-	public RelationshipType saveRelationshipType(RelationshipType relationshipType) throws APIException;
+	RelationshipType saveRelationshipType(RelationshipType relationshipType) throws APIException;
 	
 	/**
 	 * Purge relationship type from the database (cannot be undone)
@@ -664,7 +664,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should delete relationship type from the database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_RELATIONSHIP_TYPES })
-	public void purgeRelationshipType(RelationshipType relationshipType) throws APIException;
+	void purgeRelationshipType(RelationshipType relationshipType) throws APIException;
 	
 	/**
 	 * Gets the types defined for the given person type (person, user, patient) and the given type
@@ -676,7 +676,7 @@ public interface PersonService extends OpenmrsService {
 	 * @return list of PersonAttributeTypes that should be displayed
 	 */
 	// this has anonymous access because its cached into generic js files
-	public List<PersonAttributeType> getPersonAttributeTypes(PERSON_TYPE personType, ATTR_VIEW_TYPE viewType)
+	List<PersonAttributeType> getPersonAttributeTypes(PERSON_TYPE personType, ATTR_VIEW_TYPE viewType)
 	        throws APIException;
 	
 	/**
@@ -689,7 +689,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should void personName with the given reason
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonName voidPersonName(PersonName personName, String voidReason);
+	PersonName voidPersonName(PersonName personName, String voidReason);
 	
 	/**
 	 * Unvoid PersonName in the database, effectively marking this as a valid personName again
@@ -700,7 +700,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should unvoid voided personName
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonName unvoidPersonName(PersonName personName) throws APIException;
+	PersonName unvoidPersonName(PersonName personName) throws APIException;
 	
 	/**
 	 * Inserts or updates the given personName object in the database
@@ -711,7 +711,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should fail if you try to void the last non voided name
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonName savePersonName(PersonName personName);
+	PersonName savePersonName(PersonName personName);
 	
 	/**
 	 * Parses a name into a PersonName (separate Given, Middle, and Family names)
@@ -724,7 +724,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should not fail when ending with a comma
 	 * @should parse four person name
 	 */
-	public PersonName parsePersonName(String name) throws APIException;
+	PersonName parsePersonName(String name) throws APIException;
 	
 	/**
 	 * Get all relationships for a given type of relationship mapped from the personA to all of the
@@ -736,7 +736,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should return empty map when no relationship has the matching relationship type
 	 */
 	@Authorized( { PrivilegeConstants.GET_RELATIONSHIPS })
-	public Map<Person, List<Person>> getRelationshipMap(RelationshipType relationshipType) throws APIException;
+	Map<Person, List<Person>> getRelationshipMap(RelationshipType relationshipType) throws APIException;
 	
 	/**
 	 * Builds the serialized data from
@@ -756,7 +756,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should serialize PersonMergeLogData
 	 * @should save PersonMergeLog
 	 */
-	public PersonMergeLog savePersonMergeLog(PersonMergeLog personMergeLog) throws SerializationException, APIException;
+	PersonMergeLog savePersonMergeLog(PersonMergeLog personMergeLog) throws SerializationException, APIException;
 	
 	/**
 	 * Gets a PersonMergeLog object from the model using the UUID identifier. Deserializes the
@@ -770,7 +770,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should retrieve personMergeLog without deserializing data
 	 * @should retrieve personMergeLog and deserialize data
 	 */
-	public PersonMergeLog getPersonMergeLogByUuid(String uuid, boolean deserialize) throws SerializationException,
+	PersonMergeLog getPersonMergeLogByUuid(String uuid, boolean deserialize) throws SerializationException,
 	        APIException;
 	
 	/**
@@ -781,7 +781,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should retrieve all PersonMergeLogs from the model
 	 * @should retrieve all PersonMergeLogs and deserialize them
 	 */
-	public List<PersonMergeLog> getAllPersonMergeLogs(boolean deserialize) throws SerializationException;
+	List<PersonMergeLog> getAllPersonMergeLogs(boolean deserialize) throws SerializationException;
 	
 	/**
 	 * Gets <code>PersonMergeLog</code> objects by winning person p. Useful for to getting all persons merged into p.
@@ -790,7 +790,7 @@ public interface PersonService extends OpenmrsService {
 	 * @throws SerializationException
 	 * @should retrieve PersonMergeLogs by winner
 	 */
-	public List<PersonMergeLog> getWinningPersonMergeLogs(Person person, boolean deserialize) throws SerializationException;
+	List<PersonMergeLog> getWinningPersonMergeLogs(Person person, boolean deserialize) throws SerializationException;
 	
 	/**
 	 * Gets the <code>PersonMergeLog</code> where person p is the loser. Useful for getting the person that p was merged into.
@@ -799,7 +799,7 @@ public interface PersonService extends OpenmrsService {
 	 * @throws SerializationException
 	 * @should find PersonMergeLog by loser
 	 */
-	public PersonMergeLog getLosingPersonMergeLog(Person person, boolean deserialize) throws SerializationException;
+	PersonMergeLog getLosingPersonMergeLog(Person person, boolean deserialize) throws SerializationException;
 	
 	/**
 	 * Voids the given PersonAddress, effectively deleting the personAddress, from the end-user's
@@ -812,7 +812,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should void personAddress with the given reason
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonAddress voidPersonAddress(PersonAddress personAddress, String voidReason);
+	PersonAddress voidPersonAddress(PersonAddress personAddress, String voidReason);
 	
 	/**
 	 * Unvoid PersonAddress in the database, effectively marking this as a valid PersonAddress again
@@ -823,7 +823,7 @@ public interface PersonService extends OpenmrsService {
 	 * @should unvoid voided personAddress
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonAddress unvoidPersonAddress(PersonAddress personAddress) throws APIException;
+	PersonAddress unvoidPersonAddress(PersonAddress personAddress) throws APIException;
 	
 	/**
 	 * Inserts or updates the given personAddress object in the database
@@ -833,12 +833,12 @@ public interface PersonService extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_PERSONS })
-	public PersonAddress savePersonAddress(PersonAddress personAddress);
+	PersonAddress savePersonAddress(PersonAddress personAddress);
 	
 	/**
 	 * Check if the person attribute types are locked, and if they are throws an exception during manipulation of a person attribute type
 	 * 
 	 * @throws PersonAttributeTypeLockedException
 	 */
-	public void checkIfPersonAttributeTypesAreLocked() throws PersonAttributeTypeLockedException;
+	void checkIfPersonAttributeTypesAreLocked() throws PersonAttributeTypeLockedException;
 }

--- a/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
+++ b/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
@@ -45,7 +45,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * 
 	 * @param dao - The DAO for this service
 	 */
-	public void setProgramWorkflowDAO(ProgramWorkflowDAO dao);
+	void setProgramWorkflowDAO(ProgramWorkflowDAO dao);
 	
 	// **************************
 	// PROGRAM
@@ -64,7 +64,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should update detached program
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public Program saveProgram(Program program) throws APIException;
+	Program saveProgram(Program program) throws APIException;
 	
 	/**
 	 * Returns a program given that programs primary key <code>programId</code> A null value is
@@ -77,7 +77,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return null when programId does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public Program getProgram(Integer programId) throws APIException;
+	Program getProgram(Integer programId) throws APIException;
 	
 	/**
 	 * Returns a program given the program's exact <code>name</code> A null value is returned if
@@ -93,7 +93,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should fail when two programs found with same name
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public Program getProgramByName(String name) throws APIException;
+	Program getProgramByName(String name) throws APIException;
 	
 	/**
 	 * Returns all programs, includes retired programs. This method delegates to the
@@ -103,7 +103,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public List<Program> getAllPrograms() throws APIException;
+	List<Program> getAllPrograms() throws APIException;
 	
 	/**
 	 * Returns all programs
@@ -115,7 +115,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return all programs excluding retired when includeRetired equals false
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public List<Program> getAllPrograms(boolean includeRetired) throws APIException;
+	List<Program> getAllPrograms(boolean includeRetired) throws APIException;
 	
 	/**
 	 * Returns programs that match the given string. A null list will never be returned. An empty
@@ -136,7 +136,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return empty list when nameFragment does not match any
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public List<Program> getPrograms(String nameFragment) throws APIException;
+	List<Program> getPrograms(String nameFragment) throws APIException;
 	
 	/**
 	 * Completely remove a program from the database (not reversible) This method delegates to
@@ -147,7 +147,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should delete program successfully
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public void purgeProgram(Program program) throws APIException;
+	void purgeProgram(Program program) throws APIException;
 	
 	/**
 	 * Completely remove a program from the database (not reversible)
@@ -160,7 +160,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should purge program with patients enrolled
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public void purgeProgram(Program program, boolean cascade) throws APIException;
+	void purgeProgram(Program program, boolean cascade) throws APIException;
 	
 	/**
 	 * Retires the given program
@@ -174,7 +174,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should retire states associated with given program
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public Program retireProgram(Program program, String reason) throws APIException;
+	Program retireProgram(Program program, String reason) throws APIException;
 	
 	/**
 	 * Unretires the given program
@@ -187,7 +187,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should unretire states associated with given program
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public Program unretireProgram(Program program) throws APIException;
+	Program unretireProgram(Program program) throws APIException;
 	
 	// **************************
 	// PATIENT PROGRAM 
@@ -204,7 +204,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return program with given uuid
 	 * @should throw error when multiple programs with same uuid are found
 	 */
-	public Program getProgramByUuid(String uuid);
+	Program getProgramByUuid(String uuid);
 	
 	/**
 	 * Get a program state by its uuid. There should be only one of these in the database. If
@@ -217,7 +217,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return program state with the given uuid
 	 * @should throw error when multiple program states with same uuid are found
 	 */
-	public PatientState getPatientStateByUuid(String uuid);
+	PatientState getPatientStateByUuid(String uuid);
 	
 	/**
 	 * Save patientProgram to database (create if new or update if changed)
@@ -230,7 +230,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return patient program with assigned patient program id
 	 */
 	@Authorized( { PrivilegeConstants.ADD_PATIENT_PROGRAMS, PrivilegeConstants.EDIT_PATIENT_PROGRAMS })
-	public PatientProgram savePatientProgram(PatientProgram patientProgram) throws APIException;
+	PatientProgram savePatientProgram(PatientProgram patientProgram) throws APIException;
 	
 	/**
 	 * Returns a PatientProgram given that PatientPrograms primary key <code>patientProgramId</code>
@@ -245,7 +245,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return null if program does not exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public PatientProgram getPatientProgram(Integer patientProgramId) throws APIException;
+	PatientProgram getPatientProgram(Integer patientProgramId) throws APIException;
 	
 	/**
 	 * Returns PatientPrograms that match the input parameters. If an input parameter is set to
@@ -279,8 +279,8 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return empty list when matches not found
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public List<PatientProgram> getPatientPrograms(Patient patient, Program program, Date minEnrollmentDate,
-	        Date maxEnrollmentDate, Date minCompletionDate, Date maxCompletionDate, boolean includeVoided)
+	List<PatientProgram> getPatientPrograms(Patient patient, Program program, Date minEnrollmentDate,
+			Date maxEnrollmentDate, Date minCompletionDate, Date maxCompletionDate, boolean includeVoided)
 	        throws APIException;
 	
 	/**
@@ -292,7 +292,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should delete patient program from database without cascade
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PATIENT_PROGRAMS })
-	public void purgePatientProgram(PatientProgram patientProgram) throws APIException;
+	void purgePatientProgram(PatientProgram patientProgram) throws APIException;
 	
 	/**
 	 * Completely remove a patientProgram from the database (not reversible)
@@ -305,7 +305,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should not cascade delete patient program states when cascade equals false
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PATIENT_PROGRAMS })
-	public void purgePatientProgram(PatientProgram patientProgram, boolean cascade) throws APIException;
+	void purgePatientProgram(PatientProgram patientProgram, boolean cascade) throws APIException;
 	
 	/**
 	 * Voids the given patientProgram
@@ -318,7 +318,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should fail when reason is empty
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_PATIENT_PROGRAMS })
-	public PatientProgram voidPatientProgram(PatientProgram patientProgram, String reason) throws APIException;
+	PatientProgram voidPatientProgram(PatientProgram patientProgram, String reason) throws APIException;
 	
 	/**
 	 * Unvoids the given patientProgram
@@ -329,7 +329,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should void patient program when reason is valid
 	 */
 	@Authorized( { PrivilegeConstants.DELETE_PATIENT_PROGRAMS })
-	public PatientProgram unvoidPatientProgram(PatientProgram patientProgram) throws APIException;
+	PatientProgram unvoidPatientProgram(PatientProgram patientProgram) throws APIException;
 	
 	/**
 	 * Get all possible outcome concepts for a program. Will return all concept answers
@@ -340,7 +340,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return outcome concepts or empty List if none exist
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public List<Concept> getPossibleOutcomes(Integer programId);
+	List<Concept> getPossibleOutcomes(Integer programId);
 	
 	// **************************
 	// CONCEPT STATE CONVERSION
@@ -353,7 +353,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return the program workflow matching given id or null if not found
 	 * @since 2.2.0
 	 */
-	public ProgramWorkflow getWorkflow(Integer workflowId);
+	ProgramWorkflow getWorkflow(Integer workflowId);
 	
 	/**
 	 * Get ProgramWorkflow by its UUID
@@ -363,7 +363,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public ProgramWorkflow getWorkflowByUuid(String uuid);
+	ProgramWorkflow getWorkflowByUuid(String uuid);
 	
 	/**
 	 * Save ConceptStateConversion to database (create if new or update if changed)
@@ -374,7 +374,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should save state conversion
 	 */
 	@Authorized( { PrivilegeConstants.ADD_PATIENT_PROGRAMS, PrivilegeConstants.EDIT_PATIENT_PROGRAMS })
-	public ConceptStateConversion saveConceptStateConversion(ConceptStateConversion conceptStateConversion)
+	ConceptStateConversion saveConceptStateConversion(ConceptStateConversion conceptStateConversion)
 	        throws APIException;
 	
 	/**
@@ -390,7 +390,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return concept state conversion for given identifier
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public ConceptStateConversion getConceptStateConversion(Integer conceptStateConversionId) throws APIException;
+	ConceptStateConversion getConceptStateConversion(Integer conceptStateConversionId) throws APIException;
 	
 	/**
 	 * Returns all conceptStateConversions
@@ -400,7 +400,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return all concept state conversions
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROGRAMS })
-	public List<ConceptStateConversion> getAllConceptStateConversions() throws APIException;
+	List<ConceptStateConversion> getAllConceptStateConversions() throws APIException;
 	
 	/**
 	 * Completely remove a conceptStateConversion from the database (not reversible) This method
@@ -410,7 +410,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public void purgeConceptStateConversion(ConceptStateConversion conceptStateConversion) throws APIException;
+	void purgeConceptStateConversion(ConceptStateConversion conceptStateConversion) throws APIException;
 	
 	/**
 	 * Completely remove a conceptStateConversion from the database (not reversible)
@@ -422,7 +422,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should not cascade delete given concept state conversion when given cascade is false
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROGRAMS })
-	public void purgeConceptStateConversion(ConceptStateConversion conceptStateConversion, boolean cascade)
+	void purgeConceptStateConversion(ConceptStateConversion conceptStateConversion, boolean cascade)
 	        throws APIException;
 		
 	/**
@@ -436,7 +436,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @throws APIException
 	 * @should return concept state conversion for given workflow and trigger
 	 */
-	public ConceptStateConversion getConceptStateConversion(ProgramWorkflow workflow, Concept trigger) throws APIException;
+	ConceptStateConversion getConceptStateConversion(ProgramWorkflow workflow, Concept trigger) throws APIException;
 	
 	/**
 	 * Get {@code ProgramWorkflowState} by internal identifier.
@@ -445,7 +445,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return the program workflow state matching given id or null if not found
 	 * @since 2.2.0
 	 */
-	public ProgramWorkflowState getState(Integer stateId);
+	ProgramWorkflowState getState(Integer stateId);
 	
 	/**
 	 * Get a state by its uuid. There should be only one of these in the database. If multiple are
@@ -458,7 +458,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return a state with the given uuid
 	 * @should throw an error when multiple states with same uuid are found
 	 */
-	public ProgramWorkflowState getStateByUuid(String uuid);
+	ProgramWorkflowState getStateByUuid(String uuid);
 					
 	/**
 	 * Get a patient program by its uuid. There should be only one of these in the database. If
@@ -471,7 +471,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return a patient program with the given uuid
 	 * @should throw an error when multiple patient programs with same uuid are found
 	 */
-	public PatientProgram getPatientProgramByUuid(String uuid);
+	PatientProgram getPatientProgramByUuid(String uuid);
 	
 	/**
 	 * 
@@ -489,7 +489,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should not fail when given program is empty
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public List<PatientProgram> getPatientPrograms(Cohort cohort, Collection<Program> programs);
+	List<PatientProgram> getPatientPrograms(Cohort cohort, Collection<Program> programs);
 		
 	/**
 	 * Returns a list of Programs that are using a particular concept.
@@ -498,7 +498,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return - A List of Programs
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public List<Program> getProgramsByConcept(Concept concept);
+	List<Program> getProgramsByConcept(Concept concept);
 	
 	/**
 	 * Returns a list of ProgramWorkflows that are using a particular concept.
@@ -507,7 +507,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return - A List of ProgramWorkflows
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public List<ProgramWorkflow> getProgramWorkflowsByConcept(Concept concept);
+	List<ProgramWorkflow> getProgramWorkflowsByConcept(Concept concept);
 	
 	/**
 	 * Returns a list of ProgramWorkflowStates that are using a particular concept.
@@ -516,7 +516,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @return - A List of ProgramWorkflowStates
 	 */
 	@Authorized( { PrivilegeConstants.GET_PATIENT_PROGRAMS })
-	public List<ProgramWorkflowState> getProgramWorkflowStatesByConcept(Concept concept);
+	List<ProgramWorkflowState> getProgramWorkflowStatesByConcept(Concept concept);
 	
 	/**
 	 * Get a concept state conversion by its uuid. There should be only one of these in the
@@ -529,5 +529,5 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @should return a program state with the given uuid
 	 * @should throw an error when multiple program states with same uuid are found
 	 */
-	public ConceptStateConversion getConceptStateConversionByUuid(String uuid);
+	ConceptStateConversion getConceptStateConversionByUuid(String uuid);
 }

--- a/api/src/main/java/org/openmrs/api/ProviderService.java
+++ b/api/src/main/java/org/openmrs/api/ProviderService.java
@@ -38,7 +38,7 @@ public interface ProviderService extends OpenmrsService {
 	 */
 	
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public List<Provider> getAllProviders();
+	List<Provider> getAllProviders();
 	
 	/**
 	 * Gets all Provider
@@ -47,7 +47,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get all providers that are unretired
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public List<Provider> getAllProviders(boolean includeRetired);
+	List<Provider> getAllProviders(boolean includeRetired);
 	
 	/**
 	 * Retires a given Provider
@@ -57,7 +57,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should retire a provider
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROVIDERS })
-	public void retireProvider(Provider provider, String reason);
+	void retireProvider(Provider provider, String reason);
 	
 	/**
 	 * Unretire a given Provider
@@ -66,7 +66,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should unretire a provider
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROVIDERS })
-	public Provider unretireProvider(Provider provider);
+	Provider unretireProvider(Provider provider);
 	
 	/**
 	 * Deletes a given Provider
@@ -75,7 +75,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should delete a provider
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PROVIDERS })
-	public void purgeProvider(Provider provider);
+	void purgeProvider(Provider provider);
 	
 	/**
 	 * Gets a provider by its provider id
@@ -85,7 +85,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get provider given ID
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Provider getProvider(Integer providerId);
+	Provider getProvider(Integer providerId);
 	
 	/**
 	 * @param provider
@@ -94,7 +94,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should not save a Provider person being null
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PROVIDERS })
-	public Provider saveProvider(Provider provider);
+	Provider saveProvider(Provider provider);
 	
 	/**
 	 * @param uuid
@@ -102,7 +102,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get provider given Uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Provider getProviderByUuid(String uuid);
+	Provider getProviderByUuid(String uuid);
 	
 	/**
 	 * Gets the Providers for the given person.
@@ -113,7 +113,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should fail if person is null
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Collection<Provider> getProvidersByPerson(Person person);
+	Collection<Provider> getProvidersByPerson(Person person);
 	
 	/**
 	 * Gets the Providers for the given person including or excluding retired.
@@ -127,7 +127,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @since 1.10, 1.9.1
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Collection<Provider> getProvidersByPerson(Person person, boolean includeRetired);
+	Collection<Provider> getProvidersByPerson(Person person, boolean includeRetired);
 	
 	/**
 	 * @param query
@@ -149,8 +149,8 @@ public interface ProviderService extends OpenmrsService {
 	 * @should find provider by identifier
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public List<Provider> getProviders(String query, Integer start, Integer length,
-	        Map<ProviderAttributeType, Object> attributes, boolean includeRetired);
+	List<Provider> getProviders(String query, Integer start, Integer length,
+			Map<ProviderAttributeType, Object> attributes, boolean includeRetired);
 	
 	/**
 	 * @param query
@@ -171,8 +171,8 @@ public interface ProviderService extends OpenmrsService {
 	 * @should return retired providers
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public List<Provider> getProviders(String query, Integer start, Integer length,
-	        Map<ProviderAttributeType, Object> attributes);
+	List<Provider> getProviders(String query, Integer start, Integer length,
+			Map<ProviderAttributeType, Object> attributes);
 	
 	/**
 	 * @param query
@@ -180,7 +180,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should exclude retired providers
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Integer getCountOfProviders(String query);
+	Integer getCountOfProviders(String query);
 	
 	/**
 	 * Gets the count of providers with a person name or identifier or name that matches the
@@ -194,7 +194,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @since 1.9.4
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Integer getCountOfProviders(String query, boolean includeRetired);
+	Integer getCountOfProviders(String query, boolean includeRetired);
 	
 	/**
 	 * Gets all provider attribute types including retired provider attribute types. This method
@@ -203,7 +203,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return a list of provider attribute type objects.
 	 * @should get all provider attribute types including retired by default
 	 */
-	public List<ProviderAttributeType> getAllProviderAttributeTypes();
+	List<ProviderAttributeType> getAllProviderAttributeTypes();
 	
 	/**
 	 * Gets all provider attribute types optionally including retired provider attribute types.
@@ -213,7 +213,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get all provider attribute types excluding retired
 	 * @should get all provider attribute types including retired
 	 */
-	public List<ProviderAttributeType> getAllProviderAttributeTypes(boolean includeRetired);
+	List<ProviderAttributeType> getAllProviderAttributeTypes(boolean includeRetired);
 	
 	/**
 	 * Gets a provider attribute type by it's id
@@ -222,7 +222,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the provider type attribute by it's id
 	 * @should get provider attribute type for the given id
 	 */
-	public ProviderAttributeType getProviderAttributeType(Integer providerAttributeTypeId);
+	ProviderAttributeType getProviderAttributeType(Integer providerAttributeTypeId);
 	
 	/**
 	 * Get a provider attribute type by it's uuid
@@ -231,7 +231,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the provider attribute type for the given uuid
 	 * @should get the provider attribute type by it's uuid
 	 */
-	public ProviderAttributeType getProviderAttributeTypeByUuid(String uuid);
+	ProviderAttributeType getProviderAttributeTypeByUuid(String uuid);
 	
 	/**
 	 * Get a provider attribute by it's providerAttributeID
@@ -240,7 +240,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the provider attribute for the given providerAttributeID
 	 * @should get the provider attribute by it's providerAttributeID
 	 */
-	public ProviderAttribute getProviderAttribute(Integer providerAttributeID);
+	ProviderAttribute getProviderAttribute(Integer providerAttributeID);
 	
 	/**
 	 * Get a provider attribute by it's providerAttributeUuid
@@ -249,7 +249,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the provider attribute for the given providerAttributeUuid
 	 * @should get the provider attribute by it's providerAttributeUuid
 	 */
-	public ProviderAttribute getProviderAttributeByUuid(String uuid);
+	ProviderAttribute getProviderAttributeByUuid(String uuid);
 	
 	/**
 	 * Save the provider attribute type
@@ -258,7 +258,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the saved provider attribute type
 	 * @should save the provider attribute type
 	 */
-	public ProviderAttributeType saveProviderAttributeType(ProviderAttributeType providerAttributeType);
+	ProviderAttributeType saveProviderAttributeType(ProviderAttributeType providerAttributeType);
 	
 	/**
 	 * Retire a provider attribute type
@@ -268,7 +268,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the retired provider attribute type
 	 * @should retire provider type attribute
 	 */
-	public ProviderAttributeType retireProviderAttributeType(ProviderAttributeType providerAttributeType, String reason);
+	ProviderAttributeType retireProviderAttributeType(ProviderAttributeType providerAttributeType, String reason);
 	
 	/**
 	 * Un-Retire a provider attribute type
@@ -277,7 +277,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @return the unretire provider attribute type
 	 * @should unretire a provider attribute type
 	 */
-	public ProviderAttributeType unretireProviderAttributeType(ProviderAttributeType providerAttributeType);
+	ProviderAttributeType unretireProviderAttributeType(ProviderAttributeType providerAttributeType);
 	
 	/**
 	 * Deletes a provider attribute type
@@ -285,7 +285,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @param providerAttributeType provider attribute type to be deleted
 	 * @should delete a provider attribute type
 	 */
-	public void purgeProviderAttributeType(ProviderAttributeType providerAttributeType);
+	void purgeProviderAttributeType(ProviderAttributeType providerAttributeType);
 	
 	/**
 	 * Checks if the identifier for the specified provider is unique
@@ -298,7 +298,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should return true if the identifier is a blank string
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public boolean isProviderIdentifierUnique(Provider provider) throws APIException;
+	boolean isProviderIdentifierUnique(Provider provider) throws APIException;
 	
 	/**
 	 * Gets a provider with a matching identifier, this method performs a case insensitive search
@@ -308,7 +308,7 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get a provider matching the specified identifier ignoring case
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Provider getProviderByIdentifier(String identifier);
+	Provider getProviderByIdentifier(String identifier);
 	
 	/**
 	 * Gets the unknown provider account, i.e. the provider account that matches the uuid specified
@@ -320,5 +320,5 @@ public interface ProviderService extends OpenmrsService {
 	 * @should get the unknown provider account
 	 */
 	@Authorized( { PrivilegeConstants.GET_PROVIDERS })
-	public Provider getUnknownProvider();
+	Provider getUnknownProvider();
 }

--- a/api/src/main/java/org/openmrs/api/SerializationService.java
+++ b/api/src/main/java/org/openmrs/api/SerializationService.java
@@ -31,7 +31,7 @@ public interface SerializationService extends OpenmrsService {
 	 * @return {@link OpenmrsSerializer} the default configured serializer
 	 * @should return a serializer
 	 */
-	public OpenmrsSerializer getDefaultSerializer();
+	OpenmrsSerializer getDefaultSerializer();
 	
 	/**
 	 * Returns the serializer that matches the passed class, or null if no such serializer exists.
@@ -40,7 +40,7 @@ public interface SerializationService extends OpenmrsService {
 	 * @return {@link OpenmrsSerializer} that matches the passed class
 	 * @should return a serializer of the given class
 	 */
-	public OpenmrsSerializer getSerializer(Class<? extends OpenmrsSerializer> serializationClass);
+	OpenmrsSerializer getSerializer(Class<? extends OpenmrsSerializer> serializationClass);
 	
 	/**
 	 * Serialize the passed object into an identifying string that can be retrieved later using the
@@ -52,7 +52,7 @@ public interface SerializationService extends OpenmrsService {
 	 * @should Serialize And Deserialize Correctly
 	 * @should Serialize And Deserialize Hibernate Objects Correctly
 	 */
-	public String serialize(Object o, Class<? extends OpenmrsSerializer> clazz) throws SerializationException;
+	String serialize(Object o, Class<? extends OpenmrsSerializer> clazz) throws SerializationException;
 	
 	/**
 	 * Deserialize the given string into a full object using the given {@link OpenmrsSerializer}
@@ -66,8 +66,8 @@ public interface SerializationService extends OpenmrsService {
 	 */
 	@Logging(ignoredArgumentIndexes = { 0 })
     @Authorized
-	public <T extends Object> T deserialize(String serializedObject, Class<? extends T> objectClass,
-	        Class<? extends OpenmrsSerializer> serializerClass) throws SerializationException;
+	<T extends Object> T deserialize(String serializedObject, Class<? extends T> objectClass,
+			Class<? extends OpenmrsSerializer> serializerClass) throws SerializationException;
 	
 	/**
 	 * Gets the list of OpenmrsSerializers that have been registered with this service. <br>
@@ -88,5 +88,5 @@ public interface SerializationService extends OpenmrsService {
 	 * 
 	 * @return list of serializers currently loaded in openmrs
 	 */
-	public List<? extends OpenmrsSerializer> getSerializers();
+	List<? extends OpenmrsSerializer> getSerializers();
 }

--- a/api/src/main/java/org/openmrs/api/UserService.java
+++ b/api/src/main/java/org/openmrs/api/UserService.java
@@ -46,7 +46,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.ADD_USERS })
 	@Logging(ignoredArgumentIndexes = { 1 })
-	public User createUser(User user, String password) throws APIException;
+	User createUser(User user, String password) throws APIException;
 	
 	/**
 	 * Change user password.
@@ -65,7 +65,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
 	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changePassword(User user, String oldPassword, String newPassword) throws APIException;
+	void changePassword(User user, String oldPassword, String newPassword) throws APIException;
 	
 	/**
 	 * Get user by internal user identifier.
@@ -76,7 +76,7 @@ public interface UserService extends OpenmrsService {
 	 * @should fetch user with given userId
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUser(Integer userId) throws APIException;
+	User getUser(Integer userId) throws APIException;
 	
 	/**
 	 * Get user by the given uuid.
@@ -89,7 +89,7 @@ public interface UserService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByUuid(String uuid) throws APIException;
+	User getUserByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get user by username (user's login identifier)
@@ -100,7 +100,7 @@ public interface UserService extends OpenmrsService {
 	 * @should get user by username
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByUsername(String username) throws APIException;
+	User getUserByUsername(String username) throws APIException;
 	
 	/**
 	 * true/false if username or systemId is already in db in username or system_id columns
@@ -111,7 +111,7 @@ public interface UserService extends OpenmrsService {
 	 * @should verify that username and system id is unique
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public boolean hasDuplicateUsername(User user) throws APIException;
+	boolean hasDuplicateUsername(User user) throws APIException;
 	
 	/**
 	 * Get users by role granted
@@ -123,7 +123,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not fetch user that does not belong to given role
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByRole(Role role) throws APIException;
+	List<User> getUsersByRole(Role role) throws APIException;
 	
 	/**
 	 * Updates a given <code>user</code> in the database.
@@ -133,7 +133,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User saveUser(User user) throws APIException;
+	User saveUser(User user) throws APIException;
 	
 	/**
 	 * Deactivate a user account so that it can no longer log in.
@@ -144,7 +144,7 @@ public interface UserService extends OpenmrsService {
 	 * @should retire user and set attributes
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User retireUser(User user, String reason) throws APIException;
+	User retireUser(User user, String reason) throws APIException;
 	
 	/**
 	 * Clears retired flag for a user.
@@ -154,7 +154,7 @@ public interface UserService extends OpenmrsService {
 	 * @should unretire and unmark all attributes
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User unretireUser(User user) throws APIException;
+	User unretireUser(User user) throws APIException;
 	
 	/**
 	 * Completely remove a location from the database (not reversible). This method delegates to
@@ -164,7 +164,7 @@ public interface UserService extends OpenmrsService {
 	 * @should delete given user
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_USERS })
-	public void purgeUser(User user) throws APIException;
+	void purgeUser(User user) throws APIException;
 	
 	/**
 	 * Completely remove a user from the database (not reversible). This is a delete from the
@@ -182,7 +182,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not delete user roles for given user when cascade equals false
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_USERS })
-	public void purgeUser(User user, boolean cascade) throws APIException;
+	void purgeUser(User user, boolean cascade) throws APIException;
 	
 	/**
 	 * Returns all privileges currently possible for any User
@@ -191,7 +191,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @should return all privileges in the system
 	 */
-	public List<Privilege> getAllPrivileges() throws APIException;
+	List<Privilege> getAllPrivileges() throws APIException;
 	
 	/**
 	 * Returns all roles currently possible for any User
@@ -200,7 +200,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @should return all roles in the system
 	 */
-	public List<Role> getAllRoles() throws APIException;
+	List<Role> getAllRoles() throws APIException;
 	
 	/**
 	 * Save the given role in the database
@@ -212,7 +212,7 @@ public interface UserService extends OpenmrsService {
 	 * @should save given role to the database
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ROLES })
-	public Role saveRole(Role role) throws APIException;
+	Role saveRole(Role role) throws APIException;
 	
 	/**
 	 * Complete remove a role from the database
@@ -224,7 +224,7 @@ public interface UserService extends OpenmrsService {
 	 * @should delete given role from database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ROLES })
-	public void purgeRole(Role role) throws APIException;
+	void purgeRole(Role role) throws APIException;
 	
 	/**
 	 * Save the given privilege in the database
@@ -235,7 +235,7 @@ public interface UserService extends OpenmrsService {
 	 * @should save given privilege to the database
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PRIVILEGES })
-	public Privilege savePrivilege(Privilege privilege) throws APIException;
+	Privilege savePrivilege(Privilege privilege) throws APIException;
 	
 	/**
 	 * Completely remove a privilege from the database
@@ -246,7 +246,7 @@ public interface UserService extends OpenmrsService {
 	 * @should throw error when privilege is core privilege
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PRIVILEGES })
-	public void purgePrivilege(Privilege privilege) throws APIException;
+	void purgePrivilege(Privilege privilege) throws APIException;
 	
 	/**
 	 * Returns role object with given string role
@@ -255,7 +255,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @should fetch role for given role name
 	 */
-	public Role getRole(String r) throws APIException;
+	Role getRole(String r) throws APIException;
 	
 	/**
 	 * Get Role by its UUID
@@ -265,7 +265,7 @@ public interface UserService extends OpenmrsService {
 	 * @should find object given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public Role getRoleByUuid(String uuid) throws APIException;
+	Role getRoleByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns Privilege in the system with given String privilege
@@ -274,7 +274,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @should fetch privilege for given name
 	 */
-	public Privilege getPrivilege(String p) throws APIException;
+	Privilege getPrivilege(String p) throws APIException;
 	
 	/**
 	 * Get Privilege by its UUID
@@ -285,7 +285,7 @@ public interface UserService extends OpenmrsService {
 	 * @should return null if no object found with given uuid
 	 * @should fetch privilege for given uuid
 	 */
-	public Privilege getPrivilegeByUuid(String uuid) throws APIException;
+	Privilege getPrivilegeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns all users in the system
@@ -296,7 +296,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not contains any duplicate users
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getAllUsers() throws APIException;
+	List<User> getAllUsers() throws APIException;
 	
 	/**
 	 * Changes the current user's password.
@@ -310,7 +310,7 @@ public interface UserService extends OpenmrsService {
 	 * @should be able to update password multiple times
 	 */
 	@Logging(ignoredArgumentIndexes = { 0, 1 })
-	public void changePassword(String pw, String pw2) throws APIException;
+	void changePassword(String pw, String pw2) throws APIException;
 
 	/**
 	 * Changes password of {@link User} passed in
@@ -321,7 +321,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not update password of given user when logged in user does not have edit users password privilege
 	 */
 	@Authorized({PrivilegeConstants.EDIT_USER_PASSWORDS})
-	public void changePassword(User user, String newPassword) throws APIException;
+	void changePassword(User user, String newPassword) throws APIException;
 	
 	/**
 	 * Changes the current user's password directly. This is most useful if migrating users from
@@ -336,7 +336,7 @@ public interface UserService extends OpenmrsService {
 	 * @should change the hashed password for the given user
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
-	public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException;
+	void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException;
 	
 	/**
 	 * Changes the passed user's secret question and answer.
@@ -350,7 +350,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
 	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changeQuestionAnswer(User u, String question, String answer) throws APIException;
+	void changeQuestionAnswer(User u, String question, String answer) throws APIException;
 	
 	/**
 	 * Changes the current user's secret question and answer.
@@ -363,7 +363,7 @@ public interface UserService extends OpenmrsService {
 	 * @should match on incorrectly hashed stored password
 	 */
 	@Logging(ignoreAllArgumentValues = true)
-	public void changeQuestionAnswer(String pw, String q, String a) throws APIException;
+	void changeQuestionAnswer(String pw, String q, String a) throws APIException;
 	
 	/**
 	 * Returns secret question for the given user.
@@ -373,7 +373,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @since 2.0
 	 */
-	public String getSecretQuestion(User user) throws APIException;
+	String getSecretQuestion(User user) throws APIException;
 	
 	/**
 	 * Compares <code>answer</code> against the <code>user</code>'s secret answer.
@@ -385,7 +385,7 @@ public interface UserService extends OpenmrsService {
 	 * @should return false when given answer does not match the stored secret answer
 	 */
 	@Logging(ignoredArgumentIndexes = { 1 })
-	public boolean isSecretAnswer(User u, String answer) throws APIException;
+	boolean isSecretAnswer(User u, String answer) throws APIException;
 	
 	/**
 	 * Return a list of users sorted by personName (see {@link PersonByNameComparator}) if any part
@@ -408,7 +408,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not fail if roles are searched but name is empty
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException;
+	List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException;
 	
 	/**
 	 * Search for a list of users by exact first name and last name.
@@ -423,7 +423,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not fetch any duplicate users
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByName(String givenName, String familyName, boolean includeRetired) throws APIException;
+	List<User> getUsersByName(String givenName, String familyName, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get all user accounts that belong to a given person.
@@ -436,7 +436,7 @@ public interface UserService extends OpenmrsService {
 	 * @should not fetch retired accounts when include retired is false
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException;
+	List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Adds the <code>key</code>/<code>value</code> pair to the given <code>user</code>.
@@ -452,7 +452,7 @@ public interface UserService extends OpenmrsService {
 	 * @should add property with given key and value when key does not already exist
 	 * @should modify property with given key and value when key already exists
 	 */
-	public User setUserProperty(User user, String key, String value) throws APIException;
+	User setUserProperty(User user, String key, String value) throws APIException;
 	
 	/**
 	 * Removes the property denoted by <code>key</code> from the <code>user</code>'s properties.
@@ -465,7 +465,7 @@ public interface UserService extends OpenmrsService {
 	 * @should throw error when user is not authorized to edit users
 	 * @should remove user property for given user and key
 	 */
-	public User removeUserProperty(User user, String key) throws APIException;
+	User removeUserProperty(User user, String key) throws APIException;
 	
 	/**
 	 * Get/generate/find the next system id to be doled out. Assume check digit /not/ applied in
@@ -473,7 +473,7 @@ public interface UserService extends OpenmrsService {
 	 * 
 	 * @return new system id
 	 */
-	public String generateSystemId();
+	String generateSystemId();
 	
 	/**
 	 * Return a batch of users of a specific size sorted by personName (see
@@ -493,7 +493,7 @@ public interface UserService extends OpenmrsService {
 	 * @should return users whose roles inherit requested roles
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
+	List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
 	        throws APIException;
 	
 	/**
@@ -507,7 +507,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
+	Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
 	
 	/**
 	 * Notifies privilege listener beans about any privilege check.
@@ -521,7 +521,7 @@ public interface UserService extends OpenmrsService {
 	 *            if it is a proxy privilege
 	 * @since 1.8.4, 1.9.1, 1.10
 	 */
-	public void notifyPrivilegeListeners(User user, String privilege, boolean hasPrivilege);
+	void notifyPrivilegeListeners(User user, String privilege, boolean hasPrivilege);
 	
 	/**
 	 * Saves the current key/value as a user property for the current user.
@@ -531,7 +531,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized
-	public User saveUserProperty(String key, String value);
+	User saveUserProperty(String key, String value);
 	
 	/**
 	 * Replaces all user properties with the given map of properties for the current user
@@ -540,7 +540,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized
-	public User saveUserProperties(Map<String, String> properties);
+	User saveUserProperties(Map<String, String> properties);
 	
 	/**
 	 * Change user password given the answer to the secret question
@@ -550,6 +550,6 @@ public interface UserService extends OpenmrsService {
 	 * @should not update password if secret is not correct
 	 */
 	@Authorized
-	public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException;
+	void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException;
 
 }

--- a/api/src/main/java/org/openmrs/api/VisitService.java
+++ b/api/src/main/java/org/openmrs/api/VisitService.java
@@ -50,7 +50,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should get all visit types based on include retired flag.
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_VISIT_TYPES })
-	public List<VisitType> getAllVisitTypes(boolean includeRetired);
+	List<VisitType> getAllVisitTypes(boolean includeRetired);
 	
 	/**
 	 * Gets a visit type by its visit type id.
@@ -133,7 +133,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should return all unvoided visits
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public List<Visit> getAllVisits() throws APIException;
+	List<Visit> getAllVisits() throws APIException;
 	
 	/**
 	 * Gets a visit by its visit id.
@@ -143,7 +143,7 @@ public interface VisitService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public Visit getVisit(Integer visitId) throws APIException;
+	Visit getVisit(Integer visitId) throws APIException;
 	
 	/**
 	 * Gets a visit by its UUID.
@@ -154,7 +154,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should return a visit matching the specified uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public Visit getVisitByUuid(String uuid) throws APIException;
+	Visit getVisitByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Creates or updates the given visit in the database.
@@ -173,7 +173,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should should save new visit with encounters successfully
 	 */
 	@Authorized( { PrivilegeConstants.ADD_VISITS, PrivilegeConstants.EDIT_VISITS })
-	public Visit saveVisit(Visit visit) throws APIException;
+	Visit saveVisit(Visit visit) throws APIException;
 	
 	/**
 	 * Sets the stopDate of a given visit.
@@ -187,7 +187,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should fail if validation errors are found
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_VISITS })
-	public Visit endVisit(Visit visit, Date stopDate) throws APIException;
+	Visit endVisit(Visit visit, Date stopDate) throws APIException;
 	
 	/**
 	 * Voids the given visit.
@@ -200,7 +200,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should void encounters with visit
 	 */
 	@Authorized(PrivilegeConstants.DELETE_VISITS)
-	public Visit voidVisit(Visit visit, String reason) throws APIException;
+	Visit voidVisit(Visit visit, String reason) throws APIException;
 	
 	/**
 	 * Unvoids the given visit.
@@ -212,7 +212,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should unvoid encounters voided with visit
 	 */
 	@Authorized(PrivilegeConstants.DELETE_VISITS)
-	public Visit unvoidVisit(Visit visit) throws APIException;
+	Visit unvoidVisit(Visit visit) throws APIException;
 	
 	/**
 	 * Completely erases a visit from the database. This is not reversible.
@@ -223,7 +223,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should fail if the visit has encounters associated to it
 	 */
 	@Authorized(PrivilegeConstants.PURGE_VISITS)
-	public void purgeVisit(Visit visit) throws APIException;
+	void purgeVisit(Visit visit) throws APIException;
 	
 	/**
 	 * Gets the visits matching the specified arguments
@@ -253,10 +253,10 @@ public interface VisitService extends OpenmrsService {
 	 * @should not find any visits if none have given attribute values
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public List<Visit> getVisits(Collection<VisitType> visitTypes, Collection<Patient> patients,
-	        Collection<Location> locations, Collection<Concept> indications, Date minStartDatetime, Date maxStartDatetime,
-	        Date minEndDatetime, Date maxEndDatetime, Map<VisitAttributeType, Object> attributeValues,
-	        boolean includeInactive, boolean includeVoided) throws APIException;
+	List<Visit> getVisits(Collection<VisitType> visitTypes, Collection<Patient> patients,
+			Collection<Location> locations, Collection<Concept> indications, Date minStartDatetime, Date maxStartDatetime,
+			Date minEndDatetime, Date maxEndDatetime, Map<VisitAttributeType, Object> attributeValues,
+			boolean includeInactive, boolean includeVoided) throws APIException;
 	
 	/**
 	 * Gets all unvoided visits for the specified patient
@@ -267,7 +267,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should return all unvoided visits for the specified patient
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public List<Visit> getVisitsByPatient(Patient patient) throws APIException;
+	List<Visit> getVisitsByPatient(Patient patient) throws APIException;
 	
 	/**
 	 * Convenience method that delegates to getVisitsByPatient(patient, false, false)
@@ -277,7 +277,7 @@ public interface VisitService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public List<Visit> getActiveVisitsByPatient(Patient patient) throws APIException;
+	List<Visit> getActiveVisitsByPatient(Patient patient) throws APIException;
 	
 	/**
 	 * Gets all visits for the specified patient
@@ -292,7 +292,7 @@ public interface VisitService extends OpenmrsService {
 	 * @should return all active visits for the specified patient
 	 */
 	@Authorized(PrivilegeConstants.GET_VISITS)
-	public List<Visit> getVisitsByPatient(Patient patient, boolean includeInactive, boolean includeVoided)
+	List<Visit> getVisitsByPatient(Patient patient, boolean includeInactive, boolean includeVoided)
 	        throws APIException;
 	
 	/**
@@ -378,5 +378,5 @@ public interface VisitService extends OpenmrsService {
 	 * @should close all unvoided active visit matching the specified visit types
 	 */
 	@Authorized(PrivilegeConstants.EDIT_VISITS)
-	public void stopVisits(Date maximumStartDate);
+	void stopVisits(Date maximumStartDate);
 }

--- a/api/src/main/java/org/openmrs/api/db/AdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/AdministrationDAO.java
@@ -27,57 +27,57 @@ public interface AdministrationDAO {
 	/**
 	 * @see org.openmrs.api.AdministrationService#getGlobalProperty(String)
 	 */
-	public String getGlobalProperty(String propertyName) throws DAOException;
+	String getGlobalProperty(String propertyName) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#getGlobalPropertyObject(java.lang.String)
 	 */
-	public GlobalProperty getGlobalPropertyObject(String propertyName);
+	GlobalProperty getGlobalPropertyObject(String propertyName);
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#getAllGlobalProperties()
 	 */
-	public List<GlobalProperty> getAllGlobalProperties() throws DAOException;
+	List<GlobalProperty> getAllGlobalProperties() throws DAOException;
 	
-	public GlobalProperty getGlobalPropertyByUuid(String uuid) throws DAOException;
+	GlobalProperty getGlobalPropertyByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#getGlobalPropertiesByPrefix(java.lang.String)
 	 */
-	public List<GlobalProperty> getGlobalPropertiesByPrefix(String prefix);
+	List<GlobalProperty> getGlobalPropertiesByPrefix(String prefix);
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#getGlobalPropertiesBySuffix(java.lang.String)
 	 */
-	public List<GlobalProperty> getGlobalPropertiesBySuffix(String suffix);
+	List<GlobalProperty> getGlobalPropertiesBySuffix(String suffix);
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#purgeGlobalProperty(org.openmrs.GlobalProperty)
 	 */
-	public void deleteGlobalProperty(GlobalProperty gp) throws DAOException;
+	void deleteGlobalProperty(GlobalProperty gp) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#saveGlobalProperty(org.openmrs.GlobalProperty)
 	 */
-	public GlobalProperty saveGlobalProperty(GlobalProperty gp) throws DAOException;
+	GlobalProperty saveGlobalProperty(GlobalProperty gp) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.db.AdministrationDAO#executeSQL(java.lang.String, boolean)
 	 */
-	public List<List<Object>> executeSQL(String sql, boolean selectOnly) throws DAOException;
+	List<List<Object>> executeSQL(String sql, boolean selectOnly) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#getMaximumPropertyLength(Class, String)
 	 */
-	public int getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName);
+	int getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName);
 	
 	/**
 	 * @see org.openmrs.api.AdministrationService#validate(Object, Errors)
 	 */
-	public void validate(Object object, Errors errors) throws DAOException;
+	void validate(Object object, Errors errors) throws DAOException;
 	
 	/**
 	 * @see AdministrationService#isDatabaseStringComparisonCaseSensitive()
 	 */
-	public boolean isDatabaseStringComparisonCaseSensitive() throws DAOException;
+	boolean isDatabaseStringComparisonCaseSensitive() throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
@@ -51,13 +51,13 @@ public interface ConceptDAO {
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConcept(org.openmrs.Concept)
 	 */
-	public Concept saveConcept(Concept concept) throws DAOException;
+	Concept saveConcept(Concept concept) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConcept(org.openmrs.Concept)
 	 * @should purge concept
 	 */
-	public void purgeConcept(Concept concept) throws DAOException;
+	void purgeConcept(Concept concept) throws DAOException;
 	
 	/**
 	 * Get a ConceptComplex. The Concept.getDatatype() is "Complex" and the Concept.getHandler() is
@@ -66,34 +66,34 @@ public interface ConceptDAO {
 	 * @param conceptId
 	 * @return the ConceptComplex
 	 */
-	public ConceptComplex getConceptComplex(Integer conceptId);
+	ConceptComplex getConceptComplex(Integer conceptId);
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeDrug(org.openmrs.Drug)
 	 */
-	public void purgeDrug(Drug drug) throws DAOException;
+	void purgeDrug(Drug drug) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveDrug(org.openmrs.Drug)
 	 */
-	public Drug saveDrug(Drug drug) throws DAOException;
+	Drug saveDrug(Drug drug) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConcept(java.lang.Integer)
 	 */
-	public Concept getConcept(Integer conceptId) throws DAOException;
+	Concept getConcept(Integer conceptId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptName(java.lang.Integer)
 	 * @param conceptNameId
 	 * @return The ConceptName matching the specified conceptNameId
 	 */
-	public ConceptName getConceptName(Integer conceptNameId) throws DAOException;
+	ConceptName getConceptName(Integer conceptNameId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConcepts(java.lang.String, boolean, boolean)
 	 */
-	public List<Concept> getAllConcepts(String sortBy, boolean asc, boolean includeRetired) throws DAOException;
+	List<Concept> getAllConcepts(String sortBy, boolean asc, boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Returns a list of concepts based on the search criteria
@@ -105,8 +105,8 @@ public interface ConceptDAO {
 	 * @throws DAOException
 	 * @should not return concepts with matching names that are voided
 	 */
-	public List<Concept> getConcepts(String name, Locale loc, boolean searchOnPhrase, List<ConceptClass> classes,
-	        List<ConceptDatatype> datatypes) throws DAOException;
+	List<Concept> getConcepts(String name, Locale loc, boolean searchOnPhrase, List<ConceptClass> classes,
+			List<ConceptDatatype> datatypes) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConcepts(String, List, boolean, List, List, List, List, Concept,
@@ -115,24 +115,24 @@ public interface ConceptDAO {
 	 * @should return correct results for concept with names that contains words with more weight
 	 * @should return correct results if a concept name contains same word more than once
 	 */
-	public List<ConceptSearchResult> getConcepts(String phrase, List<Locale> locales, boolean includeRetired,
-	        List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
-	        List<ConceptDatatype> excludeDatatypes, Concept answersToConcept, Integer start, Integer size)
+	List<ConceptSearchResult> getConcepts(String phrase, List<Locale> locales, boolean includeRetired,
+			List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
+			List<ConceptDatatype> excludeDatatypes, Concept answersToConcept, Integer start, Integer size)
 	        throws DAOException;
 	
-	public Integer getCountOfConcepts(String phrase, List<Locale> locales, boolean includeRetired,
-	        List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
-	        List<ConceptDatatype> excludeDatatypes, Concept answersToConcept) throws DAOException;
+	Integer getCountOfConcepts(String phrase, List<Locale> locales, boolean includeRetired,
+			List<ConceptClass> requireClasses, List<ConceptClass> excludeClasses, List<ConceptDatatype> requireDatatypes,
+			List<ConceptDatatype> excludeDatatypes, Concept answersToConcept) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptAnswer(java.lang.Integer)
 	 */
-	public ConceptAnswer getConceptAnswer(Integer conceptAnswerId) throws DAOException;
+	ConceptAnswer getConceptAnswer(Integer conceptAnswerId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getDrug(java.lang.Integer)
 	 */
-	public Drug getDrug(Integer drugId) throws DAOException;
+	Drug getDrug(Integer drugId) throws DAOException;
 	
 	/**
 	 * DAO for retrieving a list of drugs based on the following criteria
@@ -143,47 +143,47 @@ public interface ConceptDAO {
 	 * @return List&lt;Drug&gt;
 	 * @throws DAOException
 	 */
-	public List<Drug> getDrugs(String drugName, Concept concept, boolean includeRetired) throws DAOException;
+	List<Drug> getDrugs(String drugName, Concept concept, boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getDrugs(java.lang.String)
 	 */
-	public List<Drug> getDrugs(String phrase) throws DAOException;
+	List<Drug> getDrugs(String phrase) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptClass(java.lang.Integer)
 	 */
-	public ConceptClass getConceptClass(Integer i) throws DAOException;
+	ConceptClass getConceptClass(Integer i) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptClassByName(java.lang.String)
 	 */
-	public List<ConceptClass> getConceptClasses(String name) throws DAOException;
+	List<ConceptClass> getConceptClasses(String name) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptClasses(boolean)
 	 */
-	public List<ConceptClass> getAllConceptClasses(boolean includeRetired) throws DAOException;
+	List<ConceptClass> getAllConceptClasses(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConceptClass(org.openmrs.ConceptClass)
 	 */
-	public ConceptClass saveConceptClass(ConceptClass cc) throws DAOException;
+	ConceptClass saveConceptClass(ConceptClass cc) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConceptClass(org.openmrs.ConceptClass)
 	 */
-	public void purgeConceptClass(ConceptClass cc) throws DAOException;
+	void purgeConceptClass(ConceptClass cc) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConceptNameTag(org.openmrs.ConceptNameTag)
 	 */
-	public void deleteConceptNameTag(ConceptNameTag cnt) throws DAOException;
+	void deleteConceptNameTag(ConceptNameTag cnt) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptDatatypes(boolean)
 	 */
-	public List<ConceptDatatype> getAllConceptDatatypes(boolean includeRetired) throws DAOException;
+	List<ConceptDatatype> getAllConceptDatatypes(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @param name
@@ -191,211 +191,211 @@ public interface ConceptDAO {
 	 *         not exist.
 	 * @throws DAOException
 	 */
-	public ConceptDatatype getConceptDatatypeByName(String name) throws DAOException;
+	ConceptDatatype getConceptDatatypeByName(String name) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptDatatype(java.lang.Integer)
 	 */
-	public ConceptDatatype getConceptDatatype(Integer i) throws DAOException;
+	ConceptDatatype getConceptDatatype(Integer i) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConceptDatatype(org.openmrs.ConceptDatatype)
 	 */
-	public ConceptDatatype saveConceptDatatype(ConceptDatatype cd) throws DAOException;
+	ConceptDatatype saveConceptDatatype(ConceptDatatype cd) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConceptDatatype(org.openmrs.ConceptDatatype)
 	 */
-	public void purgeConceptDatatype(ConceptDatatype cd) throws DAOException;
+	void purgeConceptDatatype(ConceptDatatype cd) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptSetsByConcept(org.openmrs.Concept)
 	 */
-	public List<ConceptSet> getConceptSetsByConcept(Concept c) throws DAOException;
+	List<ConceptSet> getConceptSetsByConcept(Concept c) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getSetsContainingConcept(org.openmrs.Concept)
 	 */
-	public List<ConceptSet> getSetsContainingConcept(Concept concept) throws DAOException;
+	List<ConceptSet> getSetsContainingConcept(Concept concept) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptNumeric(java.lang.Integer)
 	 */
-	public ConceptNumeric getConceptNumeric(Integer conceptId) throws DAOException;
+	ConceptNumeric getConceptNumeric(Integer conceptId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptsByAnswer(org.openmrs.Concept)
 	 * @should return concepts for the given answer concept
 	 */
-	public List<Concept> getConceptsByAnswer(Concept concept) throws DAOException;
+	List<Concept> getConceptsByAnswer(Concept concept) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getPrevConcept(org.openmrs.Concept)
 	 */
-	public Concept getPrevConcept(Concept c) throws DAOException;
+	Concept getPrevConcept(Concept c) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getNextConcept(org.openmrs.Concept)
 	 */
-	public Concept getNextConcept(Concept c) throws DAOException;
+	Concept getNextConcept(Concept c) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptProposals(boolean)
 	 */
-	public List<ConceptProposal> getAllConceptProposals(boolean includeComplete) throws DAOException;
+	List<ConceptProposal> getAllConceptProposals(boolean includeComplete) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptProposal(java.lang.Integer)
 	 */
-	public ConceptProposal getConceptProposal(Integer i) throws DAOException;
+	ConceptProposal getConceptProposal(Integer i) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptProposals(java.lang.String)
 	 */
-	public List<ConceptProposal> getConceptProposals(String text) throws DAOException;
+	List<ConceptProposal> getConceptProposals(String text) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getProposedConcepts(java.lang.String)
 	 */
-	public List<Concept> getProposedConcepts(String text) throws DAOException;
+	List<Concept> getProposedConcepts(String text) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConceptProposal(org.openmrs.ConceptProposal)
 	 */
-	public ConceptProposal saveConceptProposal(ConceptProposal cp) throws DAOException;
+	ConceptProposal saveConceptProposal(ConceptProposal cp) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConceptProposal(org.openmrs.ConceptProposal)
 	 */
-	public void purgeConceptProposal(ConceptProposal cp) throws DAOException;
+	void purgeConceptProposal(ConceptProposal cp) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptsWithDrugsInFormulary()
 	 */
-	public List<Concept> getConceptsWithDrugsInFormulary() throws DAOException;
+	List<Concept> getConceptsWithDrugsInFormulary() throws DAOException;
 	
-	public ConceptNameTag saveConceptNameTag(ConceptNameTag nameTag);
+	ConceptNameTag saveConceptNameTag(ConceptNameTag nameTag);
 	
-	public ConceptNameTag getConceptNameTag(Integer i);
+	ConceptNameTag getConceptNameTag(Integer i);
 	
-	public ConceptNameTag getConceptNameTagByName(String name);
+	ConceptNameTag getConceptNameTagByName(String name);
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptNameTags()
 	 */
-	public List<ConceptNameTag> getAllConceptNameTags();
+	List<ConceptNameTag> getAllConceptNameTags();
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptSource(java.lang.Integer)
 	 */
-	public ConceptSource getConceptSource(Integer conceptSourceId) throws DAOException;
+	ConceptSource getConceptSource(Integer conceptSourceId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptSources(boolean)
 	 */
-	public List<ConceptSource> getAllConceptSources(boolean includeRetired) throws DAOException;
+	List<ConceptSource> getAllConceptSources(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConceptSource(org.openmrs.ConceptSource)
 	 */
-	public ConceptSource saveConceptSource(ConceptSource conceptSource) throws DAOException;
+	ConceptSource saveConceptSource(ConceptSource conceptSource) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#purgeConceptSource(org.openmrs.ConceptSource)
 	 */
-	public ConceptSource deleteConceptSource(ConceptSource cs) throws DAOException;
+	ConceptSource deleteConceptSource(ConceptSource cs) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getLocalesOfConceptNames()
 	 */
-	public Set<Locale> getLocalesOfConceptNames();
+	Set<Locale> getLocalesOfConceptNames();
 	
 	/**
 	 * @see ConceptService#getMaxConceptId()
 	 */
-	public Integer getMaxConceptId();
+	Integer getMaxConceptId();
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#conceptIterator()
 	 */
-	public Iterator<Concept> conceptIterator();
+	Iterator<Concept> conceptIterator();
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptsByMapping(java.lang.String, java.lang.String)
 	 */
-	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired);
+	List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired);
 	
 	/**
 	 * @param uuid
 	 * @return concept or null
 	 */
-	public Concept getConceptByUuid(String uuid);
+	Concept getConceptByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return concept class or null
 	 */
-	public ConceptClass getConceptClassByUuid(String uuid);
+	ConceptClass getConceptClassByUuid(String uuid);
 	
-	public ConceptAnswer getConceptAnswerByUuid(String uuid);
+	ConceptAnswer getConceptAnswerByUuid(String uuid);
 	
-	public ConceptName getConceptNameByUuid(String uuid);
+	ConceptName getConceptNameByUuid(String uuid);
 	
-	public ConceptSet getConceptSetByUuid(String uuid);
+	ConceptSet getConceptSetByUuid(String uuid);
 	
-	public ConceptSource getConceptSourceByUuid(String uuid);
+	ConceptSource getConceptSourceByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return concept data type or null
 	 */
-	public ConceptDatatype getConceptDatatypeByUuid(String uuid);
+	ConceptDatatype getConceptDatatypeByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return concept numeric or null
 	 */
-	public ConceptNumeric getConceptNumericByUuid(String uuid);
+	ConceptNumeric getConceptNumericByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return concept proposal or null
 	 */
-	public ConceptProposal getConceptProposalByUuid(String uuid);
+	ConceptProposal getConceptProposalByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return drug or null
 	 */
-	public Drug getDrugByUuid(String uuid);
+	Drug getDrugByUuid(String uuid);
 	
-	public DrugIngredient getDrugIngredientByUuid(String uuid);
+	DrugIngredient getDrugIngredientByUuid(String uuid);
 	
-	public Map<Integer, String> getConceptUuids();
+	Map<Integer, String> getConceptUuids();
 	
-	public ConceptDescription getConceptDescriptionByUuid(String uuid);
+	ConceptDescription getConceptDescriptionByUuid(String uuid);
 	
-	public ConceptNameTag getConceptNameTagByUuid(String uuid);
+	ConceptNameTag getConceptNameTagByUuid(String uuid);
 	
 	/**
 	 * @see ConceptService#getConceptMappingsToSource(ConceptSource)
 	 */
-	public List<ConceptMap> getConceptMapsBySource(ConceptSource conceptSource) throws DAOException;
+	List<ConceptMap> getConceptMapsBySource(ConceptSource conceptSource) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptSourceByName(java.lang.String)
 	 */
-	public ConceptSource getConceptSourceByName(String conceptSourceName) throws DAOException;
+	ConceptSource getConceptSourceByName(String conceptSourceName) throws DAOException;
 
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptSourceByUniqueId(java.lang.String)
 	 */
-	public ConceptSource getConceptSourceByUniqueId(String uniqueId);
+	ConceptSource getConceptSourceByUniqueId(String uniqueId);
 
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptSourceByHL7Code(java.lang.String)
 	 */
-	public ConceptSource getConceptSourceByHL7Code(String hl7Code);
+	ConceptSource getConceptSourceByHL7Code(String hl7Code);
 
 	/**
 	 * Gets the value of conceptDatatype currently saved in the database for the given concept,
@@ -406,7 +406,7 @@ public interface ConceptDAO {
 	 * @return the conceptDatatype currently in the database for this concept
 	 * @should get saved conceptDatatype from database
 	 */
-	public ConceptDatatype getSavedConceptDatatype(Concept concept);
+	ConceptDatatype getSavedConceptDatatype(Concept concept);
 	
 	/**
 	 * Gets the persisted copy of the conceptName currently saved in the database for the given
@@ -417,129 +417,129 @@ public interface ConceptDAO {
 	 * @return the persisted copy of the conceptName currently saved in the database for this
 	 *         conceptName
 	 */
-	public ConceptName getSavedConceptName(ConceptName conceptName);
+	ConceptName getSavedConceptName(ConceptName conceptName);
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#saveConceptStopWord(org.openmrs.ConceptStopWord)
 	 */
-	public ConceptStopWord saveConceptStopWord(ConceptStopWord conceptStopWord) throws DAOException;
+	ConceptStopWord saveConceptStopWord(ConceptStopWord conceptStopWord) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#deleteConceptStopWord(Integer)
 	 */
-	public void deleteConceptStopWord(Integer conceptStopWordId) throws DAOException;
+	void deleteConceptStopWord(Integer conceptStopWordId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptStopWords(java.util.Locale)
 	 */
-	public List<String> getConceptStopWords(Locale locale) throws DAOException;
+	List<String> getConceptStopWords(Locale locale) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getAllConceptStopWords()
 	 */
-	public List<ConceptStopWord> getAllConceptStopWords();
+	List<ConceptStopWord> getAllConceptStopWords();
 	
 	/**
 	 * @see ConceptService#getCountOfDrugs(String, Concept, boolean, boolean, boolean)
 	 */
-	public Long getCountOfDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
-	        boolean includeRetired) throws DAOException;
+	Long getCountOfDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
+			boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getDrugs(String, Concept, boolean, boolean, boolean, Integer, Integer)
 	 */
-	public List<Drug> getDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
-	        boolean includeRetired, Integer start, Integer length) throws DAOException;
+	List<Drug> getDrugs(String drugName, Concept concept, boolean searchOnPhrase, boolean searchDrugConceptNames,
+			boolean includeRetired, Integer start, Integer length) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getDrugsByIngredient(Concept)
 	 */
-	public List<Drug> getDrugsByIngredient(Concept ingredient);
+	List<Drug> getDrugsByIngredient(Concept ingredient);
 	
 	/**
 	 * @see ConceptService#getConceptMapTypes(boolean, boolean)
 	 */
-	public List<ConceptMapType> getConceptMapTypes(boolean includeRetired, boolean includeHidden) throws DAOException;
+	List<ConceptMapType> getConceptMapTypes(boolean includeRetired, boolean includeHidden) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptMapType(Integer)
 	 */
-	public ConceptMapType getConceptMapType(Integer conceptMapTypeId) throws DAOException;
+	ConceptMapType getConceptMapType(Integer conceptMapTypeId) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptMapTypeByUuid(String)
 	 */
-	public ConceptMapType getConceptMapTypeByUuid(String uuid) throws DAOException;
+	ConceptMapType getConceptMapTypeByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptMapTypeByName(String)
 	 */
-	public ConceptMapType getConceptMapTypeByName(String name) throws DAOException;
+	ConceptMapType getConceptMapTypeByName(String name) throws DAOException;
 	
 	/**
 	 * @see ConceptService#saveConceptMapType(ConceptMapType)
 	 */
-	public ConceptMapType saveConceptMapType(ConceptMapType conceptMapType) throws DAOException;
+	ConceptMapType saveConceptMapType(ConceptMapType conceptMapType) throws DAOException;
 	
 	/**
 	 * @see ConceptService#purgeConceptMapType(ConceptMapType)
 	 */
-	public void deleteConceptMapType(ConceptMapType conceptMapType) throws DAOException;
+	void deleteConceptMapType(ConceptMapType conceptMapType) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTerms(boolean)
 	 */
-	public List<ConceptReferenceTerm> getConceptReferenceTerms(boolean includeRetired) throws DAOException;
+	List<ConceptReferenceTerm> getConceptReferenceTerms(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTerm(Integer)
 	 */
-	public ConceptReferenceTerm getConceptReferenceTerm(Integer conceptReferenceTermId) throws DAOException;
+	ConceptReferenceTerm getConceptReferenceTerm(Integer conceptReferenceTermId) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTermByUuid(String)
 	 */
-	public ConceptReferenceTerm getConceptReferenceTermByUuid(String uuid) throws DAOException;
+	ConceptReferenceTerm getConceptReferenceTermByUuid(String uuid) throws DAOException;
 	
-	public List<ConceptReferenceTerm> getConceptReferenceTermsBySource(ConceptSource conceptSource) throws DAOException;
+	List<ConceptReferenceTerm> getConceptReferenceTermsBySource(ConceptSource conceptSource) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTermByName(String, ConceptSource)
 	 */
-	public ConceptReferenceTerm getConceptReferenceTermByName(String name, ConceptSource conceptSource) throws DAOException;
+	ConceptReferenceTerm getConceptReferenceTermByName(String name, ConceptSource conceptSource) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTermByCode(String, ConceptSource)
 	 */
-	public ConceptReferenceTerm getConceptReferenceTermByCode(String code, ConceptSource conceptSource) throws DAOException;
+	ConceptReferenceTerm getConceptReferenceTermByCode(String code, ConceptSource conceptSource) throws DAOException;
 	
 	/**
 	 * @see ConceptService#saveConceptReferenceTerm(ConceptReferenceTerm)
 	 */
-	public ConceptReferenceTerm saveConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws DAOException;
+	ConceptReferenceTerm saveConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws DAOException;
 	
 	/**
 	 * @see ConceptService#purgeConceptReferenceTerm(ConceptReferenceTerm)
 	 */
-	public void deleteConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws DAOException;
+	void deleteConceptReferenceTerm(ConceptReferenceTerm conceptReferenceTerm) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getCountOfConceptReferenceTerms(String, ConceptSource, boolean)
 	 */
-	public Long getCountOfConceptReferenceTerms(String query, ConceptSource conceptSource, boolean includeRetired)
+	Long getCountOfConceptReferenceTerms(String query, ConceptSource conceptSource, boolean includeRetired)
 	        throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptReferenceTerms(String, ConceptSource, Integer, Integer,
 	 *      boolean)
 	 */
-	public List<ConceptReferenceTerm> getConceptReferenceTerms(String query, ConceptSource conceptSource, Integer start,
-	        Integer length, boolean includeRetired) throws APIException;
+	List<ConceptReferenceTerm> getConceptReferenceTerms(String query, ConceptSource conceptSource, Integer start,
+			Integer length, boolean includeRetired) throws APIException;
 	
 	/**
 	 * @see ConceptService#getReferenceTermMappingsTo(ConceptReferenceTerm)
 	 */
-	public List<ConceptReferenceTermMap> getReferenceTermMappingsTo(ConceptReferenceTerm term) throws DAOException;
+	List<ConceptReferenceTermMap> getReferenceTermMappingsTo(ConceptReferenceTerm term) throws DAOException;
 	
 	/**
 	 * Checks if there are any {@link ConceptReferenceTermMap}s or {@link ConceptMap}s using the
@@ -552,7 +552,7 @@ public interface ConceptDAO {
 	 * @should return true if a term has a conceptReferenceTermMap or more using it
 	 * @should return false if a term has no maps using it
 	 */
-	public boolean isConceptReferenceTermInUse(ConceptReferenceTerm term) throws DAOException;
+	boolean isConceptReferenceTermInUse(ConceptReferenceTerm term) throws DAOException;
 	
 	/**
 	 * Checks if there are any {@link ConceptReferenceTermMap}s or {@link ConceptMap}s using the
@@ -565,17 +565,17 @@ public interface ConceptDAO {
 	 * @should return true if a mapType has a conceptReferenceTermMap or more using it
 	 * @should return false if a mapType has no maps using it
 	 */
-	public boolean isConceptMapTypeInUse(ConceptMapType mapType) throws DAOException;
+	boolean isConceptMapTypeInUse(ConceptMapType mapType) throws DAOException;
 	
 	/**
 	 * @see ConceptService#getConceptsByName(String, Locale, Boolean)
 	 */
-	public List<Concept> getConceptsByName(String name, Locale locale, Boolean exactLocal);
+	List<Concept> getConceptsByName(String name, Locale locale, Boolean exactLocal);
 	
 	/**
 	 * @see ConceptService#getConceptByName(String)
 	 */
-	public Concept getConceptByName(String name);
+	Concept getConceptByName(String name);
 	
 	/**
 	 * It is in the DAO, because it must be done in the MANUAL flush mode to prevent premature
@@ -584,24 +584,24 @@ public interface ConceptDAO {
 	 * 
 	 * @see ConceptService#getDefaultConceptMapType()
 	 */
-	public ConceptMapType getDefaultConceptMapType() throws DAOException;
+	ConceptMapType getDefaultConceptMapType() throws DAOException;
 	
 	/**
 	 * @see ConceptService#isConceptNameDuplicate(ConceptName)
 	 */
-	public boolean isConceptNameDuplicate(ConceptName name);
+	boolean isConceptNameDuplicate(ConceptName name);
 	
 	/**
 	 * @see ConceptService#getDrugs(String, java.util.Locale, boolean, boolean)
 	 */
-	public List<Drug> getDrugs(String searchPhrase, Locale locale, boolean exactLocale, boolean includeRetired);
+	List<Drug> getDrugs(String searchPhrase, Locale locale, boolean exactLocale, boolean includeRetired);
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getDrugsByMapping(String, ConceptSource, Collection,
 	 *      boolean)
 	 */
-	public List<Drug> getDrugsByMapping(String code, ConceptSource conceptSource,
-	        Collection<ConceptMapType> withAnyOfTheseTypes, boolean includeRetired) throws DAOException;
+	List<Drug> getDrugsByMapping(String code, ConceptSource conceptSource,
+			Collection<ConceptMapType> withAnyOfTheseTypes, boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getDrugByMapping(String, org.openmrs.ConceptSource, java.util.Collection)
@@ -633,25 +633,25 @@ public interface ConceptDAO {
 	/**
 	 * @see ConceptService#purgeConceptAttributeType(ConceptAttributeType)
 	 */
-	public void deleteConceptAttributeType(ConceptAttributeType conceptAttributeType);
+	void deleteConceptAttributeType(ConceptAttributeType conceptAttributeType);
 
 	/**
 	 * @see ConceptService#getConceptAttributeTypes(String)
 	 */
-	public List<ConceptAttributeType> getConceptAttributeTypes(String name);
+	List<ConceptAttributeType> getConceptAttributeTypes(String name);
 
 	/**
 	 * @see ConceptService#getConceptAttributeTypeByName(String)
 	 */
-	public ConceptAttributeType getConceptAttributeTypeByName(String exactName);
+	ConceptAttributeType getConceptAttributeTypeByName(String exactName);
 
 	/**
 	 * @see ConceptService#getConceptAttributeByUuid(String)
 	 */
-	public ConceptAttribute getConceptAttributeByUuid(String uuid);
+	ConceptAttribute getConceptAttributeByUuid(String uuid);
 
 	/**
 	 * @see ConceptService#hasAnyConceptAttribute(ConceptAttributeType)
 	 */
-	public long getConceptAttributeCount(ConceptAttributeType conceptAttributeType);
+	long getConceptAttributeCount(ConceptAttributeType conceptAttributeType);
 }

--- a/api/src/main/java/org/openmrs/api/db/ContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ContextDAO.java
@@ -50,7 +50,7 @@ public interface ContextDAO {
 	 * @should throw a ContextAuthenticationException if username is an empty string
 	 * @should throw a ContextAuthenticationException if username is white space
 	 */
-	public User authenticate(String username, String password) throws ContextAuthenticationException;
+	User authenticate(String username, String password) throws ContextAuthenticationException;
 	
 	/**
 	 * Gets a user given the uuid. Privilege checks are not done here because this is used by the
@@ -60,27 +60,27 @@ public interface ContextDAO {
 	 * @return the User from the database
 	 * @throws ContextAuthenticationException
 	 */
-	public User getUserByUuid(String uuid) throws ContextAuthenticationException;
+	User getUserByUuid(String uuid) throws ContextAuthenticationException;
 	
 	/**
 	 * Open session.
 	 */
-	public void openSession();
+	void openSession();
 	
 	/**
 	 * Close session.
 	 */
-	public void closeSession();
+	void closeSession();
 	
 	/**
 	 * @see org.openmrs.api.context.Context#clearSession()
 	 */
-	public void clearSession();
+	void clearSession();
 	
 	/**
 	 * @see org.openmrs.api.context.Context#flushSession()
 	 */
-	public void flushSession();
+	void flushSession();
 	
 	/**
 	 * Used to clear a cached object out of a session in the middle of a unit of work. Future
@@ -90,7 +90,7 @@ public interface ContextDAO {
 	 * @param obj The object to evict/remove from the session
 	 * @see org.openmrs.api.context.Context#evictFromSession(Object)
 	 */
-	public void evictFromSession(Object obj);
+	void evictFromSession(Object obj);
 
 	/**
 	 * Used to re-read the state of the given instance from the underlying database.
@@ -99,7 +99,7 @@ public interface ContextDAO {
 	 * @param obj The object to refresh from the database in the session
 	 * @see org.openmrs.api.context.Context#refreshEntity(Object)
 	 */
-	public void refreshEntity(Object obj);
+	void refreshEntity(Object obj);
 
 	/**
 	 * Starts the OpenMRS System
@@ -108,20 +108,20 @@ public interface ContextDAO {
 	 * 
 	 * @param props Properties
 	 */
-	public void startup(Properties props);
+	void startup(Properties props);
 	
 	/**
 	 * Stops the OpenMRS System Should be called after all activity has ended and application is
 	 * closing
 	 */
-	public void shutdown();
+	void shutdown();
 	
 	/**
 	 * Merge in the default properties defined for this database connection
 	 * 
 	 * @param runtimeProperties The current user specific runtime properties
 	 */
-	public void mergeDefaultRuntimeProperties(Properties runtimeProperties);
+	void mergeDefaultRuntimeProperties(Properties runtimeProperties);
 	
 	/**
 	 * Updates the search index if necessary.
@@ -129,25 +129,25 @@ public interface ContextDAO {
 	 * The update is triggered if {@link OpenmrsConstants#GP_SEARCH_INDEX_VERSION} is blank
 	 * or the value does not match {@link OpenmrsConstants#SEARCH_INDEX_VERSION}.
 	 */
-	public void setupSearchIndex();
+	void setupSearchIndex();
 	
 	/**
 	 * @see Context#updateSearchIndex()
 	 */
-	public void updateSearchIndex();
+	void updateSearchIndex();
 
 	/**
 	 * @see Context#updateSearchIndexAsync()
 	 */
-	public Future<?> updateSearchIndexAsync();
+	Future<?> updateSearchIndexAsync();
 	
 	/**
 	 * @see Context#updateSearchIndexForObject(Object)
 	 */
-	public void updateSearchIndexForObject(Object object);
+	void updateSearchIndexForObject(Object object);
 	
 	/**
 	 * @see Context#updateSearchIndexForType(Class)
 	 */
-	public void updateSearchIndexForType(Class<?> type);
+	void updateSearchIndexForType(Class<?> type);
 }

--- a/api/src/main/java/org/openmrs/api/db/EncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/EncounterDAO.java
@@ -34,14 +34,14 @@ public interface EncounterDAO {
 	 * @param encounter to be saved
 	 * @throws DAOException
 	 */
-	public Encounter saveEncounter(Encounter encounter) throws DAOException;
+	Encounter saveEncounter(Encounter encounter) throws DAOException;
 	
 	/**
 	 * Purge an encounter from database.
 	 * 
 	 * @param encounter encounter object to be purged
 	 */
-	public void deleteEncounter(Encounter encounter) throws DAOException;
+	void deleteEncounter(Encounter encounter) throws DAOException;
 	
 	/**
 	 * Get encounter by internal identifier
@@ -50,26 +50,26 @@ public interface EncounterDAO {
 	 * @return encounter with given internal identifier
 	 * @throws DAOException
 	 */
-	public Encounter getEncounter(Integer encounterId) throws DAOException;
+	Encounter getEncounter(Integer encounterId) throws DAOException;
 	
 	/**
 	 * @param patientId
 	 * @return all encounters for the given patient identifier
 	 * @throws DAOException
 	 */
-	public List<Encounter> getEncountersByPatientId(Integer patientId) throws DAOException;
+	List<Encounter> getEncountersByPatientId(Integer patientId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.EncounterService#getEncounters(org.openmrs.parameter.EncounterSearchCriteria)
 	 */
-	public List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
+	List<Encounter> getEncounters(EncounterSearchCriteria encounterSearchCriteria);
 	
 	/**
 	 * Save an Encounter Type
 	 * 
 	 * @param encounterType
 	 */
-	public EncounterType saveEncounterType(EncounterType encounterType);
+	EncounterType saveEncounterType(EncounterType encounterType);
 	
 	/**
 	 * Purge encounter type from database.
@@ -77,7 +77,7 @@ public interface EncounterDAO {
 	 * @param encounterType
 	 * @throws DAOException
 	 */
-	public void deleteEncounterType(EncounterType encounterType) throws DAOException;
+	void deleteEncounterType(EncounterType encounterType) throws DAOException;
 	
 	/**
 	 * Get encounterType by internal identifier
@@ -86,7 +86,7 @@ public interface EncounterDAO {
 	 * @return EncounterType with given internal identifier
 	 * @throws DAOException
 	 */
-	public EncounterType getEncounterType(Integer encounterTypeId) throws DAOException;
+	EncounterType getEncounterType(Integer encounterTypeId) throws DAOException;
 	
 	/**
 	 * Get encounterType by name
@@ -95,7 +95,7 @@ public interface EncounterDAO {
 	 * @return EncounterType
 	 * @throws DAOException
 	 */
-	public EncounterType getEncounterType(String name) throws DAOException;
+	EncounterType getEncounterType(String name) throws DAOException;
 	
 	/**
 	 * Get all encounter types
@@ -103,7 +103,7 @@ public interface EncounterDAO {
 	 * @return encounter types list
 	 * @throws DAOException
 	 */
-	public List<EncounterType> getAllEncounterTypes(Boolean includeVoided) throws DAOException;
+	List<EncounterType> getAllEncounterTypes(Boolean includeVoided) throws DAOException;
 	
 	/**
 	 * Find Encounter Types matching the given name. Search string is case insensitive, so that
@@ -113,7 +113,7 @@ public interface EncounterDAO {
 	 * @return all EncounterTypes that match
 	 * @throws DAOException
 	 */
-	public List<EncounterType> findEncounterTypes(String name) throws DAOException;
+	List<EncounterType> findEncounterTypes(String name) throws DAOException;
 	
 	/**
 	 * Gets the value of encounterDatetime currently saved in the database for the given encounter,
@@ -124,7 +124,7 @@ public interface EncounterDAO {
 	 * @return the encounterDatetime currently in the database for this encounter
 	 * @should get saved encounter datetime from database
 	 */
-	public Date getSavedEncounterDatetime(Encounter encounter);
+	Date getSavedEncounterDatetime(Encounter encounter);
 	
 	/**
 	 * Find {@link Encounter} matching a uuid
@@ -132,7 +132,7 @@ public interface EncounterDAO {
 	 * @param uuid
 	 * @return {@link Encounter}
 	 */
-	public Encounter getEncounterByUuid(String uuid);
+	Encounter getEncounterByUuid(String uuid);
 	
 	/**
 	 * Find {@link EncounterType} matching a uuid
@@ -140,7 +140,7 @@ public interface EncounterDAO {
 	 * @param uuid
 	 * @return {@link EncounterType}
 	 */
-	public EncounterType getEncounterTypeByUuid(String uuid);
+	EncounterType getEncounterTypeByUuid(String uuid);
 	
 	/**
 	 * Get a list of {@link Encounter} by Patient name or identifier based on batch settings
@@ -161,12 +161,12 @@ public interface EncounterDAO {
 	 * @param encounter to be retrieved from the database
 	 * @return {@link Location}
 	 */
-	public Location getSavedEncounterLocation(Encounter encounter);
+	Location getSavedEncounterLocation(Encounter encounter);
 	
 	/**
 	 * @see EncounterService#getAllEncounters(Cohort)
 	 */
-	public Map<Integer, List<Encounter>> getAllEncounters(Cohort patients);
+	Map<Integer, List<Encounter>> getAllEncounters(Cohort patients);
 	
 	/**
 	 * Return the number of encounters matching a patient name or patient identifier
@@ -177,12 +177,12 @@ public interface EncounterDAO {
 	 * @return the number of encounters matching the given search phrase
 	 * @see EncounterService#getCountOfEncounters(String, boolean)
 	 */
-	public Long getCountOfEncounters(String query, Integer patientId, boolean includeVoided);
+	Long getCountOfEncounters(String query, Integer patientId, boolean includeVoided);
 	
 	/**
 	 * @see EncounterService#getEncountersByVisit(Visit, boolean)
 	 */
-	public List<Encounter> getEncountersByVisit(Visit visit, boolean includeVoided);
+	List<Encounter> getEncountersByVisit(Visit visit, boolean includeVoided);
 	
 	/**
 	 * Saves an encounter role
@@ -190,14 +190,14 @@ public interface EncounterDAO {
 	 * @param encounterRole role to be saved
 	 * @throws org.openmrs.api.db.DAOException
 	 */
-	public EncounterRole saveEncounterRole(EncounterRole encounterRole) throws DAOException;
+	EncounterRole saveEncounterRole(EncounterRole encounterRole) throws DAOException;
 	
 	/**
 	 * Purge an encounter role from database.
 	 * 
 	 * @param encounterRole encounter role object to be purged
 	 */
-	public void deleteEncounterRole(EncounterRole encounterRole) throws DAOException;
+	void deleteEncounterRole(EncounterRole encounterRole) throws DAOException;
 	
 	/**
 	 * Get encounter role by internal identifier
@@ -206,7 +206,7 @@ public interface EncounterDAO {
 	 * @return encounter role with given internal identifier
 	 * @throws org.openmrs.api.db.DAOException
 	 */
-	public EncounterRole getEncounterRole(Integer encounterRoleId) throws DAOException;
+	EncounterRole getEncounterRole(Integer encounterRoleId) throws DAOException;
 	
 	/**
 	 * Find {@link org.openmrs.EncounterRole} matching a uuid
@@ -214,7 +214,7 @@ public interface EncounterDAO {
 	 * @param uuid
 	 * @return {@link org.openmrs.EncounterRole}
 	 */
-	public EncounterRole getEncounterRoleByUuid(String uuid);
+	EncounterRole getEncounterRoleByUuid(String uuid);
 	
 	/**
 	 * Get all encounter roles and optionally specify whether to include retired encountered roles
@@ -224,17 +224,17 @@ public interface EncounterDAO {
 	 * @throws org.openmrs.api.db.DAOException
 	 * @see org.openmrs.api.EncounterService#getAllEncounterRoles(boolean)
 	 */
-	public List<EncounterRole> getAllEncounterRoles(boolean includeRetired) throws DAOException;
+	List<EncounterRole> getAllEncounterRoles(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.EncounterService#getEncounterRoleByName(String name)
 	 */
-	public EncounterRole getEncounterRoleByName(String name) throws DAOException;
+	EncounterRole getEncounterRoleByName(String name) throws DAOException;
 	
 	/**
 	 * @see EncounterService#getEncountersNotAssignedToAnyVisit(Patient)
 	 */
-	public List<Encounter> getEncountersNotAssignedToAnyVisit(Patient patient) throws DAOException;
+	List<Encounter> getEncountersNotAssignedToAnyVisit(Patient patient) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.EncounterService#getEncountersByVisitsAndPatient(org.openmrs.Patient, boolean, java.lang.String, java.lang.Integer, java.lang.Integer)
@@ -255,6 +255,6 @@ public interface EncounterDAO {
 	 * @throws org.openmrs.api.db.DAOException
 	 * @see org.openmrs.api.EncounterService#getEncounterRolesByName(String name)
 	 */
-	
-	public List<EncounterRole> getEncounterRolesByName(String name) throws DAOException;
+
+	List<EncounterRole> getEncounterRolesByName(String name) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/FormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/FormDAO.java
@@ -30,7 +30,7 @@ public interface FormDAO {
 	/**
 	 * @see FormService#saveForm(Form)
 	 */
-	public Form saveForm(Form form) throws DAOException;
+	Form saveForm(Form form) throws DAOException;
 	
 	/**
 	 * Creates new form from the given <code>Form</code>
@@ -39,7 +39,7 @@ public interface FormDAO {
 	 * @return newly duplicated <code>Form</code>
 	 * @throws DAOException
 	 */
-	public Form duplicateForm(Form form) throws DAOException;
+	Form duplicateForm(Form form) throws DAOException;
 	
 	/**
 	 * Get form by internal form identifier
@@ -48,7 +48,7 @@ public interface FormDAO {
 	 * @return requested <code>Form</code>
 	 * @throws DAOException
 	 */
-	public Form getForm(Integer formId) throws DAOException;
+	Form getForm(Integer formId) throws DAOException;
 	
 	/**
 	 * Get form by exact name and version
@@ -58,7 +58,7 @@ public interface FormDAO {
 	 * @return the form with the exact name and version given
 	 * @throws DAOException
 	 */
-	public Form getForm(String name, String version) throws DAOException;
+	Form getForm(String name, String version) throws DAOException;
 	
 	/**
 	 * Gets all forms with the given name, sorted (alphabetically) by descending version
@@ -67,7 +67,7 @@ public interface FormDAO {
 	 * @return All forms with the given name, sorted by (alphabetically) by descending version
 	 * @throws DAOException
 	 */
-	public List<Form> getFormsByName(String name) throws DAOException;
+	List<Form> getFormsByName(String name) throws DAOException;
 	
 	/**
 	 * Delete form from database. This is included for troubleshooting and low-level system
@@ -81,7 +81,7 @@ public interface FormDAO {
 	 * @param form Form to delete
 	 * @throws DAOException
 	 */
-	public void deleteForm(Form form) throws DAOException;
+	void deleteForm(Form form) throws DAOException;
 	
 	/**
 	 * Get all field types
@@ -90,7 +90,7 @@ public interface FormDAO {
 	 * @return List&lt;FieldTypes&gt; object with all FieldTypes, possibly including retired ones
 	 * @throws DAOException
 	 */
-	public List<FieldType> getAllFieldTypes(boolean includeRetired) throws DAOException;
+	List<FieldType> getAllFieldTypes(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Get fieldType by internal identifier
@@ -99,7 +99,7 @@ public interface FormDAO {
 	 * @return The FieldType with specified internal identifier
 	 * @throws DAOException
 	 */
-	public FieldType getFieldType(Integer fieldTypeId) throws DAOException;
+	FieldType getFieldType(Integer fieldTypeId) throws DAOException;
 	
 	/**
 	 * Returns all forms in the database, possibly including retired ones
@@ -108,7 +108,7 @@ public interface FormDAO {
 	 * @return List&lt;Form&gt; object of all forms, possibly including retired ones
 	 * @throws DAOException
 	 */
-	public List<Form> getAllForms(boolean includeRetired) throws DAOException;
+	List<Form> getAllForms(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Returns all FormFields in the database
@@ -116,13 +116,13 @@ public interface FormDAO {
 	 * @return List&lt;FormField&gt; object of all FormFields in the database
 	 * @throws DAOException
 	 */
-	public List<FormField> getAllFormFields() throws DAOException;
+	List<FormField> getAllFormFields() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.FormService#getFormField(org.openmrs.Form, org.openmrs.Concept,
 	 *      java.util.Collection, boolean)
 	 */
-	public FormField getFormField(Form form, Concept concept, Collection<FormField> ignoreFormFields, boolean force)
+	FormField getFormField(Form form, Concept concept, Collection<FormField> ignoreFormFields, boolean force)
 	        throws DAOException;
 	
 	/**
@@ -130,7 +130,7 @@ public interface FormDAO {
 	 * @return list of fields in the database matching search phrase
 	 * @throws DAOException
 	 */
-	public List<Field> getFields(String search) throws DAOException;
+	List<Field> getFields(String search) throws DAOException;
 	
 	/**
 	 * Returns all fields in the database, possibly including retired ones
@@ -139,17 +139,17 @@ public interface FormDAO {
 	 * @return all fields in the database, possibly including retired ones
 	 * @throws DAOException
 	 */
-	public List<Field> getAllFields(boolean includeRetired) throws DAOException;
+	List<Field> getAllFields(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see FormService#getField(Integer)
 	 */
-	public Field getField(Integer fieldId) throws DAOException;
+	Field getField(Integer fieldId) throws DAOException;
 	
 	/**
 	 * @see FormService#saveField(Field)
 	 */
-	public Field saveField(Field field) throws DAOException;
+	Field saveField(Field field) throws DAOException;
 	
 	/**
 	 * Deletes a field from the database.
@@ -159,17 +159,17 @@ public interface FormDAO {
 	 * @param field the Field to delete
 	 * @throws DAOException
 	 */
-	public void deleteField(Field field) throws DAOException;
+	void deleteField(Field field) throws DAOException;
 	
 	/**
 	 * @see FormService#getFormField(Integer)
 	 */
-	public FormField getFormField(Integer formFieldId) throws DAOException;
+	FormField getFormField(Integer formFieldId) throws DAOException;
 	
 	/**
 	 * @see FormService#saveFormField(FormField)
 	 */
-	public FormField saveFormField(FormField formField) throws DAOException;
+	FormField saveFormField(FormField formField) throws DAOException;
 	
 	/**
 	 * Deletes a FormField from the database. This will fail if any other entities reference this
@@ -178,7 +178,7 @@ public interface FormDAO {
 	 * @param formField the FormField to delete
 	 * @throws DAOException
 	 */
-	public void deleteFormField(FormField formField) throws DAOException;
+	void deleteFormField(FormField formField) throws DAOException;
 	
 	/**
 	 * Returns all fields that match a broad range of (nullable) criteria
@@ -201,9 +201,9 @@ public interface FormDAO {
 	 * @param retired <code>Boolean</code> retired status that fields must match
 	 * @return All Fields that match the criteria
 	 */
-	public List<Field> getFields(Collection<Form> forms, Collection<FieldType> fieldTypes, Collection<Concept> concepts,
-	        Collection<String> tableNames, Collection<String> attributeNames, Boolean selectMultiple,
-	        Collection<FieldAnswer> containsAllAnswers, Collection<FieldAnswer> containsAnyAnswer, Boolean retired)
+	List<Field> getFields(Collection<Form> forms, Collection<FieldType> fieldTypes, Collection<Concept> concepts,
+			Collection<String> tableNames, Collection<String> attributeNames, Boolean selectMultiple,
+			Collection<FieldAnswer> containsAllAnswers, Collection<FieldAnswer> containsAnyAnswer, Boolean retired)
 	        throws DAOException;
 	
 	/**
@@ -213,7 +213,7 @@ public interface FormDAO {
 	 * @param concept the <code>Concept</code> to search through form fields for
 	 * @return forms that contain a form field referencing the given concept
 	 */
-	public List<Form> getFormsContainingConcept(Concept concept) throws DAOException;
+	List<Form> getFormsContainingConcept(Concept concept) throws DAOException;
 	
 	/**
 	 * Gets all forms that match all the criteria. Expects the list objects to be non-null
@@ -232,37 +232,37 @@ public interface FormDAO {
 	 *      java.util.Collection, java.lang.Boolean, java.util.Collection, java.util.Collection,
 	 *      java.util.Collection)
 	 */
-	public List<Form> getForms(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
-	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
-	        Collection<Field> fields) throws DAOException;
+	List<Form> getForms(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
+			Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
+			Collection<Field> fields) throws DAOException;
 	
 	/**
 	 * @see #getForms(String, Boolean, Collection, Boolean, Collection, Collection, Collection)
 	 */
-	public Integer getFormCount(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
-	        Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
-	        Collection<Field> fields) throws DAOException;
+	Integer getFormCount(String partialName, Boolean published, Collection<EncounterType> encounterTypes,
+			Boolean retired, Collection<FormField> containingAnyFormField, Collection<FormField> containingAllFormFields,
+			Collection<Field> fields) throws DAOException;
 	
 	/**
 	 * Delete the given field type from the database
 	 * 
 	 * @param fieldType FieldType to delete
 	 */
-	public void deleteFieldType(FieldType fieldType) throws DAOException;
+	void deleteFieldType(FieldType fieldType) throws DAOException;
 	
 	/**
 	 * @param uuid
 	 * @return field or null
 	 */
-	public Field getFieldByUuid(String uuid);
+	Field getFieldByUuid(String uuid);
 	
-	public FieldAnswer getFieldAnswerByUuid(String uuid);
+	FieldAnswer getFieldAnswerByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return field type or null
 	 */
-	public FieldType getFieldTypeByUuid(String uuid);
+	FieldType getFieldTypeByUuid(String uuid);
 	
 	/**
 	 * Return fieldType  associated with given name
@@ -270,19 +270,19 @@ public interface FormDAO {
 	 * @param name Name of the fileType to query
 	 * @return fieldType object associate with given name
 	 */
-	public FieldType getFieldTypeByName(String name);
+	FieldType getFieldTypeByName(String name);
 	
 	/**
 	 * @param uuid
 	 * @return form or null
 	 */
-	public Form getFormByUuid(String uuid);
+	Form getFormByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return form field or null
 	 */
-	public FormField getFormFieldByUuid(String uuid);
+	FormField getFormFieldByUuid(String uuid);
 	
 	/**
 	 * Save the given field type to the database
@@ -290,7 +290,7 @@ public interface FormDAO {
 	 * @param fieldType FieldType to save to the database
 	 * @return the newly saved field type
 	 */
-	public FieldType saveFieldType(FieldType fieldType) throws DAOException;
+	FieldType saveFieldType(FieldType fieldType) throws DAOException;
 	
 	/**
 	 * Return a list of FormFields given a Field
@@ -298,42 +298,42 @@ public interface FormDAO {
 	 * @param field
 	 * @return List of FormFields
 	 */
-	public List<FormField> getFormFieldsByField(Field field);
+	List<FormField> getFormFieldsByField(Field field);
 	
 	/**
 	 * @see FormService#getFormResource(java.lang.Integer) 
 	 * @since 1.9
 	 */
-	public FormResource getFormResource(Integer formResourceId);
+	FormResource getFormResource(Integer formResourceId);
 	
 	/**
 	 * @see FormService#getFormResourceByUuid(java.lang.String) 
 	 * @since 1.9
 	 */
-	public FormResource getFormResourceByUuid(String uuid);
+	FormResource getFormResourceByUuid(String uuid);
 	
 	/**
 	 * @see FormService#getFormResource(org.openmrs.Form, java.lang.String)
 	 * @since 1.9
 	 */
-	public FormResource getFormResource(Form form, String name);
+	FormResource getFormResource(Form form, String name);
 	
 	/**
 	 * @see FormService#getFormResourcesForForm(org.openmrs.Form)
 	 * @since 1.9
 	 */
-	public Collection<FormResource> getFormResourcesForForm(Form form);
+	Collection<FormResource> getFormResourcesForForm(Form form);
 	
 	/**
 	 * @see FormService#saveFormResource(org.openmrs.FormResource)
 	 * @since 1.9
 	 */
-	public FormResource saveFormResource(FormResource formResource);
+	FormResource saveFormResource(FormResource formResource);
 	
 	/**
 	 * @see FormService#purgeFormResource(org.openmrs.FormResource)
 	 * @since 1.9
 	 */
-	public void deleteFormResource(FormResource formResource);
+	void deleteFormResource(FormResource formResource);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/LocationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/LocationDAO.java
@@ -29,7 +29,7 @@ public interface LocationDAO {
 	 * 
 	 * @param sessionFactory
 	 */
-	public void setSessionFactory(SessionFactory sessionFactory);
+	void setSessionFactory(SessionFactory sessionFactory);
 	
 	/**
 	 * Create or update a location.
@@ -37,7 +37,7 @@ public interface LocationDAO {
 	 * @param location <code>Location</code> to save
 	 * @return the saved <code>Location</code>
 	 */
-	public Location saveLocation(Location location);
+	Location saveLocation(Location location);
 	
 	/**
 	 * Get a location by locationId
@@ -45,7 +45,7 @@ public interface LocationDAO {
 	 * @param locationId Internal <code>Integer</code> identifier of the <code>Location</code> to get
 	 * @return the requested <code>Location</code>
 	 */
-	public Location getLocation(Integer locationId);
+	Location getLocation(Integer locationId);
 	
 	/**
 	 * Get a location by name
@@ -53,7 +53,7 @@ public interface LocationDAO {
 	 * @param name String name of the <code>Location</code> to get
 	 * @return the requested <code>Location</code>
 	 */
-	public Location getLocation(String name);
+	Location getLocation(String name);
 	
 	/**
 	 * Get all locations
@@ -62,7 +62,7 @@ public interface LocationDAO {
 	 * @return <code>List&lt;Location&gt;</code> object of all <code>Location</code>s, possibly including
 	 *         retired locations
 	 */
-	public List<Location> getAllLocations(boolean includeRetired);
+	List<Location> getAllLocations(boolean includeRetired);
 	
 	/**
 	 * Gets the locations matching the specified arguments
@@ -75,16 +75,16 @@ public interface LocationDAO {
 	 * @param length the number of matching locations to return
 	 * @return the list of locations
 	 */
-	public List<Location> getLocations(String nameFragment, Location parent,
-	        Map<LocationAttributeType, String> serializedAttributeValues, boolean includeRetired, Integer start,
-	        Integer length) throws DAOException;
+	List<Location> getLocations(String nameFragment, Location parent,
+			Map<LocationAttributeType, String> serializedAttributeValues, boolean includeRetired, Integer start,
+			Integer length) throws DAOException;
 	
 	/**
 	 * Completely remove the location from the database.
 	 * 
 	 * @param location <code>Location</code> object to delete
 	 */
-	public void deleteLocation(Location location);
+	void deleteLocation(Location location);
 	
 	/**
 	 * Create or update a location tag.
@@ -92,7 +92,7 @@ public interface LocationDAO {
 	 * @param tag
 	 * @return the saved <code>LocationTag</code>
 	 */
-	public LocationTag saveLocationTag(LocationTag tag);
+	LocationTag saveLocationTag(LocationTag tag);
 	
 	/**
 	 * Get a location tag by <code>locationTagId</code>
@@ -100,7 +100,7 @@ public interface LocationDAO {
 	 * @param locationTagId Internal <code>Integer</code> identifier of the tag to get
 	 * @return the requested <code>LocationTag</code>
 	 */
-	public LocationTag getLocationTag(Integer locationTagId);
+	LocationTag getLocationTag(Integer locationTagId);
 	
 	/**
 	 * Get a location tag by name
@@ -108,7 +108,7 @@ public interface LocationDAO {
 	 * @param tag String representation of the <code>LocationTag</code> to get
 	 * @return the requested <code>LocationTag</code>
 	 */
-	public LocationTag getLocationTagByName(String tag);
+	LocationTag getLocationTagByName(String tag);
 	
 	/**
 	 * Get all location tags
@@ -117,7 +117,7 @@ public interface LocationDAO {
 	 * @return List&lt;LocationTag&gt; object with all <code>LocationTag</code>s, possibly included
 	 *         retired ones
 	 */
-	public List<LocationTag> getAllLocationTags(boolean includeRetired);
+	List<LocationTag> getAllLocationTags(boolean includeRetired);
 	
 	/**
 	 * Find all location tags with matching names.
@@ -125,71 +125,71 @@ public interface LocationDAO {
 	 * @param search name to search
 	 * @return List&lt;LocationTag&gt; with all matching <code>LocationTags</code>
 	 */
-	public List<LocationTag> getLocationTags(String search);
+	List<LocationTag> getLocationTags(String search);
 	
 	/**
 	 * Completely remove the location tag from the database.
 	 * 
 	 * @param tag The <code>LocationTag</code> to delete
 	 */
-	public void deleteLocationTag(LocationTag tag);
+	void deleteLocationTag(LocationTag tag);
 	
 	/**
 	 * @param uuid the uuid to look for
 	 * @return location matching uuid
 	 */
-	public Location getLocationByUuid(String uuid);
+	Location getLocationByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return location tag or null
 	 */
-	public LocationTag getLocationTagByUuid(String uuid);
+	LocationTag getLocationTagByUuid(String uuid);
 	
 	/**
 	 * @see org.openmrs.api.LocationService#getCountOfLocations(String, Boolean)
 	 */
-	public Long getCountOfLocations(String nameFragment, Boolean includeRetired);
+	Long getCountOfLocations(String nameFragment, Boolean includeRetired);
 	
 	/**
 	 * @see LocationService#getRootLocations(boolean)
 	 */
-	public List<Location> getRootLocations(boolean includeRetired);
+	List<Location> getRootLocations(boolean includeRetired);
 	
 	/**
 	 * @see LocationService#getAllLocationAttributeTypes()
 	 */
-	public List<LocationAttributeType> getAllLocationAttributeTypes();
+	List<LocationAttributeType> getAllLocationAttributeTypes();
 	
 	/**
 	 * @see LocationService#getLocationAttributeType(Integer)
 	 */
-	public LocationAttributeType getLocationAttributeType(Integer id);
+	LocationAttributeType getLocationAttributeType(Integer id);
 	
 	/**
 	 * @see LocationService#getLocationAttributeTypeByUuid(String)
 	 */
-	public LocationAttributeType getLocationAttributeTypeByUuid(String uuid);
+	LocationAttributeType getLocationAttributeTypeByUuid(String uuid);
 	
 	/**
 	 * @see LocationService#saveLocationAttributeType(LocationAttributeType)
 	 */
-	public LocationAttributeType saveLocationAttributeType(LocationAttributeType locationAttributeType);
+	LocationAttributeType saveLocationAttributeType(LocationAttributeType locationAttributeType);
 	
 	/**
 	 * @see LocationService#purgeLocationAttributeType(LocationAttributeType)
 	 */
-	public void deleteLocationAttributeType(LocationAttributeType locationAttributeType);
+	void deleteLocationAttributeType(LocationAttributeType locationAttributeType);
 	
 	/**
 	 * @see LocationService#getLocationAttributeByUuid(String)
 	 */
-	public LocationAttribute getLocationAttributeByUuid(String uuid);
+	LocationAttribute getLocationAttributeByUuid(String uuid);
 	
 	/**
 	 * @see LocationService#getLocationAttributeTypeByName(String)
 	 */
-	public LocationAttributeType getLocationAttributeTypeByName(String name);
+	LocationAttributeType getLocationAttributeTypeByName(String name);
 	
 	/**
 	 * Get locations that have all the location tags specified.

--- a/api/src/main/java/org/openmrs/api/db/ObsDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ObsDAO.java
@@ -31,17 +31,17 @@ public interface ObsDAO {
 	/**
 	 * @see org.openmrs.api.ObsService#saveObs(org.openmrs.Obs, String)
 	 */
-	public Obs saveObs(Obs obs) throws DAOException;
+	Obs saveObs(Obs obs) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ObsService#getObs(java.lang.Integer)
 	 */
-	public Obs getObs(Integer obsId) throws DAOException;
+	Obs getObs(Integer obsId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ObsService#purgeObs(Obs)
 	 */
-	public void deleteObs(Obs obs) throws DAOException;
+	void deleteObs(Obs obs) throws DAOException;
 		
 	/**
 	 * @see org.openmrs.api.ObsService#getObservations(java.util.List, java.util.List,
@@ -49,10 +49,10 @@ public interface ObsDAO {
 	 *      java.lang.Integer, java.lang.Integer, java.util.Date, java.util.Date, boolean,
 	 *      java.lang.String)
 	 */
-	public List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
-	        Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs,
-	        String accessionNumber) throws DAOException;
+	List<Obs> getObservations(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, List<String> sort,
+			Integer mostRecentN, Integer obsGroupId, Date fromDate, Date toDate, boolean includeVoidedObs,
+			String accessionNumber) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.ObsService#getObservationCount(java.util.List, java.util.List,
@@ -60,23 +60,23 @@ public interface ObsDAO {
 	 *      java.util.Date, java.util.Date, boolean, java.lang.String)
 	 * @see ObsService#getObservationCount(List, boolean)
 	 */
-	public Long getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
-	        List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
-	        Date fromDate, Date toDate, List<ConceptName> valueCodedNameAnswers, boolean includeVoidedObs,
-	        String accessionNumber) throws DAOException;
+	Long getObservationCount(List<Person> whom, List<Encounter> encounters, List<Concept> questions,
+			List<Concept> answers, List<PERSON_TYPE> personTypes, List<Location> locations, Integer obsGroupId,
+			Date fromDate, Date toDate, List<ConceptName> valueCodedNameAnswers, boolean includeVoidedObs,
+			String accessionNumber) throws DAOException;
 	
 	/**
 	 * @param uuid
 	 * @return obs or null
 	 */
-	public Obs getObsByUuid(String uuid);
+	Obs getObsByUuid(String uuid);
 
 	/**
 	 * @see org.openmrs.api.ObsService#getRevisionObs(org.openmrs.Obs)
 	 * @param initialObs
 	 * @return Obs or null
 	 */
-	public Obs getRevisionObs(Obs initialObs);
+	Obs getRevisionObs(Obs initialObs);
 	
 	/**
 	 * Gets the value of status currently saved in the database for the given obs, bypassing any caches. This is used
@@ -85,6 +85,6 @@ public interface ObsDAO {
 	 * @return
 	 * @since 2.1.0
 	 */
-	public Obs.Status getSavedStatus(Obs obs);
+	Obs.Status getSavedStatus(Obs obs);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/OrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/OrderDAO.java
@@ -38,17 +38,17 @@ public interface OrderDAO {
 	/**
 	 * @see org.openmrs.api.OrderService#saveOrder(org.openmrs.Order, org.openmrs.api.OrderContext)
 	 */
-	public Order saveOrder(Order order) throws DAOException;
+	Order saveOrder(Order order) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.OrderService#purgeOrder(Order)
 	 */
-	public void deleteOrder(Order order) throws DAOException;
+	void deleteOrder(Order order) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrder(Integer)
 	 */
-	public Order getOrder(Integer orderId) throws DAOException;
+	Order getOrder(Integer orderId) throws DAOException;
 	
 	/**
 	 * This searches for orders given the parameters. Most arguments are optional (nullable). If
@@ -62,44 +62,44 @@ public interface OrderDAO {
 	 * @param encounters The encounters that the orders are assigned to
 	 * @return list of Orders matching the parameters
 	 */
-	public List<Order> getOrders(OrderType orderType, List<Patient> patients, List<Concept> concepts, List<User> orderers,
-	        List<Encounter> encounters);
+	List<Order> getOrders(OrderType orderType, List<Patient> patients, List<Concept> concepts, List<User> orderers,
+			List<Encounter> encounters);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrders(org.openmrs.Patient, org.openmrs.CareSetting,
 	 *      org.openmrs.OrderType, boolean)
 	 */
-	public List<Order> getOrders(Patient patient, CareSetting careSetting, List<OrderType> orderTypes,
-	        boolean includeVoided, boolean includeDiscontinuationOrders);
+	List<Order> getOrders(Patient patient, CareSetting careSetting, List<OrderType> orderTypes,
+			boolean includeVoided, boolean includeDiscontinuationOrders);
 	
 	/**
 	 * @param uuid
 	 * @return order or null
 	 */
-	public Order getOrderByUuid(String uuid);
+	Order getOrderByUuid(String uuid);
 	
 	/**
 	 * Delete Obs that references an order
 	 */
-	public void deleteObsThatReference(Order order);
+	void deleteObsThatReference(Order order);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderByOrderNumber(java.lang.String)
 	 */
-	public Order getOrderByOrderNumber(String orderNumber);
+	Order getOrderByOrderNumber(String orderNumber);
 	
 	/**
 	 * Gets the next available order number seed
 	 * 
 	 * @return the order number seed
 	 */
-	public Long getNextOrderNumberSeedSequenceValue();
+	Long getNextOrderNumberSeedSequenceValue();
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getActiveOrders(org.openmrs.Patient, org.openmrs.OrderType,
 	 *      org.openmrs.CareSetting, java.util.Date)
 	 */
-	public List<Order> getActiveOrders(Patient patient, List<OrderType> orderTypes, CareSetting careSetting, Date asOfDate);
+	List<Order> getActiveOrders(Patient patient, List<OrderType> orderTypes, CareSetting careSetting, Date asOfDate);
 	
 	/**
 	 * Get care setting by type
@@ -107,37 +107,37 @@ public interface OrderDAO {
 	 * @param careSettingId
 	 * @return the care setting type
 	 */
-	public CareSetting getCareSetting(Integer careSettingId);
+	CareSetting getCareSetting(Integer careSettingId);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getCareSettingByUuid(String)
 	 */
-	public CareSetting getCareSettingByUuid(String uuid);
+	CareSetting getCareSettingByUuid(String uuid);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getCareSettingByName(String)
 	 */
-	public CareSetting getCareSettingByName(String name);
+	CareSetting getCareSettingByName(String name);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getCareSettings(boolean)
 	 */
-	public List<CareSetting> getCareSettings(boolean includeRetired);
+	List<CareSetting> getCareSettings(boolean includeRetired);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderTypeByName(String)
 	 */
-	public OrderType getOrderTypeByName(String orderTypeName);
+	OrderType getOrderTypeByName(String orderTypeName);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderFrequency
 	 */
-	public OrderFrequency getOrderFrequency(Integer orderFrequencyId);
+	OrderFrequency getOrderFrequency(Integer orderFrequencyId);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderFrequencyByUuid
 	 */
-	public OrderFrequency getOrderFrequencyByUuid(String uuid);
+	OrderFrequency getOrderFrequencyByUuid(String uuid);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderFrequencies(boolean)
@@ -147,18 +147,18 @@ public interface OrderDAO {
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderFrequencies(String, java.util.Locale, boolean, boolean)
 	 */
-	public List<OrderFrequency> getOrderFrequencies(String searchPhrase, Locale locale, boolean exactLocale,
-	        boolean includeRetired);
+	List<OrderFrequency> getOrderFrequencies(String searchPhrase, Locale locale, boolean exactLocale,
+			boolean includeRetired);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#saveOrderFrequency(org.openmrs.OrderFrequency)
 	 */
-	public OrderFrequency saveOrderFrequency(OrderFrequency orderFrequency);
+	OrderFrequency saveOrderFrequency(OrderFrequency orderFrequency);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#purgeOrderFrequency(org.openmrs.OrderFrequency)
 	 */
-	public void purgeOrderFrequency(OrderFrequency orderFrequency);
+	void purgeOrderFrequency(OrderFrequency orderFrequency);
 	
 	/**
 	 * Checks if an order frequency is being referenced by any order
@@ -166,47 +166,47 @@ public interface OrderDAO {
 	 * @param orderFrequency the order frequency
 	 * @return true if in use, else false
 	 */
-	public boolean isOrderFrequencyInUse(OrderFrequency orderFrequency);
+	boolean isOrderFrequencyInUse(OrderFrequency orderFrequency);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderFrequencyByConcept
 	 */
-	public OrderFrequency getOrderFrequencyByConcept(Concept concept);
+	OrderFrequency getOrderFrequencyByConcept(Concept concept);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderType
 	 */
-	public OrderType getOrderType(Integer orderTypeId);
+	OrderType getOrderType(Integer orderTypeId);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderTypeByUuid
 	 */
-	public OrderType getOrderTypeByUuid(String uuid);
+	OrderType getOrderTypeByUuid(String uuid);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderTypes
 	 */
-	public List<OrderType> getOrderTypes(boolean includeRetired);
+	List<OrderType> getOrderTypes(boolean includeRetired);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderTypeByConceptClass(org.openmrs.ConceptClass)
 	 */
-	public OrderType getOrderTypeByConceptClass(ConceptClass conceptClass);
+	OrderType getOrderTypeByConceptClass(ConceptClass conceptClass);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#saveOrderType(org.openmrs.OrderType)
 	 */
-	public OrderType saveOrderType(OrderType orderType);
+	OrderType saveOrderType(OrderType orderType);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#purgeOrderType(org.openmrs.OrderType)
 	 */
-	public void purgeOrderType(OrderType orderType);
+	void purgeOrderType(OrderType orderType);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getSubtypes(org.openmrs.OrderType, boolean)
 	 */
-	public List<OrderType> getOrderSubtypes(OrderType orderType, boolean includeRetired);
+	List<OrderType> getOrderSubtypes(OrderType orderType, boolean includeRetired);
 	
 	/**
 	 * Check whether give order type is used by any order
@@ -214,17 +214,17 @@ public interface OrderDAO {
 	 * @param orderType the order type to check the usage
 	 * @return true if used else false
 	 */
-	public boolean isOrderTypeInUse(OrderType orderType);
+	boolean isOrderTypeInUse(OrderType orderType);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getDiscontinuationOrder(Order)
 	 */
-	public Order getDiscontinuationOrder(Order order);
+	Order getDiscontinuationOrder(Order order);
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getRevisionOrder(org.openmrs.Order)
 	 */
-	public Order getRevisionOrder(Order order) throws APIException;
+	Order getRevisionOrder(Order order) throws APIException;
 	
 	/**
 	 * Get the fresh order from the database
@@ -233,7 +233,7 @@ public interface OrderDAO {
 	 * @param isOrderADrugOrder is the order a previous order
 	 * @return a list of orders from the database
 	 */
-	public List<Object[]> getOrderFromDatabase(Order order, boolean isOrderADrugOrder) throws APIException;
+	List<Object[]> getOrderFromDatabase(Order order, boolean isOrderADrugOrder) throws APIException;
 
 	/**
 	 * Saves an orderGroup to the database
@@ -242,15 +242,15 @@ public interface OrderDAO {
 	 * @return an orderGroup
 	 * @throws DAOException
 	 */
-	public OrderGroup saveOrderGroup(OrderGroup orderGroup) throws DAOException;
+	OrderGroup saveOrderGroup(OrderGroup orderGroup) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderGroupByUuid(String)
 	 */
-	public OrderGroup getOrderGroupByUuid(String uuid) throws DAOException;
+	OrderGroup getOrderGroupByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.OrderService#getOrderGroup(Integer)
 	 */
-	public OrderGroup getOrderGroupById(Integer orderGroupId) throws DAOException;
+	OrderGroup getOrderGroupById(Integer orderGroupId) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/PatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/PatientDAO.java
@@ -29,12 +29,12 @@ public interface PatientDAO {
 	/**
 	 * @see org.openmrs.api.PatientService#savePatient(org.openmrs.Patient)
 	 */
-	public Patient savePatient(Patient patient) throws DAOException;
+	Patient savePatient(Patient patient) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatient(Integer)
 	 */
-	public Patient getPatient(Integer patientId) throws DAOException;
+	Patient getPatient(Integer patientId) throws DAOException;
 	
 	/**
 	 * Delete patient from database. This <b>should not be called</b> except for testing and
@@ -44,12 +44,12 @@ public interface PatientDAO {
 	 * @see org.openmrs.api.PatientService#deletePatient(org.openmrs.Patient)
 	 * @see org.openmrs.api.PatientService#voidPatient(Patient, String)
 	 */
-	public void deletePatient(Patient patient) throws DAOException;
+	void deletePatient(Patient patient) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getAllPatients(boolean)
 	 */
-	public List<Patient> getAllPatients(boolean includeVoided) throws DAOException;
+	List<Patient> getAllPatients(boolean includeVoided) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatients(String, Integer, Integer)
@@ -114,14 +114,14 @@ public interface PatientDAO {
 	 * @should not get patients with match mode anywhere _ signature no 2
 	 *
 	 */
-	public List<Patient> getPatients(String query, Integer start, Integer length) throws DAOException;
+	List<Patient> getPatients(String query, Integer start, Integer length) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatients(String, boolean, Integer, Integer)
 	 * @should get voided person when voided true is passed
 	 * @should get no voided person when voided false is passed
 	 */
-	public List<Patient> getPatients(String query, boolean includeVoided, Integer start, Integer length) throws DAOException;
+	List<Patient> getPatients(String query, boolean includeVoided, Integer start, Integer length) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifiers(java.lang.String, java.util.List,
@@ -136,14 +136,14 @@ public interface PatientDAO {
 	 * @should not fetch patient identifiers that partially matches given identifier  
 	 * @should not get voided patient identifiers 
 	 */
-	public List<PatientIdentifier> getPatientIdentifiers(String identifier,
-	        List<PatientIdentifierType> patientIdentifierTypes, List<Location> locations, List<Patient> patients,
-	        Boolean isPreferred) throws DAOException;
+	List<PatientIdentifier> getPatientIdentifiers(String identifier,
+			List<PatientIdentifierType> patientIdentifierTypes, List<Location> locations, List<Patient> patients,
+			Boolean isPreferred) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#savePatientIdentifierType(org.openmrs.PatientIdentifierType)
 	 */
-	public PatientIdentifierType savePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws DAOException;
+	PatientIdentifierType savePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws DAOException;
 	
 	/**
 	 * @should not return null when includeRetired is false
@@ -152,63 +152,63 @@ public interface PatientDAO {
 	 * @should return all when includeRetired is true
 	 * @see org.openmrs.api.PatientService#getAllPatientIdentifierTypes(boolean)
 	 */
-	public List<PatientIdentifierType> getAllPatientIdentifierTypes(boolean includeRetired) throws DAOException;
+	List<PatientIdentifierType> getAllPatientIdentifierTypes(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifierTypes(java.lang.String,
 	 *      java.lang.String, java.lang.Boolean, java.lang.Boolean)
 	 */
-	public List<PatientIdentifierType> getPatientIdentifierTypes(String name, String format, Boolean required,
-	        Boolean hasCheckDigit) throws DAOException;
+	List<PatientIdentifierType> getPatientIdentifierTypes(String name, String format, Boolean required,
+			Boolean hasCheckDigit) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifierType(java.lang.Integer)
 	 */
-	public PatientIdentifierType getPatientIdentifierType(Integer patientIdentifierTypeId) throws DAOException;
+	PatientIdentifierType getPatientIdentifierType(Integer patientIdentifierTypeId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#purgePatientIdentifierType(org.openmrs.PatientIdentifierType)
 	 */
-	public void deletePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws DAOException;
+	void deletePatientIdentifierType(PatientIdentifierType patientIdentifierType) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getDuplicatePatientsByAttributes(java.util.List)
 	 */
-	public List<Patient> getDuplicatePatientsByAttributes(List<String> attributes) throws DAOException;
+	List<Patient> getDuplicatePatientsByAttributes(List<String> attributes) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#isIdentifierInUseByAnotherPatient(PatientIdentifier)
 	 */
-	public boolean isIdentifierInUseByAnotherPatient(PatientIdentifier patientIdentifier);
+	boolean isIdentifierInUseByAnotherPatient(PatientIdentifier patientIdentifier);
 	
 	/**
 	 * @param uuid
 	 * @return patient or null
 	 */
-	public Patient getPatientByUuid(String uuid);
+	Patient getPatientByUuid(String uuid);
 	
-	public PatientIdentifier getPatientIdentifierByUuid(String uuid);
+	PatientIdentifier getPatientIdentifierByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return patient identifier type or null
 	 */
-	public PatientIdentifierType getPatientIdentifierTypeByUuid(String uuid);
+	PatientIdentifierType getPatientIdentifierTypeByUuid(String uuid);
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getPatientIdentifier(java.lang.Integer)
 	 */
-	public PatientIdentifier getPatientIdentifier(Integer patientIdentifierId) throws DAOException;
+	PatientIdentifier getPatientIdentifier(Integer patientIdentifierId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#savePatientIdentifier(org.openmrs.PatientIdentifier)
 	 */
-	public PatientIdentifier savePatientIdentifier(PatientIdentifier patientIdentifier);
+	PatientIdentifier savePatientIdentifier(PatientIdentifier patientIdentifier);
 	
 	/**
 	 * @see org.openmrs.api.PatientService#purgePatientIdentifier(org.openmrs.PatientIdentifier)
 	 */
-	public void deletePatientIdentifier(PatientIdentifier patientIdentifier) throws DAOException;
+	void deletePatientIdentifier(PatientIdentifier patientIdentifier) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getCountOfPatients(String)
@@ -226,12 +226,12 @@ public interface PatientDAO {
 	 * @should count patients by searchable attribute _ signature no 2
 	 * @should obey attribute match mode
 	 */
-	public Long getCountOfPatients(String query);
+	Long getCountOfPatients(String query);
 	
 	/**
 	 * @see org.openmrs.api.PatientService#getCountOfPatients(String, boolean)
 	 */
-	public Long getCountOfPatients(String query, boolean includeVoided);
+	Long getCountOfPatients(String query, boolean includeVoided);
 	
 	/**
 	 * Gets a list of allergies that a patient has
@@ -239,7 +239,7 @@ public interface PatientDAO {
 	 * @param patient the patient
 	 * @return the allergy list
 	 */
-	public List<Allergy> getAllergies(Patient patient);
+	List<Allergy> getAllergies(Patient patient);
 	
 	/**
 	 * Gets a patient's allergy status
@@ -247,7 +247,7 @@ public interface PatientDAO {
 	 * @param patient the patient
 	 * @return the allergy status
 	 */
-	public String getAllergyStatus(Patient patient);
+	String getAllergyStatus(Patient patient);
 	
 	/**
 	 * Saves patient allergies to the database.
@@ -256,7 +256,7 @@ public interface PatientDAO {
 	 * @param allergies the allergies
 	 * @return the saved allergies
 	 */
-	public Allergies saveAllergies(Patient patient, Allergies allergies);
+	Allergies saveAllergies(Patient patient, Allergies allergies);
 	
 	/**
 	 * Gets a allergy matching the given allergyId
@@ -266,7 +266,7 @@ public interface PatientDAO {
 	 * @should return allergy given valid allergyId
 	 * @should return null if no object found with given allergyId
 	 */
-	public Allergy getAllergy(Integer allergyId);
+	Allergy getAllergy(Integer allergyId);
 	
 	
 	/**
@@ -278,7 +278,7 @@ public interface PatientDAO {
 	 * @should return allergy given valid uuid
 	 * @should return null if no object found with given uuid
 	 */
-	public Allergy getAllergyByUuid(String uuid);
+	Allergy getAllergyByUuid(String uuid);
 	
 	/**
 	 * Saves an allergy to the database
@@ -286,6 +286,6 @@ public interface PatientDAO {
 	 * @param allergy the allergy to save
 	 * @return the saved allergy
 	 */
-	public Allergy saveAllergy(Allergy allergy);
+	Allergy saveAllergy(Allergy allergy);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/PersonDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/PersonDAO.java
@@ -44,148 +44,148 @@ public interface PersonDAO {
 	 * @see org.openmrs.api.PersonService#getSimilarPeople(java.lang.String, java.lang.Integer,
 	 *      java.lang.String)
 	 */
-	public Set<Person> getSimilarPeople(String name, Integer birthyear, String gender) throws DAOException;
+	Set<Person> getSimilarPeople(String name, Integer birthyear, String gender) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getPeople(String, Boolean)
 	 */
-	public List<Person> getPeople(String searchPhrase, Boolean dead) throws DAOException;
+	List<Person> getPeople(String searchPhrase, Boolean dead) throws DAOException;
 	
-	public List<Person> getPeople(String searchPhrase, Boolean dead, Boolean voided) throws DAOException;
+	List<Person> getPeople(String searchPhrase, Boolean dead, Boolean voided) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#savePersonAttributeType(org.openmrs.PersonAttributeType)
 	 */
-	public PersonAttributeType savePersonAttributeType(PersonAttributeType type) throws DAOException;
+	PersonAttributeType savePersonAttributeType(PersonAttributeType type) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#purgePersonAttributeType(org.openmrs.PersonAttributeType)
 	 */
-	public void deletePersonAttributeType(PersonAttributeType type) throws DAOException;
+	void deletePersonAttributeType(PersonAttributeType type) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getPersonAttributeTypes(java.lang.String,
 	 *      java.lang.String, java.lang.Integer, java.lang.Boolean)
 	 */
-	public List<PersonAttributeType> getPersonAttributeTypes(String exactName, String format, Integer foreignKey,
-	        Boolean searchable) throws DAOException;
+	List<PersonAttributeType> getPersonAttributeTypes(String exactName, String format, Integer foreignKey,
+			Boolean searchable) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getAllPersonAttributeTypes()
 	 * @see org.openmrs.api.PersonService#getAllPersonAttributeTypes(boolean)
 	 */
-	public List<PersonAttributeType> getAllPersonAttributeTypes(boolean includeRetired) throws DAOException;
+	List<PersonAttributeType> getAllPersonAttributeTypes(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getPersonAttributeType(java.lang.Integer)
 	 */
-	public PersonAttributeType getPersonAttributeType(Integer typeId) throws DAOException;
+	PersonAttributeType getPersonAttributeType(Integer typeId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getPersonAttribute(java.lang.Integer)
 	 */
-	public PersonAttribute getPersonAttribute(Integer id) throws DAOException;
+	PersonAttribute getPersonAttribute(Integer id) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getRelationship(java.lang.Integer)
 	 */
-	public Relationship getRelationship(Integer relationshipId) throws DAOException;
+	Relationship getRelationship(Integer relationshipId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getAllRelationships(boolean)
 	 */
-	public List<Relationship> getAllRelationships(boolean includeVoided) throws DAOException;
+	List<Relationship> getAllRelationships(boolean includeVoided) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getRelationshipType(java.lang.Integer)
 	 */
-	public RelationshipType getRelationshipType(Integer relationshipTypeId) throws DAOException;
+	RelationshipType getRelationshipType(Integer relationshipTypeId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getRelationshipTypes(java.lang.String, java.lang.Boolean)
 	 */
-	public List<RelationshipType> getRelationshipTypes(String relationshipTypeName, Boolean preferred) throws DAOException;
+	List<RelationshipType> getRelationshipTypes(String relationshipTypeName, Boolean preferred) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#savePerson(org.openmrs.Person)
 	 */
-	public Person savePerson(Person person) throws DAOException;
+	Person savePerson(Person person) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#deletePerson(org.openmrs.Person)
 	 */
-	public void deletePerson(Person person) throws DAOException;
+	void deletePerson(Person person) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getPerson(java.lang.Integer)
 	 */
-	public Person getPerson(Integer personId) throws DAOException;
+	Person getPerson(Integer personId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#saveRelationship(org.openmrs.Relationship)
 	 */
-	public Relationship saveRelationship(Relationship relationship) throws DAOException;
+	Relationship saveRelationship(Relationship relationship) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#purgeRelationship(org.openmrs.Relationship)
 	 */
-	public void deleteRelationship(Relationship relationship) throws DAOException;
+	void deleteRelationship(Relationship relationship) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getRelationships(org.openmrs.Person, org.openmrs.Person,
 	 *      org.openmrs.RelationshipType)
 	 */
-	public List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType)
+	List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType)
 	        throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getRelationships(org.openmrs.Person, org.openmrs.Person,
 	 *      org.openmrs.RelationshipType, java.util.Date, java.util.Date)
 	 */
-	public List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
-	        Date startEffectiveDate, Date endEffectiveDate) throws DAOException;
+	List<Relationship> getRelationships(Person fromPerson, Person toPerson, RelationshipType relType,
+			Date startEffectiveDate, Date endEffectiveDate) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#saveRelationshipType(org.openmrs.RelationshipType)
 	 */
-	public RelationshipType saveRelationshipType(RelationshipType relationshipType) throws DAOException;
+	RelationshipType saveRelationshipType(RelationshipType relationshipType) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#deleteRelationshipType(org.openmrs.RelationshipType)
 	 */
-	public void deleteRelationshipType(RelationshipType relationshipType) throws DAOException;
+	void deleteRelationshipType(RelationshipType relationshipType) throws DAOException;
 	
 	/**
 	 * @param uuid
 	 * @return person or null
 	 */
-	public Person getPersonByUuid(String uuid);
+	Person getPersonByUuid(String uuid);
 	
-	public PersonAddress getPersonAddressByUuid(String uuid);
+	PersonAddress getPersonAddressByUuid(String uuid);
 	
-	public PersonAttribute getPersonAttributeByUuid(String uuid);
+	PersonAttribute getPersonAttributeByUuid(String uuid);
 	
-	public PersonName getPersonName(Integer personNameId);
+	PersonName getPersonName(Integer personNameId);
 	
-	public PersonName getPersonNameByUuid(String uuid);
+	PersonName getPersonNameByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return relationship or null
 	 */
-	public Relationship getRelationshipByUuid(String uuid);
+	Relationship getRelationshipByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return relationship type or null
 	 */
-	public RelationshipType getRelationshipTypeByUuid(String uuid);
+	RelationshipType getRelationshipTypeByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return person attribute type or null
 	 */
-	public PersonAttributeType getPersonAttributeTypeByUuid(String uuid);
+	PersonAttributeType getPersonAttributeTypeByUuid(String uuid);
 	
 	/**
 	 * Gets the value of name currently saved in the database for the given personAttributeType,
@@ -198,12 +198,12 @@ public interface PersonDAO {
 	 * @return the name currently in the database for this personAttributeType
 	 * @should get saved personAttributeType name from database
 	 */
-	public String getSavedPersonAttributeTypeName(PersonAttributeType personAttributeType);
+	String getSavedPersonAttributeTypeName(PersonAttributeType personAttributeType);
 	
 	/**
 	 * @see org.openmrs.api.PersonService#getAllRelationshipTypes(boolean)
 	 */
-	public List<RelationshipType> getAllRelationshipTypes(boolean includeRetired);
+	List<RelationshipType> getAllRelationshipTypes(boolean includeRetired);
 	
 	/**
 	 * Saves a <code>PersonMergeLog</code> object to the database
@@ -211,7 +211,7 @@ public interface PersonDAO {
 	 * @param personMergeLog the <code>PersonMergeLog</code> object to save
 	 * @return the persisted <code>PersonMergeLog</code> object
 	 */
-	public PersonMergeLog savePersonMergeLog(PersonMergeLog personMergeLog) throws DAOException;
+	PersonMergeLog savePersonMergeLog(PersonMergeLog personMergeLog) throws DAOException;
 	
 	/**
 	 * Gets a <code>PersonMergeLog</code> object from the model by id
@@ -220,7 +220,7 @@ public interface PersonDAO {
 	 * @return the <code>PersonMergeLog</code> object
 	 * @throws DAOException
 	 */
-	public PersonMergeLog getPersonMergeLog(Integer id) throws DAOException;
+	PersonMergeLog getPersonMergeLog(Integer id) throws DAOException;
 	
 	/**
 	 * Gets a PersonMergeLog object from the model using UUID
@@ -229,7 +229,7 @@ public interface PersonDAO {
 	 * @return the PersonMergeLog object
 	 * @throws DAOException
 	 */
-	public PersonMergeLog getPersonMergeLogByUuid(String uuid) throws DAOException;
+	PersonMergeLog getPersonMergeLogByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * Gets all the PersonMergeLog objects in the model
@@ -237,7 +237,7 @@ public interface PersonDAO {
 	 * @return list of PersonMergeLog objects
 	 * @throws DAOException
 	 */
-	public List<PersonMergeLog> getAllPersonMergeLogs() throws DAOException;
+	List<PersonMergeLog> getAllPersonMergeLogs() throws DAOException;
 	
 	/**
 	 * Gets the PersonMergeLog objects by winner
@@ -246,7 +246,7 @@ public interface PersonDAO {
 	 * @return List of <code>PersonMergeLog</code> objects
 	 * @throws DAOException
 	 */
-	public List<PersonMergeLog> getWinningPersonMergeLogs(Person person) throws DAOException;
+	List<PersonMergeLog> getWinningPersonMergeLogs(Person person) throws DAOException;
 	
 	/**
 	 * Finds the PersonMergeLog by loser
@@ -255,16 +255,16 @@ public interface PersonDAO {
 	 * @return <code>PersonMergeLog</code> object
 	 * @throws DAOException
 	 */
-	public PersonMergeLog getLosingPersonMergeLogs(Person person) throws DAOException;
+	PersonMergeLog getLosingPersonMergeLogs(Person person) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.PersonService#savePersonName(org.openmrs.PersonName)
 	 */
-	public PersonName savePersonName(PersonName personName);
+	PersonName savePersonName(PersonName personName);
 	
 	/**
 	 * @see org.openmrs.api.PersonService#savePersonAddress(org.openmrs.PersonAddress)
 	 */
-	public PersonAddress savePersonAddress(PersonAddress personAddress);
+	PersonAddress savePersonAddress(PersonAddress personAddress);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/ProgramWorkflowDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ProgramWorkflowDAO.java
@@ -41,7 +41,7 @@ public interface ProgramWorkflowDAO {
 	 * @return The saved {@link Program}
 	 * @throws DAOException
 	 */
-	public Program saveProgram(Program program) throws DAOException;
+	Program saveProgram(Program program) throws DAOException;
 	
 	/**
 	 * Retrieves a {@link Program} from the database by primary key programId
@@ -50,7 +50,7 @@ public interface ProgramWorkflowDAO {
 	 * @return Program - The {@link Program} matching the passed programId
 	 * @throws DAOException
 	 */
-	public Program getProgram(Integer programId) throws DAOException;
+	Program getProgram(Integer programId) throws DAOException;
 	
 	/**
 	 * Returns all programs
@@ -59,7 +59,7 @@ public interface ProgramWorkflowDAO {
 	 * @return List&lt;Program&gt; all existing programs, including retired based on the input parameter
 	 * @throws DAOException
 	 */
-	public List<Program> getAllPrograms(boolean includeRetired) throws DAOException;
+	List<Program> getAllPrograms(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Returns programs that match the given string. A null list will never be returned. An empty
@@ -69,7 +69,7 @@ public interface ProgramWorkflowDAO {
 	 * @return List&lt;Program&gt; - list of Programs whose name matches the input parameter
 	 * @throws DAOException
 	 */
-	public List<Program> findPrograms(String nameFragment) throws DAOException;
+	List<Program> findPrograms(String nameFragment) throws DAOException;
 	
 	/**
 	 * Completely remove a program from the database (not reversible) This method delegates to
@@ -78,7 +78,7 @@ public interface ProgramWorkflowDAO {
 	 * @param program the Program to clean out of the database.
 	 * @throws DAOException
 	 */
-	public void deleteProgram(Program program) throws DAOException;
+	void deleteProgram(Program program) throws DAOException;
 	
 	// **************************
 	// PATIENT PROGRAM
@@ -91,7 +91,7 @@ public interface ProgramWorkflowDAO {
 	 * @return PatientProgram - the saved PatientProgram
 	 * @throws DAOException
 	 */
-	public PatientProgram savePatientProgram(PatientProgram patientProgram) throws DAOException;
+	PatientProgram savePatientProgram(PatientProgram patientProgram) throws DAOException;
 	
 	/**
 	 * Returns a PatientProgram given that PatientPrograms primary key <code>patientProgramId</code>
@@ -102,9 +102,9 @@ public interface ProgramWorkflowDAO {
 	 *         <code>patientProgramId</code> passed in.
 	 * @throws DAOException
 	 */
-	public PatientProgram getPatientProgram(Integer id);
+	PatientProgram getPatientProgram(Integer id);
 	
-	public List<PatientProgram> getPatientPrograms(Cohort cohort, Collection<Program> programs);
+	List<PatientProgram> getPatientPrograms(Cohort cohort, Collection<Program> programs);
 	
 	/**
 	 * Returns PatientPrograms that match the input parameters. If an input parameter is set to
@@ -127,8 +127,8 @@ public interface ProgramWorkflowDAO {
 	 * @return List&lt;PatientProgram&gt; of PatientPrograms that match the passed input parameters
 	 * @throws DAOException
 	 */
-	public List<PatientProgram> getPatientPrograms(Patient patient, Program program, Date minEnrollmentDate,
-	        Date maxEnrollmentDate, Date minCompletionDate, Date maxCompletionDate, boolean includeVoided)
+	List<PatientProgram> getPatientPrograms(Patient patient, Program program, Date minEnrollmentDate,
+			Date maxEnrollmentDate, Date minCompletionDate, Date maxCompletionDate, boolean includeVoided)
 	        throws DAOException;
 	
 	/**
@@ -138,7 +138,7 @@ public interface ProgramWorkflowDAO {
 	 * @param patientProgram the PatientProgram to clean out of the database.
 	 * @throws DAOException
 	 */
-	public void deletePatientProgram(PatientProgram patientProgram) throws DAOException;
+	void deletePatientProgram(PatientProgram patientProgram) throws DAOException;
 	
 	// **************************
 	// CONCEPT STATE CONVERSION
@@ -151,7 +151,7 @@ public interface ProgramWorkflowDAO {
 	 * @return The saved ConceptStateConversion
 	 * @throws DAOException
 	 */
-	public ConceptStateConversion saveConceptStateConversion(ConceptStateConversion csc) throws DAOException;
+	ConceptStateConversion saveConceptStateConversion(ConceptStateConversion csc) throws DAOException;
 	
 	/**
 	 * Returns all conceptStateConversions
@@ -159,7 +159,7 @@ public interface ProgramWorkflowDAO {
 	 * @return List&lt;ConceptStateConversion&gt; of all ConceptStateConversions that exist
 	 * @throws DAOException
 	 */
-	public List<ConceptStateConversion> getAllConceptStateConversions() throws DAOException;
+	List<ConceptStateConversion> getAllConceptStateConversions() throws DAOException;
 	
 	/**
 	 * Returns a conceptStateConversion given that conceptStateConversions primary key
@@ -172,7 +172,7 @@ public interface ProgramWorkflowDAO {
 	 *         <code>conceptStateConversionId</code> passed in.
 	 * @throws DAOException
 	 */
-	public ConceptStateConversion getConceptStateConversion(Integer id);
+	ConceptStateConversion getConceptStateConversion(Integer id);
 	
 	/**
 	 * Completely remove a conceptStateConversion from the database (not reversible)
@@ -180,7 +180,7 @@ public interface ProgramWorkflowDAO {
 	 * @param csc the ConceptStateConversion to clean out of the database.
 	 * @throws DAOException
 	 */
-	public void deleteConceptStateConversion(ConceptStateConversion csc);
+	void deleteConceptStateConversion(ConceptStateConversion csc);
 	
 	/**
 	 * Retrieves the ConceptStateConversion that matches the passed <code>ProgramWorkflow</code> and
@@ -192,25 +192,25 @@ public interface ProgramWorkflowDAO {
 	 *         <code>Concept</code>
 	 * @throws DAOException
 	 */
-	public ConceptStateConversion getConceptStateConversion(ProgramWorkflow workflow, Concept trigger);
+	ConceptStateConversion getConceptStateConversion(ProgramWorkflow workflow, Concept trigger);
 	
 	/**
 	 * @param uuid
 	 * @return concept state conversion or null
 	 */
-	public ConceptStateConversion getConceptStateConversionByUuid(String uuid);
+	ConceptStateConversion getConceptStateConversionByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return patient program or null
 	 */
-	public PatientProgram getPatientProgramByUuid(String uuid);
+	PatientProgram getPatientProgramByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return program or null
 	 */
-	public Program getProgramByUuid(String uuid);
+	Program getProgramByUuid(String uuid);
 	
 	/**
 	 * Retrieves the Programs from the dB which have the given name.
@@ -220,7 +220,7 @@ public interface ProgramWorkflowDAO {
 	 * @should return only and exactly the programs with the given name
 	 * @return all Programs with the given name.
 	 */
-	public List<Program> getProgramsByName(String name, boolean includeRetired);
+	List<Program> getProgramsByName(String name, boolean includeRetired);
 	
 	/**
 	 * Retrieves a {@code ProgramWorkflowState} from the database by its primary key.
@@ -229,15 +229,15 @@ public interface ProgramWorkflowDAO {
 	 * @return the program workflow state matching given id or null if not found
 	 * @since 2.2.0
 	 */
-	public ProgramWorkflowState getState(Integer stateId);
+	ProgramWorkflowState getState(Integer stateId);
 	
 	/**
 	 * @param uuid
 	 * @return program workflow state or null
 	 */
-	public ProgramWorkflowState getStateByUuid(String uuid);
+	ProgramWorkflowState getStateByUuid(String uuid);
 	
-	public PatientState getPatientStateByUuid(String uuid);
+	PatientState getPatientStateByUuid(String uuid);
 	
 	/**
 	 * Retrieves a {@code ProgramWorkflow} from the database by its primary key.
@@ -246,13 +246,13 @@ public interface ProgramWorkflowDAO {
 	 * @return the program workflow matching given id or null if not found
 	 * @since 2.2.0
 	 */
-	public ProgramWorkflow getWorkflow(Integer workflowId);
+	ProgramWorkflow getWorkflow(Integer workflowId);
 	
 	/**
 	 * @param uuid
 	 * @return program workflow or null
 	 */
-	public ProgramWorkflow getWorkflowByUuid(String uuid);
+	ProgramWorkflow getWorkflowByUuid(String uuid);
 	
 	/**
 	 * Returns a list of Programs that are using a particular concept.
@@ -260,7 +260,7 @@ public interface ProgramWorkflowDAO {
 	 * @param concept - The Concept being used.
 	 * @return - A List of Programs
 	 */
-	public List<Program> getProgramsByConcept(Concept concept);
+	List<Program> getProgramsByConcept(Concept concept);
 	
 	/**
 	 * Returns a list of ProgramWorkflows that are using a particular concept.
@@ -268,7 +268,7 @@ public interface ProgramWorkflowDAO {
 	 * @param concept - The Concept being used.
 	 * @return - A List of ProgramWorkflows
 	 */
-	public List<ProgramWorkflow> getProgramWorkflowsByConcept(Concept concept);
+	List<ProgramWorkflow> getProgramWorkflowsByConcept(Concept concept);
 	
 	/**
 	 * Returns a list of ProgramWorkflowStates that are using a particular concept.
@@ -276,5 +276,5 @@ public interface ProgramWorkflowDAO {
 	 * @param concept - The Concept being used.
 	 * @return - A List of ProgramWorkflowStates
 	 */
-	public List<ProgramWorkflowState> getProgramWorkflowStatesByConcept(Concept concept);
+	List<ProgramWorkflowState> getProgramWorkflowStatesByConcept(Concept concept);
 }

--- a/api/src/main/java/org/openmrs/api/db/ProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ProviderDAO.java
@@ -36,30 +36,30 @@ public interface ProviderDAO {
 	/**
 	 * Saves/Updates a given Provider
 	 */
-	public Provider saveProvider(Provider provider);
+	Provider saveProvider(Provider provider);
 	
 	/**
 	 * deletes an exisiting Provider
 	 */
-	public void deleteProvider(Provider provider);
+	void deleteProvider(Provider provider);
 	
 	/**
 	 * @param id
 	 * @return Provider gets the Provider based on id
 	 */
-	public Provider getProvider(Integer id);
+	Provider getProvider(Integer id);
 	
 	/**
 	 * @param uuid
 	 * @return Provider gets the Provider based on uuid
 	 */
-	
-	public Provider getProviderByUuid(String uuid);
+
+	Provider getProviderByUuid(String uuid);
 	
 	/**
 	 * @see ProviderService#getProvidersByPerson( Person, boolean )
 	 */
-	public Collection<Provider> getProvidersByPerson(Person person, boolean includeRetired);
+	Collection<Provider> getProvidersByPerson(Person person, boolean includeRetired);
 	
 	/**
 	 * @param name
@@ -69,15 +69,15 @@ public interface ProviderDAO {
 	 * @param includeRetired
 	 * @return List of Providers
 	 */
-	public List<Provider> getProviders(String name, Map<ProviderAttributeType, String> serializedAttributeValues,
-	        Integer start, Integer length, boolean includeRetired);
+	List<Provider> getProviders(String name, Map<ProviderAttributeType, String> serializedAttributeValues,
+			Integer start, Integer length, boolean includeRetired);
 	
 	/**
 	 * @param name
 	 * @param includeRetired
 	 * @return Count of providers satisfying the given query
 	 */
-	public Long getCountOfProviders(String name, boolean includeRetired);
+	Long getCountOfProviders(String name, boolean includeRetired);
 	
 	/**
 	 * @see ProviderService#getAllProviderAttributeTypes(boolean)
@@ -119,10 +119,10 @@ public interface ProviderDAO {
 	/**
 	 * @see ProviderService#isProviderIdentifierUnique(Provider)
 	 */
-	public boolean isProviderIdentifierUnique(Provider provider) throws DAOException;
+	boolean isProviderIdentifierUnique(Provider provider) throws DAOException;
 	
 	/**
 	 * @see ProviderService#getProviderByIdentifier(String)
 	 */
-	public Provider getProviderByIdentifier(String identifier);
+	Provider getProviderByIdentifier(String identifier);
 }

--- a/api/src/main/java/org/openmrs/api/db/SerializedObjectDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/SerializedObjectDAO.java
@@ -58,7 +58,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return the saved serialized object
 	 */
-	public SerializedObject getSerializedObject(Integer id) throws DAOException;
+	SerializedObject getSerializedObject(Integer id) throws DAOException;
 	
 	/**
 	 * Retrieves the saved object of the passed type from the database by it's id
@@ -69,7 +69,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return the saved object
 	 */
-	public <T extends OpenmrsObject> T getObject(Class<T> type, Integer id) throws DAOException;
+	<T extends OpenmrsObject> T getObject(Class<T> type, Integer id) throws DAOException;
 	
 	/**
 	 * Retrieves the raw Serialized Object from the database by uuid
@@ -79,7 +79,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return the saved serialized object
 	 */
-	public SerializedObject getSerializedObjectByUuid(String uuid) throws DAOException;
+	SerializedObject getSerializedObjectByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * Retrieves the saved object of the passed type from the database by it's uuid
@@ -90,7 +90,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return the saved object
 	 */
-	public <T extends OpenmrsObject> T getObjectByUuid(Class<T> type, String uuid) throws DAOException;
+	<T extends OpenmrsObject> T getObjectByUuid(Class<T> type, String uuid) throws DAOException;
 	
 	/**
 	 * Saves an object to the database in serialized form
@@ -101,7 +101,7 @@ public interface SerializedObjectDAO {
 	 * @should save the passed object if supported
 	 * @should throw an exception if object not supported
 	 */
-	public <T extends OpenmrsObject> T saveObject(T object) throws DAOException;
+	<T extends OpenmrsObject> T saveObject(T object) throws DAOException;
 	
 	/**
 	 * Saves an object to the database, in serialized form, using the specified
@@ -115,7 +115,7 @@ public interface SerializedObjectDAO {
 	 * @should throw an exception if object not supported
 	 * @should set auditable fields before serializing
 	 */
-	public <T extends OpenmrsObject> T saveObject(T object, OpenmrsSerializer serializer) throws DAOException;
+	<T extends OpenmrsObject> T saveObject(T object, OpenmrsSerializer serializer) throws DAOException;
 	
 	/**
 	 * Retrieves all raw Serialized Object from the database that match the passed type and
@@ -127,7 +127,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return all objects of the passed type
 	 */
-	public List<SerializedObject> getAllSerializedObjects(Class<?> type, boolean includeRetired) throws DAOException;
+	List<SerializedObject> getAllSerializedObjects(Class<?> type, boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Retrieves all non-retired objects of the passed type from the database that have been saved
@@ -138,7 +138,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should return all non-retired objects of the passed type
 	 */
-	public <T extends OpenmrsObject> List<T> getAllObjects(Class<T> type) throws DAOException;
+	<T extends OpenmrsObject> List<T> getAllObjects(Class<T> type) throws DAOException;
 	
 	/**
 	 * Retrieves all objects from the database that match the passed type that have been saved
@@ -152,7 +152,7 @@ public interface SerializedObjectDAO {
 	 * @should return all saved objects of the passed type if includeRetired
 	 * @should return only non-retired objects of the passed type if not includeRetired
 	 */
-	public <T extends OpenmrsObject> List<T> getAllObjects(Class<T> type, boolean includeRetired) throws DAOException;
+	<T extends OpenmrsObject> List<T> getAllObjects(Class<T> type, boolean includeRetired) throws DAOException;
 	
 	/**
 	 * Retrieves all raw Serialized Objects from the database that match the passed type and name
@@ -165,7 +165,7 @@ public interface SerializedObjectDAO {
 	 * @should return all saved objects with the given type and exact name
 	 * @should return all saved objects with the given type and partial name
 	 */
-	public List<SerializedObject> getAllSerializedObjectsByName(Class<?> type, String name, boolean exactMatchOnly)
+	List<SerializedObject> getAllSerializedObjectsByName(Class<?> type, String name, boolean exactMatchOnly)
 	        throws DAOException;
 	
 	/**
@@ -180,7 +180,7 @@ public interface SerializedObjectDAO {
 	 * @should return all saved objects with the given type and exact name
 	 * @should return all saved objects with the given type and partial name
 	 */
-	public <T extends OpenmrsMetadata> List<T> getAllObjectsByName(Class<T> type, String name, boolean exactMatchOnly)
+	<T extends OpenmrsMetadata> List<T> getAllObjectsByName(Class<T> type, String name, boolean exactMatchOnly)
 	        throws DAOException;
 	
 	/**
@@ -191,7 +191,7 @@ public interface SerializedObjectDAO {
 	 * @return an OpenmrsObject of the passed clazz from the passed SerializedObject
 	 * @throws DAOException
 	 */
-	public <T extends OpenmrsObject> T convertSerializedObject(Class<T> clazz, SerializedObject serializedObject)
+	<T extends OpenmrsObject> T convertSerializedObject(Class<T> clazz, SerializedObject serializedObject)
 	        throws DAOException;
 	
 	/**
@@ -201,7 +201,7 @@ public interface SerializedObjectDAO {
 	 * @throws DAOException
 	 * @should delete the object with the passed id
 	 */
-	public void purgeObject(Integer id) throws DAOException;
+	void purgeObject(Integer id) throws DAOException;
 	
 	/**
 	 * Returns the registered class for the passed object, or null if none found For example, if the
@@ -212,24 +212,24 @@ public interface SerializedObjectDAO {
 	 * @param object The object to check for the registered type
 	 * @return The registered type for the passed object, or null if not found
 	 */
-	public Class<? extends OpenmrsObject> getRegisteredTypeForObject(OpenmrsObject object);
+	Class<? extends OpenmrsObject> getRegisteredTypeForObject(OpenmrsObject object);
 	
 	/**
 	 * @return all supported types that this class can manage
 	 */
-	public List<Class<? extends OpenmrsObject>> getSupportedTypes();
+	List<Class<? extends OpenmrsObject>> getSupportedTypes();
 	
 	/**
 	 * Registers a class as one that should be supported
 	 * 
 	 * @param clazz The class to register
 	 */
-	public void registerSupportedType(Class<? extends OpenmrsObject> clazz) throws DAOException;
+	void registerSupportedType(Class<? extends OpenmrsObject> clazz) throws DAOException;
 	
 	/**
 	 * Removes this class as one that should be supported
 	 * 
 	 * @param clazz The class to un-register
 	 */
-	public void unregisterSupportedType(Class<? extends OpenmrsObject> clazz) throws DAOException;
+	void unregisterSupportedType(Class<? extends OpenmrsObject> clazz) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/TemplateDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/TemplateDAO.java
@@ -25,7 +25,7 @@ public interface TemplateDAO {
 	 * 
 	 * @throws DAOException
 	 */
-	public List<Template> getTemplates() throws DAOException;
+	List<Template> getTemplates() throws DAOException;
 	
 	/**
 	 * Get message template by id
@@ -34,7 +34,7 @@ public interface TemplateDAO {
 	 * @return message template with given internal identifier
 	 * @throws DAOException
 	 */
-	public Template getTemplate(Integer id) throws DAOException;
+	Template getTemplate(Integer id) throws DAOException;
 	
 	/**
 	 * Get message template by name
@@ -43,7 +43,7 @@ public interface TemplateDAO {
 	 * @return message template with given name
 	 * @throws DAOException
 	 */
-	public List<Template> getTemplatesByName(String name) throws DAOException;
+	List<Template> getTemplatesByName(String name) throws DAOException;
 	
 	/**
 	 * Create new template.
@@ -51,7 +51,7 @@ public interface TemplateDAO {
 	 * @param template
 	 * @throws DAOException
 	 */
-	public void createTemplate(Template template) throws DAOException;
+	void createTemplate(Template template) throws DAOException;
 	
 	/**
 	 * Update existing template.
@@ -59,7 +59,7 @@ public interface TemplateDAO {
 	 * @param template
 	 * @throws DAOException
 	 */
-	public void updateTemplate(Template template) throws DAOException;
+	void updateTemplate(Template template) throws DAOException;
 	
 	/**
 	 * Delete existing template.
@@ -67,6 +67,6 @@ public interface TemplateDAO {
 	 * @param template
 	 * @throws DAOException
 	 */
-	public void deleteTemplate(Template template) throws DAOException;
+	void deleteTemplate(Template template) throws DAOException;
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/UserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/UserDAO.java
@@ -28,142 +28,142 @@ public interface UserDAO {
 	/**
 	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User, java.lang.String)
 	 */
-	public User saveUser(User user, String password) throws DAOException;
+	User saveUser(User user, String password) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getUser(Integer)
 	 */
-	public User getUser(Integer userId) throws DAOException;
+	User getUser(Integer userId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getUserByUsername(java.lang.String)
 	 */
-	public User getUserByUsername(String username) throws DAOException;
+	User getUserByUsername(String username) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#hasDuplicateUsername(org.openmrs.User)
 	 */
-	public boolean hasDuplicateUsername(String username, String systemId, Integer userId) throws DAOException;
+	boolean hasDuplicateUsername(String username, String systemId, Integer userId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User)
 	 */
-	public void deleteUser(User user) throws DAOException;
+	void deleteUser(User user) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getAllUsers()
 	 */
-	public List<User> getAllUsers() throws DAOException;
+	List<User> getAllUsers() throws DAOException;
 	
 	// Role stuff
 	
 	/**
 	 * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
 	 */
-	public Role saveRole(Role role) throws DAOException;
+	Role saveRole(Role role) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
 	 */
-	public void deleteRole(Role role) throws DAOException;
+	void deleteRole(Role role) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getRole(java.lang.String)
 	 */
-	public Role getRole(String r) throws DAOException;
+	Role getRole(String r) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getAllRoles()
 	 */
-	public List<Role> getAllRoles() throws DAOException;
+	List<Role> getAllRoles() throws DAOException;
 	
 	// Privilege stuff
 	
 	/**
 	 * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
 	 */
-	public Privilege savePrivilege(Privilege privilege) throws DAOException;
+	Privilege savePrivilege(Privilege privilege) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getPrivilege(java.lang.String)
 	 */
-	public Privilege getPrivilege(String p) throws DAOException;
+	Privilege getPrivilege(String p) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getAllPrivileges()
 	 */
-	public List<Privilege> getAllPrivileges() throws DAOException;
+	List<Privilege> getAllPrivileges() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
 	 */
-	public void deletePrivilege(Privilege privilege) throws DAOException;
+	void deletePrivilege(Privilege privilege) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#getUsersByName(java.lang.String, java.lang.String, boolean)
 	 */
-	public List<User> getUsersByName(String givenName, String familyName, boolean includeVoided);
+	List<User> getUsersByName(String givenName, String familyName, boolean includeVoided);
 	
 	/**
 	 * @see org.openmrs.api.UserService#changePassword(org.openmrs.User, java.lang.String)
 	 */
-	public void changePassword(User u, String pw) throws DAOException;
+	void changePassword(User u, String pw) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#changePassword(java.lang.String, java.lang.String)
 	 */
-	public void changePassword(String pw, String pw2) throws DAOException;
+	void changePassword(String pw, String pw2) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#changeHashedPassword(User, String, String)
 	 */
-	public void changeHashedPassword(User user, String hashedPassword, String salt) throws DAOException;
+	void changeHashedPassword(User user, String hashedPassword, String salt) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#changeQuestionAnswer(User, String, String)
 	 */
-	public void changeQuestionAnswer(User u, String question, String answer) throws DAOException;
+	void changeQuestionAnswer(User u, String question, String answer) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#changeQuestionAnswer(java.lang.String, java.lang.String,
 	 *      java.lang.String)
 	 */
-	public void changeQuestionAnswer(String pw, String q, String a) throws DAOException;
+	void changeQuestionAnswer(String pw, String q, String a) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.UserService#isSecretAnswer(org.openmrs.User, java.lang.String)
 	 */
-	public boolean isSecretAnswer(User u, String answer) throws DAOException;
+	boolean isSecretAnswer(User u, String answer) throws DAOException;
 	
 	/**
 	 * @param uuid
 	 * @return privilege or null
 	 */
-	public Privilege getPrivilegeByUuid(String uuid);
+	Privilege getPrivilegeByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return role or null
 	 */
-	public Role getRoleByUuid(String uuid);
+	Role getRoleByUuid(String uuid);
 	
 	/**
 	 * @param uuid
 	 * @return user or null
 	 */
-	public User getUserByUuid(String uuid);
+	User getUserByUuid(String uuid);
 	
 	/**
 	 * @param user
 	 * @return The login credentials for a specified user.
 	 */
-	public LoginCredential getLoginCredential(User user);
+	LoginCredential getLoginCredential(User user);
 	
 	/**
 	 * @param uuid
 	 * @return login credential or null
 	 */
-	public LoginCredential getLoginCredentialByUuid(String uuid);
+	LoginCredential getLoginCredentialByUuid(String uuid);
 	
 	/**
 	 * Updates a user's login credentials. Note that there is no
@@ -172,27 +172,27 @@ public interface UserDAO {
 	 * 
 	 * @param credential
 	 */
-	public void updateLoginCredential(LoginCredential credential);
+	void updateLoginCredential(LoginCredential credential);
 	
 	/**
 	 * @see org.openmrs.api.UserService#generateSystemId()
 	 */
-	public Integer generateSystemId() throws DAOException;
+	Integer generateSystemId() throws DAOException;
 	
 	/**
 	 * @see UserService#getUsersByPerson(Person, boolean)
 	 */
-	public List<User> getUsersByPerson(Person person, boolean includeRetired);
+	List<User> getUsersByPerson(Person person, boolean includeRetired);
 	
 	/**
 	 * @see UserService#getUsers(String, List, boolean, Integer, Integer)
 	 */
-	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
+	List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
 	        throws DAOException;
 	
 	/**
 	 * @see UserService#getCountOfUsers(String, List, boolean)
 	 */
-	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
+	Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/VisitDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/VisitDAO.java
@@ -39,7 +39,7 @@ public interface VisitDAO {
 	/**
 	 * @see org.openmrs.api.VisitService#getAllVisitTypes(boolean)
 	 */
-	public List<VisitType> getAllVisitTypes(boolean includeRetired) throws DAOException;
+	List<VisitType> getAllVisitTypes(boolean includeRetired) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.api.VisitService#getVisitType(java.lang.Integer)
@@ -70,25 +70,25 @@ public interface VisitDAO {
 	 * @see VisitService#getVisit(Integer)
 	 * @throws DAOException
 	 */
-	public Visit getVisit(Integer visitId) throws DAOException;
+	Visit getVisit(Integer visitId) throws DAOException;
 	
 	/**
 	 * @see VisitService#getVisitByUuid(String)
 	 * @throws DAOException
 	 */
-	public Visit getVisitByUuid(String uuid) throws DAOException;
+	Visit getVisitByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see VisitService#saveVisit(Visit)
 	 * @throws DAOException
 	 */
-	public Visit saveVisit(Visit visit) throws DAOException;
+	Visit saveVisit(Visit visit) throws DAOException;
 	
 	/**
 	 * @see VisitService#purgeVisit(Visit)
 	 * @throws DAOException
 	 */
-	public void deleteVisit(Visit visit) throws DAOException;
+	void deleteVisit(Visit visit) throws DAOException;
 	
 	/**
 	 * Gets the visits matching the specified arguments
@@ -108,10 +108,10 @@ public interface VisitDAO {
 	 * @should return all unvoided visits if includeEnded is set to true
 	 * @should return only active visits if includeEnded is set to false
 	 */
-	public List<Visit> getVisits(Collection<VisitType> visitTypes, Collection<Patient> patients,
-	        Collection<Location> locations, Collection<Concept> indications, Date minStartDatetime, Date maxStartDatetime,
-	        Date minEndDatetime, Date maxEndDatetime, Map<VisitAttributeType, String> serializedAttributeValues,
-	        boolean includeInactive, boolean includeVoided) throws DAOException;
+	List<Visit> getVisits(Collection<VisitType> visitTypes, Collection<Patient> patients,
+			Collection<Location> locations, Collection<Concept> indications, Date minStartDatetime, Date maxStartDatetime,
+			Date minEndDatetime, Date maxEndDatetime, Map<VisitAttributeType, String> serializedAttributeValues,
+			boolean includeInactive, boolean includeVoided) throws DAOException;
 	
 	/**
 	 * @see VisitService#getAllVisitAttributeTypes()
@@ -154,6 +154,6 @@ public interface VisitDAO {
 	 * @return a {@link Visit}
 	 * @should return the next unvoided active visit matching the specified types and startDate
 	 */
-	public Visit getNextVisit(Visit previousVisit, Collection<VisitType> visitTypes, Date maximumStartDate);
+	Visit getNextVisit(Visit previousVisit, Collection<VisitType> visitTypes, Date maximumStartDate);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/EncounterVisitHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/EncounterVisitHandler.java
@@ -29,14 +29,14 @@ public interface EncounterVisitHandler {
 	/**
 	 * @return a displayable string so that users can pick between different assignment handlers
 	 */
-	public String getDisplayName();
+	String getDisplayName();
 	
 	/**
 	 * @param locale optional locale to specify. If none is passed, {@link Context#getLocale()}
 	 *            should be used
 	 * @return a displayable string so that users can pick between different assignment handlers
 	 */
-	public String getDisplayName(Locale locale);
+	String getDisplayName(Locale locale);
 	
 	/**
 	 * Implementations of this method should look at the given <code>encounter</code> and choose
@@ -50,6 +50,6 @@ public interface EncounterVisitHandler {
 	 * 
 	 * @param encounter the new unsaved encounter in question of whether to assign to a visit
 	 */
-	public void beforeCreateEncounter(Encounter encounter);
+	void beforeCreateEncounter(Encounter encounter);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/RequiredDataHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/RequiredDataHandler.java
@@ -39,6 +39,6 @@ public interface RequiredDataHandler<O extends OpenmrsObject> {
 	 * @param other (optional) would be the second argument in the save/void/unvoid/etc method, if
 	 *            exists
 	 */
-	public void handle(O openmrsObject, User currentUser, Date currentDate, String other);
+	void handle(O openmrsObject, User currentUser, Date currentDate, String other);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/RetireHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/RetireHandler.java
@@ -39,6 +39,6 @@ public interface RetireHandler<R extends Retireable> extends RequiredDataHandler
 	 *      org.openmrs.User, java.util.Date, java.lang.String)
 	 */
 	@Override
-	public void handle(R retireableObject, User retiringUser, Date retireDate, String retireReason);
+	void handle(R retireableObject, User retiringUser, Date retireDate, String retireReason);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/SaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/SaveHandler.java
@@ -39,6 +39,6 @@ public interface SaveHandler<O extends OpenmrsObject> extends RequiredDataHandle
 	 *      org.openmrs.User, java.util.Date, java.lang.String)
 	 */
 	@Override
-	public void handle(O object, User creator, Date dateCreated, String other);
+	void handle(O object, User creator, Date dateCreated, String other);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/UnretireHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/UnretireHandler.java
@@ -41,6 +41,6 @@ public interface UnretireHandler<R extends Retireable> extends RequiredDataHandl
 	 *      org.openmrs.User, java.util.Date, java.lang.String)
 	 */
 	@Override
-	public void handle(R retireableObject, User retiringUser, Date origParentRetiredDate, String unused);
+	void handle(R retireableObject, User retiringUser, Date origParentRetiredDate, String unused);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/UnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/UnvoidHandler.java
@@ -41,6 +41,6 @@ public interface UnvoidHandler<V extends Voidable> extends RequiredDataHandler<V
 	 *      org.openmrs.User, java.util.Date, java.lang.String)
 	 */
 	@Override
-	public void handle(V voidableObject, User voidingUser, Date origParentVoidedDate, String unused);
+	void handle(V voidableObject, User voidingUser, Date origParentVoidedDate, String unused);
 	
 }

--- a/api/src/main/java/org/openmrs/api/handler/VoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/VoidHandler.java
@@ -38,5 +38,5 @@ public interface VoidHandler<V extends Voidable> extends RequiredDataHandler<V> 
 	 *      org.openmrs.User, java.util.Date, java.lang.String)
 	 */
 	@Override
-	public void handle(V voidableObject, User voidingUser, Date voidedDate, String voidReason);
+	void handle(V voidableObject, User voidingUser, Date voidedDate, String voidReason);
 }

--- a/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
@@ -121,5 +121,5 @@ public class OrderSetServiceImpl extends BaseOpenmrsService implements OrderSetS
 	@Transactional(readOnly = true)
 	public OrderSetMember getOrderSetMemberByUuid(String uuid) {
 		return dao.getOrderSetMemberByUuid(uuid);
-	};
+	}
 }

--- a/api/src/main/java/org/openmrs/customdatatype/CustomDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/CustomDatatype.java
@@ -87,7 +87,7 @@ public interface CustomDatatype<T> {
 	 * A short representation of a custom value, along with an indication of whether this is the complete value,
 	 * or just a summary.
 	 */
-	public class Summary {
+	class Summary {
 		
 		private String summary;
 		

--- a/api/src/main/java/org/openmrs/hl7/HL7Service.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Service.java
@@ -38,7 +38,7 @@ public interface HL7Service extends OpenmrsService {
 	 * 
 	 * @param dao
 	 */
-	public void setHL7DAO(HL7DAO dao);
+	void setHL7DAO(HL7DAO dao);
 	
 	/**
 	 * Save the given <code>hl7Source</code> to the database
@@ -47,7 +47,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return the saved source
 	 */
 	@Authorized(PrivilegeConstants.PRIV_UPDATE_HL7_SOURCE)
-	public HL7Source saveHL7Source(HL7Source hl7Source) throws APIException;
+	HL7Source saveHL7Source(HL7Source hl7Source) throws APIException;
 	
 	/**
 	 * Auto generated method comment
@@ -56,7 +56,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return <code>HL7Source</code>object for given identifier
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_SOURCE)
-	public HL7Source getHL7Source(Integer hl7SourceId) throws APIException;
+	HL7Source getHL7Source(Integer hl7SourceId) throws APIException;
 	
 	/**
 	 * Get the hl7 source object from the database that has the given name
@@ -65,7 +65,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return hl7 source object
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_SOURCE)
-	public HL7Source getHL7SourceByName(String name) throws APIException;
+	HL7Source getHL7SourceByName(String name) throws APIException;
 	
 	/**
 	 * Get all of the hl7 source objects from the database. This includes retired ones
@@ -73,7 +73,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return list of hl7 source objects
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_SOURCE)
-	public List<HL7Source> getAllHL7Sources() throws APIException;
+	List<HL7Source> getAllHL7Sources() throws APIException;
 	
 	/**
 	 * Mark the given <code>hl7Source</code> as no longer active
@@ -82,7 +82,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return the retired source
 	 */
 	@Authorized(PrivilegeConstants.PRIV_UPDATE_HL7_SOURCE)
-	public HL7Source retireHL7Source(HL7Source hl7Source) throws APIException;
+	HL7Source retireHL7Source(HL7Source hl7Source) throws APIException;
 	
 	/**
 	 * Completely remove the source from the database. This should only be used in rare cases. See
@@ -91,7 +91,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @param hl7Source
 	 */
 	@Authorized(PrivilegeConstants.PRIV_PURGE_HL7_SOURCE)
-	public void purgeHL7Source(HL7Source hl7Source) throws APIException;
+	void purgeHL7Source(HL7Source hl7Source) throws APIException;
 	
 	/**
 	 * Save the given <code>hl7InQueue</code> to the database
@@ -101,7 +101,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should add generated uuid if uuid is null
 	 */
 	@Authorized(value = { PrivilegeConstants.PRIV_UPDATE_HL7_IN_QUEUE, PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE }, requireAll = false)
-	public HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws APIException;
+	HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws APIException;
 	
 	/**
 	 * Get the hl7 queue item with the given primary key id
@@ -111,7 +111,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws APIException;
+	HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws APIException;
 	
 	/**
 	 * Get the hl7 queue item with the given uuid
@@ -122,7 +122,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public HL7InQueue getHL7InQueueByUuid(String uuid) throws APIException;
+	HL7InQueue getHL7InQueueByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Return a list of all hl7 in queues in the database
@@ -131,7 +131,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public List<HL7InQueue> getAllHL7InQueues() throws APIException;
+	List<HL7InQueue> getAllHL7InQueues() throws APIException;
 	
 	/**
 	 * Return a list of all hl7 in queues based on batch settings and a query string
@@ -145,7 +145,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public List<HL7InQueue> getHL7InQueueBatch(int start, int length, int messageState, String query) throws APIException;
+	List<HL7InQueue> getHL7InQueueBatch(int start, int length, int messageState, String query) throws APIException;
 	
 	/**
 	 * the total count of all HL7InQueue objects in the database
@@ -157,7 +157,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public Integer countHL7InQueue(int messageState, String query) throws APIException;
+	Integer countHL7InQueue(int messageState, String query) throws APIException;
 	
 	/**
 	 * Return a list of all hl7 in errors based on batch settings and a query string
@@ -170,7 +170,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public List<HL7InError> getHL7InErrorBatch(int start, int length, String query) throws APIException;
+	List<HL7InError> getHL7InErrorBatch(int start, int length, String query) throws APIException;
 	
 	/**
 	 * the total count of all HL7InError objects in the database
@@ -181,7 +181,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public Integer countHL7InError(String query) throws APIException;
+	Integer countHL7InError(String query) throws APIException;
 	
 	/**
 	 * Return a list of all hl7 in archives based on batch settings and a query string
@@ -195,7 +195,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public List<HL7InArchive> getHL7InArchiveBatch(int start, int length, int messageState, String query)
+	List<HL7InArchive> getHL7InArchiveBatch(int start, int length, int messageState, String query)
 	        throws APIException;
 	
 	/**
@@ -208,7 +208,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public Integer countHL7InArchive(int messageState, String query) throws APIException;
+	Integer countHL7InArchive(int messageState, String query) throws APIException;
 	
 	/**
 	 * Get the first queue item in the database
@@ -216,7 +216,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return the first queue item
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public HL7InQueue getNextHL7InQueue() throws APIException;
+	HL7InQueue getNextHL7InQueue() throws APIException;
 	
 	/**
 	 * Completely delete the hl7 in queue item from the database.
@@ -224,7 +224,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @param hl7InQueue
 	 */
 	@Authorized(PrivilegeConstants.PRIV_PURGE_HL7_IN_QUEUE)
-	public void purgeHL7InQueue(HL7InQueue hl7InQueue);
+	void purgeHL7InQueue(HL7InQueue hl7InQueue);
 	
 	/**
 	 * Save the given hl7 in archive to the database
@@ -234,7 +234,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(value = { PrivilegeConstants.PRIV_UPDATE_HL7_IN_ARCHIVE, PrivilegeConstants.PRIV_ADD_HL7_IN_ARCHIVE }, requireAll = false)
-	public HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws APIException;
+	HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws APIException;
 
 	/**
 	 * Get the archive item with the given id, If hl7 archives were moved to the file system, you
@@ -245,7 +245,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return the matching archive item
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public HL7InArchive getHL7InArchive(Integer hl7InArchiveId);
+	HL7InArchive getHL7InArchive(Integer hl7InArchiveId);
 	
 	/**
 	 * Get the archive item with the given uuid
@@ -256,7 +256,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since Version 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public HL7InArchive getHL7InArchiveByUuid(String uuid) throws APIException;
+	HL7InArchive getHL7InArchiveByUuid(String uuid) throws APIException;
 	
 	/**
 	 * If hl7 migration has been run and the state matches that of processed items, the method
@@ -270,7 +270,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.5
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public List<HL7InArchive> getHL7InArchiveByState(Integer state) throws APIException;
+	List<HL7InArchive> getHL7InArchiveByState(Integer state) throws APIException;
 	
 	/**
 	 * Get the queue items given a state (deleted, error, pending, processing, processed).
@@ -280,7 +280,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_QUEUE)
-	public List<HL7InQueue> getHL7InQueueByState(Integer state) throws APIException;
+	List<HL7InQueue> getHL7InQueueByState(Integer state) throws APIException;
 	
 	/**
 	 * Get all archive hl7 queue items from the database
@@ -288,7 +288,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return list of archive items
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
-	public List<HL7InArchive> getAllHL7InArchives() throws APIException;
+	List<HL7InArchive> getAllHL7InArchives() throws APIException;
 	
 	/**
 	 * Completely delete the hl7 in archive item from the database
@@ -297,7 +297,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE)
-	public void purgeHL7InArchive(HL7InArchive hl7InArchive) throws APIException;
+	void purgeHL7InArchive(HL7InArchive hl7InArchive) throws APIException;
 	
 	/**
 	 * Save the given error item to the database
@@ -307,7 +307,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(value = { PrivilegeConstants.PRIV_UPDATE_HL7_IN_EXCEPTION, PrivilegeConstants.PRIV_ADD_HL7_IN_EXCEPTION }, requireAll = false)
-	public HL7InError saveHL7InError(HL7InError hl7InError) throws APIException;
+	HL7InError saveHL7InError(HL7InError hl7InError) throws APIException;
 	
 	/**
 	 * Get the error item with the given id
@@ -316,7 +316,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return the matching error item
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_EXCEPTION)
-	public HL7InError getHL7InError(Integer hl7InErrorId) throws APIException;
+	HL7InError getHL7InError(Integer hl7InErrorId) throws APIException;
 	
 	/**
 	 * Get the error item with the given uuid
@@ -327,7 +327,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @since 1.9
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_EXCEPTION)
-	public HL7InError getHL7InErrorByUuid(String uuid) throws APIException;
+	HL7InError getHL7InErrorByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get all <code>HL7InError</code> items from the database
@@ -336,7 +336,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.GET_HL7_IN_EXCEPTION)
-	public List<HL7InError> getAllHL7InErrors() throws APIException;
+	List<HL7InError> getAllHL7InErrors() throws APIException;
 	
 	/**
 	 * Completely remove this error item from the database
@@ -345,7 +345,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.PRIV_PURGE_HL7_IN_EXCEPTION)
-	public void purgeHL7InError(HL7InError hl7InError) throws APIException;
+	void purgeHL7InError(HL7InError hl7InError) throws APIException;
 	
 	/**
 	 * @param xcn HL7 component of data type XCN (extended composite ID number and name for persons)
@@ -353,7 +353,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return Internal ID # of the specified user, or null if that user can't be found or is
 	 *         ambiguous
 	 */
-	public Integer resolveUserId(XCN xcn) throws HL7Exception;
+	Integer resolveUserId(XCN xcn) throws HL7Exception;
 	
 	/**
 	 * @param xcn HL7 component of data type XCN (extended composite ID number and name for persons)
@@ -361,7 +361,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @return Internal ID # of the specified person, or null if that person can't be found or is
 	 *         ambiguous
 	 */
-	public Integer resolvePersonId(XCN xcn) throws HL7Exception;
+	Integer resolvePersonId(XCN xcn) throws HL7Exception;
 	
 	/**
 	 * Resolves location from person location object, and if location id is specified then returns
@@ -375,7 +375,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should return internal identifier of location if only location id is specified
 	 * @should return null if location id and name are incorrect
 	 */
-	public Integer resolveLocationId(PL pl) throws HL7Exception;
+	Integer resolveLocationId(PL pl) throws HL7Exception;
 	
 	/**
 	 * @param pid A PID segment of an hl7 message
@@ -383,7 +383,7 @@ public interface HL7Service extends OpenmrsService {
 	 *         patient is not found or if the PID segment is ambiguous
 	 * @throws HL7Exception
 	 */
-	public Integer resolvePatientId(PID pid) throws HL7Exception;
+	Integer resolvePatientId(PID pid) throws HL7Exception;
 	
 	/**
 	 * determines a person (or patient) based on identifiers from a CX array, as found in a PID or
@@ -398,12 +398,12 @@ public interface HL7Service extends OpenmrsService {
 	 * @should find a person based on the internal person ID
 	 * @should return null if no person is found
 	 */
-	public Person resolvePersonFromIdentifiers(CX[] identifiers) throws HL7Exception;
+	Person resolvePersonFromIdentifiers(CX[] identifiers) throws HL7Exception;
 	
 	/**
 	 * Clean up the current memory consumption
 	 */
-	public void garbageCollect();
+	void garbageCollect();
 	
 	/**
 	 * Process the given {@link HL7InQueue} item. <br>
@@ -419,7 +419,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should fail if given inQueue is already marked as processing
 	 * @should parse oru r01 message using overridden parser provided by a module
 	 */
-	public HL7InQueue processHL7InQueue(HL7InQueue inQueue) throws HL7Exception;
+	HL7InQueue processHL7InQueue(HL7InQueue inQueue) throws HL7Exception;
 	
 	/**
 	 * Parses the given string and returns the resulting {@link Message}
@@ -431,7 +431,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should parse the given string into Message
 	 */
 	@Logging(ignoreAllArgumentValues = true)
-	public Message parseHL7String(String hl7String) throws HL7Exception;
+	Message parseHL7String(String hl7String) throws HL7Exception;
 	
 	/**
 	 * Parses the given {@link Message} and saves the resulting content to the database
@@ -443,7 +443,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should save hl7Message to the database
 	 * @should parse message type supplied by module
 	 */
-	public Message processHL7Message(Message hl7Message) throws HL7Exception;
+	Message processHL7Message(Message hl7Message) throws HL7Exception;
 	
 	/**
 	 * Method is called by the archives migration thread to transfer hl7 in archives from the
@@ -455,7 +455,7 @@ public interface HL7Service extends OpenmrsService {
 	 */
 	@Authorized(requireAll = true, value = { PrivilegeConstants.GET_HL7_IN_ARCHIVE, PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE,
 			PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE })
-	public void migrateHl7InArchivesToFileSystem(Map<String, Integer> progressStatusMap) throws APIException;
+	void migrateHl7InArchivesToFileSystem(Map<String, Integer> progressStatusMap) throws APIException;
 	
 	/**
 	 * finds a UUID from an array of identifiers
@@ -469,7 +469,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should not fail if no assigning authority is found
 	 * @should fail if multiple different UUIDs exist in identifiers
 	 */
-	public String getUuidFromIdentifiers(CX[] identifiers) throws HL7Exception;
+	String getUuidFromIdentifiers(CX[] identifiers) throws HL7Exception;
 	
 	/**
 	 * creates a Person from information held in an NK1 segment; if valid PatientIdentifiers exist,
@@ -485,7 +485,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @should fail if no gender specified
 	 * @should fail if no birthdate specified
 	 */
-	public Person createPersonFromNK1(NK1 nk1) throws HL7Exception;
+	Person createPersonFromNK1(NK1 nk1) throws HL7Exception;
 	
 	/**
 	 * Loads data for a list of HL7 archives from the filesystem
@@ -494,7 +494,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 * @param archives
 	 */
-	public void loadHL7InArchiveData(List<HL7InArchive> archives) throws APIException;
+	void loadHL7InArchiveData(List<HL7InArchive> archives) throws APIException;
 	
 	/**
 	 * Loads HL7 data from the filesystem for an archived HL7InArchive
@@ -503,7 +503,7 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 * @param archive
 	 */
-	public void loadHL7InArchiveData(HL7InArchive archive) throws APIException;
+	void loadHL7InArchiveData(HL7InArchive archive) throws APIException;
 	
 	/**
 	 * Get {@link HL7QueueItem} with the given uuid.
@@ -516,6 +516,6 @@ public interface HL7Service extends OpenmrsService {
 	 * @throws APIException
 	 * @since 1.9
 	 */
-	public HL7QueueItem getHl7QueueItemByUuid(String uuid) throws APIException;
+	HL7QueueItem getHl7QueueItemByUuid(String uuid) throws APIException;
 	
 }

--- a/api/src/main/java/org/openmrs/hl7/db/HL7DAO.java
+++ b/api/src/main/java/org/openmrs/hl7/db/HL7DAO.java
@@ -31,59 +31,59 @@ public interface HL7DAO {
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7Source(org.openmrs.hl7.HL7Source)
 	 */
-	public HL7Source saveHL7Source(HL7Source hl7Source) throws DAOException;
+	HL7Source saveHL7Source(HL7Source hl7Source) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7Source(Integer)
 	 */
-	public HL7Source getHL7Source(Integer hl7SourceId) throws DAOException;
+	HL7Source getHL7Source(Integer hl7SourceId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7SourceByName(String)
 	 */
-	public HL7Source getHL7SourceByName(String name) throws DAOException;
+	HL7Source getHL7SourceByName(String name) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7Sources()
 	 */
-	public List<HL7Source> getAllHL7Sources() throws DAOException;
+	List<HL7Source> getAllHL7Sources() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#deleteHL7Source(org.openmrs.hl7.HL7Source)
 	 */
-	public void deleteHL7Source(HL7Source hl7Source) throws DAOException;
+	void deleteHL7Source(HL7Source hl7Source) throws DAOException;
 	
 	/* HL7InQueue */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
-	public HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
+	HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InQueue(Integer)
 	 */
-	public HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws DAOException;
+	HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws DAOException;
 	
 	/**
 	 * @see HL7Service#getHL7InQueueByUuid(String)
 	 */
-	public HL7InQueue getHL7InQueueByUuid(String uuid) throws DAOException;
+	HL7InQueue getHL7InQueueByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InQueues()
 	 */
-	public List<HL7InQueue> getAllHL7InQueues() throws DAOException;
+	List<HL7InQueue> getAllHL7InQueues() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getNextHL7InQueue()
 	 */
-	public HL7InQueue getNextHL7InQueue() throws DAOException;
+	HL7InQueue getNextHL7InQueue() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#deleteHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
-	public void deleteHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
+	void deleteHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
 	
 	/**
 	 * Returns hl7s based on batch settings and filtered by a query
@@ -96,7 +96,7 @@ public interface HL7DAO {
 	 * @return list of hl7s
 	 */
 	@SuppressWarnings("rawtypes")
-	public <T> List<T> getHL7Batch(Class clazz, int start, int length, Integer messageState, String query);
+	<T> List<T> getHL7Batch(Class clazz, int start, int length, Integer messageState, String query);
 	
 	/**
 	 * Returns the amount of HL7 items in the database
@@ -107,39 +107,39 @@ public interface HL7DAO {
 	 * @return count of HL7 items
 	 */
 	@SuppressWarnings("rawtypes")
-	public Long countHL7s(Class clazz, Integer messageState, String query);
+	Long countHL7s(Class clazz, Integer messageState, String query);
 	
 	/* HL7InArchive */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
-	public HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
+	HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchive(Integer)
 	 */
-	public HL7InArchive getHL7InArchive(Integer hl7InArchiveId) throws DAOException;
+	HL7InArchive getHL7InArchive(Integer hl7InArchiveId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchiveByUuid(String)
 	 */
-	public HL7InArchive getHL7InArchiveByUuid(String uuid) throws DAOException;
+	HL7InArchive getHL7InArchiveByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchiveByState(Integer state)
 	 */
-	public List<HL7InArchive> getHL7InArchiveByState(Integer state) throws DAOException;
+	List<HL7InArchive> getHL7InArchiveByState(Integer state) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InQueueByState(Integer stateId)
 	 */
-	public List<HL7InQueue> getHL7InQueueByState(Integer stateId) throws DAOException;
+	List<HL7InQueue> getHL7InQueueByState(Integer stateId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InArchives()
 	 */
-	public List<HL7InArchive> getAllHL7InArchives() throws DAOException;
+	List<HL7InArchive> getAllHL7InArchives() throws DAOException;
 	
 	/**
 	 * Returns hl7 in archives but with a limited resultset size to save memory
@@ -147,50 +147,50 @@ public interface HL7DAO {
 	 * @param maxResults the maximum number of rows to be returned from the database
 	 * @return list of hl7 archives
 	 */
-	public List<HL7InArchive> getAllHL7InArchives(Integer maxResults);
+	List<HL7InArchive> getAllHL7InArchives(Integer maxResults);
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#deleteHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
-	public void deleteHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
+	void deleteHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
 	
 	/**
 	 * provides a list of archives to be migrated
 	 */
-	public List<HL7InArchive> getHL7InArchivesToMigrate();
+	List<HL7InArchive> getHL7InArchivesToMigrate();
 	
 	/* HL7InError */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InError(org.openmrs.hl7.HL7InError)
 	 */
-	public HL7InError saveHL7InError(HL7InError hl7InError) throws DAOException;
+	HL7InError saveHL7InError(HL7InError hl7InError) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InError(Integer)
 	 */
-	public HL7InError getHL7InError(Integer hl7InErrorId) throws DAOException;
+	HL7InError getHL7InError(Integer hl7InErrorId) throws DAOException;
 	
 	/**
 	 * @see HL7Service#getHL7InErrorByUuid(String)
 	 */
-	public HL7InError getHL7InErrorByUuid(String uuid) throws DAOException;
+	HL7InError getHL7InErrorByUuid(String uuid) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InErrors()
 	 */
-	public List<HL7InError> getAllHL7InErrors() throws DAOException;
+	List<HL7InError> getAllHL7InErrors() throws DAOException;
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#deleteHL7InError(org.openmrs.hl7.HL7InError)
 	 */
-	public void deleteHL7InError(HL7InError hl7InError) throws DAOException;
+	void deleteHL7InError(HL7InError hl7InError) throws DAOException;
 	
 	// miscellaneous
 	
 	/**
 	 * @see org.openmrs.hl7.HL7Service#garbageCollect()
 	 */
-	public void garbageCollect();
+	void garbageCollect();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/LogicContext.java
+++ b/api/src/main/java/org/openmrs/logic/LogicContext.java
@@ -28,7 +28,7 @@ public interface LogicContext {
 	 * @param patientId
 	 * @return patient object
 	 */
-	public Patient getPatient(Integer patientId);
+	Patient getPatient(Integer patientId);
 	
 	/**
 	 * Evaluate a rule for a single patient
@@ -39,7 +39,7 @@ public interface LogicContext {
 	 * @throws LogicException
 	 * @see org.openmrs.logic.LogicService#eval(Patient, String)
 	 */
-	public Result eval(Integer patientId, String token) throws LogicException;
+	Result eval(Integer patientId, String token) throws LogicException;
 	
 	/**
 	 * Evaluate a rule with parameters for a single patient
@@ -51,7 +51,7 @@ public interface LogicContext {
 	 * @throws LogicException
 	 * @see org.openmrs.logic.LogicService#eval(Patient, String, Map)
 	 */
-	public Result eval(Integer patientId, String token, Map<String, Object> parameters) throws LogicException;
+	Result eval(Integer patientId, String token, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Evaluate a rule with criteria and parameters for a single patient
@@ -63,7 +63,7 @@ public interface LogicContext {
 	 * @throws LogicException
 	 * @see org.openmrs.logic.LogicService#eval(Patient, LogicCriteria, Map)
 	 */
-	public Result eval(Integer patientId, LogicCriteria criteria, Map<String, Object> parameters) throws LogicException;
+	Result eval(Integer patientId, LogicCriteria criteria, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Fetches a logic data source by name
@@ -71,7 +71,7 @@ public interface LogicContext {
 	 * @param name
 	 * @return the requested <code>LogicDataSource</code>
 	 */
-	public LogicDataSource getLogicDataSource(String name);
+	LogicDataSource getLogicDataSource(String name);
 	
 	/**
 	 * Reads a key from a logic data source
@@ -82,7 +82,7 @@ public interface LogicContext {
 	 * @return <code>Result</code> of the read operation
 	 * @throws LogicException
 	 */
-	public Result read(Integer patientId, LogicDataSource dataSource, String key) throws LogicException;
+	Result read(Integer patientId, LogicDataSource dataSource, String key) throws LogicException;
 	
 	/**
 	 * Reads a key from a logic data source
@@ -92,7 +92,7 @@ public interface LogicContext {
 	 * @return <code>Result</code> of the read operation
 	 * @throws LogicException
 	 */
-	public Result read(Integer patientId, String key) throws LogicException;
+	Result read(Integer patientId, String key) throws LogicException;
 	
 	/**
 	 * Reads a key with criteria from a logic data source
@@ -102,7 +102,7 @@ public interface LogicContext {
 	 * @return <code>Result</code> of the read
 	 * @throws LogicException
 	 */
-	public Result read(Integer patientId, LogicCriteria criteria) throws LogicException;
+	Result read(Integer patientId, LogicCriteria criteria) throws LogicException;
 	
 	/**
 	 * Reads a key with criteria from a logic data source
@@ -113,7 +113,7 @@ public interface LogicContext {
 	 * @return <code>Result</code> of the read
 	 * @throws LogicException
 	 */
-	public Result read(Integer patientId, LogicDataSource dataSource, LogicCriteria criteria) throws LogicException;
+	Result read(Integer patientId, LogicDataSource dataSource, LogicCriteria criteria) throws LogicException;
 	
 	/**
 	 * Changes the index date for this logic context
@@ -121,18 +121,18 @@ public interface LogicContext {
 	 * @param indexDate the new <code>Date</code> value for "today" to be used by rules within this
 	 *            logic context
 	 */
-	public void setIndexDate(Date indexDate);
+	void setIndexDate(Date indexDate);
 	
 	/**
 	 * @return the value of "today" within this logic context
 	 */
-	public Date getIndexDate();
+	Date getIndexDate();
 	
 	/**
 	 * @return the index date for the logic context (effective value of "today")
 	 * @see #getIndexDate()
 	 */
-	public Date today();
+	Date today();
 	
 	/**
 	 * Assigns a value to a global parameters within this logic context
@@ -141,7 +141,7 @@ public interface LogicContext {
 	 * @param value
 	 * @return the value of the parameter that was set
 	 */
-	public Object setGlobalParameter(String id, Object value);
+	Object setGlobalParameter(String id, Object value);
 	
 	/**
 	 * Fetches a global parameter value by name
@@ -149,10 +149,10 @@ public interface LogicContext {
 	 * @param id
 	 * @return The requested Global parameter <code>Object</code>
 	 */
-	public Object getGlobalParameter(String id);
+	Object getGlobalParameter(String id);
 	
 	/**
 	 * @return all global parameters defined within this logic context
 	 */
-	public Collection<String> getGlobalParameters();
+	Collection<String> getGlobalParameters();
 }

--- a/api/src/main/java/org/openmrs/logic/LogicCriteria.java
+++ b/api/src/main/java/org/openmrs/logic/LogicCriteria.java
@@ -60,17 +60,17 @@ public interface LogicCriteria {
 	 * @param operand one of the Operand object
 	 * @return a new LogicCriteria containing the existing and new LogicExpression
 	 */
-	public LogicCriteria appendExpression(Operator operator, Operand operand);
+	LogicCriteria appendExpression(Operator operator, Operand operand);
 	
 	/**
 	 * @see LogicCriteria#appendExpression(Operator, Operand)
 	 */
-	public LogicCriteria appendExpression(Operator operator, String operand);
+	LogicCriteria appendExpression(Operator operator, String operand);
 	
 	/**
 	 * @see LogicCriteria#appendExpression(Operator, Operand)
 	 */
-	public LogicCriteria appendExpression(Operator operator, double operand);
+	LogicCriteria appendExpression(Operator operator, double operand);
 	
 	/**
 	 * Apply a transformation operator to a logic expression
@@ -78,7 +78,7 @@ public interface LogicCriteria {
 	 * @param operator type of the {@link TransformOperator}
 	 * @return new logic criteria containing the {@link TransformOperator}
 	 */
-	public LogicCriteria applyTransform(Operator operator);
+	LogicCriteria applyTransform(Operator operator);
 	
 	// --Logic Operators joining criteria
 	/**
@@ -88,7 +88,7 @@ public interface LogicCriteria {
 	 * @param logicCriteria {@link LogicCriteria} to be appended
 	 * @return new {@link LogicCriteria} containing existing and the new {@link LogicCriteria}
 	 */
-	public LogicCriteria appendCriteria(Operator operator, LogicCriteria logicCriteria);
+	LogicCriteria appendCriteria(Operator operator, LogicCriteria logicCriteria);
 	
 	/**
 	 * Append the LogicCriteria using the {@link And} operator
@@ -97,7 +97,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria that is the combination of existing and the new LogicCriteria
 	 * @see And
 	 */
-	public LogicCriteria and(LogicCriteria logicCriteria);
+	LogicCriteria and(LogicCriteria logicCriteria);
 	
 	/**
 	 * Append the LogicCriteria using the {@link Or} operator
@@ -106,9 +106,9 @@ public interface LogicCriteria {
 	 * @return LogicCriteria that is the combination of existing and the new LogicCriteria
 	 * @see Or
 	 */
-	public LogicCriteria or(LogicCriteria logicCriteria);
+	LogicCriteria or(LogicCriteria logicCriteria);
 	
-	public LogicCriteria not();
+	LogicCriteria not();
 	
 	//--Transform Operators
 	/**
@@ -117,7 +117,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with count applied
 	 * @see Count
 	 */
-	public LogicCriteria count();
+	LogicCriteria count();
 	
 	/**
 	 * Apply the {@link Average} operator to the LogicCriteria
@@ -125,7 +125,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Average applied
 	 * @see Average
 	 */
-	public LogicCriteria average();
+	LogicCriteria average();
 	
 	/**
 	 * Apply the {@link Last} operator to the LogicCriteria
@@ -133,12 +133,12 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Last applied
 	 * @see Last
 	 */
-	public LogicCriteria last();
+	LogicCriteria last();
 	
 	/**
 	 * @see LogicCriteria#last()
 	 */
-	public LogicCriteria last(Integer numResults);
+	LogicCriteria last(Integer numResults);
 	
 	/**
 	 * Apply the {@link First} operator to the LogicCriteria
@@ -146,22 +146,22 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with First applied
 	 * @see First
 	 */
-	public LogicCriteria first();
+	LogicCriteria first();
 	
 	/**
 	 * @see LogicCriteria#first()
 	 */
-	public LogicCriteria first(Integer numResults);
+	LogicCriteria first(Integer numResults);
 	
 	/**
 	 * @see LogicCriteria#first()
 	 */
-	public LogicCriteria first(String sortComponent);
+	LogicCriteria first(String sortComponent);
 	
 	/**
 	 * @see LogicCriteria#first()
 	 */
-	public LogicCriteria first(Integer numResults, String sortComponent);
+	LogicCriteria first(Integer numResults, String sortComponent);
 	
 	/**
 	 * Apply the {@link Distinct} operator to the LogicCriteria
@@ -169,11 +169,11 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Distinct operator in it
 	 * @see org.openmrs.logic.op.Distinct
 	 */
-	public LogicCriteria distinct();
+	LogicCriteria distinct();
 	
-	public LogicCriteria exists();
+	LogicCriteria exists();
 	
-	public LogicCriteria notExists();
+	LogicCriteria notExists();
 	
 	//--Comparison Operators
 	/**
@@ -183,7 +183,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with AsOf expression
 	 * @see AsOf
 	 */
-	public LogicCriteria asOf(Date value);
+	LogicCriteria asOf(Date value);
 	
 	/**
 	 * Add a {@link org.openmrs.logic.op.Before} expression to the current LogicCriteria
@@ -192,7 +192,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Before expression
 	 * @see org.openmrs.logic.op.Before
 	 */
-	public LogicCriteria before(Date value);
+	LogicCriteria before(Date value);
 	
 	/**
 	 * Add a {@link In} expression to the current LogicCriteria
@@ -201,7 +201,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with In expression
 	 * @see In
 	 */
-	public LogicCriteria after(Date value);
+	LogicCriteria after(Date value);
 	
 	/**
 	 * Add a {@link org.openmrs.logic.op.After} expression to the current LogicCriteria
@@ -210,27 +210,27 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with After expression
 	 * @see org.openmrs.logic.op.After
 	 */
-	public LogicCriteria in(Collection<?> value);
+	LogicCriteria in(Collection<?> value);
 	
 	/**
 	 * @see LogicCriteria#contains(String)
 	 */
-	public LogicCriteria contains(Operand value);
+	LogicCriteria contains(Operand value);
 	
 	/**
 	 * @see LogicCriteria#contains(String)
 	 */
-	public LogicCriteria contains(int value);
+	LogicCriteria contains(int value);
 	
 	/**
 	 * @see LogicCriteria#contains(String)
 	 */
-	public LogicCriteria contains(float value);
+	LogicCriteria contains(float value);
 	
 	/**
 	 * @see LogicCriteria#contains(String)
 	 */
-	public LogicCriteria contains(double value);
+	LogicCriteria contains(double value);
 	
 	/**
 	 * Add a {@link org.openmrs.logic.op.Contains} expression to the current LogicCriteria
@@ -239,27 +239,27 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Contains expression
 	 * @see org.openmrs.logic.op.Contains
 	 */
-	public LogicCriteria contains(String value);
+	LogicCriteria contains(String value);
 	
 	/**
 	 * @see LogicCriteria#equalTo(String)
 	 */
-	public LogicCriteria equalTo(Operand value);
+	LogicCriteria equalTo(Operand value);
 	
 	/**
 	 * @see LogicCriteria#equalTo(String)
 	 */
-	public LogicCriteria equalTo(int value);
+	LogicCriteria equalTo(int value);
 	
 	/**
 	 * @see LogicCriteria#equalTo(String)
 	 */
-	public LogicCriteria equalTo(float value);
+	LogicCriteria equalTo(float value);
 	
 	/**
 	 * @see LogicCriteria#equalTo(String)
 	 */
-	public LogicCriteria equalTo(double value);
+	LogicCriteria equalTo(double value);
 	
 	/**
 	 * Add a {@link org.openmrs.logic.op.Equals} expression to the current LogicCriteria
@@ -268,22 +268,22 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with Equals expression
 	 * @see org.openmrs.logic.op.Equals
 	 */
-	public LogicCriteria equalTo(String value);
+	LogicCriteria equalTo(String value);
 	
 	/**
 	 * @see LogicCriteria#gte(double)
 	 */
-	public LogicCriteria gte(Operand value);
+	LogicCriteria gte(Operand value);
 	
 	/**
 	 * @see LogicCriteria#gte(double)
 	 */
-	public LogicCriteria gte(int value);
+	LogicCriteria gte(int value);
 	
 	/**
 	 * @see LogicCriteria#gte(double)
 	 */
-	public LogicCriteria gte(float value);
+	LogicCriteria gte(float value);
 	
 	/**
 	 * Add a {@link GreaterThanEquals} expression to the current LogicCriteria
@@ -292,22 +292,22 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with GreaterThanEquals expression
 	 * @see GreaterThanEquals
 	 */
-	public LogicCriteria gte(double value);
+	LogicCriteria gte(double value);
 	
 	/**
 	 * @see LogicCriteria#gt(double)
 	 */
-	public LogicCriteria gt(Operand value);
+	LogicCriteria gt(Operand value);
 	
 	/**
 	 * @see LogicCriteria#gt(double)
 	 */
-	public LogicCriteria gt(int value);
+	LogicCriteria gt(int value);
 	
 	/**
 	 * @see LogicCriteria#gt(double)
 	 */
-	public LogicCriteria gt(float value);
+	LogicCriteria gt(float value);
 	
 	/**
 	 * Add a {@link GreaterThan} expression to the current LogicCriteria
@@ -316,22 +316,22 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with GreaterThan expression
 	 * @see GreaterThan
 	 */
-	public LogicCriteria gt(double value);
+	LogicCriteria gt(double value);
 	
 	/**
 	 * @see LogicCriteria#lt(double)
 	 */
-	public LogicCriteria lt(Operand value);
+	LogicCriteria lt(Operand value);
 	
 	/**
 	 * @see LogicCriteria#lt(double)
 	 */
-	public LogicCriteria lt(int value);
+	LogicCriteria lt(int value);
 	
 	/**
 	 * @see LogicCriteria#lt(double)
 	 */
-	public LogicCriteria lt(float value);
+	LogicCriteria lt(float value);
 	
 	/**
 	 * Add a {@link LessThan} expression to the current LogicCriteria
@@ -340,22 +340,22 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with LessThan expression
 	 * @see LessThan
 	 */
-	public LogicCriteria lt(double value);
+	LogicCriteria lt(double value);
 	
 	/**
 	 * @see LogicCriteria#lte(double)
 	 */
-	public LogicCriteria lte(Operand value);
+	LogicCriteria lte(Operand value);
 	
 	/**
 	 * @see LogicCriteria#lte(double)
 	 */
-	public LogicCriteria lte(int value);
+	LogicCriteria lte(int value);
 	
 	/**
 	 * @see LogicCriteria#lte(double)
 	 */
-	public LogicCriteria lte(float value);
+	LogicCriteria lte(float value);
 	
 	/**
 	 * Add a {@link LessThanEquals} expression to the current LogicCriteria
@@ -364,7 +364,7 @@ public interface LogicCriteria {
 	 * @return LogicCriteria with LessThanEquals expression
 	 * @see LessThanEquals
 	 */
-	public LogicCriteria lte(double value);
+	LogicCriteria lte(double value);
 	
 	/**
 	 * Add a duration expression to the current LogicCriteria
@@ -373,17 +373,17 @@ public interface LogicCriteria {
 	 * @return LogicCriteria containing duration expression
 	 * @see Within
 	 */
-	public LogicCriteria within(Duration duration);
+	LogicCriteria within(Duration duration);
 	
 	/**
 	 * @return logic parameters
 	 */
-	public Map<String, Object> getLogicParameters();
+	Map<String, Object> getLogicParameters();
 	
 	/**
 	 * @param logicParameters
 	 */
-	public void setLogicParameters(Map<String, Object> logicParameters);
+	void setLogicParameters(Map<String, Object> logicParameters);
 	
 	/**
 	 * Method to get the root token of the current LogicCriteria. <code>
@@ -392,13 +392,13 @@ public interface LogicCriteria {
 	 * 
 	 * @return the root token of the LogicCriteria
 	 */
-	public String getRootToken();
+	String getRootToken();
 	
 	/**
 	 * Method to get the LogicExpression backing the current LogicCriteria
 	 * 
 	 * @return the LogicExpression of the current LogicCriteria
 	 */
-	public LogicExpression getExpression();
+	LogicExpression getExpression();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/LogicExpression.java
+++ b/api/src/main/java/org/openmrs/logic/LogicExpression.java
@@ -29,7 +29,7 @@ public interface LogicExpression extends Operand {
 	 * 
 	 * @return current operator of the LogicExpression
 	 */
-	public Operator getOperator();
+	Operator getOperator();
 	
 	/**
 	 * Method to get the root token of the current LogicCriteria.
@@ -37,7 +37,7 @@ public interface LogicExpression extends Operand {
 	 * @return the root token of the LogicExpression
 	 * @see LogicCriteria#getRootToken()
 	 */
-	public String getRootToken();
+	String getRootToken();
 	
 	/**
 	 * Get the right operand of the LogicExpression. Both LogicExpressionBinary and
@@ -45,7 +45,7 @@ public interface LogicExpression extends Operand {
 	 * 
 	 * @return right operand of the LogicExpression
 	 */
-	public Operand getRightOperand();
+	Operand getRightOperand();
 	
 	/**
 	 * Get the transformation expression applied to the LogicExpression
@@ -53,12 +53,12 @@ public interface LogicExpression extends Operand {
 	 * @return transformation expression of the LogicExpression
 	 * @see TransformOperator
 	 */
-	public LogicTransform getTransform();
+	LogicTransform getTransform();
 	
 	/**
 	 * Set the transformation expression applied to the LogicExpression
 	 * 
 	 * @see TransformOperator
 	 */
-	public void setTransform(LogicTransform transform);
+	void setTransform(LogicTransform transform);
 }

--- a/api/src/main/java/org/openmrs/logic/LogicService.java
+++ b/api/src/main/java/org/openmrs/logic/LogicService.java
@@ -69,7 +69,7 @@ public interface LogicService {
 	 * @return all known (registered) tokens
 	 * @should return all registered token
 	 */
-	public List<String> getAllTokens();
+	List<String> getAllTokens();
 	
 	/**
 	 * Fetch all known (registered) tokens matching a given string
@@ -80,7 +80,7 @@ public interface LogicService {
 	 * @should return all registered token matching the input partially
 	 * @should not fail when input is null
 	 */
-	public List<String> getTokens(String partialToken);
+	List<String> getTokens(String partialToken);
 	
 	/**
 	 * Registers a new rule with the logic service.
@@ -92,7 +92,7 @@ public interface LogicService {
 	 * @should not fail when another rule is registered on the same token
 	 * @should persist the rule and associate it with the token
 	 */
-	public void addRule(String token, Rule rule) throws LogicException;
+	void addRule(String token, Rule rule) throws LogicException;
 	
 	/**
 	 * Registers a new rule with the logic service, associating the tags with the given token
@@ -104,7 +104,7 @@ public interface LogicService {
 	 * @should not fail when no tags is specified
 	 * @should persist rule with the tags
 	 */
-	public void addRule(String token, String[] tags, Rule rule) throws LogicException;
+	void addRule(String token, String[] tags, Rule rule) throws LogicException;
 	
 	/**
 	 * Gets the rule registered under a given token
@@ -116,7 +116,7 @@ public interface LogicService {
 	 * @should fail when no Rule is associated with the input token
 	 * @should return ReferenceRule
 	 */
-	public Rule getRule(String token) throws LogicException;
+	Rule getRule(String token) throws LogicException;
 	
 	/**
 	 * Update a rule that has previously been registered
@@ -126,7 +126,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @should update Rule when another Rule is registered under the same token
 	 */
-	public void updateRule(String token, Rule rule) throws LogicException;
+	void updateRule(String token, Rule rule) throws LogicException;
 	
 	/**
 	 * Removes a rule from the logic service
@@ -135,7 +135,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @should remove rule
 	 */
-	public void removeRule(String token) throws LogicException;
+	void removeRule(String token) throws LogicException;
 	
 	/**
 	 * Evaluates a rule for a given patient, given the token for the rule.
@@ -147,7 +147,7 @@ public interface LogicService {
 	 * @see #parse(String)
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Result eval(Integer patientId, String expression) throws LogicException;
+	Result eval(Integer patientId, String expression) throws LogicException;
 	
 	/**
 	 * Evaluates a rule for a given patient, given a token and parameters for the rule.
@@ -160,7 +160,7 @@ public interface LogicService {
 	 * @see #parse(String)
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Result eval(Integer patientId, String expression, Map<String, Object> parameters) throws LogicException;
+	Result eval(Integer patientId, String expression, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Evaluates a query for a given patient
@@ -171,7 +171,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Result eval(Integer patientId, LogicCriteria criteria) throws LogicException;
+	Result eval(Integer patientId, LogicCriteria criteria) throws LogicException;
 	
 	/**
 	 * Evaluates a query for a given patient
@@ -184,7 +184,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Result eval(Integer patientId, LogicCriteria criteria, Map<String, Object> parameters) throws LogicException;
+	Result eval(Integer patientId, LogicCriteria criteria, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Evaluates multiple logic expressions for a single patient.
@@ -199,7 +199,7 @@ public interface LogicService {
 	 * @see #parse(String)
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Map<String, Result> eval(Integer patientId, Map<String, Object> parameters, String... expressions)
+	Map<String, Result> eval(Integer patientId, Map<String, Object> parameters, String... expressions)
 	        throws LogicException;
 	
 	/**
@@ -214,7 +214,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @since 1.6.3, 1.7.2, and 1.8
 	 */
-	public Map<LogicCriteria, Result> eval(Integer patientId, Map<String, Object> parameters, LogicCriteria... criteria)
+	Map<LogicCriteria, Result> eval(Integer patientId, Map<String, Object> parameters, LogicCriteria... criteria)
 	        throws LogicException;
 		
 	/**
@@ -226,7 +226,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @see #parse(String)
 	 */
-	public Map<Integer, Result> eval(Cohort who, String expression) throws LogicException;
+	Map<Integer, Result> eval(Cohort who, String expression) throws LogicException;
 	
 	/**
 	 * Evaluates a query over a list of patients
@@ -238,7 +238,7 @@ public interface LogicService {
 	 * @throws LogicException
 	 * @see #parse(String)
 	 */
-	public Map<Integer, Result> eval(Cohort who, String expression, Map<String, Object> parameters) throws LogicException;
+	Map<Integer, Result> eval(Cohort who, String expression, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Evaluates a query over a list of patients
@@ -248,7 +248,7 @@ public interface LogicService {
 	 * @return result for each patient
 	 * @throws LogicException
 	 */
-	public Map<Integer, Result> eval(Cohort who, LogicCriteria criteria) throws LogicException;
+	Map<Integer, Result> eval(Cohort who, LogicCriteria criteria) throws LogicException;
 	
 	/**
 	 * Evaluates a query over a list of patients
@@ -259,7 +259,7 @@ public interface LogicService {
 	 * @return result for each patient
 	 * @throws LogicException
 	 */
-	public Map<Integer, Result> eval(Cohort who, LogicCriteria criteria, Map<String, Object> parameters)
+	Map<Integer, Result> eval(Cohort who, LogicCriteria criteria, Map<String, Object> parameters)
 	        throws LogicException;
 	
 	/**
@@ -270,8 +270,8 @@ public interface LogicService {
 	 * @return results for each patient
 	 * @throws LogicException
 	 */
-	
-	public Map<LogicCriteria, Map<Integer, Result>> eval(Cohort who, List<LogicCriteria> criterias) throws LogicException;
+
+	Map<LogicCriteria, Map<Integer, Result>> eval(Cohort who, List<LogicCriteria> criterias) throws LogicException;
 	
 	/**
 	 * Adds a tag to the given token.
@@ -280,7 +280,7 @@ public interface LogicService {
 	 * @param tag
 	 * @should add tag for a token
 	 */
-	public void addTokenTag(String token, String tag);
+	void addTokenTag(String token, String tag);
 	
 	/**
 	 * Removes a token's previously assigned tag.
@@ -289,7 +289,7 @@ public interface LogicService {
 	 * @param tag
 	 * @should remove tag from a token
 	 */
-	public void removeTokenTag(String token, String tag);
+	void removeTokenTag(String token, String tag);
 	
 	/**
 	 * Gets all tags associated with this token.
@@ -298,7 +298,7 @@ public interface LogicService {
 	 * @return collection of tags
 	 * @should return set of tags for a certain token
 	 */
-	public Set<String> getTokenTags(String token);
+	Set<String> getTokenTags(String token);
 	
 	/**
 	 * Gets all tokens associated with this tag.
@@ -307,7 +307,7 @@ public interface LogicService {
 	 * @return collection of tokens
 	 * @should return set of token associated with a tag
 	 */
-	public List<String> getTokensWithTag(String tag);
+	List<String> getTokensWithTag(String tag);
 	
 	/**
 	 * Performs a partial match search for token tags among all known tokens.
@@ -316,7 +316,7 @@ public interface LogicService {
 	 * @return collection of tags
 	 * @should return set of tags matching input tag partially
 	 */
-	public List<String> getTags(String partialTag);
+	List<String> getTags(String partialTag);
 	
 	/**
 	 * Fetches the default datatype this token will return when fed to an eval() call. Results
@@ -327,21 +327,21 @@ public interface LogicService {
 	 * @param token token to look the datatype up for
 	 * @return datatype of the given token
 	 */
-	public Datatype getDefaultDatatype(String token);
+	Datatype getDefaultDatatype(String token);
 	
 	/**
 	 * Fetches the parameters expected by a given rule
 	 * 
 	 * @return list of parameters
 	 */
-	public Set<RuleParameterInfo> getParameterList(String token);
+	Set<RuleParameterInfo> getParameterList(String token);
 		
 	/**
 	 * Get all registered logic data sources
 	 * 
 	 * @return all registered logic data sources
 	 */
-	public Map<String, LogicDataSource> getLogicDataSources();
+	Map<String, LogicDataSource> getLogicDataSources();
 		
 	/**
 	 * Get a logic data source by name
@@ -350,7 +350,7 @@ public interface LogicService {
 	 * @return the logic data source with the given name or <code>null</code> if there is no data
 	 *         source registered under the given name (must be an exact match)
 	 */
-	public LogicDataSource getLogicDataSource(String name);
+	LogicDataSource getLogicDataSource(String name);
 	
 	/**
 	 * Parse a criteria String to create a new LogicCriteria. <br>
@@ -361,6 +361,6 @@ public interface LogicService {
 	 * @param criteria LogicCriteria expression in a plain String object.
 	 * @return LogicCriteria using all possible operand and operator from the String input
 	 */
-	public LogicCriteria parse(String criteria);
+	LogicCriteria parse(String criteria);
 	
 }

--- a/api/src/main/java/org/openmrs/logic/Rule.java
+++ b/api/src/main/java/org/openmrs/logic/Rule.java
@@ -30,14 +30,14 @@ public interface Rule {
 	 * @return result of the rule for the given patient with given criteria applied
 	 * @throws LogicException TODO
 	 */
-	public Result eval(LogicContext context, Integer patientId, Map<String, Object> parameters) throws LogicException;
+	Result eval(LogicContext context, Integer patientId, Map<String, Object> parameters) throws LogicException;
 	
 	/**
 	 * Returns the list of arguments.
 	 * 
 	 * @return list of arguments or null if no arguments
 	 */
-	public Set<RuleParameterInfo> getParameterList();
+	Set<RuleParameterInfo> getParameterList();
 	
 	/**
 	 * Returns a list of dependencies (tokens for rules upon which this rule may depend).
@@ -46,7 +46,7 @@ public interface Rule {
 	 */
 	// TODO: it would be better to be able to query for dependency on both rules
 	// and/or data source keys
-	public String[] getDependencies();
+	String[] getDependencies();
 	
 	/**
 	 * Gets the time (in seconds) during which the Rule's results are considered to be valid. This
@@ -54,7 +54,7 @@ public interface Rule {
 	 * 
 	 * @return duration (in seconds) the results are considered valid for this rule
 	 */
-	public int getTTL();
+	int getTTL();
 	
 	/**
 	 * Gets the default datatype that the rule returns, when supplied with a given token. While
@@ -63,6 +63,6 @@ public interface Rule {
 	 * 
 	 * @return datatype
 	 */
-	public Datatype getDefaultDatatype();
+	Datatype getDefaultDatatype();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/datasource/LogicDataSource.java
+++ b/api/src/main/java/org/openmrs/logic/datasource/LogicDataSource.java
@@ -87,7 +87,7 @@ public interface LogicDataSource {
 	 * Implementations should override this like
 	 *     public static final String NAME = "person";
 	 */
-	public static String NAME = "org.openmrs.logic.LogicDataSource.name";
+	String NAME = "org.openmrs.logic.LogicDataSource.name";
 	
 	/**
 	 * Extracts data from the data source. Actually, this function only checks for cached data and
@@ -98,12 +98,12 @@ public interface LogicDataSource {
 	 * @param criteria <code>LogicCriteria</code> identifying which data is to be extracted
 	 * @return <code>Map</code> of results for each patient, grouped by requested data element
 	 */
-	public Map<Integer, Result> read(LogicContext context, Cohort patients, LogicCriteria criteria) throws LogicException;
+	Map<Integer, Result> read(LogicContext context, Cohort patients, LogicCriteria criteria) throws LogicException;
 	
-	public abstract Collection<String> getKeys();
+	Collection<String> getKeys();
 	
-	public boolean hasKey(String key);
+	boolean hasKey(String key);
 	
-	public abstract int getDefaultTTL();
+	int getDefaultTTL();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/op/ComparisonOperator.java
+++ b/api/src/main/java/org/openmrs/logic/op/ComparisonOperator.java
@@ -17,24 +17,24 @@ package org.openmrs.logic.op;
 public interface ComparisonOperator extends Operator {
 	
 	// comparison operators
-	public static final ComparisonOperator CONTAINS = new Contains();
+	ComparisonOperator CONTAINS = new Contains();
 	
-	public static final ComparisonOperator EQUALS = new Equals();
+	ComparisonOperator EQUALS = new Equals();
 	
-	public static final ComparisonOperator WITHIN = new Within();
+	ComparisonOperator WITHIN = new Within();
 	
-	public static final ComparisonOperator GT = new GreaterThan();
+	ComparisonOperator GT = new GreaterThan();
 	
-	public static final ComparisonOperator GTE = new GreaterThanEquals();
+	ComparisonOperator GTE = new GreaterThanEquals();
 	
-	public static final ComparisonOperator LT = new LessThan();
+	ComparisonOperator LT = new LessThan();
 	
-	public static final ComparisonOperator LTE = new LessThanEquals();
+	ComparisonOperator LTE = new LessThanEquals();
 	
-	public static final ComparisonOperator BEFORE = new Before();
+	ComparisonOperator BEFORE = new Before();
 	
-	public static final ComparisonOperator AFTER = new After();
+	ComparisonOperator AFTER = new After();
 	
-	public static final ComparisonOperator IN = new In();
+	ComparisonOperator IN = new In();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/op/LogicalOperator.java
+++ b/api/src/main/java/org/openmrs/logic/op/LogicalOperator.java
@@ -14,10 +14,10 @@ package org.openmrs.logic.op;
  */
 public interface LogicalOperator extends Operator {
 	
-	public static final LogicalOperator AND = new And();
+	LogicalOperator AND = new And();
 	
-	public static final LogicalOperator OR = new Or();
+	LogicalOperator OR = new Or();
 	
-	public static final LogicalOperator NOT = new Not();
+	LogicalOperator NOT = new Not();
 	
 }

--- a/api/src/main/java/org/openmrs/logic/op/Operand.java
+++ b/api/src/main/java/org/openmrs/logic/op/Operand.java
@@ -23,6 +23,6 @@ public interface Operand {
 	 * @param operator The operator to test against this Operand
 	 * @return true/false about whether this Operand supports this {@link ComparisonOperator}
 	 */
-	public boolean supports(ComparisonOperator operator);
+	boolean supports(ComparisonOperator operator);
 	
 }

--- a/api/src/main/java/org/openmrs/logic/op/Operator.java
+++ b/api/src/main/java/org/openmrs/logic/op/Operator.java
@@ -15,49 +15,49 @@ package org.openmrs.logic.op;
 public interface Operator {
 	
 	// comparison operators
-	public static final Operator CONTAINS = ComparisonOperator.CONTAINS;
+	Operator CONTAINS = ComparisonOperator.CONTAINS;
 	
-	public static final Operator EQUALS = ComparisonOperator.EQUALS;
+	Operator EQUALS = ComparisonOperator.EQUALS;
 	
-	public static final Operator WITHIN = ComparisonOperator.WITHIN;
+	Operator WITHIN = ComparisonOperator.WITHIN;
 	
-	public static final Operator GT = ComparisonOperator.GT;
+	Operator GT = ComparisonOperator.GT;
 	
-	public static final Operator GTE = ComparisonOperator.GTE;
+	Operator GTE = ComparisonOperator.GTE;
 	
-	public static final Operator LT = ComparisonOperator.LT;
+	Operator LT = ComparisonOperator.LT;
 	
-	public static final Operator LTE = ComparisonOperator.LTE;
+	Operator LTE = ComparisonOperator.LTE;
 	
-	public static final Operator BEFORE = ComparisonOperator.BEFORE;
+	Operator BEFORE = ComparisonOperator.BEFORE;
 	
-	public static final Operator AFTER = ComparisonOperator.AFTER;
+	Operator AFTER = ComparisonOperator.AFTER;
 	
-	public static final Operator IN = ComparisonOperator.IN;
+	Operator IN = ComparisonOperator.IN;
 	
 	// weird operator
-	public static final Operator ASOF = new AsOf();
+	Operator ASOF = new AsOf();
 	
 	// logical operators
-	public static final Operator AND = LogicalOperator.AND;
+	Operator AND = LogicalOperator.AND;
 	
-	public static final Operator OR = LogicalOperator.OR;
+	Operator OR = LogicalOperator.OR;
 	
-	public static final Operator NOT = LogicalOperator.NOT;
+	Operator NOT = LogicalOperator.NOT;
 	
 	// transform operators
-	public static final Operator LAST = TransformOperator.LAST;
+	Operator LAST = TransformOperator.LAST;
 	
-	public static final Operator FIRST = TransformOperator.FIRST;
+	Operator FIRST = TransformOperator.FIRST;
 	
-	public static final Operator DISTINCT = TransformOperator.DISTINCT;
+	Operator DISTINCT = TransformOperator.DISTINCT;
 	
-	public static final Operator EXISTS = TransformOperator.EXISTS;
+	Operator EXISTS = TransformOperator.EXISTS;
 	
-	public static final Operator NOT_EXISTS = TransformOperator.NOT_EXISTS;
+	Operator NOT_EXISTS = TransformOperator.NOT_EXISTS;
 	
-	public static final Operator COUNT = TransformOperator.COUNT;
+	Operator COUNT = TransformOperator.COUNT;
 	
-	public static final Operator AVERAGE = TransformOperator.AVERAGE;
+	Operator AVERAGE = TransformOperator.AVERAGE;
 	
 }

--- a/api/src/main/java/org/openmrs/logic/op/TransformOperator.java
+++ b/api/src/main/java/org/openmrs/logic/op/TransformOperator.java
@@ -14,18 +14,18 @@ package org.openmrs.logic.op;
  */
 public interface TransformOperator extends Operator {
 	
-	public static final TransformOperator LAST = new Last();
+	TransformOperator LAST = new Last();
 	
-	public static final TransformOperator FIRST = new First();
+	TransformOperator FIRST = new First();
 	
-	public static final TransformOperator DISTINCT = new Distinct();
+	TransformOperator DISTINCT = new Distinct();
 	
-	public static final TransformOperator EXISTS = new Exists();
+	TransformOperator EXISTS = new Exists();
 	
-	public static final TransformOperator NOT_EXISTS = new NotExists();
+	TransformOperator NOT_EXISTS = new NotExists();
 	
-	public static final TransformOperator COUNT = new Count();
+	TransformOperator COUNT = new Count();
 	
-	public static final TransformOperator AVERAGE = new Average();
+	TransformOperator AVERAGE = new Average();
 	
 }

--- a/api/src/main/java/org/openmrs/messagesource/MessageSourceService.java
+++ b/api/src/main/java/org/openmrs/messagesource/MessageSourceService.java
@@ -23,30 +23,30 @@ public interface MessageSourceService extends MutableMessageSource {
 	 * @param s message code to retrieve
 	 * @return the translated message
 	 */
-	public String getMessage(String s);
+	String getMessage(String s);
 	
 	/**
 	 * Gets the message source service which is currently providing services.
 	 * 
 	 * @return the activeMessageSource
 	 */
-	public MutableMessageSource getActiveMessageSource();
+	MutableMessageSource getActiveMessageSource();
 	
 	/**
 	 * Sets the message source service which will actually provide services.
 	 * 
 	 * @param activeMessageSource the <code>MutableMessageSource</code> to set
 	 */
-	public void setActiveMessageSource(MutableMessageSource activeMessageSource);
+	void setActiveMessageSource(MutableMessageSource activeMessageSource);
 	
 	/**
 	 * @return the availableMessageSources
 	 */
-	public Set<MutableMessageSource> getMessageSources();
+	Set<MutableMessageSource> getMessageSources();
 	
 	/**
 	 * @param availableMessageSources the availableMessageSources to set
 	 */
-	public void setMessageSources(Set<MutableMessageSource> availableMessageSources);
+	void setMessageSources(Set<MutableMessageSource> availableMessageSources);
 	
 }

--- a/api/src/main/java/org/openmrs/messagesource/MutableMessageSource.java
+++ b/api/src/main/java/org/openmrs/messagesource/MutableMessageSource.java
@@ -26,14 +26,14 @@ public interface MutableMessageSource extends MessageSource, HierarchicalMessage
 	 * 
 	 * @return available message locales
 	 */
-	public Collection<Locale> getLocales();
+	Collection<Locale> getLocales();
 		
 	/**
 	 * Gets all of the available messages, packaged as PresentationMessages.
 	 * 
 	 * @return collection of presentation messages
 	 */
-	public Collection<PresentationMessage> getPresentations();
+	Collection<PresentationMessage> getPresentations();
 	
 	/**
 	 * Gets alll the available messages in a particular locale, packaged as PresentationMessages.
@@ -41,7 +41,7 @@ public interface MutableMessageSource extends MessageSource, HierarchicalMessage
 	 * @param locale locale for which to get the messages
 	 * @return collection of PresentationMessages in the locale
 	 */
-	public Collection<PresentationMessage> getPresentationsInLocale(Locale locale);
+	Collection<PresentationMessage> getPresentationsInLocale(Locale locale);
 	
 	/**
 	 * Adds a presentation message to the source. This operation should overwrite any existing
@@ -49,7 +49,7 @@ public interface MutableMessageSource extends MessageSource, HierarchicalMessage
 	 * 
 	 * @param message message to add to the source
 	 */
-	public void addPresentation(PresentationMessage message);
+	void addPresentation(PresentationMessage message);
 	
 	/**
 	 * Gets the PresentationMessage for a particular locale.
@@ -58,14 +58,14 @@ public interface MutableMessageSource extends MessageSource, HierarchicalMessage
 	 * @param forLocale locale for which to get the message
 	 * @return corresponding PresentationMessage, or null if not available
 	 */
-	public PresentationMessage getPresentation(String key, Locale forLocale);
+	PresentationMessage getPresentation(String key, Locale forLocale);
 	
 	/**
 	 * Removes a presentation message from the source.
 	 * 
 	 * @param message the message to remove
 	 */
-	public void removePresentation(PresentationMessage message);
+	void removePresentation(PresentationMessage message);
 	
 	/**
 	 * Merge messages from another source into this source.
@@ -73,6 +73,6 @@ public interface MutableMessageSource extends MessageSource, HierarchicalMessage
 	 * @param fromSource message source from which messages should be merge
 	 * @param overwrite whether to overwrite existing messages
 	 */
-	public void merge(MutableMessageSource fromSource, boolean overwrite);
+	void merge(MutableMessageSource fromSource, boolean overwrite);
 	
 }

--- a/api/src/main/java/org/openmrs/module/ModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/ModuleActivator.java
@@ -24,13 +24,13 @@ public interface ModuleActivator {
 	 * times i.e. whenever a new module gets started, at application startup or a developer chooses
 	 * to refresh the context.
 	 */
-	public void willRefreshContext();
+	void willRefreshContext();
 	
 	/**
 	 * Called after spring's application context is refreshed , this method is called multiple times
 	 * i.e. whenever a new module gets started and at application startup.
 	 */
-	public void contextRefreshed();
+	void contextRefreshed();
 	
 	/**
 	 * Called after a module has been loaded but before the application context is refreshed, at
@@ -38,22 +38,22 @@ public interface ModuleActivator {
 	 * <br>
 	 * This method will be authenticated as the Daemon user and have all privileges.
 	 */
-	public void willStart();
+	void willStart();
 	
 	/**
 	 * Called after a module is started, the application context has been refreshed and the module's
 	 * service methods are ready to be called.
 	 */
-	public void started();
+	void started();
 	
 	/**
 	 * Called just before a module is stopped
 	 */
-	public void willStop();
+	void willStop();
 	
 	/**
 	 * Called after a module is stopped
 	 */
-	public void stopped();
+	void stopped();
 	
 }

--- a/api/src/main/java/org/openmrs/notification/AlertService.java
+++ b/api/src/main/java/org/openmrs/notification/AlertService.java
@@ -35,7 +35,7 @@ public interface AlertService extends OpenmrsService {
 	 * 
 	 * @param dao The dao implementation to use
 	 */
-	public void setAlertDAO(AlertDAO dao);
+	void setAlertDAO(AlertDAO dao);
 	
 	/**
 	 * Save the given <code>alert</code> in the database
@@ -48,7 +48,7 @@ public interface AlertService extends OpenmrsService {
 	 * @should assign uuid to alert
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ALERTS)
-	public Alert saveAlert(Alert alert) throws APIException;
+	Alert saveAlert(Alert alert) throws APIException;
 	
 	/**
 	 * Get alert by internal identifier
@@ -57,7 +57,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return alert with given internal identifier
 	 * @throws APIException
 	 */
-	public Alert getAlert(Integer alertId) throws APIException;
+	Alert getAlert(Integer alertId) throws APIException;
 	
 	/**
 	 * Completely delete the given alert from the database
@@ -66,7 +66,7 @@ public interface AlertService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ALERTS)
-	public void purgeAlert(Alert alert) throws APIException;
+	void purgeAlert(Alert alert) throws APIException;
 	
 	/**
 	 * Find all alerts for a user that have not expired
@@ -76,7 +76,7 @@ public interface AlertService extends OpenmrsService {
 	 * @see #getAlerts(User, boolean, boolean)
 	 * @throws APIException
 	 */
-	public List<Alert> getAllActiveAlerts(User user) throws APIException;
+	List<Alert> getAllActiveAlerts(User user) throws APIException;
 	
 	/**
 	 * Find the alerts that are not read and have not expired for a user This will probably be the
@@ -88,7 +88,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return alerts that are unread and not expired
 	 * @throws APIException
 	 */
-	public List<Alert> getAlertsByUser(User user) throws APIException;
+	List<Alert> getAlertsByUser(User user) throws APIException;
 	
 	/**
 	 * Finds alerts for the given user with the given status
@@ -99,7 +99,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return alerts for this user with these options
 	 * @throws APIException
 	 */
-	public List<Alert> getAlerts(User user, boolean includeRead, boolean includeExpired) throws APIException;
+	List<Alert> getAlerts(User user, boolean includeRead, boolean includeExpired) throws APIException;
 	
 	/**
 	 * Get all unexpired alerts for all users
@@ -107,7 +107,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return list of unexpired alerts
 	 * @throws APIException
 	 */
-	public List<Alert> getAllAlerts() throws APIException;
+	List<Alert> getAllAlerts() throws APIException;
 	
 	/**
 	 * Get alerts for all users while obeying includeExpired
@@ -116,7 +116,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return list of alerts
 	 * @throws APIException
 	 */
-	public List<Alert> getAllAlerts(boolean includeExpired) throws APIException;
+	List<Alert> getAllAlerts(boolean includeExpired) throws APIException;
 	
 	/**
 	 * Sends an alert to all superusers
@@ -129,5 +129,5 @@ public interface AlertService extends OpenmrsService {
 	 * @should add an alert to the database
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ALERTS)
-	public void notifySuperUsers(String messageCode, Exception cause, Object... messageArguments);
+	void notifySuperUsers(String messageCode, Exception cause, Object... messageArguments);
 }

--- a/api/src/main/java/org/openmrs/notification/MessagePreparator.java
+++ b/api/src/main/java/org/openmrs/notification/MessagePreparator.java
@@ -20,6 +20,6 @@ public interface MessagePreparator {
 	 * @param template
 	 * @return the prepared <code>Message</code>
 	 */
-	public Message prepare(Template template) throws MessageException;
+	Message prepare(Template template) throws MessageException;
 	
 }

--- a/api/src/main/java/org/openmrs/notification/MessageSender.java
+++ b/api/src/main/java/org/openmrs/notification/MessageSender.java
@@ -11,5 +11,5 @@ package org.openmrs.notification;
 
 public interface MessageSender {
 	
-	public void send(Message message) throws MessageException;
+	void send(Message message) throws MessageException;
 }

--- a/api/src/main/java/org/openmrs/notification/MessageService.java
+++ b/api/src/main/java/org/openmrs/notification/MessageService.java
@@ -20,13 +20,13 @@ public interface MessageService {
 	
 	// Set dependencies for message services
 	// TODO Should these be required or do we let the implementations constructor dictate the dependencies?
-	public void setMessageSender(MessageSender sender);
+	void setMessageSender(MessageSender sender);
 	
-	public MessageSender getMessageSender();
+	MessageSender getMessageSender();
 	
-	public void setMessagePreparator(MessagePreparator preparator);
+	void setMessagePreparator(MessagePreparator preparator);
 	
-	public MessagePreparator getMessagePreparator();
+	MessagePreparator getMessagePreparator();
 	
 	/* Send Message Methods */
 
@@ -37,29 +37,29 @@ public interface MessageService {
 	 * @throws MessageException
 	 * @should send message
 	 */
-	public void sendMessage(Message message) throws MessageException;
+	void sendMessage(Message message) throws MessageException;
 	
 	//sends message to everyone of a certain role
-	public void sendMessage(Message message, String roleName) throws MessageException;
+	void sendMessage(Message message, String roleName) throws MessageException;
 	
 	//sends message to user with the given id
-	public void sendMessage(Message message, Integer userId) throws MessageException;
+	void sendMessage(Message message, Integer userId) throws MessageException;
 	
 	//sends message to user
-	public void sendMessage(Message message, User user) throws MessageException;
+	void sendMessage(Message message, User user) throws MessageException;
 	
 	//sends message to all users with a given role
-	public void sendMessage(Message message, Role role) throws MessageException;
+	void sendMessage(Message message, Role role) throws MessageException;
 	
 	//sends message to a collection of users
-	public void sendMessage(Message message, Collection<User> users) throws MessageException;
+	void sendMessage(Message message, Collection<User> users) throws MessageException;
 	
-	public void sendMessage(String recipients, String sender, String subject, String message) throws MessageException;
+	void sendMessage(String recipients, String sender, String subject, String message) throws MessageException;
 	
 	// Prepare message methods
-	public Message createMessage(String subject, String message) throws MessageException;
+	Message createMessage(String subject, String message) throws MessageException;
 	
-	public Message createMessage(String sender, String subject, String message) throws MessageException;
+	Message createMessage(String sender, String subject, String message) throws MessageException;
 	
 	/**
 	 * TODO Auto generated method comment
@@ -72,19 +72,19 @@ public interface MessageService {
 	 * @throws MessageException
 	 * @should create message
 	 */
-	public Message createMessage(String recipients, String sender, String subject, String message) throws MessageException;
+	Message createMessage(String recipients, String sender, String subject, String message) throws MessageException;
 	
-	public Message createMessage(String recipients, String sender, String subject, String message, String attachment,
-	        String attachmentContentType, String attachmentFileName) throws MessageException;
+	Message createMessage(String recipients, String sender, String subject, String message, String attachment,
+			String attachmentContentType, String attachmentFileName) throws MessageException;
 	
-	public Message prepareMessage(String templateName, Map data) throws MessageException;
+	Message prepareMessage(String templateName, Map data) throws MessageException;
 	
-	public Message prepareMessage(Template template) throws MessageException;
+	Message prepareMessage(Template template) throws MessageException;
 	
 	// Template methods
-	public List getAllTemplates() throws MessageException;
+	List getAllTemplates() throws MessageException;
 	
-	public Template getTemplate(Integer id) throws MessageException;
+	Template getTemplate(Integer id) throws MessageException;
 	
-	public List getTemplatesByName(String name) throws MessageException;
+	List getTemplatesByName(String name) throws MessageException;
 }

--- a/api/src/main/java/org/openmrs/notification/db/AlertDAO.java
+++ b/api/src/main/java/org/openmrs/notification/db/AlertDAO.java
@@ -26,26 +26,26 @@ public interface AlertDAO {
 	/**
 	 * @see org.openmrs.notification.AlertService#saveAlert(org.openmrs.notification.Alert)
 	 */
-	public Alert saveAlert(Alert alert) throws DAOException;
+	Alert saveAlert(Alert alert) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.notification.AlertService#getAlert(Integer)
 	 */
-	public Alert getAlert(Integer alertId) throws DAOException;
+	Alert getAlert(Integer alertId) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.notification.AlertService#getAlerts(org.openmrs.User, boolean, boolean)
 	 */
-	public List<Alert> getAlerts(User user, boolean includeRead, boolean includeVoided) throws DAOException;
+	List<Alert> getAlerts(User user, boolean includeRead, boolean includeVoided) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.notification.AlertService#purgeAlert(org.openmrs.notification.Alert)
 	 */
-	public void deleteAlert(Alert alert) throws DAOException;
+	void deleteAlert(Alert alert) throws DAOException;
 	
 	/**
 	 * @see org.openmrs.notification.AlertService#getAllAlerts(boolean)
 	 */
-	public List<Alert> getAllAlerts(boolean includeExpired);
+	List<Alert> getAllAlerts(boolean includeExpired);
 	
 }

--- a/api/src/main/java/org/openmrs/obs/ComplexObsHandler.java
+++ b/api/src/main/java/org/openmrs/obs/ComplexObsHandler.java
@@ -32,17 +32,17 @@ import org.openmrs.api.APIException;
 public interface ComplexObsHandler {
 	
 	// Complex observation views
-	public static final String RAW_VIEW = "RAW_VIEW";
+	String RAW_VIEW = "RAW_VIEW";
 	
-	public static final String TITLE_VIEW = "TITLE_VIEW";
+	String TITLE_VIEW = "TITLE_VIEW";
 	
-	public static final String TEXT_VIEW = "TEXT_VIEW";
+	String TEXT_VIEW = "TEXT_VIEW";
 	
-	public static final String HTML_VIEW = "HTML_VIEW";
+	String HTML_VIEW = "HTML_VIEW";
 	
-	public static final String PREVIEW_VIEW = "PREVIEW_VIEW";
+	String PREVIEW_VIEW = "PREVIEW_VIEW";
 	
-	public static final String URI_VIEW = "URI_VIEW";
+	String URI_VIEW = "URI_VIEW";
 	
 	/**
 	 * Save a complex obs. This extracts the ComplexData from an Obs, stores it to a location
@@ -51,7 +51,7 @@ public interface ComplexObsHandler {
 	 * @param obs
 	 * @return the Obs with the ComplexData nullified
 	 */
-	public Obs saveObs(Obs obs) throws APIException;
+	Obs saveObs(Obs obs) throws APIException;
 	
 	/**
 	 * Fetches the ComplexData from the location indicated from Obs.value_complex, attaches
@@ -65,7 +65,7 @@ public interface ComplexObsHandler {
 	 * @return the obs with complex data filled in
 	 * @see org.openmrs.util.OpenmrsConstants
 	 */
-	public Obs getObs(Obs obs, String view);
+	Obs getObs(Obs obs, String view);
 	
 	/**
 	 * Completely removes the ComplexData Object from its storage location. <br>
@@ -75,7 +75,7 @@ public interface ComplexObsHandler {
 	 * 
 	 * @param obs
 	 */
-	public boolean purgeComplexData(Obs obs);
+	boolean purgeComplexData(Obs obs);
 	
 	/**
 	 * Supported views getter
@@ -83,7 +83,7 @@ public interface ComplexObsHandler {
 	 * @return all views supported by this handler
 	 * @since 1.12
 	 */
-	public String[] getSupportedViews();
+	String[] getSupportedViews();
 	
 	/**
 	 * View support check
@@ -92,5 +92,5 @@ public interface ComplexObsHandler {
 	 * @return true if given view is supported by this handler
 	 * @since 1.12
 	 */
-	public boolean supportsView(String view);
+	boolean supportsView(String view);
 }

--- a/api/src/main/java/org/openmrs/obs/SerializableComplexObsHandler.java
+++ b/api/src/main/java/org/openmrs/obs/SerializableComplexObsHandler.java
@@ -30,7 +30,7 @@ public interface SerializableComplexObsHandler extends ComplexObsHandler {
 	 * 
 	 * @return Set of form fields
 	 */
-	public Set<FormField> getFormFields();
+	Set<FormField> getFormFields();
 	
 	/**
 	 * Transforms the incoming data from one format to another. For example, this can be useful if
@@ -39,6 +39,6 @@ public interface SerializableComplexObsHandler extends ComplexObsHandler {
 	 * @param data the data to serialize
 	 * @return the serialized form data
 	 */
-	public String serializeFormData(String data);
+	String serializeFormData(String data);
 	
 }

--- a/api/src/main/java/org/openmrs/patient/IdentifierValidator.java
+++ b/api/src/main/java/org/openmrs/patient/IdentifierValidator.java
@@ -20,7 +20,7 @@ public interface IdentifierValidator {
 	/**
 	 * @return The name of this validator. E.g. "Luhn Algorithm"
 	 */
-	public String getName();
+	String getName();
 	
 	/**
 	 * @param identifier The Identifier to check.
@@ -28,7 +28,7 @@ public interface IdentifierValidator {
 	 * @throws UnallowedIdentifierException if the identifier contains unallowed characters or is
 	 *             otherwise not appropriate for this validator.
 	 */
-	public boolean isValid(String identifier) throws UnallowedIdentifierException;
+	boolean isValid(String identifier) throws UnallowedIdentifierException;
 	
 	/**
 	 * @param undecoratedIdentifier The identifier prior to being given a check digit or other form
@@ -37,10 +37,10 @@ public interface IdentifierValidator {
 	 * @throws UnallowedIdentifierException if the identifier contains unallowed characters or is
 	 *             otherwise not appropriate for this validator.
 	 */
-	public String getValidIdentifier(String undecoratedIdentifier) throws UnallowedIdentifierException;
+	String getValidIdentifier(String undecoratedIdentifier) throws UnallowedIdentifierException;
 	
 	/**
 	 * @return A string containing all the characters allowed in this type of identifier validation.
 	 */
-	public String getAllowedCharacters();
+	String getAllowedCharacters();
 }

--- a/api/src/main/java/org/openmrs/scheduler/SchedulerService.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerService.java
@@ -29,21 +29,21 @@ public interface SchedulerService extends OpenmrsService {
 	 * @return the <code>String</code> status of the task with the given identifier
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public String getStatus(Integer id);
+	String getStatus(Integer id);
 	
 	/**
 	 * Start all tasks that are scheduled to run on startup.
 	 */
 	@Override
 	@Authorized( { "Manage Scheduler" })
-	public void onStartup();
+	void onStartup();
 	
 	/**
 	 * Stop all tasks and clean up the scheduler instance.
 	 */
 	@Override
 	@Authorized( { "Manage Scheduler" })
-	public void onShutdown();
+	void onShutdown();
 	
 	/**
 	 * Cancel a scheduled task.
@@ -51,7 +51,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @param task the <code>TaskDefinition</code> for the task to cancel
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public void shutdownTask(TaskDefinition task) throws SchedulerException;
+	void shutdownTask(TaskDefinition task) throws SchedulerException;
 	
 	/**
 	 * Start a scheduled task as specified in a TaskDefinition.
@@ -61,7 +61,7 @@ public interface SchedulerService extends OpenmrsService {
 	 *         scheduling the task
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public Task scheduleTask(TaskDefinition task) throws SchedulerException;
+	Task scheduleTask(TaskDefinition task) throws SchedulerException;
 	
 	/**
 	 * Stop and start a scheduled task.
@@ -69,14 +69,14 @@ public interface SchedulerService extends OpenmrsService {
 	 * @param task the <code>TaskDefinition</code> to reschedule
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public Task rescheduleTask(TaskDefinition task) throws SchedulerException;
+	Task rescheduleTask(TaskDefinition task) throws SchedulerException;
 	
 	/**
 	 * Loop over all currently started tasks and cycle them. This should be done after the
 	 * classloader has been changed (e.g. during module start/stop)
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public void rescheduleAllTasks() throws SchedulerException;
+	void rescheduleAllTasks() throws SchedulerException;
 	
 	/**
 	 * Get scheduled tasks.
@@ -84,7 +84,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @return all scheduled tasks
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public Collection<TaskDefinition> getScheduledTasks();
+	Collection<TaskDefinition> getScheduledTasks();
 	
 	/**
 	 * Get the list of tasks that are available to be scheduled. Eventually, these should go in the
@@ -93,7 +93,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @return all available tasks
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public Collection<TaskDefinition> getRegisteredTasks();
+	Collection<TaskDefinition> getRegisteredTasks();
 	
 	/**
 	 * Get the task with the given identifier.
@@ -101,7 +101,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @param id the identifier of the task
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public TaskDefinition getTask(Integer id);
+	TaskDefinition getTask(Integer id);
 	
 	/**
 	 * Get the task with the given name.
@@ -109,7 +109,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @param name name of the task
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public TaskDefinition getTaskByName(String name);
+	TaskDefinition getTaskByName(String name);
 	
 	/**
 	 * Delete the task with the given identifier.
@@ -117,7 +117,7 @@ public interface SchedulerService extends OpenmrsService {
 	 * @param id the identifier of the task
 	 */
 	@Authorized( { "Manage Scheduler" })
-	public void deleteTask(Integer id);
+	void deleteTask(Integer id);
 	
 	/**
 	 * Create the given task
@@ -127,34 +127,34 @@ public interface SchedulerService extends OpenmrsService {
 	 */
 	@Authorized( { "Manage Scheduler" })
 	@Logging(ignore = true)
-	public void saveTaskDefinition(TaskDefinition task);
+	void saveTaskDefinition(TaskDefinition task);
 	
 	/**
 	 * Return SchedulerConstants
 	 * 
 	 * @return SortedMap&lt;String, String&gt;
 	 */
-	public SortedMap<String, String> getSystemVariables();
+	SortedMap<String, String> getSystemVariables();
 	
 	/**
 	 * Save the state of the scheduler service to Memento
 	 * 
 	 * @return OpenmrsMemento that contains data about this serive.
 	 */
-	public OpenmrsMemento saveToMemento();
+	OpenmrsMemento saveToMemento();
 	
 	/**
 	 * Restore the scheduler service to state defined by Memento
 	 * 
 	 * @param memento
 	 */
-	public void restoreFromMemento(OpenmrsMemento memento);
+	void restoreFromMemento(OpenmrsMemento memento);
 	
 	/**
 	 * Schedules a task for execution if not already running
 	 * @param taskDef
 	 * @since 1.10
 	 */
-	public void scheduleIfNotRunning(TaskDefinition taskDef);
+	void scheduleIfNotRunning(TaskDefinition taskDef);
 	
 }

--- a/api/src/main/java/org/openmrs/scheduler/Task.java
+++ b/api/src/main/java/org/openmrs/scheduler/Task.java
@@ -14,21 +14,21 @@ public interface Task {
 	/**
 	 * Executes the task defined in the task definition.
 	 */
-	public void execute();
+	void execute();
 	
 	/**
 	 * Initializes the task and sets the task definition.
 	 * 
 	 * @param definition
 	 */
-	public void initialize(TaskDefinition definition);
+	void initialize(TaskDefinition definition);
 	
 	/**
 	 * Returns the task definition associated with this task.
 	 * 
 	 * @return a task definition
 	 */
-	public TaskDefinition getTaskDefinition();
+	TaskDefinition getTaskDefinition();
 	
 	/**
 	 * Returns true if the task is currently in its execute() method.

--- a/api/src/main/java/org/openmrs/scheduler/db/SchedulerDAO.java
+++ b/api/src/main/java/org/openmrs/scheduler/db/SchedulerDAO.java
@@ -28,7 +28,7 @@ public interface SchedulerDAO {
 	 * @param taskDefinition task to be created
 	 * @throws DAOException
 	 */
-	public void createTask(TaskDefinition taskDefinition) throws DAOException;
+	void createTask(TaskDefinition taskDefinition) throws DAOException;
 	
 	/**
 	 * Get task by internal identifier
@@ -37,7 +37,7 @@ public interface SchedulerDAO {
 	 * @return task with given internal identifier
 	 * @throws DAOException
 	 */
-	public TaskDefinition getTask(Integer taskId) throws DAOException;
+	TaskDefinition getTask(Integer taskId) throws DAOException;
 	
 	/**
 	 * Update task
@@ -45,7 +45,7 @@ public interface SchedulerDAO {
 	 * @param task to be updated
 	 * @throws DAOException
 	 */
-	public void updateTask(TaskDefinition task) throws DAOException;
+	void updateTask(TaskDefinition task) throws DAOException;
 	
 	/**
 	 * Find all tasks in the database
@@ -53,7 +53,7 @@ public interface SchedulerDAO {
 	 * @return <code>List&lt;TaskDefinition&gt;</code> of all tasks
 	 * @throws DAOException
 	 */
-	public List<TaskDefinition> getTasks() throws DAOException;
+	List<TaskDefinition> getTasks() throws DAOException;
 	
 	/**
 	 * Delete task from database.
@@ -61,7 +61,7 @@ public interface SchedulerDAO {
 	 * @param task task to be deleted
 	 * @throws DAOException
 	 */
-	public void deleteTask(TaskDefinition task) throws DAOException;
+	void deleteTask(TaskDefinition task) throws DAOException;
 	
 	/**
 	 * Delete task from database.
@@ -69,7 +69,7 @@ public interface SchedulerDAO {
 	 * @param taskId identifier of task to be deleted
 	 * @throws DAOException
 	 */
-	public void deleteTask(Integer taskId) throws DAOException;
+	void deleteTask(Integer taskId) throws DAOException;
 	
 	/**
 	 * Get schedule by internal identifier
@@ -78,7 +78,7 @@ public interface SchedulerDAO {
 	 * @return schedule with given internal identifier
 	 * @throws DAOException
 	 */
-	public Schedule getSchedule(Integer scheduleId) throws DAOException;
+	Schedule getSchedule(Integer scheduleId) throws DAOException;
 	
 	/**
 	 * Get task by public name.
@@ -87,5 +87,5 @@ public interface SchedulerDAO {
 	 * @return task with given public name
 	 * @throws DAOException
 	 */
-	public TaskDefinition getTaskByName(String name) throws DAOException;
+	TaskDefinition getTaskByName(String name) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/serialization/OpenmrsSerializer.java
+++ b/api/src/main/java/org/openmrs/serialization/OpenmrsSerializer.java
@@ -20,7 +20,7 @@ public interface OpenmrsSerializer {
 	 * @param o - the object to serialize
 	 * @return String representing this object
 	 */
-	public String serialize(Object o) throws SerializationException;
+	String serialize(Object o) throws SerializationException;
 	
 	/**
 	 * Deserialize the given string into a full object
@@ -29,5 +29,5 @@ public interface OpenmrsSerializer {
 	 * @param clazz - The class to deserialize the Object into
 	 * @return hydrated object of the appropriate type
 	 */
-	public <T extends Object> T deserialize(String serializedObject, Class<? extends T> clazz) throws SerializationException;
+	<T extends Object> T deserialize(String serializedObject, Class<? extends T> clazz) throws SerializationException;
 }

--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -122,7 +122,7 @@ public class DatabaseUpdater {
 		 * @param changeSet the liquibase changeset that was just run
 		 * @param numChangeSetsToRun the total number of changesets in the current file
 		 */
-		public void executing(ChangeSet changeSet, int numChangeSetsToRun);
+		void executing(ChangeSet changeSet, int numChangeSetsToRun);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/util/OpenmrsMemento.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsMemento.java
@@ -22,8 +22,8 @@ package org.openmrs.util;
 public abstract class OpenmrsMemento {
 	
 	public OpenmrsMemento() {
-	};
-	
+	}
+
 	public abstract Object getState();
 	
 	public abstract void setState(Object state);

--- a/api/src/test/java/org/openmrs/test/Verifies.java
+++ b/api/src/test/java/org/openmrs/test/Verifies.java
@@ -35,12 +35,12 @@ public @interface Verifies {
 	 * 
 	 * @return the text after the "@should" on the method this unit test is testing
 	 */
-	public String value();
+	String value();
 	
 	/**
 	 * The method name within the class that this unit test is testing.
 	 * 
 	 * @return the name of the method being tested
 	 */
-	public String method();
+	String method();
 }

--- a/api/src/test/java/org/openmrs/util/ProviderByPersonNameComparatorTest.java
+++ b/api/src/test/java/org/openmrs/util/ProviderByPersonNameComparatorTest.java
@@ -87,7 +87,6 @@ public class ProviderByPersonNameComparatorTest {
 		
 		int actualValue = new ProviderByPersonNameComparator().compare(provider1, provider2);
 		Assert.assertTrue("Expected a positive value but it was: " + actualValue, actualValue > 0);
-		;
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/util/UserByNameComparatorTest.java
+++ b/api/src/test/java/org/openmrs/util/UserByNameComparatorTest.java
@@ -63,6 +63,5 @@ public class UserByNameComparatorTest {
 		Assert.assertTrue("Expected user2 to be the second in the sorted user list but wasn't", user2.equals(it.next()));
 		Assert.assertTrue("Expected user3 to be the third in the sorted user list but wasn't", user3.equals(it.next()));
 		Assert.assertTrue("Expected user4 to be the fourth in the sorted user list but wasn't", user4.equals(it.next()));
-		;
 	}
 }


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-142
Related PR: #2366

I've deleted redundant interface method indentifiers e.g. "public", "static". Because all Java interfaces methods are by default public and static. I don't know if it's right with your coding conventions so forgive me :)