### PR TITLE
[TRUNK-5240] Override missing equals() methods

### DIFF
--- a/api/src/main/java/org/openmrs/CohortMembership.java
+++ b/api/src/main/java/org/openmrs/CohortMembership.java
@@ -10,6 +10,7 @@
 package org.openmrs;
 
 import java.util.Date;
+import java.util.Objects;
 
 import org.openmrs.util.OpenmrsUtil;
 
@@ -143,5 +144,27 @@ public class CohortMembership extends BaseChangeableOpenmrsData implements Compa
 			ret = this.getUuid().compareTo(o.getUuid());
 		}
 		return ret;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+		CohortMembership that = (CohortMembership) o;
+		return Objects.equals(cohortMemberId, that.cohortMemberId) &&
+				Objects.equals(cohort, that.cohort) &&
+				Objects.equals(patientId, that.patientId) &&
+				Objects.equals(startDate, that.startDate) &&
+				Objects.equals(endDate, that.endDate);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(super.hashCode(), cohortMemberId, cohort, patientId, startDate, endDate);
 	}
 }

--- a/api/src/main/java/org/openmrs/FormField.java
+++ b/api/src/main/java/org/openmrs/FormField.java
@@ -10,6 +10,7 @@
 package org.openmrs;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 import org.codehaus.jackson.annotate.JsonIgnore;
 
@@ -263,7 +264,37 @@ public class FormField extends BaseChangeableOpenmrsMetadata implements java.io.
 		DefaultComparator pnDefaultComparator = new DefaultComparator();
 		return pnDefaultComparator.compare(this, other);
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+		FormField formField = (FormField) o;
+		return Objects.equals(formFieldId, formField.formFieldId) &&
+				Objects.equals(parent, formField.parent) &&
+				Objects.equals(form, formField.form) &&
+				Objects.equals(field, formField.field) &&
+				Objects.equals(fieldNumber, formField.fieldNumber) &&
+				Objects.equals(fieldPart, formField.fieldPart) &&
+				Objects.equals(pageNumber, formField.pageNumber) &&
+				Objects.equals(minOccurs, formField.minOccurs) &&
+				Objects.equals(maxOccurs, formField.maxOccurs) &&
+				Objects.equals(required, formField.required) &&
+				Objects.equals(sortWeight, formField.sortWeight);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects
+				.hash(super.hashCode(), formFieldId, parent, form, field, fieldNumber, fieldPart, pageNumber, minOccurs,
+						maxOccurs, required, sortWeight);
+	}
+
 	/**
 	 Provides a default comparator.
 	 @since 1.12

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -13,6 +13,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Objects;
 
 import org.apache.commons.lang.StringUtils;
 import org.hibernate.search.annotations.Analyzer;
@@ -305,7 +306,28 @@ public class PersonAttribute extends BaseChangeableOpenmrsData implements java.i
 		DefaultComparator paDComparator = new DefaultComparator();
 		return paDComparator.compare(this, other);
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+		PersonAttribute that = (PersonAttribute) o;
+		return Objects.equals(personAttributeId, that.personAttributeId) &&
+				Objects.equals(person, that.person) &&
+				Objects.equals(attributeType, that.attributeType) &&
+				Objects.equals(value, that.value);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects.hash(super.hashCode(), personAttributeId, person, attributeType, value);
+	}
+
 	/**
 	 * @since 1.5
 	 * @see org.openmrs.OpenmrsObject#getId()

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -478,7 +479,37 @@ public class PersonName extends BaseChangeableOpenmrsData implements java.io.Ser
 		DefaultComparator pnDefaultComparator = new DefaultComparator();
 		return pnDefaultComparator.compare(this, other);
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+		PersonName that = (PersonName) o;
+		return Objects.equals(personNameId, that.personNameId) &&
+				Objects.equals(person, that.person) &&
+				Objects.equals(preferred, that.preferred) &&
+				Objects.equals(givenName, that.givenName) &&
+				Objects.equals(prefix, that.prefix) &&
+				Objects.equals(middleName, that.middleName) &&
+				Objects.equals(familyNamePrefix, that.familyNamePrefix) &&
+				Objects.equals(familyName, that.familyName) &&
+				Objects.equals(familyName2, that.familyName2) &&
+				Objects.equals(familyNameSuffix, that.familyNameSuffix) &&
+				Objects.equals(degree, that.degree);
+	}
+
+	@Override
+	public int hashCode() {
+
+		return Objects
+				.hash(super.hashCode(), personNameId, person, preferred, givenName, prefix, middleName, familyNamePrefix,
+						familyName, familyName2, familyNameSuffix, degree);
+	}
+
 	/**
 	 * @since 1.5
 	 * @see org.openmrs.OpenmrsObject#setId(java.lang.Integer)


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5240

Overrided missing equals() method to comply with the contract of compareTo() method