### PR TITLE
[TRUNK-5240] Replace Long constructor with Long.valueOf call

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
@@ -345,7 +345,7 @@ public class HibernateLocationDAO implements LocationDAO {
 		    Projections.rowCount()).add(Restrictions.eqProperty("alias.locationId", "outer.locationId"));
 		
 		return sessionFactory.getCurrentSession().createCriteria(Location.class, "outer").add(
-		    Restrictions.eq("retired", false)).add(Subqueries.eq(new Long(tags.size()), numberOfMatchingTags)).list();
+		    Restrictions.eq("retired", false)).add(Subqueries.eq(Long.valueOf(tags.size()), numberOfMatchingTags)).list();
 	}
 	
 	/**


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5240

I've replaced new Long() call with Long.valueOf() because it is more effcient