### PR TITLE
TRUNK-4929: PersonName.compareTo should be controlled by a global property

### DIFF
--- a/api/src/main/java/org/openmrs/PersonName.java
+++ b/api/src/main/java/org/openmrs/PersonName.java
@@ -473,10 +473,6 @@ public class PersonName extends BaseChangeableOpenmrsData implements java.io.Ser
 	}
 	
 	/**
-	 * TODO: the behaviour of this method needs to be controlled by some sort of global property
-	 * because an implementation can define how they want their names to look (which fields to
-	 * show/hide)
-	 * 
 	 * @see java.lang.Comparable#compareTo(java.lang.Object)
 	 * @should return negative if other name is voided
 	 * @should return negative if this name is preferred


### PR DESCRIPTION
TRUNK-4929 PersonName.compareTo should be controlled by a global property
## Description of what I changed
According to Darius Jazayeri, a new comparator class should be used instead of a global property control system, however, that class is already implemented with PersonByNameComparator. Therefore, it was determined that the TODO comment should be removed, and the ticked closed. I removed the comment so that the ticket can be closed.


## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4929

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

