### PR TITLE
TRUNK-5093 - AbstractHandler allows blind rewriting of existing compl…

### DIFF
--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -12,10 +12,9 @@ package org.openmrs.obs.handler;
 import java.io.File;
 import java.io.IOException;
 import java.text.NumberFormat;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Date;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
@@ -37,8 +36,6 @@ public class AbstractHandler {
 	
 	protected NumberFormat nf;
 	
-	protected SimpleDateFormat longfmt;
-	
 	/**
 	 * Constructor initializes formats for alternative file names to protect from unintentionally
 	 * overwriting existing files.
@@ -47,7 +44,6 @@ public class AbstractHandler {
 		nf = NumberFormat.getInstance();
 		nf.setMaximumFractionDigits(0);
 		nf.setMinimumIntegerDigits(2);
-		longfmt = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 	}
 	
 	/**
@@ -59,65 +55,51 @@ public class AbstractHandler {
 	 * @return File that the complex data should be written to
 	 */
 	public File getOutputFileToWrite(Obs obs) throws IOException {
-		// Get the title and remove the extension.
 		String title = obs.getComplexData().getTitle();
-		String extension = "." + getExtension(title);
+		String titleWithoutExtension = FilenameUtils.removeExtension(title);
+		String extension = "." + StringUtils.defaultIfEmpty(FilenameUtils.getExtension(title), "dat");
+		String uuid = obs.getUuid();
+		String filename;
 		
-		// If getExtension returns the title, there was no extension
-		if (getExtension(title).equals(title)) {
-			extension = "";
-		}
-		
-		File dir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(Context.getAdministrationService().getGlobalProperty(
-		    OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
-		File outputfile;
-		
-		// Get the output stream
-		if (null == title) {
-			String now = longfmt.format(new Date());
-			outputfile = new File(dir, now);
+		if (StringUtils.isNotBlank(titleWithoutExtension)) {
+			filename = titleWithoutExtension + "_" + uuid + extension;
 		} else {
-			title = title.replace(extension, "");
-			
-			outputfile = new File(dir, title + extension);
+			filename = uuid + extension;
 		}
 		
-		int i = 0;
-		String tmp;
-		
-		// If the Obs does not exist, but the File does, append a two-digit
-		// count number to the filename and save it.
-		while (obs.getObsId() == null && outputfile.exists() && i < 100) {
-			// Remove the extension from the filename.
-			tmp = String.valueOf(outputfile.getAbsolutePath().replace(extension, ""));
-			// Append two-digit count number to the filename.
-			String filename = (i < 1) ? tmp + "_" + nf.format(Integer.valueOf(++i)) : tmp.replace(nf.format(Integer
-			        .valueOf(i)), nf.format(Integer.valueOf(++i)));
-			// Append the extension to the filename
-			outputfile = new File(filename + extension);
-		}
+		File dir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(
+		    Context.getAdministrationService().getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
+		File outputfile = new File(dir, filename);
 		
 		return outputfile;
-		
 	}
 	
 	/**
-	 * Get the extension for a given filename. <br>
-	 * If given "asdf.jpg", will return "jpg". <br>
-	 * If given "asdf", will return "asdf". <br>
+	 * Get the extension for a given filename if it exists, else return the filename. If there is no
+	 * filename in the input string, "raw" is returned. 
+	 * 
+	 * If given "asdf.jpg", will return "jpg".
+	 * If given "asdf", will return "asdf". 
+	 * If given "" or "a/b/c/" will return "raw".
 	 * 
 	 * @param filename
-	 * @return the filepart after the period in the given filename
+	 * @return the part after the period in the given filename, the filename, or "raw"
+	 * @deprecated since 2.1.3 use {@link org.apache.commons.io.FilenameUtils#getExtension(String)}
+	 *             instead.
 	 */
+	@Deprecated
 	public String getExtension(String filename) {
-		String[] filenameParts = filename.split("\\.");
+		String result = FilenameUtils.getExtension(filename);
 		
-		log.debug("titles length: " + filenameParts.length);
+		if (StringUtils.isEmpty(result)) {
+			result = FilenameUtils.getBaseName(filename);
+			
+			if (StringUtils.isEmpty(result)) {
+				result = "raw";
+			}
+		}
 		
-		String extension = (filenameParts.length < 2) ? filenameParts[0] : filenameParts[filenameParts.length - 1];
-		extension = StringUtils.isNotEmpty(extension) ? extension : "raw";
-		
-		return extension;
+		return result;
 	}
 	
 	/**
@@ -153,8 +135,8 @@ public class AbstractHandler {
 			return true;
 		}
 		
-		log.warn("Could not delete complex data object for obsId=" + obs.getObsId() + " located at "
-		        + file.getAbsolutePath());
+		log.warn(
+		    "Could not delete complex data object for obsId=" + obs.getObsId() + " located at " + file.getAbsolutePath());
 		return false;
 	}
 	
@@ -167,8 +149,8 @@ public class AbstractHandler {
 	public static File getComplexDataFile(Obs obs) {
 		String[] names = obs.getValueComplex().split("\\|");
 		String filename = names.length < 2 ? names[0] : names[names.length - 1];
-		File dir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(Context.getAdministrationService().getGlobalProperty(
-		    OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
+		File dir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(
+		    Context.getAdministrationService().getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
 		return new File(dir, filename);
 	}
 	

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -642,14 +642,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		ObsService os = Context.getObsService();
 		ConceptService cs = Context.getConceptService();
 		AdministrationService as = Context.getAdministrationService();
-		
-		// make sure the file isn't there to begin with
-		File complexObsDir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(as
-		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
-		File createdFile = new File(complexObsDir, "nameOfFile.txt");
-		if (createdFile.exists())
-			createdFile.delete();
-		
+				
 		// the complex data to put onto an obs that will be saved
 		Reader input = new CharArrayReader("This is a string to save to a file".toCharArray());
 		ComplexData complexData = new ComplexData("nameOfFile.txt", input);
@@ -660,6 +653,15 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 		
 		Obs obsToSave = new Obs(new Person(1), questionConcept, new Date(), new Location(1));
 		obsToSave.setComplexData(complexData);
+		
+		// make sure the file isn't there to begin with
+		String filename = "nameOfFile_" + obsToSave.getUuid() + ".txt";
+		File complexObsDir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(as
+	        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));
+		File createdFile = new File(complexObsDir, filename);
+		if (createdFile.exists()) {
+			createdFile.delete();
+		}
 		
 		try {
 			os.saveObs(obsToSave, null);

--- a/api/src/test/java/org/openmrs/obs/AbstractHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/AbstractHandlerTest.java
@@ -1,0 +1,166 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.obs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Matchers.any;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.Obs;
+import org.openmrs.api.APIException;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.obs.handler.AbstractHandler;
+import org.openmrs.util.OpenmrsUtil;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ AbstractHandler.class, OpenmrsUtil.class, Context.class })
+
+public class AbstractHandlerTest {
+	
+	private final String FILENAME = "mytxtfile.txt";
+	
+	private final AbstractHandler handler = new AbstractHandler();
+	
+	@Mock
+	private AdministrationService administrationService;
+	
+	@Rule
+	public TemporaryFolder complexObsTestFolder = new TemporaryFolder();
+	
+	@Before
+	public void initializeContext() throws APIException, IOException {
+		mockStatic(Context.class);
+		when(Context.getAdministrationService()).thenReturn(administrationService);
+		when(administrationService.getGlobalProperty(any())).thenReturn(complexObsTestFolder.newFolder().getAbsolutePath());
+	}
+	
+	@Test
+	public void getOutputFileToWrite_shouldNeverOverwritePreviousFiles() throws IOException {
+		String content1 = "A";
+		String content2 = "B";
+		
+		File previousFile = null;
+		File currentFile = null;
+		
+		for (int i = 0; i <= 101; i++) {
+			String currentData = (i % 2 == 0) ? content1 : content2;
+			
+			ComplexData complexData = new ComplexData(FILENAME, currentData);
+			
+			Obs obs = new Obs();
+			obs.setComplexData(complexData);
+			
+			currentFile = handler.getOutputFileToWrite(obs);
+			
+			try (BufferedWriter fout = new BufferedWriter(
+			        new OutputStreamWriter(new FileOutputStream(currentFile), StandardCharsets.UTF_8))) {
+				fout.write(currentData);
+			}
+			
+			try (BufferedReader fin = new BufferedReader(
+			        new InputStreamReader(new FileInputStream(currentFile), StandardCharsets.UTF_8))) {
+				String readData = fin.readLine();
+				assertEquals(readData, currentData);
+			}
+			
+			if (i > 0) {
+				assertFalse(FileUtils.contentEquals(previousFile, currentFile));
+			}
+			
+			previousFile = currentFile;
+		}
+	}
+	
+	@Test
+	public void getOutputFileToWrite_shouldCorrectlyNameTitledFileWithExtension() throws IOException, ParseException {
+		ComplexData complexDataWithTitle = new ComplexData(FILENAME, null);
+		
+		Obs obsWithTitle = new Obs();
+		obsWithTitle.setComplexData(complexDataWithTitle);
+		
+		File titledFile = handler.getOutputFileToWrite(obsWithTitle);
+		titledFile.createNewFile();
+		
+		String[] nameWithTitle = titledFile.getName().split("_|\\.");
+		
+		String titlePart = nameWithTitle[0];
+		String uuidPartWithTitle = nameWithTitle[1];
+		String extensionPart = nameWithTitle[2];
+		
+		assertEquals(titlePart, FilenameUtils.removeExtension(FILENAME));
+		assertEquals(extensionPart, "txt");
+		assertEquals(uuidPartWithTitle, obsWithTitle.getUuid());
+	}
+	
+	@Test
+	public void getOutputFileToWrite_shouldCorrectlyNameTitledFileWithoutExtension() throws IOException, ParseException {
+		ComplexData complexDataWithoutExtension = new ComplexData(FilenameUtils.removeExtension(FILENAME), null);
+		
+		Obs obsWithoutExtension = new Obs();
+		obsWithoutExtension.setComplexData(complexDataWithoutExtension);
+		
+		File extensionlessFile = handler.getOutputFileToWrite(obsWithoutExtension);
+		extensionlessFile.createNewFile();
+		
+		String[] nameWithoutExtension = extensionlessFile.getName().split("_|\\.");
+		
+		String titlePartExtensionless = nameWithoutExtension[0];
+		String uuidPartExtensionless = nameWithoutExtension[1];
+		String extensionPartExtensionless = nameWithoutExtension[2];
+		
+		assertEquals(titlePartExtensionless, FilenameUtils.removeExtension(FILENAME));
+		assertEquals(extensionPartExtensionless, "dat");
+		assertEquals(uuidPartExtensionless, obsWithoutExtension.getUuid());
+	}
+	
+	@Test
+	public void getOutputFileToWrite_shouldCorrectlyNameNullTitledFile() throws IOException, ParseException {
+		ComplexData complexDataWithNullTitle = new ComplexData(null, null);
+		
+		Obs obsWithNullTitle = new Obs();
+		obsWithNullTitle.setComplexData(complexDataWithNullTitle);
+		
+		File nullTitleFile = handler.getOutputFileToWrite(obsWithNullTitle);
+		nullTitleFile.createNewFile();
+		
+		String[] nameWithNullTitle = nullTitleFile.getName().split("\\.");
+		
+		String uuidPartWithNullTitle = nameWithNullTitle[0];
+		String extensionPartWithNullTitle = nameWithNullTitle[1];
+		
+		assertEquals(extensionPartWithNullTitle, "dat");
+		assertEquals(uuidPartWithNullTitle, obsWithNullTitle.getUuid());
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.obs;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -17,10 +18,11 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
+import java.io.IOException;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.Obs;
@@ -37,17 +39,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 public class BinaryStreamHandlerTest {
 	
-	private final String FILENAME = "TestingComplexObsSaving";
-
-	private final String TESTBYTES = "Teststring";
-	
-	private byte[] CONTENT = TESTBYTES.getBytes();
-	
-	private String filepath;
-	
 	@Mock
 	private AdministrationService administrationService;
 	
+    @Rule
+    public TemporaryFolder complexObsTestFolder = new TemporaryFolder();
+    
     @Test
     public void shouldReturnSupportedViews() {
         BinaryStreamHandler handler = new BinaryStreamHandler();
@@ -76,20 +73,16 @@ public class BinaryStreamHandlerTest {
         assertFalse(handler.supportsView(""));
         assertFalse(handler.supportsView((String) null));
     }
-
-	/** This method sets up the test data's filepath for the mime type tests  **/
-	@Before
-	public void initFilepathForMimetypeTests() {
-		filepath = new File("target" + File.separator + "test-classes").getAbsolutePath();
-	}
-	
+    	
 	@Test
-	public void shouldRetrieveCorrectMimetype() {
-		final String mimetype = "application/octet-stream";
+	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
+		String mimetype = "application/octet-stream";
+		String filename = "TestingComplexObsSaving";
+		byte[] content = "Teststring".getBytes();
 		
-		ByteArrayInputStream byteIn = new ByteArrayInputStream(CONTENT);
+		ByteArrayInputStream byteIn = new ByteArrayInputStream(content);
 		
-		ComplexData complexData = new ComplexData(FILENAME, byteIn);
+		ComplexData complexData = new ComplexData(filename, byteIn);
 		
 		// Construct 2 Obs to also cover the case where the filename exists already
 		Obs obs1 = new Obs();
@@ -101,7 +94,7 @@ public class BinaryStreamHandlerTest {
 		// Mocked methods
 		mockStatic(Context.class);
 		when(Context.getAdministrationService()).thenReturn(administrationService);
-		when(administrationService.getGlobalProperty(any())).thenReturn(filepath);
+		when(administrationService.getGlobalProperty(any())).thenReturn(complexObsTestFolder.newFolder().getAbsolutePath());
 		
 		BinaryStreamHandler handler = new BinaryStreamHandler();
 		
@@ -110,17 +103,11 @@ public class BinaryStreamHandlerTest {
 		handler.saveObs(obs2);
 		
 		// Get observation
-		Obs complexObs = handler.getObs(obs1, "RAW_VIEW");
+		Obs complexObs1 = handler.getObs(obs1, "RAW_VIEW");
 		Obs complexObs2 = handler.getObs(obs2, "RAW_VIEW");
 		
-		assertTrue(complexObs.getComplexData().getMimeType().equals(mimetype));
-		assertTrue(complexObs2.getComplexData().getMimeType().equals(mimetype));
-		
-		// Delete created files to avoid cluttering
-		File obsFile1 = BinaryStreamHandler.getComplexDataFile(obs1);
-		File obsFile2 = BinaryStreamHandler.getComplexDataFile(obs2);
-		obsFile1.delete();
-		obsFile2.delete();
+		assertEquals(complexObs1.getComplexData().getMimeType(), mimetype);
+		assertEquals(complexObs2.getComplexData().getMimeType(), mimetype);
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/ImageHandlerTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.obs;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -22,8 +23,9 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.Obs;
@@ -40,15 +42,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 public class ImageHandlerTest {
 	
-	private final String FILENAME = "TestingComplexObsSaving.png";
-	
-	private File sourceFile;
-	
-	private String filepath;
-	
 	@Mock
 	private AdministrationService administrationService;
-
+	
+    @Rule
+    public TemporaryFolder complexObsTestFolder = new TemporaryFolder();
+    
     @Test
     public void shouldReturnSupportedViews() {
         ImageHandler handler = new ImageHandler();
@@ -78,21 +77,16 @@ public class ImageHandlerTest {
         assertFalse(handler.supportsView((String) null));
     }
 	
-	/** This method sets up the test data's parameters for the mime type tests  **/
-	@Before
-	public void initVariablesForMimetypeTests() {
-		filepath = new File("target" + File.separator + "test-classes").getAbsolutePath();
-		sourceFile = new File(
-		        "src" + File.separator + "test" + File.separator + "resources" + File.separator + "ComplexObsTestImage.png");
-	}
-	
 	@Test
-	public void shouldRetrieveCorrectMimetype() throws IOException {
-		final String mimetype = "image/png";
+	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
+		String mimetype = "image/png";
+		String filename = "TestingComplexObsSaving.png";
+		File sourceFile = new File(
+	        "src" + File.separator + "test" + File.separator + "resources" + File.separator + "ComplexObsTestImage.png");
 		
 		BufferedImage img = ImageIO.read(sourceFile);
 		
-		ComplexData complexData = new ComplexData(FILENAME, img);
+		ComplexData complexData = new ComplexData(filename, img);
 		
 		// Construct 2 Obs to also cover the case where the filename exists already
 		Obs obs1 = new Obs();
@@ -104,7 +98,7 @@ public class ImageHandlerTest {
 		// Mocked methods
 		mockStatic(Context.class);
 		when(Context.getAdministrationService()).thenReturn(administrationService);
-		when(administrationService.getGlobalProperty(any())).thenReturn(filepath);
+		when(administrationService.getGlobalProperty(any())).thenReturn(complexObsTestFolder.newFolder().getAbsolutePath());
 		
 		ImageHandler handler = new ImageHandler();
 		
@@ -113,17 +107,11 @@ public class ImageHandlerTest {
 		handler.saveObs(obs2);
 		
 		// Get observation
-		Obs complexObs = handler.getObs(obs1, "RAW_VIEW");
+		Obs complexObs1 = handler.getObs(obs1, "RAW_VIEW");
 		Obs complexObs2 = handler.getObs(obs2, "RAW_VIEW");
 		
-		assertTrue(complexObs.getComplexData().getMimeType().equals(mimetype));
-		assertTrue(complexObs2.getComplexData().getMimeType().equals(mimetype));
-		
-		// Delete created files to avoid cluttering
-		File obsFile1 = ImageHandler.getComplexDataFile(obs1);
-		File obsFile2 = ImageHandler.getComplexDataFile(obs2);
-		obsFile1.delete();
-		obsFile2.delete();
+		assertEquals(complexObs1.getComplexData().getMimeType(), mimetype);
+		assertEquals(complexObs2.getComplexData().getMimeType(), mimetype);
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.obs;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -18,10 +19,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.Obs;
@@ -37,15 +39,12 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({ AbstractHandler.class, OpenmrsUtil.class, Context.class })
 
 public class MediaHandlerTest {
-	
-	private String filename;
-	
-	private File sourceFile;
-	
-	private String filepath;
-	
+		
 	@Mock
 	private AdministrationService administrationService;
+	
+    @Rule
+    public TemporaryFolder complexObsTestFolder = new TemporaryFolder();
 
     @Test
     public void shouldReturnSupportedViews() {
@@ -75,19 +74,13 @@ public class MediaHandlerTest {
         assertFalse(handler.supportsView(""));
         assertFalse(handler.supportsView((String) null));
     }
-    
-	/** This method sets up the test data's parameters for the mime type tests  **/
-	@Before
-	public void initVariablesForMimetypeTests() {
-		filename = "TestingComplexObsSaving.mp3";
-		filepath = new File("target" + File.separator + "test-classes").getAbsolutePath();
-		sourceFile = new File(
-		        "src" + File.separator + "test" + File.separator + "resources" + File.separator + "ComplexObsTestAudio.mp3");
-	}
-    
+     
 	@Test
-	public void shouldRetrieveCorrectMimetype() throws FileNotFoundException {
-		final String mimetype = "audio/mpeg";
+	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
+		String mimetype = "audio/mpeg";
+		String filename = "TestingComplexObsSaving.mp3";
+		File sourceFile = new File(
+	        "src" + File.separator + "test" + File.separator + "resources" + File.separator + "ComplexObsTestAudio.mp3");
 		
 		FileInputStream in1 = new FileInputStream(sourceFile);
 		FileInputStream in2 = new FileInputStream(sourceFile);
@@ -105,7 +98,7 @@ public class MediaHandlerTest {
 		// Mocked methods
 		mockStatic(Context.class);
 		when(Context.getAdministrationService()).thenReturn(administrationService);
-		when(administrationService.getGlobalProperty(any())).thenReturn(filepath);
+		when(administrationService.getGlobalProperty(any())).thenReturn(complexObsTestFolder.newFolder().getAbsolutePath());
 		
 		MediaHandler handler = new MediaHandler();
 		
@@ -114,17 +107,11 @@ public class MediaHandlerTest {
 		handler.saveObs(obs2);
 		
 		// Get observation
-		Obs complexObs = handler.getObs(obs1, "RAW_VIEW");
+		Obs complexObs1 = handler.getObs(obs1, "RAW_VIEW");
 		Obs complexObs2 = handler.getObs(obs2, "RAW_VIEW");
 		
-		assertTrue(complexObs.getComplexData().getMimeType().equals(mimetype));
-		assertTrue(complexObs2.getComplexData().getMimeType().equals(mimetype));
-		
-		// Delete created files to avoid cluttering
-		File obsFile1 = MediaHandler.getComplexDataFile(obs1);
-		File obsFile2 = MediaHandler.getComplexDataFile(obs2);
-		obsFile1.delete();
-		obsFile2.delete();
+		assertEquals(complexObs1.getComplexData().getMimeType(), mimetype);
+		assertEquals(complexObs2.getComplexData().getMimeType(), mimetype);
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/TextHandlerTest.java
@@ -10,16 +10,18 @@
 package org.openmrs.obs;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-import java.io.File;
+import java.io.IOException;
 
-import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.Obs;
@@ -36,14 +38,11 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 public class TextHandlerTest {
 	
-	private final String FILENAME = "TestingComplexObsSaving.txt";
-	
-	private String filepath;
-		
-	private String content;
-	
 	@Mock
 	private AdministrationService administrationService;
+	
+    @Rule
+    public TemporaryFolder complexObsTestFolder = new TemporaryFolder();
 
     @Test
     public void shouldReturnSupportedViews() {
@@ -74,18 +73,13 @@ public class TextHandlerTest {
         assertFalse(handler.supportsView((String) null));
     }
     
-	/** This method sets up the test data's parameters for the mime type tests  **/
-	@Before
-	public void initVariablesForMimetypeTests() {
-		filepath = new File("target" + File.separator + "test-classes").getAbsolutePath();
-		content = "Teststring";
-	}
-	
 	@Test
-	public void shouldRetrieveCorrectMimetype() {
+	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
 		final String mimetype = "text/plain";
+		String filename = "TestingComplexObsSaving.txt";
+		String content = "Teststring";
 		
-		ComplexData complexData = new ComplexData(FILENAME, content);
+		ComplexData complexData = new ComplexData(filename, content);
 		
 		// Construct 2 Obs to also cover the case where the filename exists already
 		Obs obs1 = new Obs();
@@ -97,7 +91,7 @@ public class TextHandlerTest {
 		// Mocked methods
 		mockStatic(Context.class);
 		when(Context.getAdministrationService()).thenReturn(administrationService);
-		when(administrationService.getGlobalProperty(any())).thenReturn(filepath);
+		when(administrationService.getGlobalProperty(any())).thenReturn(complexObsTestFolder.newFolder().getAbsolutePath());
 		
 		TextHandler handler = new TextHandler();
 		
@@ -106,17 +100,11 @@ public class TextHandlerTest {
 		handler.saveObs(obs2);
 		
 		// Get observation
-		Obs complexObs = handler.getObs(obs1, "RAW_VIEW");
+		Obs complexObs1 = handler.getObs(obs1, "RAW_VIEW");
 		Obs complexObs2 = handler.getObs(obs2, "RAW_VIEW");
 
-		assertTrue(complexObs.getComplexData().getMimeType().equals(mimetype));
-		assertTrue(complexObs2.getComplexData().getMimeType().equals(mimetype));
-		
-		// Delete created files to avoid cluttering with new versions of the file! 
-		File obsFile1 = TextHandler.getComplexDataFile(obs1);
-		File obsFile2 = TextHandler.getComplexDataFile(obs2);
-		obsFile1.delete();
-		obsFile2.delete();
+		assertEquals(complexObs1.getComplexData().getMimeType(), mimetype);
+		assertEquals(complexObs2.getComplexData().getMimeType(), mimetype);
 	}
 
 }


### PR DESCRIPTION
JIRA: TRUNK-5093 - AbstractHandler allows blind rewriting of existing complex obs file
Link: https://issues.openmrs.org/browse/TRUNK-5093

I modified the AbstractHandler to concatenate the UUID to each complex obs filename, so that no collisions happen and no files get lost. I also added a JUnit test file AbstractHandlerTest to check that the previous error of overwritten/lost files does not occur and the files are named properly and modified an existing test in ObsServiceTest to work with the new naming scheme.

Not directly related to this ticket: As I previously worked on the Complex Obs Handlers tests for my last ticket, I went back to them and improved some things. The main point is a more reliable file clean-up through the use of temporary folders. I also got rid of unnecessary set-up methods for variables and reduced the scope of some variables, which I previously used more often globally but forgot to declare only locally after changes in the code.