### PR TITLE
TRUNK-5025 : Obs.setValueAsString supports more date formats and time…

### DIFF
--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -1081,6 +1081,10 @@ public class Obs extends BaseChangeableOpenmrsData {
 	 * @should set value as boolean if the datatype of the question concept is boolean
 	 * @should fail if the value of the string is null
 	 * @should fail if the value of the string is empty
+	 * @should fail if abbreviation is CWE
+	 * @should set value as numeric if the datatype of the question concept is numeric
+	 * @should set value as String if the datatype of the question concept is String
+	 * @should set value as Date if the datatype of the question concept is DateTime
 	 */
 	public void setValueAsString(String s) throws ParseException {
 		if (log.isDebugEnabled()) {
@@ -1095,21 +1099,27 @@ public class Obs extends BaseChangeableOpenmrsData {
 				throw new RuntimeException("Not Yet Implemented");
 			} else if ("NM".equals(abbrev) || "SN".equals(abbrev)) {
 				setValueNumeric(Double.valueOf(s));
-			} else if ("DT".equals(abbrev)) {
-				DateFormat dateFormat = new SimpleDateFormat(DATE_PATTERN);
-				setValueDatetime(dateFormat.parse(s));
-			} else if ("TM".equals(abbrev)) {
-				DateFormat timeFormat = new SimpleDateFormat(TIME_PATTERN);
-				setValueDatetime(timeFormat.parse(s));
-			} else if ("TS".equals(abbrev)) {
-				DateFormat datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
-				setValueDatetime(datetimeFormat.parse(s));
 			} else if ("ST".equals(abbrev)) {
 				setValueText(s);
 			} else {
-				throw new RuntimeException("Don't know how to handle " + abbrev);
+				String[] supportedFormats = { "yyyy-MM-dd'T'HH:mm:ss.SSSZ", "yyyy-MM-dd'T'HH:mm:ss.SSS",
+				        "yyyy-MM-dd'T'HH:mm:ssZ", "yyyy-MM-dd'T'HH:mm:ssXXX", "yyyy-MM-dd'T'HH:mm:ss", "yyyy-MM-dd HH:mm:ss",
+				        "yyyy-MM-dd" };
+				boolean flag = false;
+				for (int i = 0; i < supportedFormats.length; i++) {
+					try {
+						DateFormat dateFormat = new SimpleDateFormat(supportedFormats[i]);
+						setValueDatetime(dateFormat.parse(s));
+						flag = false;
+						break;
+					}
+					catch (Exception ex) {
+						flag = true;
+					}
+				}
+				if (flag)
+					throw new RuntimeException("Don't know how to handle " + abbrev);
 			}
-			
 		} else {
 			throw new RuntimeException("concept is null for " + this);
 		}

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -333,6 +333,110 @@ public class ObsTest {
 	}
 	
 	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldSetValueAsBooleanIfDataTypeOfQuestionConceptIsBoolean() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("BIT");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		obs.setValueAsString("false");
+		obs.setValueAsString("true");
+	}
+	
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test(expected = RuntimeException.class)
+	public void setValueAsString_shouldThrowRuntimeExceptionForAbbreviationCWE() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("CWE");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		obs.setValueAsString("ABC");
+	}
+	
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldSetValueAsNumericIfDataTypeOfQuestionConceptIsNumeric() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("NM");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		obs.setValueAsString("123");
+		
+		cdt.setHl7Abbreviation("SN");
+		Concept c1 = new Concept();
+		c1.setDatatype(cdt);
+		obs.setConcept(c1);
+		obs.setValueAsString("1234");
+	}
+	
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldSetValueAsStringIfDataTypeOfQuestionConceptIsText() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("ST");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		obs.setValueAsString("FFF");
+	}
+	
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldSetValueAsDateTimeIfDataTypeOfQuestionConceptIsDateTime() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		
+		String[] dateFormats = { "2011-05-01", "2011-05-01 00:00:00", "2011-05-01T00:00:00.000", "2011-05-01T00:00:00.000" };
+		for (int i = 0; i < dateFormats.length; i++) {
+			obs.setValueAsString(dateFormats[i]);
+		}
+	}
+	
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldSetValueAsDateTimeIfDataTypeOfQuestionConceptIsDateTimeHavingTimeZone()
+	        throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cdt = new ConceptDatatype();
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+		obs.setConcept(c);
+		
+		String[] dates1 = { "2016-01-12T06:00:00+05:30", "2016-01-12T06:00:00+0530" };
+		String[] dates2 = { "2014-02-20T11:00:00.000-05:00", "2014-02-20T11:00:00.000-05" };
+		
+		for (String date : dates1) {
+			obs.setValueAsString(date);
+		}
+		
+		for (String date : dates2) {
+			obs.setValueAsString(date);
+		}
+	}
+	
+	/**
 	 * @see Obs#getValueAsBoolean()
 	 */
 	@Test


### PR DESCRIPTION
… zones.
## Description of what I changed
Add all the time formats supported by the rest framework.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5025

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
