### PR TITLE
TRUNK-5303 Use commons-lang3 instead of legacy commons-lang

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.ContainedIn;
 import org.hibernate.search.annotations.DocumentId;

--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.standard.StandardFilterFactory;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;

--- a/api/src/main/java/org/openmrs/DrugOrder.java
+++ b/api/src/main/java/org/openmrs/DrugOrder.java
@@ -11,7 +11,7 @@ package org.openmrs;
 
 import static org.openmrs.Order.Action.DISCONTINUE;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.OpenmrsUtil;
 
 /**

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs;
 
-import static org.apache.commons.lang.time.DateUtils.addHours;
-import static org.apache.commons.lang.time.DateUtils.addMinutes;
-import static org.apache.commons.lang.time.DateUtils.addMonths;
-import static org.apache.commons.lang.time.DateUtils.addWeeks;
-import static org.apache.commons.lang.time.DateUtils.addYears;
+import static org.apache.commons.lang3.time.DateUtils.addHours;
+import static org.apache.commons.lang3.time.DateUtils.addMinutes;
+import static org.apache.commons.lang3.time.DateUtils.addMonths;
+import static org.apache.commons.lang3.time.DateUtils.addWeeks;
+import static org.apache.commons.lang3.time.DateUtils.addYears;
 import static org.apache.commons.lang3.time.DateUtils.addDays;
 import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.annotation.AllowDirectAccess;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/OrderType.java
+++ b/api/src/main/java/org/openmrs/OrderType.java
@@ -12,7 +12,7 @@ package org.openmrs;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.annotation.Independent;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/PatientIdentifierType.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifierType.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.search.annotations.Field;
 
 /**

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs;
 
-import static org.apache.commons.lang.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.util.Calendar;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;

--- a/api/src/main/java/org/openmrs/PersonAttribute.java
+++ b/api/src/main/java/org/openmrs/PersonAttribute.java
@@ -15,7 +15,7 @@ import java.lang.reflect.Method;
 import java.util.Comparator;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Boost;
 import org.hibernate.search.annotations.DocumentId;

--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs;
 
-import static org.apache.commons.lang.StringUtils.defaultString;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.hibernate.search.annotations.Analyzer;
 import org.hibernate.search.annotations.Boost;

--- a/api/src/main/java/org/openmrs/User.java
+++ b/api/src/main/java/org/openmrs/User.java
@@ -19,7 +19,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
@@ -12,7 +12,7 @@ package org.openmrs.annotation;
 import java.io.IOException;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.ModuleUtil;

--- a/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
@@ -12,7 +12,7 @@ package org.openmrs.aop;
 import java.lang.reflect.Method;
 import java.util.Collection;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.User;
 import org.openmrs.annotation.AuthorizedAnnotationAttributes;
 import org.openmrs.api.APIAuthenticationException;

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -25,7 +25,7 @@ import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
 
 import org.aopalliance.aop.Advice;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Allergen;
 import org.openmrs.GlobalProperty;
 import org.openmrs.PersonName;

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Location;
 import org.openmrs.Role;
 import org.openmrs.User;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.Query;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateEncounterDAO.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.SQLQuery;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAO.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.DetachedCriteria;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
@@ -13,7 +13,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.SQLQuery;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.FlushMode;
 import org.hibernate.LockOptions;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -21,7 +21,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
@@ -17,7 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
@@ -13,7 +13,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.hibernate.EmptyInterceptor;
 import org.hibernate.type.Type;
 import org.openmrs.Retireable;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Conjunction;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQuery.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQuery.java
@@ -11,7 +11,6 @@ package org.openmrs.api.db.hibernate.search;
 
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
 import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.openmrs.collection.ListPart;
@@ -28,8 +27,12 @@ public abstract class SearchQuery<T> {
 	private final Session session;
 	
 	public SearchQuery(Session session, Class<T> type) {
-		Validate.notNull(session);
-		Validate.notNull(type);
+		if (session == null) {
+			throw new IllegalArgumentException("session must not be null");
+		}
+		if (type == null) {
+			throw new IllegalArgumentException("type must not be null");
+		}
 		
 		this.session = session;
 		this.type = type;

--- a/api/src/main/java/org/openmrs/api/handler/ConceptSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/ConceptSaveHandler.java
@@ -11,7 +11,7 @@ package org.openmrs.api.handler;
 
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptDescription;

--- a/api/src/main/java/org/openmrs/api/handler/ExistingOrNewVisitAssignmentHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/ExistingOrNewVisitAssignmentHandler.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterType;
 import org.openmrs.GlobalProperty;

--- a/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonSaveHandler.java
@@ -11,7 +11,7 @@ package org.openmrs.api.handler;
 
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.User;

--- a/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/RequireVoidReasonVoidHandler.java
@@ -11,7 +11,7 @@ package org.openmrs.api.handler;
 
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Cohort;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;

--- a/api/src/main/java/org/openmrs/api/handler/UserSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/UserSaveHandler.java
@@ -12,7 +12,7 @@ package org.openmrs.api.handler;
 import java.util.ArrayList;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Patient;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.api.impl;
 
-import static org.apache.commons.lang.StringUtils.contains;
+import static org.apache.commons.lang3.StringUtils.contains;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Cohort;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterRole;

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -21,7 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
-import org.apache.commons.lang.time.DateUtils;
+import org.apache.commons.lang3.time.DateUtils;
 import org.hibernate.proxy.HibernateProxy;
 import org.openmrs.CareSetting;
 import org.openmrs.Concept;

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.api.impl;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Allergen;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Person;
 import org.openmrs.PersonAddress;

--- a/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.Validate;
 import org.openmrs.Person;
 import org.openmrs.Provider;
 import org.openmrs.ProviderAttribute;
@@ -132,7 +131,9 @@ public class ProviderServiceImpl extends BaseOpenmrsService implements ProviderS
 	@Override
 	@Transactional(readOnly = true)
 	public Collection<Provider> getProvidersByPerson(Person person) {
-		Validate.notNull(person, "Person must not be null");
+		if (person == null) {
+			throw new IllegalArgumentException("Person must not be null");
+		}
 		return Context.getProviderService().getProvidersByPerson(person, true);
 	}
 	

--- a/api/src/main/java/org/openmrs/api/impl/SerializationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/SerializationServiceImpl.java
@@ -14,7 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.api.SerializationService;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -16,8 +16,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.Location;
 import org.openmrs.Patient;

--- a/api/src/main/java/org/openmrs/customdatatype/CustomDatatypeUtil.java
+++ b/api/src/main/java/org/openmrs/customdatatype/CustomDatatypeUtil.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/BooleanDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/BooleanDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.customdatatype.SerializingCustomDatatype;
 import org.springframework.stereotype.Component;
 

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/ConceptDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/ConceptDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.api.context.Context;
 import org.openmrs.customdatatype.CustomDatatype;

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/DateDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/DateDatatype.java
@@ -12,7 +12,7 @@ package org.openmrs.customdatatype.datatype;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.InvalidCustomValueException;

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/FloatDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/FloatDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.customdatatype.SerializingCustomDatatype;
 import org.springframework.stereotype.Component;
 

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/LocationDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/LocationDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Component;

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/ProgramDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/ProgramDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Program;
 import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Component;

--- a/api/src/main/java/org/openmrs/customdatatype/datatype/ProviderDatatype.java
+++ b/api/src/main/java/org/openmrs/customdatatype/datatype/ProviderDatatype.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.customdatatype.datatype;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Component;

--- a/api/src/main/java/org/openmrs/hl7/HL7Util.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Util.java
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -27,8 +27,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;

--- a/api/src/main/java/org/openmrs/layout/name/NameTemplate.java
+++ b/api/src/main/java/org/openmrs/layout/name/NameTemplate.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.PersonName;
 import org.openmrs.api.APIException;
 import org.openmrs.layout.LayoutSupport;

--- a/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.messagesource.MutableMessageSource;

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;

--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -29,7 +29,7 @@ import java.util.zip.ZipEntry;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Privilege;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -38,8 +38,8 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.obs.ComplexData;

--- a/api/src/main/java/org/openmrs/propertyeditor/DateOrDatetimeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/DateOrDatetimeEditor.java
@@ -14,7 +14,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.context.Context;
 
 /**

--- a/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
+++ b/api/src/main/java/org/openmrs/scheduler/SchedulerUtil.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.PrivilegeConstants;
 import org.slf4j.Logger;

--- a/api/src/main/java/org/openmrs/util/AttributableDate.java
+++ b/api/src/main/java/org/openmrs/util/AttributableDate.java
@@ -14,7 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Attributable;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/util/ExceptionUtil.java
+++ b/api/src/main/java/org/openmrs/util/ExceptionUtil.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.util;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.api.APIAuthenticationException;
 
 /**

--- a/api/src/main/java/org/openmrs/util/Format.java
+++ b/api/src/main/java/org/openmrs/util/Format.java
@@ -14,7 +14,7 @@ import java.text.NumberFormat;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.ModuleClassLoader;

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -66,7 +66,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;

--- a/api/src/main/java/org/openmrs/util/databasechange/AddConceptMapTypesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/AddConceptMapTypesChangeset.java
@@ -17,7 +17,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Calendar;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.DatabaseUpdater;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/api/src/main/java/org/openmrs/util/databasechange/CheckDrugOrderUnitAndFrequencyTextNotMappedToConcepts.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/CheckDrugOrderUnitAndFrequencyTextNotMappedToConcepts.java
@@ -12,7 +12,7 @@ package org.openmrs.util.databasechange;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.UpgradeUtil;
 

--- a/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections.set.ListOrderedSet;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.db.hibernate.HibernateUtil;

--- a/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
@@ -16,7 +16,7 @@ import java.sql.Statement;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.OpenmrsUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/api/src/main/java/org/openmrs/util/databasechange/MigrateConceptReferenceTermChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MigrateConceptReferenceTermChangeSet.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/api/src/main/java/org/openmrs/validator/AllergyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AllergyValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Allergen;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;

--- a/api/src/main/java/org/openmrs/validator/BaseAttributeTypeValidator.java
+++ b/api/src/main/java/org/openmrs/validator/BaseAttributeTypeValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.attribute.AttributeType;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.CustomDatatypeHandler;

--- a/api/src/main/java/org/openmrs/validator/ConceptValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptValidator.java
@@ -15,7 +15,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptMap;

--- a/api/src/main/java/org/openmrs/validator/EncounterValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterValidator.java
@@ -11,7 +11,7 @@ package org.openmrs.validator;
 
 import java.util.Date;
 
-import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang3.ObjectUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Visit;
 import org.openmrs.annotation.Handler;

--- a/api/src/main/java/org/openmrs/validator/ImplementationIdValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ImplementationIdValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.ImplementationId;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.APIException;

--- a/api/src/main/java/org/openmrs/validator/PatientIdentifierValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientIdentifierValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PatientIdentifierType.LocationBehavior;

--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -13,7 +13,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.PersonAddress;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.PersonName;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.context.Context;

--- a/api/src/main/java/org/openmrs/validator/ProviderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProviderValidator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.validator;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Provider;
 import org.openmrs.annotation.Handler;

--- a/api/src/main/java/org/openmrs/validator/UserValidator.java
+++ b/api/src/main/java/org/openmrs/validator/UserValidator.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Person;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;

--- a/api/src/main/java/org/openmrs/validator/ValidateUtil.java
+++ b/api/src/main/java/org/openmrs/validator/ValidateUtil.java
@@ -12,7 +12,7 @@ package org.openmrs.validator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.api.ValidationException;
 import org.openmrs.api.context.Context;

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.TransientObjectException;
 import org.junit.Assert;
 import org.junit.Before;

--- a/api/src/test/java/org/openmrs/orders/TimestampOrderNumberGenerator.java
+++ b/api/src/test/java/org/openmrs/orders/TimestampOrderNumberGenerator.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.orders;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.OrderContext;
 import org.openmrs.api.OrderNumberGenerator;
 import org.springframework.stereotype.Component;

--- a/api/src/test/java/org/openmrs/serialization/JavaSerializationTest.java
+++ b/api/src/test/java/org/openmrs/serialization/JavaSerializationTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
 
 import java.util.Date;
 
-import org.apache.commons.lang.SerializationUtils;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptClass;

--- a/api/src/test/java/org/openmrs/serialization/SimpleXStreamSerializerTest.java
+++ b/api/src/test/java/org/openmrs/serialization/SimpleXStreamSerializerTest.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;

--- a/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
+++ b/api/src/test/java/org/openmrs/test/StartModuleExecutionListener.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.SerializedObjectDAOTest;

--- a/api/src/test/java/org/openmrs/util/databasechange/DatabaseUpgradeTestUtil.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/DatabaseUpgradeTestUtil.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.dbunit.DatabaseUnitException;
 import org.dbunit.database.DatabaseConfig;

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -113,7 +113,7 @@
 			<property name="severity" value="error"/>
 		</module>
 		<module name="IllegalImport">
-			<property name="illegalPkgs" value="sun, org.apache.commons.logging, org.openmrs.test.Verifies, org.apache.xerces" />
+			<property name="illegalPkgs" value="sun, org.apache.commons.logging, org.apache.commons.lang, org.openmrs.test.Verifies, org.apache.xerces" />
 			<property name="severity" value="error"/>
 		</module>
 		<module name="OneTopLevelClass">

--- a/web/src/main/java/org/openmrs/web/WebUtil.java
+++ b/web/src/main/java/org/openmrs/web/WebUtil.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.Locale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;

--- a/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/StartupFilter.java
@@ -33,7 +33,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.runtime.RuntimeConstants;

--- a/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
@@ -30,7 +30,7 @@ import java.util.zip.ZipFile;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;

--- a/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/startuperror/StartupErrorFilterModel.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.web.filter.startuperror;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.web.filter.StartupFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
 

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
 import org.openmrs.util.DatabaseUpdateException;

--- a/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
@@ -15,7 +15,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.OpenmrsConstants;

--- a/web/src/main/java/org/openmrs/web/filter/util/LocalizationTool.java
+++ b/web/src/main/java/org/openmrs/web/filter/util/LocalizationTool.java
@@ -12,7 +12,7 @@ package org.openmrs.web.filter.util;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.velocity.tools.config.DefaultKey;
 import org.apache.velocity.tools.generic.ResourceTool;
 import org.openmrs.util.LocaleUtility;


### PR DESCRIPTION
* replace use of legacy commons-lang methods with commons-lang3
* replace use of Validate.nonNull() with simple java code throwing an
IllegalArgumentException when the object under test is null since the
commons-lang3 switched to throwing a NullPointerException
* add checkstyle rule preventing import from commons-lang which should
be picked up by codacy so we can get rid of commons-lang at some point


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5303

