### PR TITLE
TRUNK-5368 Deprecate OpenmrsUtil.join

### DIFF
--- a/api/src/main/java/org/openmrs/module/MandatoryModuleException.java
+++ b/api/src/main/java/org/openmrs/module/MandatoryModuleException.java
@@ -54,8 +54,8 @@ public class MandatoryModuleException extends ModuleMustStartException {
 	 */
 	public MandatoryModuleException(List<String> moduleIds) {
 		super("The following modules are marked as 'mandatory' but were unable to start: "
-		        + OpenmrsUtil.join(moduleIds, ","));
-		this.moduleId = OpenmrsUtil.join(moduleIds, ",");
+		        + String.join(",", moduleIds));
+		this.moduleId = String.join(",", moduleIds);
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -882,7 +882,7 @@ public class ModuleFactory {
 	 * @return the message text.
 	 */
 	private static String getFailedToStartModuleMessage(Module module) {
-		String[] params = { module.getName(), OpenmrsUtil.join(getMissingRequiredModules(module), ", ") };
+		String[] params = { module.getName(), String.join(",", getMissingRequiredModules(module)) };
 		return Context.getMessageSourceService().getMessage("Module.error.moduleCannotBeStarted", params,
 		    Context.getLocale());
 	}

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -696,7 +696,9 @@ public class OpenmrsUtil {
 	 * @param c Collection to be joined
 	 * @param separator string to put between all elements
 	 * @return a String representing the toString() of all elements in c, separated by separator
+	 * @deprecated as of 2.2 use Java's {@link String#join} or Apache Commons StringUtils.join for iterables which do not extend {@link CharSequence}
 	 */
+	@Deprecated
 	public static <E> String join(Collection<E> c, String separator) {
 		if (c == null) {
 			return "";


### PR DESCRIPTION
in favor of javas native String.join or apache commons StringUtils.join
when the iterable does not extend CharSequence

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5368


