### PR TITLE
TRUNK-5033

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -1109,11 +1109,11 @@ public final class OpenmrsConstants {
 		return states;
 	}
 	
-	public static Locale SPANISH_LANGUAGE = new Locale("es");
+	public static final Locale SPANISH_LANGUAGE = new Locale("es");
 	
-	public static Locale PORTUGUESE_LANGUAGE = new Locale("pt");
+	public static final Locale PORTUGUESE_LANGUAGE = new Locale("pt");
 	
-	public static Locale ITALIAN_LANGUAGE = new Locale("it");
+	public static final Locale ITALIAN_LANGUAGE = new Locale("it");
 	
 	/*
 	 * User property names


### PR DESCRIPTION
TRUNK-5033 Public Static Fields Should Be Final

## Description of what I changed
3 fields that are present in the OpenMRSConstants Class have been
changed to final.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5033

## Checklist: I completed these to help reviewers :)

- [ x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  I only refactored the code, so I didn't need to create new tests.

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

