### PR TITLE
[TRUNK-5194] Updated Spring to latest 4.3.13 (with JUnit to 4.12)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -444,22 +444,22 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.11</version>
+				<version>4.12</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.9.5</version>
+				<version>1.10.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.powermock</groupId>
 				<artifactId>powermock-module-junit4</artifactId>
-				<version>1.5</version>
+				<version>1.7.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.powermock</groupId>
 				<artifactId>powermock-api-mockito</artifactId>
-				<version>1.5</version>
+				<version>1.7.3</version>
 				<exclusions>
 					<exclusion>
 						<artifactId>mockito-all</artifactId>
@@ -1010,7 +1010,7 @@
 		<openmrs.version.shortnumericonly>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</openmrs.version.shortnumericonly>
 		<openmrs.version>${project.version}</openmrs.version>
 
-		<springVersion>4.1.4.RELEASE</springVersion>
+		<springVersion>4.3.13.RELEASE</springVersion>
 		<hibernateVersion>4.3.9.Final</hibernateVersion>
 		<customArgLineForTesting/>
 

--- a/web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
+++ b/web/src/main/java/org/springframework/http/converter/json/MappingJacksonHttpMessageConverter.java
@@ -148,11 +148,6 @@ public class MappingJacksonHttpMessageConverter extends AbstractHttpMessageConve
 	}
 	
 	@Override
-	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
-		return (this.objectMapper.canSerialize(clazz) && canWrite(mediaType));
-	}
-	
-	@Override
 	protected boolean supports(Class<?> clazz) {
 		// should not be called, since we override canRead/Write instead
 		throw new UnsupportedOperationException();
@@ -173,7 +168,19 @@ public class MappingJacksonHttpMessageConverter extends AbstractHttpMessageConve
 		JavaType javaType = getJavaType(type, contextClass);
 		return readJavaType(javaType, inputMessage);
 	}
-	
+
+	@Override
+	public void write(Object o, Type type, MediaType contentType, HttpOutputMessage outputMessage)
+			throws HttpMessageNotWritableException {
+		throw new UnsupportedOperationException("write() is not implemented!");
+	}
+
+	@Override
+	public boolean canWrite(Type type, Class<?> aClass, MediaType mediaType) {
+		return (this.objectMapper.canSerialize(aClass) && canWrite(mediaType));
+	}
+
+
 	private Object readJavaType(JavaType javaType, HttpInputMessage inputMessage) {
 		try {
 			return this.objectMapper.readValue(inputMessage.getBody(), javaType);


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5193

I had to update also the JUnit dependency, because 4.11 is not compatible with new Spring.

EDIT: I also had to update powermock and mockito to be compatible with new JUnit and Spring

