### PR TITLE
TRUNK-5333 Rename concept_numeric DB field "precise" to "allow_decimal"

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -161,7 +161,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 				//We need to add a delete line for each concept sub class that is not concept_numeric
 				deleteSubclassConcept("concept_complex", concept.getConceptId());
 				
-				String insert = "INSERT INTO concept_numeric (concept_id, precise) VALUES (:conceptId, false)";
+				String insert = "INSERT INTO concept_numeric (concept_id, allow_decimal) VALUES (:conceptId, false)";
 				query = sessionFactory.getCurrentSession().createSQLQuery(insert);
 				query.setInteger("conceptId", concept.getConceptId());
 				query.executeUpdate();

--- a/api/src/main/resources/liquibase-update-to-2.2.xml
+++ b/api/src/main/resources/liquibase-update-to-2.2.xml
@@ -245,4 +245,13 @@
 								 baseTableName="encounter_diagnosis" baseColumnNames="patient_id"
 								 referencedTableName="patient" referencedColumnNames="patient_id" />
 	</changeSet>
+
+	<changeSet id="20180405131015-TRUNK-5333" author="alicerowan">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="concept_numeric" columnName="precise"/>
+		</preConditions>
+		<comment>Rename concept_numeric.precise to concept_numeric.allow_decimal</comment>
+		<renameColumn oldColumnName="precise" newColumnName="allow_decimal" tableName="concept_numeric"  columnDataType="BOOLEAN"/>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
@@ -122,7 +122,7 @@
 			<property name="lowCritical" type="java.lang.Double" column="low_critical" length="22" />
 			<property name="lowNormal" type="java.lang.Double" column="low_normal" length="22" />
 			<property name="units" type="java.lang.String" column="units" length="50" />
-			<property name="allowDecimal" type="java.lang.Boolean" column="precise" length="1" not-null="true"/>
+			<property name="allowDecimal" type="java.lang.Boolean" column="allow_decimal" length="1" not-null="true"/>
 			<property name="displayPrecision" type="java.lang.Integer" column="display_precision" not-null="false"/>
 		</joined-subclass>
 	

--- a/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-initialConcepts.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-initialConcepts.xml
@@ -20,5 +20,5 @@
   <concept_name concept_id="1" name="Some non numeric concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="1" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" voided="false" uuid="8edfd54f-b189-43dd-86e0-913591978e48"/>
   <concept_name concept_id="2" name="Some numeric concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="2" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" voided="false" uuid="d8402dab-1e32-4f17-9654-a889a4eb9a89"/>
   <concept_name concept_id="2" name="Numeric name with en_GB locale" locale="en_GB" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="3" locale_preferred="0" voided="false" uuid="bbbb2dab-1e32-4f17-a654-0000a4eb9a8e"/>
-  <concept_numeric concept_id="2" hi_absolute="123.0" precise="false"/>
+  <concept_numeric concept_id="2" hi_absolute="123.0" allow_decimal="false"/>
 </dataset>

--- a/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-numerics.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-numerics.xml
@@ -121,22 +121,22 @@
   <concept_name concept_name_id="1461" concept_id="3060" name="PGRANULOCYTE" locale="en" creator="1128" date_created="2008-04-23 21:00:43.0" uuid="5aa31cb2-b429-4b3d-8bdf-3d496ec1411d" voided="false" concept_name_type="" locale_preferred="0"/>
   <concept_name concept_name_id="232" concept_id="5089" name="WEIGHT" locale="en" creator="2" date_created="2004-12-02 00:00:00.0" uuid="1fc2fc80-26fe-102b-80cb-0017a47871b2" voided="false" concept_name_type="" locale_preferred="0"/> 
   <concept_name concept_name_id="233" concept_id="5497" name="CD4" locale="en" creator="2" date_created="2004-12-02 00:00:00.0" uuid="3fc5fc80-26fe-102b-80cb-0017a47871b2" voided="false" concept_name_type="" locale_preferred="0"/> 
-  <concept_numeric concept_id="21" units="" precise="true"/>
-  <concept_numeric concept_id="678" units="mm3" precise="true"/>
-  <concept_numeric concept_id="679" units="" precise="false"/>
-  <concept_numeric concept_id="729" units="k/mm3" precise="false"/>
-  <concept_numeric concept_id="730" units="%" precise="false"/>
-  <concept_numeric concept_id="851" units="fL" precise="false"/>
-  <concept_numeric concept_id="1015" units="" precise="true"/>
-  <concept_numeric concept_id="1016" units="%" precise="false"/>
-  <concept_numeric concept_id="1017" units="%" precise="false"/>
-  <concept_numeric concept_id="1018" units="pg" precise="false"/>
-  <concept_numeric concept_id="1019" units="" precise="false"/>
-  <concept_numeric concept_id="1021" units="%" precise="false"/>
-  <concept_numeric concept_id="3059" units="" precise="false"/>
-  <concept_numeric concept_id="3060" units="" precise="false"/>
-  <concept_numeric concept_id="5089" units="kg" precise="false"/>
-  <concept_numeric concept_id="5497" units="cells/mm3" precise="false"/>
+  <concept_numeric concept_id="21" units="" allow_decimal="true"/>
+  <concept_numeric concept_id="678" units="mm3" allow_decimal="true"/>
+  <concept_numeric concept_id="679" units="" allow_decimal="false"/>
+  <concept_numeric concept_id="729" units="k/mm3" allow_decimal="false"/>
+  <concept_numeric concept_id="730" units="%" allow_decimal="false"/>
+  <concept_numeric concept_id="851" units="fL" allow_decimal="false"/>
+  <concept_numeric concept_id="1015" units="" allow_decimal="true"/>
+  <concept_numeric concept_id="1016" units="%" allow_decimal="false"/>
+  <concept_numeric concept_id="1017" units="%" allow_decimal="false"/>
+  <concept_numeric concept_id="1018" units="pg" allow_decimal="false"/>
+  <concept_numeric concept_id="1019" units="" allow_decimal="false"/>
+  <concept_numeric concept_id="1021" units="%" allow_decimal="false"/>
+  <concept_numeric concept_id="3059" units="" allow_decimal="false"/>
+  <concept_numeric concept_id="3060" units="" allow_decimal="false"/>
+  <concept_numeric concept_id="5089" units="kg" allow_decimal="false"/>
+  <concept_numeric concept_id="5497" units="cells/mm3" allow_decimal="false"/>
   <concept_set concept_set_id="2" concept_id="21" concept_set="1019" sort_weight="1.0" creator="2" date_created="2005-12-15 13:26:49.0" uuid="3f27c330-26fe-102b-80cb-0017a47871b2"/>
   <concept_set concept_set_id="65" concept_id="678" concept_set="1019" sort_weight="8.0" creator="2" date_created="2005-12-15 13:26:49.0" uuid="3f2855ca-26fe-102b-80cb-0017a47871b2"/>
   <concept_set concept_set_id="67" concept_id="679" concept_set="1019" sort_weight="6.0" creator="2" date_created="2005-12-15 13:26:49.0" uuid="3f2857b4-26fe-102b-80cb-0017a47871b2"/>

--- a/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-initial.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ObsServiceTest-initial.xml
@@ -15,7 +15,7 @@
   <orders order_id="42" order_type_id="2" order_number="42" urgency="ROUTINE" order_action="NEW" concept_id="5497" patient_id="7" orderer="1" date_activated="2012-08-19 00:00:00.0" creator="1" date_created="2012-01-19 12:24:10.0" voided="true" uuid="1c96f25c-4949-4f72-9931-d808fbcdb615" care_setting="1" encounter_id="3" />
 
   <concept concept_id="1" retired="false" datatype_id="1" class_id="1" is_set="false" creator="1" date_created="2005-01-01 00:00:00.0" uuid="4a5048b1-cf85-4c64-9339-7cab41e5e364"/>
-  <concept_numeric concept_id="1" hi_absolute="50.0" low_absolute="2.0" precise="false"/>
+  <concept_numeric concept_id="1" hi_absolute="50.0" low_absolute="2.0" allow_decimal="false"/>
   <concept_description concept_description_id="1" concept_id="1" description="this is a description" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" uuid="8b46218d-8dcf-4f45-91b5-837d11486a53"/>
   <concept_name concept_id="1" name="Some concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="1" voided="false" uuid="8add472b-156b-468f-ad62-d9333fb86976" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
   <obs obs_id="1" person_id="2" concept_id="1" status="FINAL" obs_datetime="2006-02-09 00:00:00.0" location_id="1" value_numeric="1.0" creator="1" date_created="2006-02-10 15:57:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="AN1"/>

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-mergePatientWithExistingObsHavingGroupMember.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-mergePatientWithExistingObsHavingGroupMember.xml
@@ -73,11 +73,11 @@
 
 	<concept concept_id="603" retired="false" datatype_id="1" class_id="11" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="juydg80f-1yz9-4da3-bb88-8122ctpulse"/>
 	<concept_name concept_id="603" concept_name_id="6013" name="Pulse" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="juydg80f-1yz9-4da3-bb88-8122ctuiopl"/>
-	<concept_numeric concept_id="603" precise="0"/>
+	<concept_numeric concept_id="603" allow_decimal="0"/>
 
 	<concept concept_id="605" retired="false" datatype_id="1" class_id="11" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" version="" changed_by="1" date_changed="2005-02-25 11:43:43.0" uuid="juydg80f-1yz9-4da3-bb88-8122ctdiast"/>
 	<concept_name concept_id="605" concept_name_id="6015" name="Diastolic" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="juydg80f-1yz9-4da3-bb88-812rrtdiast"/>
-	<concept_numeric concept_id="605" precise="0"/>
+	<concept_numeric concept_id="605" allow_decimal="0"/>
 
 
 	<obs obs_id="111" status="FINAL" encounter_id="57" person_id="11" location_id="2" obs_datetime="2008-08-18 15:09:05.0" date_created="2008-08-18 15:09:05.0"

--- a/api/src/test/resources/org/openmrs/hl7/include/ORUTest-initialData.xml
+++ b/api/src/test/resources/org/openmrs/hl7/include/ORUTest-initialData.xml
@@ -48,7 +48,7 @@
   <concept_name concept_id="1726" name="FOLLOW-UP ACTION" locale="en" creator="1" date_created="2007-06-05 17:38:53.0" concept_name_id="11" voided="false" uuid="5c065fba-ffaa-4bb2-bcf5-e591bac97b7f" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
   <concept_name concept_id="1" name="" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="12" voided="false" uuid="a96dd0bd-7301-4789-a620-f7afa2fd3870" concept_name_type="FULLY_SPECIFIED" locale_preferred="0"/>
   <concept_name concept_id="5497" name="CD4 COUNT" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="13" voided="false" uuid="4debc2c4-cfcd-4bcc-b8fc-9a7f16b8eca5" concept_name_type="SHORT" locale_preferred="0"/>
-  <concept_numeric concept_id="1553" precise="false" />
+  <concept_numeric concept_id="1553" allow_decimal="false" />
   <concept_set concept_set_id="1" concept_id="1553" concept_set="1726" sort_weight="1.0" creator="1" date_created="2007-06-05 17:38:53.0" uuid="c574a329-8ac7-46bc-bb3e-45361ae48742"/>
   <concept_set concept_set_id="2" concept_id="1554" concept_set="1726" sort_weight="2.0" creator="1" date_created="2007-06-05 17:38:53.0" uuid="2282b361-8e39-41f6-a215-da6716b97bfe"/>
   <concept_set concept_set_id="3" concept_id="1558" concept_set="1726" sort_weight="0.0" creator="1" date_created="2007-06-05 17:38:53.0" uuid="7e540387-7e2e-421b-8695-5aa642889bd4"/>

--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -221,8 +221,8 @@
   <concept_name_tag concept_name_tag_id="13" tag="preferred_US" description="preferred name in the United States" creator="1" date_created="2007-06-20 00:00:00.0" voided="false" uuid="74a4b34d-b717-4bfa-ab84-07b9db2901be"/>
   <concept_name_tag concept_name_tag_id="14" tag="preferred_ZM" description="preferred name in Zambia" creator="1" date_created="2007-06-20 00:00:00.0" voided="false" uuid="e0575570-064c-4dc2-828f-30c370645139"/>
   <concept_name_tag concept_name_tag_id="15" tag="preferred_ZW" description="preferred name in Zimbabwe" creator="1" date_created="2007-06-20 00:00:00.0" voided="false" uuid="7bfa1526-8936-4ff2-b048-7d627ba26eee"/>
-  <concept_numeric concept_id="5497" hi_normal="1497.0" low_critical="99.0" low_normal="445.0" hi_critical="1800.0" hi_absolute="2500.0" low_absolute="0.0" units="cells/mmL" precise="false"/>
-  <concept_numeric concept_id="5089" hi_normal="250.0" low_critical="0.0" units="kg" precise="true" display_precision="10" />
+  <concept_numeric concept_id="5497" hi_normal="1497.0" low_critical="99.0" low_normal="445.0" hi_critical="1800.0" hi_absolute="2500.0" low_absolute="0.0" units="cells/mmL" allow_decimal="false"/>
+  <concept_numeric concept_id="5089" hi_normal="250.0" low_critical="0.0" units="kg" allow_decimal="true" display_precision="10" />
   <concept_set concept_set_id="1" concept_id="18" concept_set="23" sort_weight="0.0" creator="1" date_created="2008-08-18 12:38:58.0" uuid="1a111827-639f-4cb4-961f-1e025bf88d90"/>
   <concept_set concept_set_id="2" concept_id="19" concept_set="23" sort_weight="2.0" creator="1" date_created="2008-08-18 12:38:58.0" uuid="df26fc1a-6fc0-4867-8982-9e5dfe3f8265"/>
   <concept_set concept_set_id="3" concept_id="20" concept_set="23" sort_weight="1.0" creator="1" date_created="2008-08-18 12:38:58.0" uuid="fdefaa94-3f99-464c-8b1f-3e1d1c61335c"/>


### PR DESCRIPTION
Changed the concept_numeric database field "precise" to "allow_decimal", updated the associated Hibernate mapping files, and updated all test data files that referenced the "precise" field to instead reference "allow_decimal".

see https://issues.openmrs.org/browse/TRUNK-5333

- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.
