### PR TITLE
TRUNK-5377 Remove redundant logging on failed module start

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -106,7 +106,7 @@ public class ModuleFactory {
 	 * @return Module
 	 */
 	public static Module loadModule(File moduleFile, Boolean replaceIfExists) throws ModuleException {
-		Module module = getModuleFromFile(moduleFile);
+		Module module = new ModuleFileParser(moduleFile).parse();
 		
 		if (module != null) {
 			loadModule(module, replaceIfExists);
@@ -520,33 +520,6 @@ public class ModuleFactory {
 		}
 		
 		return startedModules;
-	}
-	
-	/**
-	 * Creates a Module object from the (jar)file pointed to by <code>moduleFile</code> returns null
-	 * if an error occurred during processing
-	 * 
-	 * @param moduleFile
-	 * @return module Module
-	 */
-	private static Module getModuleFromFile(File moduleFile) throws ModuleException {
-		
-		Module module;
-		try {
-			module = new ModuleFileParser(moduleFile).parse();
-		}
-		catch (ModuleException e) {
-			// TODO we should add a guard clause at the beginning and not even call parse() when the
-			// file is null
-			if (moduleFile != null) {
-				log.error("Error getting module object from file " + moduleFile.getName(), e);
-			} else {
-				log.error("Module was null.", e);
-			}
-			throw e;
-		}
-		
-		return module;
 	}
 	
 	/**


### PR DESCRIPTION
inline private method ModuleFactory.getModuleFromFile
since it does not add any value. (It is private and only used once.)

It simply catches ModuleExceptions, adds logging that
replicates whats inside the Exception and rethrows the ModuleException.
The same information will be visible in the log of the ModuleException
which causes the exception to be logged twice.

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5377

