### PR TITLE
TRUNK-5189: Used Daemon User to create an Alert

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -369,4 +369,8 @@ public class Daemon {
 			return null;
 		}
 	}
+
+	public static String getDaemonUserUuid() {
+		return DAEMON_USER_UUID;
+	}
 }

--- a/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
+++ b/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
@@ -17,6 +17,7 @@ import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.notification.Alert;
 import org.openmrs.notification.AlertRecipient;
@@ -196,13 +197,12 @@ public class AlertServiceImpl extends BaseOpenmrsService implements Serializable
 		alert.setSatisfiedByAny(true);
 		
 		//If there is not user creator for the alert ( because it is being created at start-up )create a user
-		//TODO switch this to use the daemon user when ticket TRUNK-120 is complete
-		if (alert.getCreator() == null) {
-			alert.setCreator(new User(1));
-		}
+		if (alert.getCreator() == null) { 
+			User daemonUser = Context.getUserService().getUserByUuid(Daemon.getDaemonUserUuid());
+			alert.setCreator(daemonUser);
+		} 
 		
 		// save the alert to send it to all administrators
 		Context.getAlertService().saveAlert(alert);
-		
 	}
 }


### PR DESCRIPTION
Issue : https://issues.openmrs.org/browse/TRUNK-5189.

This initial commit is not yet perfect, I just need your guidance @dkayiwa to complete this issue. 
Currently the alert is made by the daemon User, but there are 2 broken tests. In the [AlertServiceTest](https://github.com/openmrs/openmrs-core/blob/master/api/src/test/java/org/openmrs/notification/AlertServiceTest.java) but what has beat my understanding is that, when I comment out other tests and run one by one, they all pass fine. This has made me to anticipate that there are some thread conflicts. Could you please review my changes and direct me of what to do.
cc. @ssmusoke , @djazayeri etc. 