### PR TITLE
[GCI-142] Create List of one element by Arrays.singletonList()

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -557,7 +557,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 			locale = loc;
 		}
 		
-		LuceneQuery<ConceptName> conceptNameQuery = newConceptNameLuceneQuery(name, !searchOnPhrase, Arrays.asList(locale),
+		LuceneQuery<ConceptName> conceptNameQuery = newConceptNameLuceneQuery(name, !searchOnPhrase,
+				Collections.singletonList(locale),
 		    false, false, classes, null, datatypes, null, null);
 		
 		List<ConceptName> names = conceptNameQuery.list();
@@ -1375,8 +1376,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 		if (concept != null) {
 			query.append(" OR concept.conceptId:(").append(concept.getConceptId()).append(")^0.1");
 		} else if (searchDrugConceptNames) {
-			LuceneQuery<ConceptName> conceptNameQuery = newConceptNameLuceneQuery(drugName, searchKeywords, Arrays
-			        .asList(locale), exactLocale, includeRetired, null, null, null, null, null);
+			LuceneQuery<ConceptName> conceptNameQuery = newConceptNameLuceneQuery(drugName, searchKeywords,
+					Collections.singletonList(locale), exactLocale, includeRetired, null, null, null, null, null);
 			List<Object[]> conceptIds = conceptNameQuery.listProjection("concept.conceptId");
 			if (!conceptIds.isEmpty()) {
 				CollectionUtils.transform(conceptIds, new Transformer() {
@@ -1447,7 +1448,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 			final Set<Locale> searchLocales;
 			
 			if (locales == null) {
-				searchLocales = new HashSet<Locale>(Arrays.asList(Context.getLocale()));
+				searchLocales = new HashSet<Locale>(Collections.singletonList(Context.getLocale()));
 			} else {
 				searchLocales = new HashSet<Locale>(locales);
 			}

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -1408,7 +1408,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	@Transactional(readOnly = true)
 	public List<ConceptSearchResult> findConceptAnswers(String phrase, Locale locale, Concept concept) throws APIException {
 
-		return getConcepts(phrase, Arrays.asList(locale), false, null, null, null, null,
+		return getConcepts(phrase, Collections.singletonList(locale), false, null, null, null, null,
 		    concept, null, null);
 	}
 	

--- a/api/src/main/java/org/openmrs/layout/LayoutTemplate.java
+++ b/api/src/main/java/org/openmrs/layout/LayoutTemplate.java
@@ -11,6 +11,7 @@ package org.openmrs.layout;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ public abstract class LayoutTemplate {
 	 *            first template line
 	 */
 	public LayoutTemplate(String simpleTemplate) {
-		setLineByLineFormat(Arrays.asList(simpleTemplate));
+		setLineByLineFormat(Collections.singletonList(simpleTemplate));
 	}
 	
 	public abstract String getLayoutToken();

--- a/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/SourceMySqldiffFile.java
@@ -19,6 +19,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -143,7 +144,7 @@ public class SourceMySqldiffFile implements CustomTaskChange {
 			throw new CustomChangeException("Error while executing command: '" + commands.get(0) + "'", e);
 		}
 		
-		log.debug("Exec called: " + Arrays.asList(commands));
+		log.debug("Exec called: " + Collections.singletonList(commands));
 		
 		if (exitValue != 0) {
 			log.error("There was an error while running the " + commands.get(0) + " command.  Command output: "

--- a/api/src/test/java/org/openmrs/LocationTest.java
+++ b/api/src/test/java/org/openmrs/LocationTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -53,8 +54,8 @@ public class LocationTest {
 		//make child-parent relations
 		rootLocation.setChildLocations(new HashSet<>(Arrays.asList(locationOne, locationTwo)));
 		
-		locationOne.setChildLocations(new HashSet<>(Arrays.asList(childOflocationOne)));
-		locationTwo.setChildLocations(new HashSet<>(Arrays.asList(childOnfLocationTwo)));
+		locationOne.setChildLocations(new HashSet<>(Collections.singletonList(childOflocationOne)));
+		locationTwo.setChildLocations(new HashSet<>(Collections.singletonList(childOnfLocationTwo)));
 		
 		childOflocationOne.setChildLocations(new HashSet<Location>());
 		childOnfLocationTwo.setChildLocations(new HashSet<Location>());
@@ -86,7 +87,7 @@ public class LocationTest {
 		
 		nonRetiredLocation.setChildLocations(new HashSet<>(Arrays.asList(firstChildOfNonRetiredLocation,
 		    secondChildOfNonRetiredLocation)));
-		retiredLocation.setChildLocations(new HashSet<>(Arrays.asList(firstChildOfRetiredLocation)));
+		retiredLocation.setChildLocations(new HashSet<>(Collections.singletonList(firstChildOfRetiredLocation)));
 		
 		firstChildOfNonRetiredLocation.setChildLocations(new HashSet<Location>());
 		secondChildOfNonRetiredLocation.setChildLocations(new HashSet<Location>());

--- a/api/src/test/java/org/openmrs/PersonTest.java
+++ b/api/src/test/java/org/openmrs/PersonTest.java
@@ -20,6 +20,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -626,7 +627,7 @@ public class PersonTest extends BaseContextSensitiveTest {
 		
 		PersonName expectedPersonName = voidedName;
 		
-		checkGetPersonNameResultForVoidedPerson(expectedPersonName, new HashSet<>(Arrays.asList(voidedName)));
+		checkGetPersonNameResultForVoidedPerson(expectedPersonName, new HashSet<>(Collections.singletonList(voidedName)));
 		
 	}
 	

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -3294,9 +3294,11 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		Concept concept = conceptService.getConceptByMapping(code2, "SNOMED CT");
 		
 		//when
-		List<ConceptSearchResult> concepts1 = conceptService.getConcepts(code1, Arrays.asList(Context.getLocale()), false,
+		List<ConceptSearchResult> concepts1 = conceptService.getConcepts(code1,
+				Collections.singletonList(Context.getLocale()), false,
 		    null, null, null, null, null, null, null);
-		List<ConceptSearchResult> concepts2 = conceptService.getConcepts(code2, Arrays.asList(Context.getLocale()), false,
+		List<ConceptSearchResult> concepts2 = conceptService.getConcepts(code2,
+				Collections.singletonList(Context.getLocale()), false,
 		    null, null, null, null, null, null, null);
 		
 		//then

--- a/api/src/test/java/org/openmrs/api/OrderSetServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderSetServiceTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -349,7 +350,7 @@ public class OrderSetServiceTest extends BaseContextSensitiveTest {
 		orderSetMember.setOrderSet(orderSet);
 		
 		List<OrderSetMember> orderSetMembers = new ArrayList<>();
-		orderSetMembers.addAll(Arrays.asList(orderSetMember));
+		orderSetMembers.addAll(Collections.singletonList(orderSetMember));
 		orderSet.setOrderSetMembers(orderSetMembers);
 		orderSet.setCreator(new User(1));
 		orderSet.setDateCreated(new Date());

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateObsDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateObsDAOTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.api.db.hibernate;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.Session;
@@ -52,17 +53,17 @@ public class HibernateObsDAOTest extends BaseContextSensitiveTest {
 		//Order by id desc
 		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.desc("id")).list();
 		
-		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id"), null, null, null, null,
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Collections.singletonList("id"), null, null, null, null,
 		    false, null);
 		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
 		
-		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id desc"), null, null, null,
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Collections.singletonList("id desc"), null, null, null,
 		    null, false, null);
 		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
 		
 		//Order by id asc
 		obsListExpected = session.createCriteria(Obs.class, "obs").addOrder(Order.asc("id")).list();
-		obsListActual = dao.getObservations(null, null, null, null, null, null, Arrays.asList("id asc"), null, null, null,
+		obsListActual = dao.getObservations(null, null, null, null, null, null, Collections.singletonList("id asc"), null, null, null,
 		    null, false, null);
 		Assert.assertArrayEquals(obsListExpected.toArray(), obsListActual.toArray());
 		

--- a/api/src/test/java/org/openmrs/api/impl/PatientServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/PatientServiceImplTest.java
@@ -50,6 +50,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -214,7 +215,7 @@ public class PatientServiceImplTest {
 
     @Test(expected = APIException.class)
     public void getDuplicatePatientsByAttributes_shouldThrowErrorGivenEmptyAttributes() throws Exception {
-        patientService.getDuplicatePatientsByAttributes(Arrays.asList());
+        patientService.getDuplicatePatientsByAttributes(Collections.emptyList());
     }
 
     @Test(expected = APIException.class)
@@ -224,7 +225,8 @@ public class PatientServiceImplTest {
 
     @Test
     public void getDuplicatePatientsByAttributes_shouldCallDaoGivenAttributes() throws Exception {
-        when(patientDaoMock.getDuplicatePatientsByAttributes(anyList())).thenReturn(Arrays.asList(mock(Patient.class)));
+        when(patientDaoMock.getDuplicatePatientsByAttributes(anyList())).thenReturn(
+		        Collections.singletonList(mock(Patient.class)));
         final List<Patient> duplicatePatients = patientService.getDuplicatePatientsByAttributes(Arrays.asList("some attribute", "another attribute"));
         verify(patientDaoMock, times(1)).getDuplicatePatientsByAttributes(anyList());
         Assert.assertEquals(duplicatePatients.size(), 1);

--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -27,6 +27,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -581,7 +582,7 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 		 * Hbm2ddl used in tests creates primary key columns, which are not auto incremented, if
 		 * NativeIfNotAssignedIdentityGenerator is used. We need to alter those columns in tests.
 		 */
-		List<String> tables = Arrays.asList("concept");
+		List<String> tables = Collections.singletonList("concept");
 		for (String table : tables) {
 			getConnection().prepareStatement("ALTER TABLE " + table + " ALTER COLUMN " + table + "_id INT AUTO_INCREMENT")
 			        .execute();


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-142
Related PR: #2366

I've replaced Arrays.asList() (with one element) with .singletonList()

Using Arrays.asList() with one argument creates new List with allocated memory for 10! elements. Instead of this, .singletonList() allocates memory just for one element. So it saves a lot of memory :)