### PR TITLE
TRUNK-5408 Patient Constructor that takes in Patient (Revision)

### DIFF
--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -92,9 +92,6 @@ public class Patient extends Person {
 			newIdentifiers.add(identifierClone);
 		}
 		this.identifiers = newIdentifiers;
-		for (PatientIdentifier pid : this.getIdentifiers()) {
-			pid.setPatient(this);
-		}
 	}
 	
 	// Property accessors

--- a/api/src/main/java/org/openmrs/Patient.java
+++ b/api/src/main/java/org/openmrs/Patient.java
@@ -79,12 +79,22 @@ public class Patient extends Person {
 	 * <br>
 	 *
 	 * @param patient the person object to copy onto a new Patient
+	 * @since 2.2.0
 	 */
 	public Patient(Patient patient){
 		super(patient);
 		this.patientId = patient.getPatientId();
 		this.allergyStatus = patient.getAllergyStatus();
-		this.identifiers = patient.getIdentifiers();
+		Set<PatientIdentifier> newIdentifiers = new TreeSet<>();
+		for (PatientIdentifier pid : patient.getIdentifiers()) {
+			PatientIdentifier identifierClone = (PatientIdentifier) pid.clone();
+			identifierClone.setPatient(this);
+			newIdentifiers.add(identifierClone);
+		}
+		this.identifiers = newIdentifiers;
+		for (PatientIdentifier pid : this.getIdentifiers()) {
+			pid.setPatient(this);
+		}
 	}
 	
 	// Property accessors
@@ -381,7 +391,6 @@ public class Patient extends Person {
 	@Override
 	public void setId(Integer id) {
 		setPatientId(id);
-		
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -36,7 +36,7 @@ import org.slf4j.LoggerFactory;
  * @see org.openmrs.PatientIdentifierType
  */
 @Indexed
-public class PatientIdentifier extends BaseChangeableOpenmrsData implements java.io.Serializable, Comparable<PatientIdentifier> {
+public class PatientIdentifier extends BaseChangeableOpenmrsData implements java.io.Serializable, Cloneable, Comparable<PatientIdentifier> {
 	
 	public static final long serialVersionUID = 1123121L;
 	
@@ -261,6 +261,24 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 	 */
 	public void setPatientIdentifierId(Integer patientIdentifierId) {
 		this.patientIdentifierId = patientIdentifierId;
+	}
+
+	/**
+	 * bitwise copy of the PatientIdentifier object. NOTICE: THIS WILL NOT COPY THE PATIENT OBJECT. The
+	 * PatientIdentifier.patient object in this object AND the cloned object will point at the same
+	 * patient
+	 *
+	 * @return New PatientIdentifier object
+	 * @since 2.2.0
+	 */
+	@Override
+	public Object clone() {
+		try {
+			return super.clone();
+		}
+		catch (CloneNotSupportedException e) {
+			throw new InternalError("PatientIdentifier should be cloneable");
+		}
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/PatientTest.java
+++ b/api/src/test/java/org/openmrs/PatientTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 
 import java.util.Date;
 import java.util.HashSet;
@@ -44,17 +45,27 @@ public class PatientTest {
 		pn.setMiddleName("middleName");
 		pnSet.add(pn);
 			
-		PatientIdentifier pa1 = new PatientIdentifier();
+		PatientIdentifier pi1 = new PatientIdentifier();
 		PatientIdentifierType identifierType = new PatientIdentifierType(1);
 		Location location = new Location(1);
 
-		pa1.setIdentifier("theid");
-		pa1.setIdentifierType(identifierType);
-		pa1.setLocation(location);
-		pa1.setVoided(true);
+		pi1.setIdentifier("theid");
+		pi1.setIdentifierType(identifierType);
+		pi1.setLocation(location);
+		pi1.setVoided(true);
+
+		PatientIdentifier pi2 = new PatientIdentifier();
+		PatientIdentifierType identifierType2 = new PatientIdentifierType(2);
+		Location location2 = new Location(2);
+
+		pi2.setIdentifier("theid2");
+		pi2.setIdentifierType(identifierType2);
+		pi2.setLocation(location2);
+		pi2.setVoided(false);
 		
 		p.setNames(pnSet);
-		p.addIdentifier(pa1);
+		p.addIdentifier(pi1);
+		p.addIdentifier(pi2);
 		p.setAllergyStatus("TestAllergy");
 		p.setId(1);
 		
@@ -65,6 +76,14 @@ public class PatientTest {
 		assertEquals(p.getNames(), p2.getNames());
 		assertEquals(p.getGivenName(), p2.getGivenName());
 		assertEquals(p.getIdentifiers(),p2.getIdentifiers());
+		// Check that each identifier refers to the correct patient object
+		for (PatientIdentifier pid : p2.getIdentifiers()) {
+			assertSame(p2, pid.getPatient());
+		}
+		// Make sure that the original patient hasn't been dirtied
+		for (PatientIdentifier pid : p.getIdentifiers()) {
+			assertSame(p, pid.getPatient());
+		}
 		assertEquals(p.getPatientId(), p2.getPatientId());
 		assertEquals(p.getId(), p2.getId());
 		assertEquals(p.getPerson(), p2.getPerson());


### PR DESCRIPTION

## Description of what I changed
Added since annotations, made patient identifier clonable, ensured cloned patients identifiers refer to correct patient. Related to [Pull Request 2691](https://github.com/openmrs/openmrs-core/pull/2691)

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5408

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.