### PR TITLE
[TRUNK-5284] Replace 'l' Long literal with 'L' to avoid mistakes

### DIFF
--- a/api/src/test/java/org/openmrs/PersonAddressTest.java
+++ b/api/src/test/java/org/openmrs/PersonAddressTest.java
@@ -152,8 +152,8 @@ public class PersonAddressTest {
 	public void equalsContent_shouldIndicateUnequalWhenOnlyStartDateDiffers() {
 		PersonAddress address1 = new PersonAddress();
 		PersonAddress address2 = new PersonAddress();
-		address2.setStartDate(new Date(123l));
-		address1.setStartDate(new Date(1000000l));
+		address2.setStartDate(new Date(123L));
+		address1.setStartDate(new Date(1000000L));
 		
 		assertThat(address2.equalsContent(address1), is(false));
 	}
@@ -162,8 +162,8 @@ public class PersonAddressTest {
 	public void equalsContent_shouldIndicateUnequalWhenOnlyEndDateDiffers() {
 		PersonAddress address1 = new PersonAddress();
 		PersonAddress address2 = new PersonAddress();
-		address2.setStartDate(new Date(123l));
-		address1.setStartDate(new Date(1000000l));
+		address2.setStartDate(new Date(123L));
+		address1.setStartDate(new Date(1000000L));
 		
 		assertThat(address2.equalsContent(address1), is(false));
 	}

--- a/api/src/test/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptorTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/DropMillisecondsHibernateInterceptorTest.java
@@ -38,8 +38,8 @@ public class DropMillisecondsHibernateInterceptorTest extends BaseContextSensiti
 
 	@Test
 	public void shouldClearMillisecondsWhenSavingANewObject() {
-		Date dateWithMillisecond = new Date(567l);
-		Date dateWithoutMillisecond = new Date(0l);
+		Date dateWithMillisecond = new Date(567L);
+		Date dateWithoutMillisecond = new Date(0L);
 
 		Person person = new Person();
 		person.addName(new PersonName("Alice", null, "Paul"));
@@ -54,8 +54,8 @@ public class DropMillisecondsHibernateInterceptorTest extends BaseContextSensiti
 
 	@Test
 	public void shouldClearMillisecondsWhenUpdatingAnExistingObject() {
-		Date dateWithMillisecond = new Date(567l);
-		Date dateWithoutMillisecond = new Date(0l);
+		Date dateWithMillisecond = new Date(567L);
+		Date dateWithoutMillisecond = new Date(0L);
 
 		Person person = personService.getPerson(1);
 		person.setBirthdate(dateWithMillisecond);

--- a/api/src/test/java/org/openmrs/scheduler/SchedulerServiceTest.java
+++ b/api/src/test/java/org/openmrs/scheduler/SchedulerServiceTest.java
@@ -345,7 +345,7 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		td.setTaskClass(BareTask.class.getName());
 		td.setStartTime(null);
 		td.setName("name");
-		td.setRepeatInterval(5000l);
+		td.setRepeatInterval(5000L);
 		
 		synchronized (TASK_TEST_METHOD_LOCK) {
 			latch = new CountDownLatch(1);
@@ -384,7 +384,7 @@ public class SchedulerServiceTest extends BaseContextSensitiveTest {
 		td.setStartOnStartup(false);
 		td.setTaskClass(StoreExecutionTimeTask.class.getName());
 		td.setStartTime(null);
-		td.setRepeatInterval(0l);//0 indicates single execution
+		td.setRepeatInterval(0L);//0 indicates single execution
 		synchronized (TASK_TEST_METHOD_LOCK) {
 			latch = new CountDownLatch(1);
 			service.saveTaskDefinition(td);

--- a/api/src/test/java/org/openmrs/util/DateUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/DateUtilTest.java
@@ -20,8 +20,8 @@ public class DateUtilTest {
 
 	@Test
 	public void truncateToSeconds_shouldDropMilliseconds() {
-		Date withMilliseconds = new Date(123l);
-		Date withoutMilliseconds = new Date(0l);
+		Date withMilliseconds = new Date(123L);
+		Date withoutMilliseconds = new Date(0L);
 		assertThat(DateUtil.truncateToSeconds(withMilliseconds), is(withoutMilliseconds));
 		assertThat(DateUtil.truncateToSeconds(withoutMilliseconds), is(withoutMilliseconds));
 	}


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/TRUNK-5284