### PR TITLE
[GCI-142] Replace Collections.sort() with List.sort()

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -1509,7 +1509,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 		}
 		
 		List<ConceptMapType> conceptMapTypes = criteria.list();
-		Collections.sort(conceptMapTypes, new ConceptMapTypeComparator());
+		conceptMapTypes.sort(new ConceptMapTypeComparator());
 		
 		return conceptMapTypes;
 	}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -562,8 +562,8 @@ public class HibernateEncounterDAO implements EncounterDAO {
 				encounters.add(mockEncounter);
 			}
 			
-			Collections.sort(encounters, new Comparator<Encounter>() {
-				
+			encounters.sort(new Comparator<Encounter>() {
+
 				@Override
 				public int compare(Encounter o1, Encounter o2) {
 					Date o1Date = (o1.getVisit() != null) ? o1.getVisit().getStartDatetime() : o1.getEncounterDatetime();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -539,7 +539,7 @@ public class HibernatePatientDAO implements PatientDAO {
 				return patPos1.compareTo(patPos2);
 			}
 		}
-		Collections.sort(patients, new PatientIdComparator(patientIdOrder));
+		patients.sort(new PatientIdComparator(patientIdOrder));
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
@@ -401,7 +401,7 @@ public class HibernateUserDAO implements UserDAO {
 		List<User> returnList = query.list();
 		
 		if (!CollectionUtils.isEmpty(returnList)) {
-			Collections.sort(returnList, new UserByNameComparator());
+			returnList.sort(new UserByNameComparator());
 		}
 		
 		return returnList;

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -395,8 +395,8 @@ public class ModuleFactory {
 	public static List<Module> getLoadedModulesCoreFirst() {
 		List<Module> list = new ArrayList<>(getLoadedModules());
 		final Collection<String> coreModuleIds = ModuleConstants.CORE_MODULES.keySet();
-		Collections.sort(list, new Comparator<Module>() {
-			
+		list.sort(new Comparator<Module>() {
+
 			@Override
 			public int compare(Module left, Module right) {
 				Integer leftVal = coreModuleIds.contains(left.getModuleId()) ? 0 : 1;
@@ -723,7 +723,7 @@ public class ModuleFactory {
 				for (Map.Entry<String, List<Extension>> moduleExtensionEntry : moduleExtensionMap.entrySet()) {
 					// Sort this module's extensions for current extension point
 					List<Extension> sortedModuleExtensions = moduleExtensionEntry.getValue();
-					Collections.sort(sortedModuleExtensions, sortOrder);
+					sortedModuleExtensions.sort(sortOrder);
 					
 					// Get existing extensions, and append the ones from the new module
 					List<Extension> extensions = getExtensionMap().get(moduleExtensionEntry.getKey());

--- a/api/src/main/java/org/openmrs/util/HandlerUtil.java
+++ b/api/src/main/java/org/openmrs/util/HandlerUtil.java
@@ -143,8 +143,8 @@ public class HandlerUtil implements ApplicationListener<ContextRefreshedEvent> {
 		}
 		
 		// Return the list of handlers based on the order specified in the Handler annotation
-		Collections.sort(handlers, new Comparator<H>() {
-			
+		handlers.sort(new Comparator<H>() {
+
 			@Override
 			public int compare(H o1, H o2) {
 				return getOrderOfHandler(o1.getClass()).compareTo(getOrderOfHandler(o2.getClass()));

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2859,7 +2859,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	public void getAllPatientIdentifierTypes_shouldOrderAsDefaultComparator() throws Exception {
 		List<PatientIdentifierType> list = patientService.getAllPatientIdentifierTypes();
 		List<PatientIdentifierType> sortedList = new ArrayList<>(list);
-		Collections.sort(sortedList, new PatientIdentifierTypeDefaultComparator());
+		sortedList.sort(new PatientIdentifierTypeDefaultComparator());
 		Assert.assertEquals(sortedList, list);
 	}
 	
@@ -2870,7 +2870,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	public void getPatientIdentifierTypes_shouldOrderAsDefaultComparator() throws Exception {
 		List<PatientIdentifierType> list = patientService.getPatientIdentifierTypes(null, null, false, null);
 		List<PatientIdentifierType> sortedList = new ArrayList<>(list);
-		Collections.sort(sortedList, new PatientIdentifierTypeDefaultComparator());
+		sortedList.sort(new PatientIdentifierTypeDefaultComparator());
 		Assert.assertEquals(sortedList, list);
 	}
 	

--- a/api/src/test/java/org/openmrs/comparator/PatientIdentifierTypeDefaultComparatorTest.java
+++ b/api/src/test/java/org/openmrs/comparator/PatientIdentifierTypeDefaultComparatorTest.java
@@ -54,7 +54,7 @@ public class PatientIdentifierTypeDefaultComparatorTest {
 		
 		List<PatientIdentifierType> list = Arrays.asList(notRequiredRetired, requiredRetired2a, notRequiredNotRetiredA,
 		    requiredNotRetired, notRequiredNotRetiredB, requiredRetired1A);
-		Collections.sort(list, new PatientIdentifierTypeDefaultComparator());
+		list.sort(new PatientIdentifierTypeDefaultComparator());
 		
 		Assert.assertEquals(Arrays.asList(requiredNotRetired, notRequiredNotRetiredA, notRequiredNotRetiredB,
 		    requiredRetired1A, requiredRetired2a, notRequiredRetired), list);

--- a/api/src/test/java/org/openmrs/util/UserByNameComparatorTest.java
+++ b/api/src/test/java/org/openmrs/util/UserByNameComparatorTest.java
@@ -55,7 +55,7 @@ public class UserByNameComparatorTest {
 		listToSort.add(user2);
 		
 		// sort the list with userByNameComparator
-		Collections.sort(listToSort, new UserByNameComparator());
+		listToSort.sort(new UserByNameComparator());
 		
 		// make sure that the users are sorted in the expected order
 		Iterator<User> it = listToSort.iterator();


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-142

We don't have to call Collections.sort helper method to sort collections. We can call sort() directly on it.