### PR TITLE
TRUNK-5417 AdministrationServiceTest should count global properties correctly

### DIFF
--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -367,8 +367,9 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void getAllGlobalProperties_shouldReturnAllGlobalPropertiesInTheDatabase() {
+		int allGlobalPropertiesSize = adminService.getAllGlobalProperties().size();
 		executeDataSet(ADMIN_INITIAL_DATA_XML);
-		assertEquals(21, adminService.getAllGlobalProperties().size());
+		assertEquals(allGlobalPropertiesSize + 9, adminService.getAllGlobalProperties().size());
 	}
 	
 	@Test
@@ -410,10 +411,9 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void purgeGlobalProperty_shouldDeleteGlobalPropertyFromDatabase() {
 		executeDataSet(ADMIN_INITIAL_DATA_XML);
-		
-		assertEquals(21, adminService.getAllGlobalProperties().size());
+		int allGlobalPropertiesSize = adminService.getAllGlobalProperties().size();
 		adminService.purgeGlobalProperty(adminService.getGlobalPropertyObject("a_valid_gp_key"));
-		assertEquals(20, adminService.getAllGlobalProperties().size());
+		assertEquals(allGlobalPropertiesSize -1, adminService.getAllGlobalProperties().size());
 	}
 	
 	@Test


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-5417

## Description of what I changed
AdministrationServiceTest.java was changed so that it does not assume that exactly 21 global properties exist when running the tests:

> getAllGlobalProperties_shouldReturnAllGlobalPropertiesInTheDatabase
> purgeGlobalProperty_shouldDeleteGlobalPropertyFromDatabase

The tests now count how many global properties exist immediately prior, and after, the code under test.

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5417
Related discussion: https://talk.openmrs.org/t/openmrs-core-build-failure/15008

## Checklist: I completed these to help reviewers :)
- [x ] My pull request only contains **ONE single commit**
- [x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x ] I ran `mvn clean package` right before creating this pull request and
- [x] All new and existing **tests passed**.
- [x ] My pull request is **based on the latest changes** of the master branch.

