### PR TITLE
TRUNK-5332: HibernateProviderDAO.getCountOfProviders handles more than one match.

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -241,9 +241,8 @@ public class HibernateProviderDAO implements ProviderDAO {
 	 */
 	@Override
 	public Long getCountOfProviders(String name, boolean includeRetired) {
-		Criteria criteria = prepareProviderCriteria(name, includeRetired);
-		criteria.setProjection(Projections.countDistinct("providerId"));
-		return (Long) criteria.uniqueResult();
+	  Criteria criteria = prepareProviderCriteria(name, includeRetired);
+	  return (long) criteria.list().size();
 	}
 	
 	/* (non-Javadoc)

--- a/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
@@ -26,7 +26,6 @@ import java.util.TreeSet;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Person;
@@ -478,12 +477,11 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 		Context.getPersonService().savePerson(person);
 		assertEquals(1, service.getCountOfProviders("Hippo").intValue());
 	}
-	
+
 	/**
 	 * @see ProviderService#getCountOfProviders(String)
 	 */
 	@Test
-	@Ignore
 	public void getCountOfProviders_shouldExcludeRetiredProviders() {
 		assertEquals(2, service.getCountOfProviders("provider").intValue());
 	}
@@ -492,9 +490,8 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	 * @see ProviderService#getCountOfProviders(String,null)
 	 */
 	@Test
-	@Ignore
 	public void getCountOfProviders_shouldIncludeRetiredProvidersIfIncludeRetiredIsSetToTrue() {
-		assertEquals(4, service.getCountOfProviders("provider").intValue());
+		assertEquals(4, service.getCountOfProviders("provider", true).intValue());
 	}
 	
 	/**


### PR DESCRIPTION
Ticket: https://issues.openmrs.org/browse/TRUNK-5332