### PR TITLE
[GCI-237] Possible null pointer dereference due to return value of modu…

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -171,10 +171,11 @@ public class ModuleFactory {
 			log.debug("Loading modules from: " + modulesFolder.getAbsolutePath());
 		}
 		
-		if (modulesFolder.isDirectory()) {
-			loadModules(Arrays.asList(modulesFolder.listFiles()));
+		File[] files = modulesFolder.listFiles();
+		if (modulesFolder.isDirectory() && files != null) {
+			loadModules(Arrays.asList(files));
 		} else {
-			log.error("modules folder: '" + modulesFolder.getAbsolutePath() + "' is not a valid directory");
+			log.error("modules folder: '" + modulesFolder.getAbsolutePath() + "' is not a directory or IO error occurred");
 		}
 	}
 	


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/GCI-237

I've decided to log the same error message when files are null. Because listFiles() returns null only in two cases: 1) directory is not valid 2) there is IO Exception. And the first case is already checked by modulesFolder.isDirectory() so we're getting null only on IO Exception which is highly uncommon here (directory is checked already in ModuleUtil).