### PR TITLE
TRUNK-5331: CohortMembership should not require a startDate

### DIFF
--- a/api/src/main/java/org/openmrs/Cohort.java
+++ b/api/src/main/java/org/openmrs/Cohort.java
@@ -14,6 +14,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -28,6 +30,7 @@ public class Cohort extends BaseChangeableOpenmrsData {
 	private Integer cohortId;
 	
 	private String name;
+	
 	
 	private String description;
 	
@@ -267,10 +270,21 @@ public class Cohort extends BaseChangeableOpenmrsData {
 	public static Cohort intersect(Cohort a, Cohort b) {
 		Cohort ret = new Cohort();
 		ret.setName("(" + (a == null ? "NULL" : a.getName()) + " * " + (b == null ? "NULL" : b.getName()) + ")");
-		if (a != null && b != null) {
-			ret.getMemberships().addAll(a.getMemberships());
-			ret.getMemberships().retainAll(b.getMemberships());
+		List<CohortMembership> cohortMemberships = new ArrayList<CohortMembership>();
+			
+		for(CohortMembership  a_member: a.getMemberships()){
+			for(CohortMembership  b_member: b.getMemberships()){
+				if(a_member.getPatientId() == b_member.getPatientId()){
+					if(a_member.getStartDate() != null && b_member.getStartDate() != null ) {
+						cohortMemberships.add(a_member.getStartDate().before(b_member.getStartDate()) ||
+							a_member.getStartDate().equals(b_member.getStartDate()) ? b_member : a_member);
+					} else {
+						cohortMemberships.add(a_member.getStartDate() == null ? a_member : b_member);
+					}
+				}
+			}
 		}
+		ret.getMemberships().addAll(cohortMemberships);
 		return ret;
 	}
 	

--- a/api/src/main/resources/liquibase-update-to-2.2.xml
+++ b/api/src/main/resources/liquibase-update-to-2.2.xml
@@ -224,4 +224,31 @@
 								 baseTableName="encounter_diagnosis" baseColumnNames="changed_by"
 								 referencedTableName="users" referencedColumnNames="user_id" />
 	</changeSet>
+	<changeSet id="20180226-TRUNK-5331" author="patrick">
+		<preConditions onFail="MARK_RAN" onError="CONTINUE">
+			<sqlCheck expectedResult="NO">
+				SELECT is_Nullable
+				FROM  INFORMATION_SCHEMA.COLUMNS
+				WHERE table_name='cohort_member'
+				AND column_name='start_date'
+			</sqlCheck>
+		</preConditions>
+		<dropNotNullConstraint 
+			tableName="cohort_member"
+			columnName="start_date"
+			columnDataType="datetime"/>
+	</changeSet>
+	<changeSet author="patrick" id="20180307-TRUNK-5331">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<sqlCheck expectedResult="0">
+					SELECT COUNT(*) from cohort_member
+				</sqlCheck>
+			</not>
+		</preConditions>
+		<comment>Updating cohort_start_date with value null</comment>
+		<update tableName="cohort_member">
+			<column name="start_date" type="DATETIME" value="null"/>
+		</update>
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/CohortTest.java
+++ b/api/src/test/java/org/openmrs/CohortTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.text.SimpleDateFormat;
@@ -145,6 +146,92 @@ public class CohortTest {
 		intersectOfMemberships.forEach(m -> {
 			assertTrue(m.getPatientId().equals(7));
 			assertTrue(m.getVoided() && m.getEndDate() != null);
+		});
+	}
+	
+	@Test
+	public void intersect_shouldReturnIntersectionOfTwoCohorts() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date cohortOneMemberstartDate = dateFormat.parse("2017-01-01 00:00:00");
+		Date cohortTwoMemberstartDate = dateFormat.parse("2017-02-01 00:00:00");
+		Date endDate = dateFormat.parse("2017-02-01 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, cohortOneMemberstartDate);
+		membershipOne.setVoided(true);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		CohortMembership membershipTwo = new CohortMembership(7, cohortTwoMemberstartDate);
+		membershipTwo.setVoided(true);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		Collection<CohortMembership> intersectOfMemberships = cohortIntersect.getMemberships();
+		assertTrue(intersectOfMemberships.stream().anyMatch(m -> m.getVoided() || m.getEndDate() != null));
+		intersectOfMemberships.forEach(m -> {
+			assertTrue(m.getPatientId().equals(7));
+			assertTrue(m.getStartDate().equals(cohortTwoMemberstartDate));
+		});
+	}
+
+	@Test
+	public void intersect_shouldReturnIntersectionWithLaterStartdate() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date cohortOneMemberstartDate = dateFormat.parse("2017-02-01 00:00:00");
+		Date cohortTwoMemberstartDate = dateFormat.parse("2017-01-01 00:00:00");
+		Date endDate = dateFormat.parse("2017-02-01 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, cohortOneMemberstartDate);
+		membershipOne.setVoided(true);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		CohortMembership membershipTwo = new CohortMembership(7, cohortTwoMemberstartDate);
+		membershipTwo.setVoided(true);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		Collection<CohortMembership> intersectOfMemberships = cohortIntersect.getMemberships();
+		assertTrue(intersectOfMemberships.stream().anyMatch(m -> m.getVoided() || m.getEndDate() != null));
+		intersectOfMemberships.forEach(m -> {
+			assertTrue(m.getPatientId().equals(7));
+			assertTrue(m.getStartDate().equals(cohortOneMemberstartDate));
+		});
+	}
+
+	@Test
+	public void intersect_shouldReturnDateWhichIsNull() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date cohortOneMemberstartDate = null;
+		Date cohortTwoMemberstartDate = dateFormat.parse("2017-01-01 00:00:00");
+		Date endDate = dateFormat.parse("2017-02-01 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, cohortOneMemberstartDate);
+		membershipOne.setVoided(true);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		CohortMembership membershipTwo = new CohortMembership(7, cohortTwoMemberstartDate);
+		membershipTwo.setVoided(true);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		Collection<CohortMembership> intersectOfMemberships = cohortIntersect.getMemberships();
+		assertTrue(intersectOfMemberships.stream().anyMatch(m -> m.getVoided() || m.getEndDate() != null));
+		intersectOfMemberships.forEach(m -> {
+			assertTrue(m.getPatientId().equals(7));
+			System.out.println(m.getStartDate());
+			System.out.println(cohortOneMemberstartDate);
+			assertEquals(cohortOneMemberstartDate, m.getStartDate());
 		});
 	}
 }


### PR DESCRIPTION
## JIRA TICKET NAME

[TRUNK-5331: CohortMembership should not require a startDate](https://issues.openmrs.org/browse/TRUNK-5331)
## Description of what I changed

## Issue I worked on
* drop the not-null constraint on CohortMembership.startDate
* remove any Java logic that defaults CohortMembership.startDate to new Date(), and instead default it to null.
* Cohort.intersect should behave in a way that makes sense if you give it {Patient 123, startDate Jan 1} and {Patient 123, startDate Feb 15}.
I would be satisfied if the output is either a cohort with {Patient 123, startDate Feb 15}, or else a cohort with {Patient 123, startDate null}

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

