### PR TITLE
TRUNK-5298 Add .editorconfig to force use of tabs in IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ nb-configuration.xml
 #############
 
 *.log
+
+!.editorconfig
+


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

IntelliJ, Visual Studio Code and other IDEs/Editors support editorconfig
files out of the box, others like Eclipse, Atom, Sublime, Vim need a
plugin.

should help to reduce the spaces/tabs mess we are
currently seeing.

http://editorconfig.org/#overview


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5298

