### PR TITLE
TRUNK-5334: Rename allergy.comment to allergy.comments

### DIFF
--- a/api/src/main/java/org/openmrs/Allergy.java
+++ b/api/src/main/java/org/openmrs/Allergy.java
@@ -33,7 +33,7 @@ public class Allergy extends BaseChangeableOpenmrsData {
 	
 	private Concept severity;
 	
-	private String comment;
+	private String comments;
 	
 	private List<AllergyReaction> reactions = new ArrayList<>();
 	
@@ -47,14 +47,14 @@ public class Allergy extends BaseChangeableOpenmrsData {
 	 * @param patient the patient to set
 	 * @param allergen the allergen to set
 	 * @param severity the severity to set
-	 * @param comment the comment to set
+	 * @param comments the comments to set
 	 * @param reactions the reactions to set
 	 */
-	public Allergy(Patient patient, Allergen allergen, Concept severity, String comment, List<AllergyReaction> reactions) {
+	public Allergy(Patient patient, Allergen allergen, Concept severity, String comments, List<AllergyReaction> reactions) {
 		this.patient = patient;
 		this.allergen = allergen;
 		this.severity = severity;
-		this.comment = comment;
+		this.comments = comments;
 		
 		//we do not allow to be in a state where reactions is null
 		if (reactions != null) {
@@ -160,14 +160,14 @@ public class Allergy extends BaseChangeableOpenmrsData {
 	 * @return Returns the comment
 	 */
 	public String getComment() {
-		return comment;
+		return comments;
 	}
 	
 	/**
 	 * @param comment the comment to set
 	 */
-	public void setComment(String comment) {
-		this.comment = comment;
+	public void setComment(String comments) {
+		this.comments = comments;
 	}
 	/**
 	 * @return Returns the reactions

--- a/api/src/main/resources/liquibase-update-to-2.0.xml
+++ b/api/src/main/resources/liquibase-update-to-2.0.xml
@@ -8774,7 +8774,7 @@
             </column>
             <column name="allergen_type" type="varchar(50)">
             <constraints nullable="false"/></column>
-            <column name="comment" type="varchar(1024)"></column>
+            <column name="comments" type="varchar(1024)"></column>
             <column name="creator" type="int">
                 <constraints nullable="false"/>
             </column>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Allergy.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Allergy.hbm.xml
@@ -33,7 +33,7 @@
             <property name="nonCodedAllergen" type="java.lang.String" column="non_coded_allergen" length="255"/>
         </component>
         <many-to-one name="severity" column="severity_concept_id" class="org.openmrs.Concept"/>
-        <property name="comment" column="comment" type="java.lang.String" length="1024"/>
+        <property name="comment" column="comments" type="java.lang.String" length="1024"/>
         <bag name="reactions" inverse="true" cascade="all-delete-orphan,evict" lazy="false">
             <key>
                 <column name="allergy_id" not-null="true"/>


### PR DESCRIPTION
Acceptance Criteria
x The "allergy.comment" column is renamed to "allergy.comments"
x Any existing data should be upgraded, invisibly to the end user
x The Allergy UI module should continue to work both before and after this change.
x The REST resource for allergies should continue to work both before and after this change, and the REST representation of allergy should remain unchanged

Ticket: https://issues.openmrs.org/browse/TRUNK-5334