### PR TITLE
[GCI-237] Guarantee moduleFolder.listFiles() to be non-null

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.Vector;
@@ -170,7 +171,7 @@ public class ModuleFactory {
 		}
 		
 		if (modulesFolder.isDirectory()) {
-			loadModules(Arrays.asList(modulesFolder.listFiles()));
+			loadModules(Arrays.asList(Objects.requireNonNull(modulesFolder.listFiles())));
 		} else {
 			log.error("modules folder: '" + modulesFolder.getAbsolutePath() + "' is not a valid directory");
 		}


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-237

I see that this call should never be null in normal conditions. Therefore, I am using Objects.requireNonNull() to throw NPE if it's null.