### PR TITLE
[TRUNK-5255] Use getDead() instead of isDead()

### DIFF
--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -131,7 +131,7 @@ public class Person extends BaseChangeableOpenmrsData {
 		birthtime = person.getBirthDateTime();
 		birthdateEstimated = person.getBirthdateEstimated();
 		deathdateEstimated = person.getDeathdateEstimated();
-		dead = person.isDead();
+		dead = person.getDead();
 		deathDate = person.getDeathDate();
 		causeOfDeath = person.getCauseOfDeath();
 		


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5255