### PR TITLE
TRUNK-5225 Get List of OrderGroups by patient or encounter

### DIFF
--- a/api/src/main/java/org/openmrs/api/OrderService.java
+++ b/api/src/main/java/org/openmrs/api/OrderService.java
@@ -785,4 +785,13 @@ public interface OrderService extends OpenmrsService {
 	 */
 	@Authorized({ PrivilegeConstants.EDIT_ORDERS, PrivilegeConstants.ADD_ORDERS })
 	public OrderGroup saveOrderGroup(OrderGroup orderGroup) throws APIException;
+
+	/**
+	 * Given a patient or an encounter or both, fetches List of OrderGroups.
+	 * @param patient the patient.
+	 * @param encounter the encounter.
+	 * @return List of OrderGroup objects
+	 */
+	@Authorized(PrivilegeConstants.GET_ORDERS)
+	public List<OrderGroup> getListOfOrderGroupsByPatientAndEncounter(Patient patient, Encounter encounter);
 }

--- a/api/src/main/java/org/openmrs/api/db/OrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/OrderDAO.java
@@ -253,4 +253,9 @@ public interface OrderDAO {
 	 * @see org.openmrs.api.OrderService#getOrderGroup(Integer)
 	 */
 	public OrderGroup getOrderGroupById(Integer orderGroupId) throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.OrderService#getListOfOrderGroupsByPatientAndEncounter(Patient, Encounter)
+	 */
+	public List<OrderGroup> getOrderGroupsByPatientAndEncounter(Patient patient, Encounter encounter);
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
@@ -230,6 +230,22 @@ public class HibernateOrderDAO implements OrderDAO {
 	public OrderGroup getOrderGroupById(Integer orderGroupId) throws DAOException {
 		return (OrderGroup) sessionFactory.getCurrentSession().get(OrderGroup.class, orderGroupId);
 	}
+
+	/**
+	 * @see OrderDAO#getOrderGroupsByPatientAndEncounter(Patient, Encounter)
+	 * @see org.openmrs.api.OrderService#getListOfOrderGroupsByPatientAndEncounter(Patient, Encounter)
+	 */
+	@Override
+	public List<OrderGroup> getOrderGroupsByPatientAndEncounter(Patient patient, Encounter encounter) {
+		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(OrderGroup.class);
+		if (patient != null) {
+			criteria.add(Restrictions.eq("patient",patient));
+		}
+		if (encounter != null) {
+			criteria.add(Restrictions.eq("encounter", encounter));
+		}
+		return criteria.list();
+	}
 	
 	/**
 	 * Delete Obs that references (deleted) Order

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -1036,4 +1036,10 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		}
 		return Collections.emptyList();
 	}
+	
+	@Override
+	@Transactional(readOnly = true)
+	public List<OrderGroup> getListOfOrderGroupsByPatientAndEncounter(Patient patient, Encounter encounter) {
+		return dao.getOrderGroupsByPatientAndEncounter(patient, encounter);
+	}
 }


### PR DESCRIPTION
## Description of what I changed
Added support to get List of OrderGroups by :- 
i)Patient
ii)Encounter
iii)Patient and Encounter

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5225

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.