### PR TITLE
TRUNK-5382 add extra utility method to exclude retired concepts

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -1556,6 +1556,25 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 		return Collections.unmodifiableList(conceptMembers);
 	}
+
+	/**
+	 * If <code>includeRetired</code> is true
+	 * {@link Concept}s
+	 *
+	 * @param includeRetired true/false whether to include the retired members
+	 * @return List&lt;Concept&gt; the Concepts that are members of this Concept's set
+	 * @should return set members and includes retired ones if includeRetired is set to true
+	 * @should not return retired members if includeRetired is false
+	 */
+	public List<Concept> getSetMembers(boolean includeRetired){
+		if (includeRetired) {
+			return getSetMembers();
+		} else {
+			return getSetMembers().stream()
+				.filter(a -> !a.getRetired())
+				.collect(Collectors.toList());
+		}
+	}
 	
 	/**
 	 * Appends the concept to the end of the existing list of concept members for this Concept

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -23,9 +23,11 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptNameType;
+import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
 
@@ -33,6 +35,15 @@ import org.openmrs.test.BaseContextSensitiveTest;
  * Behavior-driven tests of the Concept class.
  */
 public class ConceptTest extends BaseContextSensitiveTest {
+	protected static final String CONCEPT_XML_DATASET_PACKAGE_PATH = "org/openmrs/api/include/ConceptTest.xml";
+	
+	private ConceptService service;
+	
+	@Before
+	public void before() throws Exception {
+		service = Context.getConceptService();
+		executeDataSet(CONCEPT_XML_DATASET_PACKAGE_PATH);
+	}
 	
 	/**
 	 * When asked for a collection of compatible names, the returned collection should not include
@@ -571,6 +582,66 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		setMembers.add(new Concept());
 	}
 	
+	/**
+	 * @see Concept#getSetMembers()
+	 */
+	@Test
+	public void getSetMembers_shouldReturnTheSameAsgetSetMembersIfincludeRetiredIsTrue() throws Exception {
+		executeDataSet(CONCEPT_XML_DATASET_PACKAGE_PATH);
+		
+		Concept c = new Concept();
+		
+		Concept setMember1 = service.getConcept(867543);
+		c.addSetMember(setMember1);
+		
+		Concept setMember2 = service.getConcept(1234567);
+		c.addSetMember(setMember2);
+		
+		Concept setMember3 = service.getConcept(8675439);
+		c.addSetMember(setMember3);
+		
+		Concept setMember4 = service.getConcept(12345679);
+		c.addSetMember(setMember4);
+		
+		List<Concept> setMembers = c.getSetMembers(true);
+		
+		Assert.assertEquals(4, setMembers.size());
+		
+		Assert.assertFalse(setMembers.get(0).getRetired());
+		Assert.assertFalse(setMembers.get(1).getRetired());
+		Assert.assertTrue(setMembers.get(2).getRetired());
+		Assert.assertTrue(setMembers.get(3).getRetired());
+	}
+
+	/**
+	 * @see Concept#getSetMembers(boolean)
+	 */
+	@Test
+	public void getSetMembers_shouldNotReturnRetiredInSetMembersIfincludeRetiredIsFalse() throws Exception {
+		executeDataSet(CONCEPT_XML_DATASET_PACKAGE_PATH);
+		
+		Concept c = new Concept();
+		
+		Concept setMember1 = service.getConcept(867543);
+		c.addSetMember(setMember1);
+		
+		Concept setMember2 = service.getConcept(1234567);
+		c.addSetMember(setMember2);
+		
+		Concept setMember3 = service.getConcept(8675439);
+		c.addSetMember(setMember3);
+		
+		Concept setMember4 = service.getConcept(12345679);
+		c.addSetMember(setMember4);
+		
+		List<Concept> setMembers = c.getSetMembers(false);
+		
+		Assert.assertEquals(2, setMembers.size());
+		Assert.assertEquals(setMember1, setMembers.get(0));
+		Assert.assertEquals(setMember2, setMembers.get(1));
+		
+		setMembers.forEach(member -> Assert.assertEquals(true, !member.getRetired()));
+	}
 	/**
 	 * @see Concept#addSetMember(Concept)
 	 */

--- a/api/src/test/resources/org/openmrs/api/include/ConceptTest.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ConceptTest.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+	<concept concept_id="867543" retired="0" datatype_id="4" class_id="3" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e5"/>
+	<concept concept_id="1234567" retired="0" datatype_id="4" class_id="5" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e6"/>
+
+	<concept concept_id="8675439" retired="1" datatype_id="4" class_id="3" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e7"/>
+	<concept concept_id="12345679" retired="1" datatype_id="4" class_id="5" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e8"/>
+</dataset>
+


### PR DESCRIPTION
TRUNK-5382 Extra utility method for excluding retired concepts while fetching setmembers

## Description of what I changed
Created utility method called getSetMembers(boolean includeRetired). If includeRetired is true it returns the same as getSetMembers(), if false it should return excluding retired members.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5382

## Checklist: I completed these to help reviewers :)

- [x ] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x ] All new and existing **tests passed**.

- [ x] My pull request is **based on the latest changes** of the master branch.



