### PR TITLE
[TRUNK-5269] Replace lambda expression in comperator with Comperator.…

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -708,7 +708,7 @@ public class ModuleFactory {
 				}
 				
 				// Sort this module's extensions, and merge them into the full extensions map
-				Comparator<Extension> sortOrder = (e1, e2) -> Integer.valueOf(e1.getOrder()).compareTo(Integer.valueOf(e2.getOrder()));
+				Comparator<Extension> sortOrder = Comparator.comparing(e1 -> (e1.getOrder()));
 				for (Map.Entry<String, List<Extension>> moduleExtensionEntry : moduleExtensionMap.entrySet()) {
 					// Sort this module's extensions for current extension point
 					List<Extension> sortedModuleExtensions = moduleExtensionEntry.getValue();


### PR DESCRIPTION
#### Issue: https://issues.openmrs.org/browse/TRUNK-5269
I also removed unnecessary boxing "Integer.valueOf(e1.getOrder()))"