### PR TITLE
[TRUNK-5240] Use isEmpty() than size() == 0

### DIFF
--- a/api/src/main/java/org/openmrs/Cohort.java
+++ b/api/src/main/java/org/openmrs/Cohort.java
@@ -337,7 +337,7 @@ public class Cohort extends BaseChangeableOpenmrsData {
 	 */
 	@Deprecated
 	public void setMemberIds(Set<Integer> memberIds) {
-		if (getMemberships().size() == 0) {
+		if (getMemberships().isEmpty()) {
 			for (Integer id : memberIds) {
 				addMembership(new CohortMembership(id));
 			}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -1807,7 +1807,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 		if (concepts.size() == 1) {
 			return concepts.iterator().next();
-		} else if (list.size() == 0) {
+		} else if (list.isEmpty()) {
 			log.warn("No concept found for '" + name + "'");
 		} else {
 			log.warn("Multiple concepts found for '" + name + "'");


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5240

It's cleaner to call isEmpty() on a collection rather than checking if size() == 0.