### PR TITLE
TRUNK-5204 . Removed unused jstl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,11 +104,6 @@
 				<version>2.0</version>
 			</dependency>
 			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>jstl</artifactId>
-				<version>1.1.2</version>
-			</dependency>
-			<dependency>
 				<groupId>taglibs</groupId>
 				<artifactId>request</artifactId>
 				<version>1.0.1</version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -54,10 +54,6 @@
          <artifactId>jsp-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>javax.servlet</groupId>
-         <artifactId>jstl</artifactId>
-      </dependency>
-      <dependency>
          <groupId>commons-io</groupId>
          <artifactId>commons-io</artifactId>
       </dependency>


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/TRUNK-5204