### PR TITLE
TRUNK-5399 Add and fix config xml dtd files 1-0.1.5

### DIFF
--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.0.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.0.dtd
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(messages*),
+		(mappingFiles?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.0">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>

--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.1.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.1.dtd
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(messages*),
+		(mappingFiles?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.1">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>

--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.2.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.2.dtd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(filter*),
+		(filter-mapping*),
+		(messages*),
+		(mappingFiles?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.2">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT filter (filter-name, filter-class, init-param*)>
+	<!ELEMENT filter-name (#PCDATA)>
+	<!ELEMENT filter-class (#PCDATA)>
+	<!ELEMENT init-param (param-name, param-value)>
+	<!ELEMENT param-name (#PCDATA)>
+	<!ELEMENT param-value (#PCDATA)>
+
+	<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+	<!ELEMENT url-pattern (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>

--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.3.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.3.dtd
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(mandatory?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(filter*),
+		(filter-mapping*),
+		(messages*),
+		(mappingFiles?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.3">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT mandatory (#PCDATA)>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT filter (filter-name, filter-class, init-param*)>
+	<!ELEMENT filter-name (#PCDATA)>
+	<!ELEMENT filter-class (#PCDATA)>
+	<!ELEMENT init-param (param-name, param-value)>
+	<!ELEMENT param-name (#PCDATA)>
+	<!ELEMENT param-value (#PCDATA)>
+
+	<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+	<!ELEMENT url-pattern (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>

--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.4.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.4.dtd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(aware_of_modules?),
+		(mandatory?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(filter*),
+		(filter-mapping*),
+		(messages*),
+		(mappingFiles?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.4">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT aware_of_modules (aware_of_module+)>
+	<!ELEMENT aware_of_module (#PCDATA)>
+	<!ATTLIST aware_of_module version CDATA #IMPLIED>
+
+	<!ELEMENT mandatory (#PCDATA)>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT filter (filter-name, filter-class, init-param*)>
+	<!ELEMENT filter-name (#PCDATA)>
+	<!ELEMENT filter-class (#PCDATA)>
+	<!ELEMENT init-param (param-name, param-value)>
+	<!ELEMENT param-name (#PCDATA)>
+	<!ELEMENT param-value (#PCDATA)>
+
+	<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+	<!ELEMENT url-pattern (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>

--- a/api/src/main/resources/org/openmrs/module/dtd/config-1.5.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-1.5.dtd
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+	<!--
+	Top level configuration element.
+	-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(aware_of_modules?),
+		(mandatory?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(filter*),
+		(filter-mapping*),
+		(messages*),
+		(mappingFiles?)
+		(packagesWithMappedClasses?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "1.5">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT aware_of_modules (aware_of_module+)>
+	<!ELEMENT aware_of_module (#PCDATA)>
+	<!ATTLIST aware_of_module version CDATA #IMPLIED>
+
+	<!ELEMENT mandatory (#PCDATA)>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT filter (filter-name, filter-class, init-param*)>
+	<!ELEMENT filter-name (#PCDATA)>
+	<!ELEMENT filter-class (#PCDATA)>
+	<!ELEMENT init-param (param-name, param-value)>
+	<!ELEMENT param-name (#PCDATA)>
+	<!ELEMENT param-value (#PCDATA)>
+
+	<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+	<!ELEMENT url-pattern (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>
+	<!ELEMENT packagesWithMappedClasses (#PCDATA)>


### PR DESCRIPTION
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

* add the DTD files for the config.xml in versions 1.0-1.5 to the
resources of org/openmrs/module/dtd so they are under version control,
can easily be found, edited and uploaded back to resource.openmrs.org
* add elements that were not declared and thus made the DTDs invalid and
not useful for devs writing their config.xml

dwr
* add missing elements judging from legacyui dwr element in config.xml
* create (param, include*) always has a param and can have 0-N include's
param and include are empty elements with required attributes
* convert has one optional param child

mappingFiles
* fix the mappingFiles quantifier since it should only occur Zero or One
time thus use `?`. mappingFiles itself can have multiple whitespace
separated filenames

require_modules
* be more strict on `require_modules` which should have 1-N `require_module`
instead of 0-N, because why declare it if you dont require any module

aware_of_modules
* add `aware_of_modules` element to version 1.4, which was missing in
the file uploaded to resources.openmrs.org and this also has to have 1-N
`aware_of_module` if added

filter-mapping
* filter-mapping added in 1.2 defines that one of the following
url-pattern or servlet-name elements must be included thus the pattern
(url-pattern | servlet-name)

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->



## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5399

