### PR TITLE
TRUNK-5232 Clean up changedBy and dateChanged fields in domain object super classes and interfaces

### DIFF
--- a/api/src/main/java/org/openmrs/BaseChangeableOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseChangeableOpenmrsData.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs;
 
+import javax.persistence.Column;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
 import java.util.Date;
 
 /**
@@ -16,38 +20,30 @@ import java.util.Date;
  * 
  * @since 2.2
  */
+@MappedSuperclass
 public abstract class BaseChangeableOpenmrsData extends BaseOpenmrsData {
-	
-	/**
-	 * @see Auditable#getChangedBy()
-	 */
-	@Override
+
+	@ManyToOne
+	@JoinColumn(name = "changed_by")
+	private User changedBy;
+
+	@Column(name = "date_changed")
+	private Date dateChanged;
+
 	public User getChangedBy() {
-		return super.getChangedBy();
+		return this.changedBy;
 	}
-	
-	/**
-	 * @see Auditable#setChangedBy(User)
-	 */
-	@Override
+
 	public void setChangedBy(User changedBy) {
-		super.setChangedBy(changedBy);
+		this.changedBy = changedBy;
 	}
-	
-	/**
-	 * @see Auditable#getDateChanged()
-	 */
-	@Override
+
 	public Date getDateChanged() {
-		return super.getDateChanged();
+		return this.dateChanged;
 	}
-	
-	/**
-	 * @see Auditable#setDateChanged(Date)
-	 */
-	@Override
+
 	public void setDateChanged(Date dateChanged) {
-		super.setDateChanged(dateChanged);
+		this.dateChanged = dateChanged;
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/BaseChangeableOpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseChangeableOpenmrsMetadata.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs;
 
+import javax.persistence.Column;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
 import java.util.Date;
 
 /**
@@ -16,37 +20,30 @@ import java.util.Date;
  * 
  * @since 2.2
  */
+@MappedSuperclass
 public abstract class BaseChangeableOpenmrsMetadata extends BaseOpenmrsMetadata {
-	
-	/**
-	 * @see Auditable#getChangedBy()
-	 */
-	@Override
+
+	@ManyToOne
+	@JoinColumn(name = "changed_by")
+	private User changedBy;
+
+	@Column(name = "date_changed")
+	private Date dateChanged;
+
+
 	public User getChangedBy() {
-		return super.getChangedBy();
+		return this.changedBy;
 	}
-	
-	/**
-	 * @see Auditable#setChangedBy(User)
-	 */
-	@Override
+
 	public void setChangedBy(User changedBy) {
-		super.setChangedBy(changedBy);
+		this.changedBy = changedBy;
 	}
-	
-	/**
-	 * @see Auditable#getDateChanged()
-	 */
-	@Override
+
 	public Date getDateChanged() {
-		return super.getDateChanged();
+		return this.dateChanged;
 	}
-	
-	/**
-	 * @see Auditable#setDateChanged(Date)
-	 */
-	@Override
+
 	public void setDateChanged(Date dateChanged) {
-		super.setDateChanged(dateChanged);
+		this.dateChanged = dateChanged;
 	}
 }

--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -38,13 +38,6 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	@Column(name = "date_created", nullable = false, updatable = false)
 	private Date dateCreated;
 	
-	@ManyToOne
-	@JoinColumn(name = "changed_by")
-	private User changedBy;
-	
-	@Column(name = "date_changed")
-	private Date dateChanged;
-	
 	@Column(name = "voided", nullable = false)
 	@Field
 	private Boolean voided = Boolean.FALSE;
@@ -99,46 +92,6 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	@Override
 	public void setDateCreated(Date dateCreated) {
 		this.dateCreated = dateCreated;
-	}
-	
-	/**
-	 * @deprecated as of version 2.2
-	 * @see org.openmrs.OpenmrsData#getChangedBy()
-	 */
-	@Override
-	@Deprecated
-	public User getChangedBy() {
-		return changedBy;
-	}
-	
-	/**
-	 * @deprecated as of version 2.2
-	 * @see org.openmrs.OpenmrsData#setChangedBy(User)
-	 */
-	@Override
-	@Deprecated
-	public void setChangedBy(User changedBy) {
-		this.changedBy = changedBy;
-	}
-	
-	/**
-	 * @deprecated as of version 2.2
-	 * @see org.openmrs.OpenmrsData#getDateChanged()
-	 */
-	@Override
-	@Deprecated
-	public Date getDateChanged() {
-		return dateChanged;
-	}
-	
-	/**
-	 * @deprecated as of version 2.2
-	 * @see org.openmrs.OpenmrsData#setDateChanged(Date)
-	 */
-	@Override
-	@Deprecated
-	public void setDateChanged(Date dateChanged) {
-		this.dateChanged = dateChanged;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
@@ -45,14 +45,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	
 	@Column(name = "date_created", nullable = false)
 	private Date dateCreated;
-	
-	@ManyToOne
-	@JoinColumn(name = "changed_by")
-	private User changedBy;
-	
-	@Column(name = "date_changed")
-	private Date dateChanged;
-	
+
 	@Column(name = "retired", nullable = false)
 	@Field
 	private Boolean retired = Boolean.FALSE;
@@ -140,47 +133,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	public void setDateCreated(Date dateCreated) {
 		this.dateCreated = dateCreated;
 	}
-	
-	/**
-	 * @see org.openmrs.OpenmrsMetadata#getChangedBy()
-	 * @deprecated as of version 2.2
-	 */
-	@Override
-	@Deprecated
-	public User getChangedBy() {
-		return changedBy;
-	}
-	
-	/**
-	 * @see org.openmrs.OpenmrsMetadata#setChangedBy(User)
-	 * @deprecated as of version 2.2
-	 */
-	@Override
-	@Deprecated
-	public void setChangedBy(User changedBy) {
-		this.changedBy = changedBy;
-	}
-	
-	/**
-	 * @see org.openmrs.OpenmrsMetadata#getDateChanged()
-	 * @deprecated as of version 2.2
-	 */
-	@Override
-	@Deprecated
-	public Date getDateChanged() {
-		return dateChanged;
-	}
-	
-	/**
-	 * @see org.openmrs.OpenmrsMetadata#setDateChanged(Date)
-	 * @deprecated as of version 2.2
-	 */
-	@Override
-	@Deprecated
-	public void setDateChanged(Date dateChanged) {
-		this.dateChanged = dateChanged;
-	}
-	
+
 	/**
 	 * @deprecated as of 2.0, use {@link #getRetired()}
 	 * @see org.openmrs.Retireable#isRetired()

--- a/api/src/main/java/org/openmrs/Changeable.java
+++ b/api/src/main/java/org/openmrs/Changeable.java
@@ -18,24 +18,5 @@ import java.util.Date;
  * @since 2.2
  */
 public interface Changeable extends OpenmrsObject {
-	
-	/**
-	 * @return User - the user who last changed the object
-	 */
-	User getChangedBy();
-	
-	/**
-	 * @param changedBy - the user who last changed the object
-	 */
-	void setChangedBy(User changedBy);
-	
-	/**
-	 * @return Date - the date the object was last changed
-	 */
-	Date getDateChanged();
-	
-	/**
-	 * @param dateChanged - the date the object was last changed
-	 */
-	void setDateChanged(Date dateChanged);
+
 }

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -232,7 +232,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @return Returns the changedBy.
 	 */
-	@Override
+
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -240,7 +240,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @param changedBy The changedBy to set.
 	 */
-	@Override
+
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -328,7 +328,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @return Returns the dateChanged.
 	 */
-	@Override
+
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -336,7 +336,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @param dateChanged The dateChanged to set.
 	 */
-	@Override
+	
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -336,7 +336,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	/**
 	 * @param dateChanged The dateChanged to set.
 	 */
-	
+
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}

--- a/api/src/main/java/org/openmrs/ConceptAnswer.java
+++ b/api/src/main/java/org/openmrs/ConceptAnswer.java
@@ -175,39 +175,28 @@ public class ConceptAnswer extends BaseOpenmrsObject implements Auditable, java.
 	
 	/**
 	 * Not currently used. Always returns null.
-	 *
-	 * @see org.openmrs.Auditable#getChangedBy()
 	 */
-	@Override
 	public User getChangedBy() {
 		return null;
 	}
 	
 	/**
 	 * Not currently used. Always returns null.
-	 *
-	 * @see org.openmrs.Auditable#getDateChanged()
 	 */
-	@Override
+
 	public Date getDateChanged() {
 		return null;
 	}
 	
 	/**
 	 * Not currently used.
-	 *
-	 * @see org.openmrs.Auditable#setChangedBy(org.openmrs.User)
 	 */
-	@Override
 	public void setChangedBy(User changedBy) {
 	}
 	
 	/**
 	 * Not currently used.
-	 *
-	 * @see org.openmrs.Auditable#setDateChanged(java.util.Date)
 	 */
-	@Override
 	public void setDateChanged(Date dateChanged) {
 	}
 	

--- a/api/src/main/java/org/openmrs/ConceptDescription.java
+++ b/api/src/main/java/org/openmrs/ConceptDescription.java
@@ -137,7 +137,6 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 	/**
 	 * @return Returns the User who last changed the description.
 	 */
-	@Override
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -145,7 +144,6 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 	/**
 	 * @param changedBy The user who changed this description
 	 */
-	@Override
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -153,7 +151,6 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 	/**
 	 * @return Returns the date the description was last changed.
 	 */
-	@Override
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -163,7 +160,6 @@ public class ConceptDescription extends BaseOpenmrsObject implements Auditable, 
 	 * 
 	 * @param dateChanged the data the description was changed.
 	 */
-	@Override
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -577,7 +577,6 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	/**
 	 * @return Returns the changedBy.
 	 */
-	@Override
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -585,7 +584,6 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	/**
 	 * @param changedBy The user that changed this object
 	 */
-	@Override
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -593,7 +591,6 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	/**
 	 * @return Returns the date this object was changed
 	 */
-	@Override
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -601,7 +598,6 @@ public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidabl
 	/**
 	 * @param dateChanged The date this object was changed
 	 */
-	@Override
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}

--- a/api/src/main/java/org/openmrs/ConceptSet.java
+++ b/api/src/main/java/org/openmrs/ConceptSet.java
@@ -146,39 +146,27 @@ public class ConceptSet extends BaseOpenmrsObject implements Auditable, java.io.
 	
 	/**
 	 * Not currently used. Always returns null.
-	 * 
-	 * @see org.openmrs.Auditable#getChangedBy()
 	 */
-	@Override
 	public User getChangedBy() {
 		return null;
 	}
 	
 	/**
 	 * Not currently used. Always returns null.
-	 * 
-	 * @see org.openmrs.Auditable#getDateChanged()
 	 */
-	@Override
 	public Date getDateChanged() {
 		return null;
 	}
 	
 	/**
 	 * Not currently used.
-	 * 
-	 * @see org.openmrs.Auditable#setChangedBy(org.openmrs.User)
 	 */
-	@Override
 	public void setChangedBy(User changedBy) {
 	}
 	
 	/**
 	 * Not currently used.
-	 * 
-	 * @see org.openmrs.Auditable#setDateChanged(java.util.Date)
 	 */
-	@Override
 	public void setDateChanged(Date dateChanged) {
 	}
 	

--- a/api/src/main/java/org/openmrs/OpenmrsData.java
+++ b/api/src/main/java/org/openmrs/OpenmrsData.java
@@ -21,40 +21,5 @@ import java.util.Date;
  * @since 1.5
  */
 public interface OpenmrsData extends Auditable, Voidable {
-	
-	/**
-	 * @deprecated As of version 2.2, OpenmrsData is immutable by default, it's up to the subclasses
-	 *             to make themselves mutable by extending BaseChangeableOpenmrsData, this method
-	 *             will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	User getChangedBy();
-	
-	/**
-	 * @deprecated As of version 2.2, OpenmrsData is immutable by default, it's up to the subclasses
-	 *             to make themselves mutable by extending BaseChangeableOpenmrsData, this method
-	 *             will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	void setChangedBy(User changedBy);
-	
-	/**
-	 * @deprecated As of version 2.2, OpenmrsData is immutable by default, it's up to the subclasses
-	 *             to make themselves mutable by extending BaseChangeableOpenmrsData, this method
-	 *             will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	Date getDateChanged();
-	
-	/**
-	 * @deprecated As of version 2.2, OpenmrsData is immutable by default, it's up to the subclasses
-	 *             to make themselves mutable by extending BaseChangeableOpenmrsData, this method
-	 *             will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	void setDateChanged(Date dateChanged);
+
 }

--- a/api/src/main/java/org/openmrs/OpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/OpenmrsMetadata.java
@@ -42,40 +42,5 @@ public interface OpenmrsMetadata extends Auditable, Retireable {
 	 * @param description the description to set
 	 */
 	public void setDescription(String description);
-	
-	/**
-	 * @deprecated As of version 2.2 OpenmrsMetadata is immutable by default, it's up to the
-	 *             subclasses to make themselves mutable by extending BaseChangeableOpenmrsMetadata,
-	 *             this method will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	User getChangedBy();
-	
-	/**
-	 * @deprecated As of version 2.2 OpenmrsMetadata is immutable by default, it's up to the
-	 *             subclasses to make themselves mutable by extending BaseChangeableOpenmrsMetadata,
-	 *             this method will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	void setChangedBy(User changedBy);
-	
-	/**
-	 * @deprecated As of version 2.2 OpenmrsMetadata is immutable by default, it's up to the
-	 *             subclasses to make themselves mutable by extending BaseChangeableOpenmrsMetadata,
-	 *             this method will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	Date getDateChanged();
-	
-	/**
-	 * @deprecated As of version 2.2 OpenmrsMetadata is immutable by default, it's up to the
-	 *             subclasses to make themselves mutable by extending BaseChangeableOpenmrsMetadata,
-	 *             this method will be removed in 2.3
-	 */
-	@Override
-	@Deprecated
-	void setDateChanged(Date dateChanged);
+
 }

--- a/api/src/main/java/org/openmrs/Order.java
+++ b/api/src/main/java/org/openmrs/Order.java
@@ -168,8 +168,6 @@ public class Order extends BaseOpenmrsData {
 		target.action = getAction();
 		target.orderNumber = getOrderNumber();
 		target.setCareSetting(getCareSetting());
-		target.setChangedBy(getChangedBy());
-		target.setDateChanged(getDateChanged());
 		target.setScheduledDate(getScheduledDate());
 		target.setOrderGroup(getOrderGroup());
 		target.setSortWeight(getSortWeight());


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-5232?filter=-1

## Description of what I changed

1. Move changedBy, dateChanged fields from BaseOpenmrsData and BaseOpenmrsMetadata to BaseChangeableOpenmrsData and BaseChangeableOpenmrsData respectively.
2. Add @MappedSuperclass annotation to BaseChangeableOpenmrsData and BaseChangeableOpenmrsData
3. Update the getters/setters for changedBy, dateChanged in BaseChangeableOpenmrsData and BaseChangeableOpenmrsMetadata to set and return their values rather than delegating to the superclasses.
4. Remove the deprecated getters/setters for the above fields from OpenmrsData, OpenmrsMetadata, BaseOpenmrsData and BaseOpenmrsMetadata

## Checklist: I completed these to help reviewers :)

- [x ] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [ x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [ x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x ] All new and existing **tests passed**.

- [ x] My pull request is **based on the latest changes** of the master branch.

