### PR TITLE
TRUNK-5429 Replace use of conditional logging with slf4j parametrized messages for openmrs-api

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -446,9 +446,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 */
 	public ConceptName getName() {
 		if (getNames().isEmpty()) {
-			if (log.isDebugEnabled()) {
-				log.debug("there are no names defined for: " + conceptId);
-			}
+			log.debug("there are no names defined for: {}", conceptId);
 			return null;
 		}
 		
@@ -593,15 +591,11 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		
 		// fail early if this concept has no names defined
 		if (getNames().isEmpty()) {
-			if (log.isDebugEnabled()) {
-				log.debug("there are no names defined for: " + conceptId);
-			}
+			log.debug("there are no names defined for: {}", conceptId);
 			return null;
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Getting conceptName for locale: " + locale);
-		}
+		log.debug("Getting conceptName for locale: {}", locale);
 		
 		ConceptName exactName = getNameInLocale(locale);
 		
@@ -649,14 +643,10 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 */
 	public ConceptName getPreferredName(Locale forLocale) {
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Getting preferred conceptName for locale: " + forLocale);
-		}
+		log.debug("Getting preferred conceptName for locale: {}", forLocale);
 		// fail early if this concept has no names defined
 		if (getNames(forLocale).isEmpty()) {
-			if (log.isDebugEnabled()) {
-				log.debug("there are no names defined for concept with id: " + conceptId + " in the  locale: " + forLocale);
-			}
+			log.debug("there are no names defined for concept with id: {} in the  locale: {}", conceptId, forLocale);
 			return null;
 		} else if (forLocale == null) {
 			log.warn("Locale cannot be null");
@@ -879,9 +869,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	public Collection<ConceptName> getShortNames() {
 		List<ConceptName> shortNames = new ArrayList<>();
 		if (getNames().isEmpty()) {
-			if (log.isDebugEnabled()) {
-				log.debug("The Concept with id: " + conceptId + " has no names");
-			}
+			log.debug("The Concept with id: {} has no names", conceptId);
 		} else {
 			shortNames = getNames().stream()
 							.filter(ConceptName::isShort)
@@ -903,9 +891,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @should return null if there are no names in the specified locale and exact is true
 	 */
 	public ConceptName getShortestName(Locale locale, Boolean exact) {
-		if (log.isDebugEnabled()) {
-			log.debug("Getting shortest conceptName for locale: " + locale);
-		}
+		log.debug("Getting shortest conceptName for locale: {}", locale);
 		
 		ConceptName shortNameInLocale = getShortNameInLocale(locale);
 		if (shortNameInLocale != null) {
@@ -1093,7 +1079,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @should not return language only match for exact matches
 	 */
 	public ConceptDescription getDescription(Locale locale, boolean exact) {
-		log.debug("Getting ConceptDescription for locale: " + locale);
+		log.debug("Getting ConceptDescription for locale: {}", locale);
 		
 		ConceptDescription foundDescription = null;
 		
@@ -1122,13 +1108,12 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			// no description with the given locale was found.
 			// return null if exact match desired
 			if (exact) {
-				log.debug("No concept description found for concept id " + conceptId + " for locale "
-				        + desiredLocale.toString());
+				log.debug("No concept description found for concept id {} for locale {}", conceptId, desiredLocale);
 			} else {
 				// returning default description locale ("en") if exact match
 				// not desired
 				if (defaultDescription == null) {
-					log.debug("No concept description found for default locale for concept id " + conceptId);
+					log.debug("No concept description found for default locale for concept id {}", conceptId);
 				} else {
 					foundDescription = defaultDescription;
 				}
@@ -1284,7 +1269,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		if (preferredConceptName != null) {
 			syns.add(0, preferredConceptName);
 		}
-		log.debug("returning: " + syns);
+		log.debug("returning: {}", syns);
 		return syns;
 	}
 	
@@ -1488,9 +1473,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 */
 	public Set<Locale> getAllConceptNameLocales() {
 		if (getNames().isEmpty()) {
-			if (log.isDebugEnabled()) {
-				log.debug("The Concept with id: " + conceptId + " has no names");
-			}
+			log.debug("The Concept with id: {} has no names", conceptId);
 			return null;
 		}
 		

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -1083,9 +1083,7 @@ public class Obs extends BaseChangeableOpenmrsData {
 	 * @should fail if the value of the string is empty
 	 */
 	public void setValueAsString(String s) throws ParseException {
-		if (log.isDebugEnabled()) {
-			log.debug("getConcept() == " + getConcept());
-		}
+		log.debug("getConcept() == {}", getConcept());
 		
 		if (getConcept() != null && !StringUtils.isBlank(s)) {
 			String abbrev = getConcept().getDatatype().getHl7Abbreviation();

--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -641,9 +641,7 @@ public class Person extends BaseChangeableOpenmrsData {
 			return attributeMap;
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Current Person Attributes: \n" + printAttributes());
-		}
+		log.debug("Current Person Attributes: {}{}", System.lineSeparator(), printAttributes());
 		
 		attributeMap = new HashMap<>();
 		for (PersonAttribute attribute : getActiveAttributes()) {
@@ -665,9 +663,7 @@ public class Person extends BaseChangeableOpenmrsData {
 			return allAttributeMap;
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Current Person Attributes: \n" + printAttributes());
-		}
+		log.debug("Current Person Attributes: {}{}", System.lineSeparator(), printAttributes());
 		
 		allAttributeMap = new HashMap<>();
 		for (PersonAttribute attribute : getAttributes()) {

--- a/api/src/main/java/org/openmrs/Role.java
+++ b/api/src/main/java/org/openmrs/Role.java
@@ -224,9 +224,7 @@ public class Role extends BaseChangeableOpenmrsMetadata {
 			}
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Total roles: " + allRoles);
-		}
+		log.debug("Total roles: {}", allRoles);
 		
 		return allRoles;
 	}
@@ -318,9 +316,7 @@ public class Role extends BaseChangeableOpenmrsMetadata {
 			}
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Total roles: " + allRoles);
-		}
+		log.debug("Total roles: {}", allRoles);
 		
 		return allRoles;
 	}

--- a/api/src/main/java/org/openmrs/User.java
+++ b/api/src/main/java/org/openmrs/User.java
@@ -145,9 +145,7 @@ public class User extends BaseChangeableOpenmrsMetadata implements java.io.Seria
 		
 		Set<Role> tmproles = getAllRoles();
 		
-		if (log.isDebugEnabled()) {
-			log.debug("User #" + userId + " has roles: " + tmproles);
-		}
+		log.debug("User #{} has roles: {}", userId, tmproles);
 		
 		return containsRole(r);
 	}
@@ -211,9 +209,7 @@ public class User extends BaseChangeableOpenmrsMetadata implements java.io.Seria
 			totalRoles.addAll(getRoles());
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("User's base roles: " + baseRoles);
-		}
+		log.debug("User's base roles: {}", baseRoles);
 		
 		try {
 			for (Role r : baseRoles) {

--- a/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
@@ -44,9 +44,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	@Override
 	public void before(Method method, Object[] args, Object target) throws Throwable {
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Calling authorization advice before " + method.getName());
-		}
+		log.debug("Calling authorization advice before {}", method.getName());
 		
 		if (log.isDebugEnabled()) {
 			User user = Context.getAuthenticatedUser();
@@ -71,9 +69,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 					return;
 				}
 				
-				if (log.isDebugEnabled()) {
-					log.debug("User has privilege " + privilege + "? " + Context.hasPrivilege(privilege));
-				}
+				log.debug("User has privilege {}? {}", privilege, Context.hasPrivilege(privilege));
 				
 				if (Context.hasPrivilege(privilege)) {
 					if (!requireAll) {
@@ -109,10 +105,8 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	 * @param method acting method
 	 * @param attrs Collection of String privilege names that the user must have
 	 */
-	private void throwUnauthorized(User user, Method method, Collection<String> attrs) {
-		if (log.isDebugEnabled()) {
-			log.debug("User " + user + " is not authorized to access " + method.getName());
-		}
+	private void throwUnauthorized(User user, Method method, Collection<String> attrs) throws APIAuthenticationException {
+		log.debug("User {} is not authorized to access {}", user, method.getName());
 		throw new APIAuthenticationException(Context.getMessageSourceService().getMessage("error.privilegesRequired",
 		    new Object[] { StringUtils.join(attrs, ",") }, null));
 	}
@@ -124,10 +118,8 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	 * @param method acting method
 	 * @param attrs privilege names that the user must have
 	 */
-	private void throwUnauthorized(User user, Method method, String attr) {
-		if (log.isDebugEnabled()) {
-			log.debug("User " + user + " is not authorized to access " + method.getName());
-		}
+	private void throwUnauthorized(User user, Method method, String attr) throws APIAuthenticationException {
+		log.debug("User {} is not authorized to access {}", user, method.getName());
 		throw new APIAuthenticationException(Context.getMessageSourceService().getMessage("error.privilegesRequired",
 		    new Object[] { attr }, null));
 	}
@@ -138,10 +130,8 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	 * @param user authenticated user
 	 * @param method acting method
 	 */
-	private void throwUnauthorized(User user, Method method) {
-		if (log.isDebugEnabled()) {
-			log.debug("User " + user + " is not authorized to access " + method.getName());
-		}
+	private void throwUnauthorized(User user, Method method) throws APIAuthenticationException {
+		log.debug("User {} is not authorized to access {}", user, method.getName());
 		throw new APIAuthenticationException(Context.getMessageSourceService().getMessage("error.aunthenticationRequired"));
 	}
 }

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -199,22 +199,15 @@ public class Context {
 	 * @param ctx UserContext to set
 	 */
 	public static void setUserContext(UserContext ctx) {
-		if (log.isTraceEnabled()) {
-			log.trace("Setting user context " + ctx);
-		}
-
-		Object[] arr = new Object[] { ctx };
-		userContextHolder.set(arr);
+		log.trace("Setting user context {}", ctx);
+		userContextHolder.set(new Object[] { ctx });
 	}
 
 	/**
 	 * Clears the user context from the threadlocal.
 	 */
 	public static void clearUserContext() {
-		if (log.isTraceEnabled()) {
-			log.trace("Clearing user context " + Arrays.toString(userContextHolder.get()));
-		}
-
+		log.trace("Clearing user context {}", Arrays.toString(userContextHolder.get()));
 		userContextHolder.remove();
 	}
 
@@ -228,9 +221,7 @@ public class Context {
 	public static UserContext getUserContext() {
 		Object[] arr = userContextHolder.get();
 
-		if (log.isTraceEnabled()) {
-			log.trace("Getting user context " + Arrays.toString(arr) + " from userContextHolder " + userContextHolder);
-		}
+		log.trace("Getting user context {} from userContextHolder {}", Arrays.toString(arr), userContextHolder);
 
 		if (arr == null) {
 			log.trace("userContext is null.");
@@ -256,9 +247,7 @@ public class Context {
 			}
 		}
 
-		if (log.isTraceEnabled()) {
-			log.trace("serviceContext: " + serviceContext);
-		}
+		log.trace("serviceContext: {}", serviceContext);
 
 		return ServiceContext.getInstance();
 	}
@@ -289,9 +278,7 @@ public class Context {
 	 * @should not authenticate with null password and proper system id
 	 */
 	public static void authenticate(String username, String password) throws ContextAuthenticationException {
-		if (log.isDebugEnabled()) {
-			log.debug("Authenticating with username: " + username);
-		}
+		log.debug("Authenticating with username: {}", username);
 
 		if (Daemon.isDaemonThread()) {
 			log.error("Authentication attempted while operating on a "
@@ -315,9 +302,7 @@ public class Context {
 			return;
 		}
 
-		if (log.isDebugEnabled()) {
-			log.debug("Refreshing authenticated user");
-		}
+		log.debug("Refreshing authenticated user");
 
 		getUserContext().refreshAuthenticatedUser();
 	}
@@ -330,9 +315,7 @@ public class Context {
 	 * @should change locale when become another user
 	 */
 	public static void becomeUser(String systemId) throws ContextAuthenticationException {
-		if (log.isInfoEnabled()) {
-			log.info("systemId: " + systemId);
-		}
+		log.info("systemId: {}", systemId);
 
 		User user = getUserContext().becomeUser(systemId);
 
@@ -355,9 +338,7 @@ public class Context {
 	 * @return copy of the runtime properties
 	 */
 	public static Properties getRuntimeProperties() {
-		if (log.isTraceEnabled()) {
-			log.trace("getting runtime properties. size: " + runtimeProperties.size());
-		}
+		log.trace("getting runtime properties. size: {}", runtimeProperties.size());
 
 		Properties props = new Properties();
 		props.putAll(runtimeProperties);
@@ -639,9 +620,7 @@ public class Context {
 			return; // fail early if there isn't even a session open
 		}
 
-		if (log.isDebugEnabled()) {
-			log.debug("Logging out : " + getAuthenticatedUser());
-		}
+		log.debug("Logging out: {}", getAuthenticatedUser());
 
 		getUserContext().logout();
 

--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -179,9 +179,7 @@ public class ServiceContext implements ApplicationContextAware {
 			}
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Destroying ServiceContext instance: " + ServiceContextHolder.instance);
-		}
+		log.debug("Destroying ServiceContext instance: {}", ServiceContextHolder.instance);
 		
 		ServiceContextHolder.instance = null;
 	}
@@ -655,24 +653,18 @@ public class ServiceContext implements ApplicationContextAware {
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> T getService(Class<? extends T> cls) {
-		if (log.isTraceEnabled()) {
-			log.trace("Getting service: " + cls);
-		}
+		log.trace("Getting service: {}", cls);
 		
 		// if the context is refreshing, wait until it is
 		// done -- otherwise a null service might be returned
 		synchronized (refreshingContextLock) {
 			try {
 				while (refreshingContext) {
-					if (log.isDebugEnabled()) {
-						log.debug("Waiting to get service: " + cls + " while the context is being refreshed");
-					}
+					log.debug("Waiting to get service: {} while the context is being refreshed", cls);
 					
 					refreshingContextLock.wait();
 					
-					if (log.isDebugEnabled()) {
-						log.debug("Finished waiting to get service " + cls + " while the context was being refreshed");
-					}
+					log.debug("Finished waiting to get service {} while the context was being refreshed", cls);
 				}
 				
 			}
@@ -697,7 +689,7 @@ public class ServiceContext implements ApplicationContextAware {
 	 */
 	public void setService(Class cls, Object classInstance) {
 		
-		log.debug("Setting service: " + cls);
+		log.debug("Setting service: {}", cls);
 		
 		if (cls != null && classInstance != null) {
 			try {
@@ -726,7 +718,7 @@ public class ServiceContext implements ApplicationContextAware {
 					
 					services.put(cls, advisedService);
 				}
-				log.debug("Service: " + cls + " set successfully");
+				log.debug("Service: {} set successfully", cls);
 			}
 			catch (Exception e) {
 				throw new APIException("service.unable.create.proxy.factory", new Object[] { classInstance.getClass()
@@ -763,24 +755,22 @@ public class ServiceContext implements ApplicationContextAware {
 			if (!useSystemClassLoader) {
 				cls = OpenmrsClassLoader.getInstance().loadClass(classString);
 				
-				if (cls != null && log.isDebugEnabled()) {
+				if (cls != null) {
 					try {
-						log.debug("cls classloader: " + cls.getClass().getClassLoader() + " uid: "
-						        + cls.getClass().getClassLoader().hashCode());
+						ClassLoader classLoader = cls.getClass().getClassLoader();
+						log.debug("cls classloader: {} uid: {}", classLoader, classLoader.hashCode());
 					}
 					catch (Exception e) { /*pass*/}
 				}
 			} else if (useSystemClassLoader) {
 				try {
 					cls = Class.forName(classString);
-					if (log.isDebugEnabled()) {
-						log.debug("cls2 classloader: " + cls.getClass().getClassLoader() + " uid: "
-						        + cls.getClass().getClassLoader().hashCode());
-						//pay attention that here, cls = Class.forName(classString), the system class loader and
-						//cls2 is the openmrs class loader, like above.
-						log.debug("cls==cls2: "
-						        + String.valueOf(cls == OpenmrsClassLoader.getInstance().loadClass(classString)));
-					}
+					ClassLoader classLoader = cls.getClass().getClassLoader();
+					log.debug("cls2 classloader: {} uid: {}", classLoader, classLoader.hashCode());
+					//pay attention that here, cls = Class.forName(classString), the system class loader and
+					//cls2 is the openmrs class loader, like above.
+					log.debug("cls==cls2: {}", 
+						String.valueOf(cls == OpenmrsClassLoader.getInstance().loadClass(classString)));
 				}
 				catch (Exception e) { /*pass*/}
 			}
@@ -878,9 +868,7 @@ public class ServiceContext implements ApplicationContextAware {
 	
 	public <T> List<T> getRegisteredComponents(Class<T> type) {
 		Map<String, T> m = getRegisteredComponents(applicationContext, type);
-		if (log.isTraceEnabled()) {
-			log.trace("getRegisteredComponents(" + type + ") = " + m);
-		}
+		log.trace("getRegisteredComponents({}) = {}", type, m);
 		return new ArrayList<>(m.values());
 	}
 	
@@ -914,9 +902,7 @@ public class ServiceContext implements ApplicationContextAware {
 	private <T> Map<String, T> getRegisteredComponents(ApplicationContext context, Class<T> type) {
 		Map<String, T> components = new HashMap<>();
 		Map registeredComponents = context.getBeansOfType(type);
-		if (log.isTraceEnabled()) {
-			log.trace("getRegisteredComponents(" + context + ", " + type + ") = " + registeredComponents);
-		}
+		log.trace("getRegisteredComponents({}, {}) = {}", new Object[] {context, type, registeredComponents});
 		if (registeredComponents != null) {
 			components.putAll(registeredComponents);
 		}
@@ -952,17 +938,11 @@ public class ServiceContext implements ApplicationContextAware {
 				synchronized (refreshingContextLock) {
 					//Need to wait for application context to finish refreshing otherwise we get into trouble.
 					while (refreshingContext) {
-						if (log.isDebugEnabled()) {
-							log.debug("Waiting to get service: " + classString + " while the context"
-							        + " is being refreshed");
-						}
+						log.debug("Waiting to get service: {} while the context is being refreshed", classString);
 
 						refreshingContextLock.wait();
 
-						if (log.isDebugEnabled()) {
-							log.debug("Finished waiting to get service " + classString
-							        + " while the context was being refreshed");
-						}
+						log.debug("Finished waiting to get service {} while the context was being refreshed", classString);
 					}
 				}
 

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -97,9 +97,7 @@ public class UserContext implements Serializable {
 	 * @throws ContextAuthenticationException
 	 */
 	public User authenticate(String username, String password, ContextDAO contextDAO) throws ContextAuthenticationException {
-		if (log.isDebugEnabled()) {
-			log.debug("Authenticating with username: " + username);
-		}
+		log.debug("Authenticating with username: {}", username);
 		try {
 			this.user = contextDAO.authenticate(username, password);
 			notifyUserSessionListener(this.user, Event.LOGIN, Status.SUCCESS);
@@ -110,9 +108,7 @@ public class UserContext implements Serializable {
 			throw e;
 		}
 		setUserLocation();
-		if (log.isDebugEnabled()) {
-			log.debug("Authenticated as: " + this.user);
-		}
+		log.debug("Authenticated as: {}", this.user);
 		
 		return this.user;
 	}
@@ -125,9 +121,7 @@ public class UserContext implements Serializable {
 	 * @since 1.5
 	 */
 	public void refreshAuthenticatedUser() {
-		if (log.isDebugEnabled()) {
-			log.debug("Refreshing authenticated user");
-		}
+		log.debug("Refreshing authenticated user");
 		
 		if (user != null) {
 			user = Context.getUserService().getUser(user.getUserId());
@@ -149,9 +143,7 @@ public class UserContext implements Serializable {
 			throw new APIAuthenticationException("You must be a superuser to assume another user's identity");
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Turning the authenticated user into user with systemId: " + systemId);
-		}
+		log.debug("Turning the authenticated user into user with systemId: {}", systemId);
 		
 		User userToBecome = Context.getUserService().getUserByUsername(systemId);
 		
@@ -174,9 +166,7 @@ public class UserContext implements Serializable {
 		//update the user's location
 		setUserLocation();
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Becoming user: " + user);
-		}
+		log.debug("Becoming user: {}", user);
 		
 		return userToBecome;
 	}
@@ -223,9 +213,7 @@ public class UserContext implements Serializable {
 	 * @param privilege to give to users
 	 */
 	public void addProxyPrivilege(String privilege) {
-		if (log.isDebugEnabled()) {
-			log.debug("Adding proxy privilege: " + privilege);
-		}
+		log.debug("Adding proxy privilege: {}", privilege);
 		
 		proxies.add(privilege);
 	}
@@ -236,9 +224,7 @@ public class UserContext implements Serializable {
 	 * @param privilege Privilege to remove in string form
 	 */
 	public void removeProxyPrivilege(String privilege) {
-		if (log.isDebugEnabled()) {
-			log.debug("Removing proxy privilege: " + privilege);
-		}
+		log.debug("Removing proxy privilege: {}", privilege);
 		
 		if (proxies.contains(privilege)) {
 			proxies.remove(privilege);
@@ -326,9 +312,7 @@ public class UserContext implements Serializable {
 			
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Checking '" + privilege + "' against proxies: " + proxies);
-		}
+		log.debug("Checking '{}' against proxies: {}", privilege, proxies);
 		
 		// check proxied privileges
 		for (String s : proxies) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/AuditableInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/AuditableInterceptor.java
@@ -78,9 +78,7 @@ public class AuditableInterceptor extends EmptyInterceptor {
 		objectWasChanged = setCreatorAndDateCreatedIfNull(entity, currentState, propertyNames);
 		
 		if (entity instanceof Auditable && propertyNames != null) {
-			if (log.isDebugEnabled()) {
-				log.debug("Setting changed by fields on " + entity.getClass());
-			}
+			log.debug("Setting changed by fields on {}", entity.getClass());
 			
 			Map<String, Object> propertyValues = getPropertyValuesToUpdate();
 			objectWasChanged = changeProperties(currentState, propertyNames, objectWasChanged, propertyValues, false);
@@ -104,9 +102,7 @@ public class AuditableInterceptor extends EmptyInterceptor {
 		boolean objectWasChanged = false;
 		
 		if (entity instanceof OpenmrsObject) {
-			if (log.isDebugEnabled()) {
-				log.debug("Setting creator and dateCreated on " + entity);
-			}
+			log.debug("Setting creator and dateCreated on {}", entity);
 			
 			Map<String, Object> propertyValues = getPropertyValuesToSave();
 			objectWasChanged = changeProperties(currentState, propertyNames, objectWasChanged, propertyValues, true);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ChainingInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ChainingInterceptor.java
@@ -51,7 +51,7 @@ public class ChainingInterceptor implements Interceptor {
 			return;
 		}
 		
-		log.debug("Adding " + interceptor + " to interceptor chain");
+		log.debug("Adding {} to interceptor chain", interceptor);
 		
 		if (interceptors == null) {
 			interceptors = new LinkedHashSet<>();

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -110,9 +110,7 @@ public class HibernateContextDAO implements ContextDAO {
 		
 		// only continue if this is a valid username and a nonempty password
 		if (candidateUser != null && password != null) {
-			if (log.isDebugEnabled()) {
-				log.debug("Candidate user id: " + candidateUser.getUserId());
-			}
+			log.debug("Candidate user id: {}", candidateUser.getUserId());
 			
 			String lockoutTimeString = candidateUser.getUserProperty(OpenmrsConstants.USER_PROPERTY_LOCKOUT_TIMESTAMP, null);
 			Long lockoutTime = null;
@@ -262,14 +260,10 @@ public class HibernateContextDAO implements ContextDAO {
 	public void openSession() {
 		log.debug("HibernateContext: Opening Hibernate Session");
 		if (TransactionSynchronizationManager.hasResource(sessionFactory)) {
-			if (log.isDebugEnabled()) {
-				log.debug("Participating in existing session (" + sessionFactory.hashCode() + ")");
-			}
+			log.debug("Participating in existing session ({})", sessionFactory.hashCode());
 			participate = true;
 		} else {
-			if (log.isDebugEnabled()) {
-				log.debug("Registering session with synchronization manager (" + sessionFactory.hashCode() + ")");
-			}
+			log.debug("Registering session with synchronization manager ({})", sessionFactory.hashCode());
 			Session session = sessionFactory.openSession();
 			session.setFlushMode(FlushMode.MANUAL);
 			TransactionSynchronizationManager.bindResource(sessionFactory, new SessionHolder(session));

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateOrderDAO.java
@@ -102,9 +102,7 @@ public class HibernateOrderDAO implements OrderDAO {
 	 */
 	@Override
 	public Order getOrder(Integer orderId) throws DAOException {
-		if (log.isDebugEnabled()) {
-			log.debug("getting order #" + orderId);
-		}
+		log.debug("getting order #{}", orderId);
 		
 		return (Order) sessionFactory.getCurrentSession().get(Order.class, orderId);
 	}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -228,9 +228,7 @@ public class HibernatePatientDAO implements PatientDAO {
 		if (length != null && length < maximumSearchResults) {
 			criteria.setMaxResults(length);
 		} else {
-			if (log.isDebugEnabled()) {
-				log.debug("Limiting the size of the number of matching patients to " + maximumSearchResults);
-			}
+			log.debug("Limiting the size of the number of matching patients to {}", maximumSearchResults);
 			criteria.setMaxResults(maximumSearchResults);
 		}
 	}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUtil.java
@@ -78,9 +78,7 @@ public class HibernateUtil {
 		SessionFactoryImplementor implementor = (SessionFactoryImplementor) sessionFactory;
 		dialect = implementor.getDialect();
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Getting dialect for session: " + dialect);
-		}
+		log.debug("Getting dialect for session: {}", dialect);
 		
 		return dialect;
 	}

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
@@ -105,9 +105,7 @@ public abstract class ImmutableEntityInterceptor extends EmptyInterceptor {
 				}
 			}
 			if (CollectionUtils.isNotEmpty(changedProperties)) {
-				if (log.isDebugEnabled()) {
-					log.debug("The following fields cannot be changed for " + getSupportedType() + ":" + changedProperties);
-				}
+				log.debug("The following fields cannot be changed for {}:{}", getSupportedType(), changedProperties);
 				
 				throw new UnchangeableObjectException("editing.fields.not.allowed", new Object[] { changedProperties,
 				        getSupportedType().getSimpleName() });

--- a/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
@@ -117,14 +117,10 @@ public class OpenmrsObjectSaveHandler implements SaveHandler<OpenmrsObject> {
 			}
 			catch (UnsupportedOperationException ex) {
 				// there is no need to log this. These should be (mostly) silently skipped over 
-				if (log.isInfoEnabled()) {
-					log.info("The property " + property.getName() + " is no longer supported and should be ignored.", ex);
-				}
+				log.info("The property " + property.getName() + " is no longer supported and should be ignored.", ex);
 			}
 			catch (InvocationTargetException ex) {
-				if (log.isWarnEnabled()) {
-					log.warn("Failed to access property " + property.getName() + "; accessor threw exception.", ex);
-				}
+				log.warn("Failed to access property " + property.getName() + "; accessor threw exception.", ex);
 			}
 			catch (Exception ex) {
 				throw new APIException("failed.change.property.value", new Object[] { property.getName() }, ex);

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -485,9 +485,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 			throw new APIException(ms);
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Response: " + response);
-		}
+		log.debug("Response: {}", response);
 		
 		if (response.startsWith("Success")) {
 			response = response.replace("Success", "");

--- a/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
@@ -63,9 +63,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 		if (cohort.getDescription() == null) {
 			throw new APIException("Cohort.save.descriptionRequired", (Object[]) null);
 		}
-		if (log.isInfoEnabled()) {
-			log.info("Saving cohort " + cohort);
-		}
+		log.info("Saving cohort {}", cohort);
 		
 		return dao.saveCohort(cohort);
 	}

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -477,7 +477,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		} else {
 			List<Drug> drugs = dao.getDrugs(drugNameOrId, null, false);
 			if (drugs.size() > 1) {
-				log.warn("more than one drug name returned with name:" + drugNameOrId);
+				log.warn("more than one drug name returned with name: {}", drugNameOrId);
 			}
 			if (drugs.isEmpty()) {
 				return null;
@@ -1285,9 +1285,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			if (!(dao.getSavedConceptDatatype(concept).isBoolean() && concept.getDatatype().isCoded())) {
 				throw new ConceptInUseException();
 			}
-			if (log.isDebugEnabled()) {
-				log.debug("Converting datatype of concept with id " + concept.getConceptId() + " from Boolean to Coded");
-			}
+			log.debug("Converting datatype of concept with id {} from Boolean to Coded", concept.getConceptId());
 		}
 	}
 	

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -649,9 +649,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		VisitService visitService = Context.getVisitService();
 		
 		for (Visit visit : visitService.getVisitsByPatient(notPreferred, true, true)) {
-			if (log.isDebugEnabled()) {
-				log.debug("Merging visit " + visit.getVisitId() + " to " + preferred.getPatientId());
-			}
+			log.debug("Merging visit {} to {}", visit.getVisitId(), preferred.getPatientId());
 			visit.setPatient(preferred);
 			Visit persisted = visitService.saveVisit(visit);
 			mergedData.addMovedVisit(persisted.getUuid());

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -810,8 +810,8 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 		if (Context.getSerializationService().getDefaultSerializer() == null) {
 			throw new APIException("serializer.default.not.found", (Object[]) null);
 		}
-		log.debug("Auditing merging of non-preferred person " + personMergeLog.getLoser().getUuid()
-		        + " with preferred person " + personMergeLog.getWinner().getId());
+		log.debug("Auditing merging of non-preferred person {} with preferred person {}", 
+			personMergeLog.getLoser().getUuid(), personMergeLog.getWinner().getId());
 		//populate the mergedData XML from the PersonMergeLogData object
 		String serialized = Context.getSerializationService().getDefaultSerializer()
 		        .serialize(personMergeLog.getPersonMergeLogData());

--- a/api/src/main/java/org/openmrs/hl7/HL7InQueueProcessor.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7InQueueProcessor.java
@@ -55,10 +55,7 @@ public class HL7InQueueProcessor /* implements Runnable */{
 	 */
 	public void processHL7InQueue(HL7InQueue hl7InQueue) {
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Processing HL7 inbound queue (id=" + hl7InQueue.getHL7InQueueId() + ",key="
-			        + hl7InQueue.getHL7SourceKey() + ")");
-		}
+		log.debug("Processing HL7 inbound queue (id={},key={})", hl7InQueue.getHL7InQueueId(), hl7InQueue.getHL7SourceKey());
 		
 		try {
 			Context.getHL7Service().processHL7InQueue(hl7InQueue);

--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -196,16 +196,11 @@ public class ORUR01Handler implements Application {
 		// Obtain message control id (unique ID for message from sending
 		// application)
 		String messageControlId = msh.getMessageControlID().getValue();
-		if (log.isDebugEnabled()) {
-			log.debug("Found HL7 message in inbound queue with control id = " + messageControlId);
-		}
-		
+		log.debug("Found HL7 message in inbound queue with control id = {}", messageControlId);
 		
 		// create the encounter
 		Patient patient = getPatient(pid);
-		if (log.isDebugEnabled()) {
-			log.debug("Processing HL7 message for patient " + patient.getPatientId());
-		}
+		log.debug("Processing HL7 message for patient {}", patient.getPatientId());
 		Encounter encounter = createEncounter(msh, patient, pv1, orc);
 		
 		// do the discharge to location logic
@@ -227,9 +222,7 @@ public class ORUR01Handler implements Application {
 		List<ConceptProposal> conceptProposals = new ArrayList<>();
 		
 		// create observations
-		if (log.isDebugEnabled()) {
-			log.debug("Creating observations for message " + messageControlId + "...");
-		}
+		log.debug("Creating observations for message {}...", messageControlId);
 		// we ignore all MEDICAL_RECORD_OBSERVATIONS that are OBRs.  We do not
 		// create obs_groups for them
 		List<Integer> ignoredConceptIds = new ArrayList<>();
@@ -250,9 +243,7 @@ public class ORUR01Handler implements Application {
 		ORU_R01_PATIENT_RESULT patientResult = oru.getPATIENT_RESULT();
 		int numObr = patientResult.getORDER_OBSERVATIONReps();
 		for (int i = 0; i < numObr; i++) {
-			if (log.isDebugEnabled()) {
-				log.debug("Processing OBR (" + i + " of " + numObr + ")");
-			}
+			log.debug("Processing OBR ({} of {})", i, numObr);
 			ORU_R01_ORDER_OBSERVATION orderObs = patientResult.getORDER_OBSERVATION(i);
 			
 			// the parent obr
@@ -308,9 +299,7 @@ public class ORUR01Handler implements Application {
 			int numObs = orderObs.getOBSERVATIONReps();
 			HL7Exception errorInHL7Queue = null;
 			for (int j = 0; j < numObs; j++) {
-				if (log.isDebugEnabled()) {
-					log.debug("Processing OBS (" + j + " of " + numObs + ")");
-				}
+				log.debug("Processing OBS ({} of {})", j, numObs);
 				
 				OBX obx = orderObs.getOBSERVATION(j).getOBX();
 				try {
@@ -369,11 +358,9 @@ public class ORUR01Handler implements Application {
 			
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Finished creating observations");
-			log.debug("Current thread: " + Thread.currentThread());
-			log.debug("Creating the encounter object");
-		}
+		log.debug("Finished creating observations");
+		log.debug("Current thread: {}", Thread.currentThread());
+		log.debug("Creating the encounter object");
 		Context.getEncounterService().saveEncounter(encounter);
 		
 		// loop over the proposed concepts and save each to the database
@@ -602,9 +589,7 @@ public class ORUR01Handler implements Application {
 	 * @should add comments to an observation group
 	 */
 	private Obs parseObs(Encounter encounter, OBX obx, OBR obr, String uid) throws HL7Exception, ProposingConceptException {
-		if (log.isDebugEnabled()) {
-			log.debug("parsing observation: " + obx);
-		}
+		log.debug("parsing observation: {}", obx);
 		Varies[] values = obx.getObservationValue();
 		
 		// bail out if no values were found
@@ -613,22 +598,14 @@ public class ORUR01Handler implements Application {
 		}
 		
 		String hl7Datatype = values[0].getName();
-		if (log.isDebugEnabled()) {
-			log.debug("  datatype = " + hl7Datatype);
-		}
+		log.debug("  datatype = {}", hl7Datatype);
 		Concept concept = getConcept(obx.getObservationIdentifier(), uid);
-		if (log.isDebugEnabled()) {
-			log.debug("  concept = " + concept.getConceptId());
-		}
+		log.debug("  concept = {}", concept.getConceptId());
 		ConceptName conceptName = getConceptName(obx.getObservationIdentifier());
-		if (log.isDebugEnabled()) {
-			log.debug("  concept-name = " + conceptName);
-		}
+		log.debug("  concept-name = {}", conceptName);
 		
 		Date datetime = getDatetime(obx);
-		if (log.isDebugEnabled()) {
-			log.debug("  timestamp = " + datetime);
-		}
+		log.debug("  timestamp = {}", datetime);
 		if (datetime == null) {
 			datetime = encounter.getEncounterDatetime();
 		}
@@ -716,13 +693,11 @@ public class ORUR01Handler implements Application {
 			log.debug("  CWE observation");
 			CWE value = (CWE) obx5;
 			String valueIdentifier = value.getIdentifier().getValue();
-			log.debug("    value id = " + valueIdentifier);
+			log.debug("    value id = {}", valueIdentifier);
 			String valueName = value.getText().getValue();
-			log.debug("    value name = " + valueName);
+			log.debug("    value name = {}", valueName);
 			if (isConceptProposal(valueIdentifier)) {
-				if (log.isDebugEnabled()) {
-					log.debug("Proposing concept");
-				}
+				log.debug("Proposing concept");
 				throw new ProposingConceptException(concept, valueName);
 			} else {
 				log.debug("    not proposal");
@@ -736,10 +711,8 @@ public class ORUR01Handler implements Application {
 					} else {
 						ConceptName valueConceptName = getConceptName(value);
 						if (valueConceptName != null) {
-							if (log.isDebugEnabled()) {
-								log.debug("    value concept-name-id = " + valueConceptName.getConceptNameId());
-								log.debug("    value concept-name = " + valueConceptName.getName());
-							}
+							log.debug("    value concept-name-id = {}", valueConceptName.getConceptNameId());
+							log.debug("    value concept-name = {}", valueConceptName.getName());
 							obs.setValueCodedName(valueConceptName);
 						}
 					}
@@ -749,9 +722,7 @@ public class ORUR01Handler implements Application {
 					    new Object[] { valueIdentifier, valueName }, null));
 				}
 			}
-			if (log.isDebugEnabled()) {
-				log.debug("  Done with CWE");
-			}
+			log.debug("  Done with CWE");
 		} else if ("CE".equals(hl7Datatype)) {
 			CE value = (CE) obx5;
 			String valueIdentifier = value.getIdentifier().getValue();
@@ -1227,11 +1198,9 @@ public class ORUR01Handler implements Application {
 	
 	private void updateHealthCenter(Patient patient, PV1 pv1) {
 		// Update patient's location if it has changed
-		if (log.isDebugEnabled()) {
-			log.debug("Checking for discharge to location");
-		}
+		log.debug("Checking for discharge to location");
 		DLD dld = pv1.getDischargedToLocation();
-		log.debug("DLD = " + dld);
+		log.debug("DLD = {}", dld);
 		if (dld == null) {
 			return;
 		}
@@ -1241,11 +1210,9 @@ public class ORUR01Handler implements Application {
 			return;
 		}
 		String dischargeToLocation = hl7DischargeToLocation.getValue();
-		log.debug("dischargeToLocation = " + dischargeToLocation);
+		log.debug("dischargeToLocation = {}", dischargeToLocation);
 		if (dischargeToLocation != null && dischargeToLocation.length() > 0) {
-			if (log.isDebugEnabled()) {
-				log.debug("Patient discharged to " + dischargeToLocation);
-			}
+			log.debug("Patient discharged to {}", dischargeToLocation);
 			// Ignore anything past the first subcomponent (or component)
 			// delimiter
 			for (int i = 0; i < dischargeToLocation.length(); i++) {

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -717,10 +717,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 			hl7InQueue.setMessageState(HL7Constants.HL7_STATUS_PROCESSING);
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Processing HL7 inbound queue (id=" + hl7InQueue.getHL7InQueueId() + ",key="
-			        + hl7InQueue.getHL7SourceKey() + ")");
-		}
+		log.debug("Processing HL7 inbound queue (id={},key={})", hl7InQueue.getHL7InQueueId(), hl7InQueue.getHL7SourceKey());
 		
 		// Parse the HL7 into an HL7Message or abort with failure
 		String hl7Message = hl7InQueue.getHL7Data();
@@ -1092,9 +1089,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 			hl7InArchives = getHL7InArchivesToMigrate();
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Transfer of HL7 archives has completed or has been stopped");
-		}
+		log.debug("Transfer of HL7 archives has completed or has been stopped");
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/layout/LayoutSupport.java
+++ b/api/src/main/java/org/openmrs/layout/LayoutSupport.java
@@ -49,7 +49,7 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 	}
 	
 	public T getLayoutTemplateByName(String templateName) {
-		log.debug("looking for template name: " + templateName);
+		log.debug("looking for template name: {}", templateName);
 		
 		if (this.layoutTemplates != null && templateName != null) {
 			T ret = null;
@@ -60,7 +60,7 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 				                || templateName.equalsIgnoreCase(at.getCodeName()) || templateName.equalsIgnoreCase(at
 				                .getCountry()))) {
 					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
+					log.debug("Found Layout Template named {}", at.getDisplayName());
 				}
 			}
 			
@@ -78,7 +78,7 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 			for (T at : this.layoutTemplates) {
 				if (at != null && templateName.equalsIgnoreCase(at.getCodeName())) {
 					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
+					log.debug("Found Layout Template named {}", at.getDisplayName());
 				}
 			}
 			
@@ -96,7 +96,7 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 			for (T at : this.layoutTemplates) {
 				if (at != null && templateName.equalsIgnoreCase(at.getCountry())) {
 					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
+					log.debug("Found Layout Template named {}", at.getDisplayName());
 				}
 			}
 			
@@ -114,7 +114,7 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 			for (T at : this.layoutTemplates) {
 				if (at != null && templateName.equalsIgnoreCase(at.getDisplayName())) {
 					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
+					log.debug("Found Layout Template named {}", at.getDisplayName());
 				}
 			}
 			

--- a/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MessageSourceServiceImpl.java
@@ -66,7 +66,7 @@ public class MessageSourceServiceImpl implements MessageSourceService {
 	@Override
 	public void setActiveMessageSource(MutableMessageSource activeMessageSource) {
 		
-		log.debug("Setting activeMessageSource: " + activeMessageSource);
+		log.debug("Setting activeMessageSource: {}", activeMessageSource);
 		
 		this.activeMessageSource = activeMessageSource;
 		if (!availableMessageSources.contains(activeMessageSource)) {

--- a/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
@@ -290,7 +290,7 @@ public class MutableResourceBundleMessageSource extends ReloadableResourceBundle
 		catch (IOException e) {
 			log.error("Error generated", e);
 		}
-		if (log.isWarnEnabled() && (resourceSet.isEmpty())) {
+		if (resourceSet.isEmpty()) {
 			log.warn("No properties files found.");
 		}
 		return resourceSet.toArray(new Resource[resourceSet.size()]);

--- a/api/src/main/java/org/openmrs/module/Extension.java
+++ b/api/src/main/java/org/openmrs/module/Extension.java
@@ -64,7 +64,7 @@ public abstract class Extension {
 	 * @param parameterMap
 	 */
 	public void initialize(Map<String, String> parameterMap) {
-		log.debug("Initializing extension for point: " + pointId);
+		log.debug("Initializing extension for point: {}", pointId);
 		this.setPointId(pointId);
 		this.setParameterMap(parameterMap);
 	}

--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -123,7 +123,7 @@ public final class Module {
 		this.author = author;
 		this.description = description;
 		this.version = version;
-		log.debug("Creating module " + name);
+		log.debug("Creating module {}", name);
 	}
 	
 	@Override
@@ -522,7 +522,7 @@ public final class Module {
 	public void setExtensionNames(Map<String, String> map) {
 		if (log.isDebugEnabled()) {
 			for (Map.Entry<String, String> entry : extensionNames.entrySet()) {
-				log.debug("Setting extension names: " + entry.getKey() + " : " + entry.getValue());
+				log.debug("Setting extension names: {} : {}", entry.getKey(), entry.getValue());
 			}
 		}
 		this.extensionNames = map;

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -89,9 +89,7 @@ public class ModuleClassLoader extends URLClassLoader {
 			throw new IllegalArgumentException("Parent must not be ModuleClassLoader");
 		}
 		
-		if (log.isDebugEnabled()){
-			log.debug("URLs length: " + urls.size());
-		}
+		log.debug("URLs length: {}", urls.size());
 		this.module = module;
 		requiredModules = collectRequiredModuleImports(module);
 		awareOfModules = collectAwareOfModuleImports(module);
@@ -133,7 +131,7 @@ public class ModuleClassLoader extends URLClassLoader {
 	private void addClassFilePackages(Collection<File> files, int dirLength) {
 		for (File file : files) {
 			String name = file.getAbsolutePath().substring(dirLength);
-			Integer indexOfLastSlash = name.lastIndexOf(File.separator);
+			int indexOfLastSlash = name.lastIndexOf(File.separator);
 			if (indexOfLastSlash > 0) {
 				String packageName = name.substring(0, indexOfLastSlash);
 				packageName = packageName.replace(File.separator, ".");
@@ -276,9 +274,7 @@ public class ModuleClassLoader extends URLClassLoader {
 		
 		// add each defined jar in the /lib folder, add as a url in the classpath of the classloader
 		try {
-			if (log.isDebugEnabled()) {
-				log.debug("Expanding /lib folder in module");
-			}
+			log.debug("Expanding /lib folder in module");
 			
 			ModuleUtil.expandJar(module.getFile(), tmpModuleDir, "lib", true);
 			File libdir = new File(tmpModuleDir, "lib");
@@ -319,14 +315,10 @@ public class ModuleClassLoader extends URLClassLoader {
 					    startedRelatedModules);
 					
 					if (include) {
-						if (log.isDebugEnabled()) {
-							log.debug("Including file in classpath: " + fileUrl);
-						}
+						log.debug("Including file in classpath: {}", fileUrl);
 						result.add(fileUrl);
 					} else {
-						if (log.isDebugEnabled()) {
-							log.debug("Excluding file from classpath: " + fileUrl);
-						}
+						log.debug("Excluding file from classpath: {}", fileUrl);
 					}
 				}
 			}
@@ -487,7 +479,7 @@ public class ModuleClassLoader extends URLClassLoader {
 		
 		for (String awareOfPackage : module.getAwareOfModules()) {
 			Module awareOfModule = ModuleFactory.getModuleByPackage(awareOfPackage);
-			if (ModuleFactory.isModuleStarted(awareOfModule)) {
+			if (awareOfModule != null && ModuleFactory.isModuleStarted(awareOfModule)) {
 				publicImportsMap.put(awareOfModule.getModuleId(), awareOfModule);
 			}
 		}
@@ -523,8 +515,7 @@ public class ModuleClassLoader extends URLClassLoader {
 	 * @see org.openmrs.module.ModuleFactory#stopModule(Module, boolean)
 	 */
 	public void dispose() {
-		if (log.isDebugEnabled())
-			log.debug("Disposing of ModuleClassLoader: " + this);
+		log.debug("Disposing of ModuleClassLoader: {}", this);
 
 		for (File file : libraryCache.values()) {
 			file.delete();
@@ -613,7 +604,7 @@ public class ModuleClassLoader extends URLClassLoader {
 				output.append(element);
 				output.append("\n");
 			}
-			log.trace("Stacktrace: " + output.toString());
+			log.trace("Stacktrace: {}", output);
 		}
 		
 		// Check if we already tried this class loader
@@ -731,17 +722,11 @@ public class ModuleClassLoader extends URLClassLoader {
 			return null;
 		}
 		
-		if (log.isTraceEnabled()) {
-			log.trace("findLibrary(String): name=" + name + ", this=" + this);
-		}
+		log.trace("findLibrary(String): name={}, this={}", name, this);
 		String libname = System.mapLibraryName(name);
 		String result = null;
 		
-		if (log.isTraceEnabled()) {
-			log
-			        .trace("findLibrary(String): name=" + name + ", libname=" + libname + ", result=" + result + ", this="
-			                + this);
-		}
+		log.trace("findLibrary(String): name={}, libname={}, result={}, this={}", new Object[]{name, libname, result, this});
 		
 		return result;
 	}
@@ -815,11 +800,8 @@ public class ModuleClassLoader extends URLClassLoader {
 			// save a link to the cached file
 			libraryCache.put(libUri, result);
 			
-			if (log.isDebugEnabled()) {
-				log.debug("library " + libname + " successfully cached from URL " + libUrl + " and saved to local file "
-				        + result);
-			}
-			
+			log.debug("library {} successfully cached from URL {} and saved to local file {}", 
+					new Object[] {libname, libUrl, result});
 		}
 		catch (IOException ioe) {
 			log.error("can't cache library " + libname + " from URL " + libUrl, ioe);
@@ -871,11 +853,11 @@ public class ModuleClassLoader extends URLClassLoader {
 	protected URL findResource(final String name, final ModuleClassLoader requestor, Set<String> seenModules) {
 		if (log.isTraceEnabled() && name != null && name.contains("starter")) {
 			if (seenModules != null) {
-				log.trace("seenModules.size: " + seenModules.size());
+				log.trace("seenModules.size: {}", seenModules.size());
 			}
-			log.trace("name: " + name);
+			log.trace("name: {}", name);
 			for (URL url : getURLs()) {
-				log.trace("url: " + url);
+				log.trace("url: {}", url);
 			}
 		}
 		

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -129,10 +129,7 @@ public class ModuleFactory {
 	 *         version, the old module
 	 */
 	public static Module loadModule(Module module, Boolean replaceIfExists) throws ModuleException {
-		
-		if (log.isDebugEnabled()) {
-			log.debug("Adding module " + module.getName() + " to the module queue");
-		}
+		log.debug("Adding module {} to the module queue", module.getName());
 		
 		Module oldModule = getLoadedModulesMap().get(module.getModuleId());
 		if (oldModule != null) {
@@ -167,15 +164,13 @@ public class ModuleFactory {
 		// load modules from the user's module repository directory
 		File modulesFolder = ModuleUtil.getModuleRepository();
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Loading modules from: " + modulesFolder.getAbsolutePath());
-		}
+		log.debug("Loading modules from: {}", modulesFolder.getAbsolutePath());
 		
 		File[] files = modulesFolder.listFiles();
 		if (modulesFolder.isDirectory() && files != null) {
 			loadModules(Arrays.asList(files));
 		} else {
-			log.error("modules folder: '" + modulesFolder.getAbsolutePath() + "' is not a directory or IO error occurred");
+			log.error("modules folder: '{}' is not a directory or IO error occurred", modulesFolder.getAbsolutePath());
 		}
 	}
 	
@@ -195,7 +190,7 @@ public class ModuleFactory {
 				if (!f.getName().startsWith(".")) {
 					try {
 						Module mod = loadModule(f, true); // last module loaded wins
-						log.debug("Loaded module: " + mod + " successfully");
+						log.debug("Loaded module: {} successfully", mod);
 					} catch (Exception e) {
 						log.debug("Unable to load file in module directory: " + f + ". Skipping file.", e);
 					}
@@ -261,9 +256,7 @@ public class ModuleFactory {
 				}
 				
 				try {
-					if (log.isDebugEnabled()) {
-						log.debug("starting module: " + mod.getModuleId());
-					}
+					log.debug("starting module: {}", mod.getModuleId());
 					startModule(mod);
 				}
 				catch (Exception e) {
@@ -915,10 +908,8 @@ public class ModuleFactory {
 		// check given version against current version
 		if (gp != null && StringUtils.hasLength(gp.getPropertyValue())) {
 			String currentDbVersion = gp.getPropertyValue();
-			if (log.isDebugEnabled()) {
-				log.debug("version:column " + version + ":" + currentDbVersion);
-				log.debug("compare: " + ModuleUtil.compareVersion(version, currentDbVersion));
-			}
+			log.debug("version:column {}:{}", version, currentDbVersion);
+			log.debug("compare: {}", ModuleUtil.compareVersion(version, currentDbVersion));
 			if (ModuleUtil.compareVersion(version, currentDbVersion) > 0) {
 				executeSQL = true;
 			}

--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -562,8 +562,7 @@ public class ModuleFileParser {
 				+ ") must be a subtype of 'org.openmrs.customdatatype.CustomDatatype<?>'.", ex);
 		}
 		catch (ClassNotFoundException ex) {
-			log.error("The class specified by 'datatypeClassname' (" + datatypeClassname
-				+ ") could not be found.", ex);
+			log.error("The class specified by 'datatypeClassname' (" + datatypeClassname + ") could not be found.", ex);
 		}
 		return globalProperty;
 	}

--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -113,11 +113,9 @@ public class ModuleUtil {
 								log.error("Unable to expand classpath found module: " + modulePath, io);
 							}
 						} else {
-							log
-							        .error("Unable to load module at path: "
-							                + modulePath
-							                + " because no file exists there and it is not found on the classpath. (absolute path tried: "
-							                + file.getAbsolutePath() + ")");
+							log.error("Unable to load module at path: " + modulePath + 
+								" because no file exists there and it is not found on the classpath. (absolute path tried: "
+							    + file.getAbsolutePath() + ")");
 						}
 					}
 				}
@@ -135,7 +133,7 @@ public class ModuleUtil {
 			if (modules == null || modules.isEmpty()) {
 				log.debug("No modules loaded");
 			} else {
-				log.debug("Found and loaded " + modules.size() + " module(s)");
+				log.debug("Found and loaded {} module(s)", modules.size());
 			}
 		}
 		
@@ -154,9 +152,7 @@ public class ModuleUtil {
 		List<Module> modules = new ArrayList<>(ModuleFactory.getStartedModules());
 		
 		for (Module mod : modules) {
-			if (log.isDebugEnabled()) {
-				log.debug("stopping module: " + mod.getModuleId());
-			}
+			log.debug("stopping module: {}", mod.getModuleId());
 			
 			if (mod.isStarted()) {
 				ModuleFactory.stopModule(mod, true, true);
@@ -342,7 +338,7 @@ public class ModuleUtil {
 					}
 				} else {
 					if (compareVersion(version, range) < 0) {
-						log.debug("Version " + version + " is below " + range);
+						log.debug("Version {} is below {}", version, range);
 					} else {
 						return true;
 					}
@@ -592,7 +588,7 @@ public class ModuleUtil {
 				}
 			}
 			if (!foundName) {
-				log.debug("Unable to find: " + name + " in file " + fileToExpand.getAbsolutePath());
+				log.debug("Unable to find: {} in file {}", name, fileToExpand.getAbsolutePath());
 			}
 			
 		}
@@ -624,9 +620,7 @@ public class ModuleUtil {
 	 * @throws IOException if an error occurred while copying
 	 */
 	private static File expand(InputStream input, String fileDir, String name) throws IOException {
-		if (log.isDebugEnabled()) {
-			log.debug("expanding: " + name);
-		}
+		log.debug("expanding: {}", name);
 		
 		File file = new File(fileDir, name);
 		FileOutputStream outStream = null;
@@ -791,8 +785,8 @@ public class ModuleUtil {
 					UpdateFileParser parser = new UpdateFileParser(content);
 					parser.parse();
 					
-					log.debug("Update for mod: " + mod.getModuleId() + " compareVersion result: "
-					        + compareVersion(mod.getVersion(), parser.getCurrentVersion()));
+					log.debug("Update for mod: {} compareVersion result: {}", mod.getModuleId(),
+						compareVersion(mod.getVersion(), parser.getCurrentVersion()));
 					
 					// check the update.rdf version against the installed version
 					if (compareVersion(mod.getVersion(), parser.getCurrentVersion()) < 0) {
@@ -801,7 +795,7 @@ public class ModuleUtil {
 							mod.setUpdateVersion(parser.getCurrentVersion());
 							updateFound = true;
 						} else {
-							log.warn("Module id does not match in update.rdf:" + parser.getModuleId());
+							log.warn("Module id does not match in update.rdf: {}", parser.getModuleId());
 						}
 					} else {
 						mod.setDownloadURL(null);
@@ -900,9 +894,7 @@ public class ModuleUtil {
 		OpenmrsClassLoader.setThreadsToNewClassLoader();
 		
 		// reload the advice points that were lost when refreshing Spring
-		if (log.isDebugEnabled()) {
-			log.debug("Reloading advice for all started modules: " + startedModules.size());
-		}
+		log.debug("Reloading advice for all started modules: {}", startedModules.size());
 		
 		try {
 			//The call backs in this block may need lazy loading of objects
@@ -1150,8 +1142,8 @@ public class ModuleUtil {
 				
 				packageName = packageName.replaceAll("/", ".");
 				
-				if (packagesProvided.add(packageName) && log.isTraceEnabled()) {
-					log.trace("Adding module's jarentry with package: " + packageName);
+				if (packagesProvided.add(packageName)) {
+					log.trace("Adding module's jarentry with package: {}", packageName);
 				}
 			}
 			

--- a/api/src/main/java/org/openmrs/scheduler/TaskFactory.java
+++ b/api/src/main/java/org/openmrs/scheduler/TaskFactory.java
@@ -53,9 +53,7 @@ public class TaskFactory {
 			// Create a new instance of the schedulable class 
 			Task task = new TaskThreadedInitializationWrapper((Task) taskClass.newInstance());
 			
-			if (log.isDebugEnabled()) {
-				log.debug("initializing " + taskClass.getName());
-			}
+			log.debug("initializing {}", taskClass.getName());
 			// Initialize the schedulable object
 			task.initialize(taskDefinition);
 			
@@ -65,17 +63,13 @@ public class TaskFactory {
 			log.error("OpenmrsClassLoader could not load class: " + taskDefinition.getTaskClass()
 			        + ".  Probably due to a module not being loaded");
 			
-			if (log.isDebugEnabled()) {
-				log.debug("Full error trace of ClassNotFoundException", cnfe);
-			}
+			log.debug("Full error trace of ClassNotFoundException", cnfe);
 			
 			throw new SchedulerException("could not load class", cnfe);
 		}
 		catch (Exception e) {
-			if (log.isDebugEnabled()) {
-				// don't need to log errors here necessarily.  If its needed, the calling method can log it.
-				log.debug("Error creating new task for class " + taskDefinition.getTaskClass(), e);
-			}
+			// don't need to log errors here necessarily.  If its needed, the calling method can log it.
+			log.debug("Error creating new task for class " + taskDefinition.getTaskClass(), e);
 			
 			throw new SchedulerException("error creating new task for class " + taskDefinition.getTaskClass(), e);
 		}

--- a/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AutoCloseVisitsTask.java
@@ -33,9 +33,7 @@ public class AutoCloseVisitsTask extends AbstractTask {
 	@Override
 	public void execute() {
 		if (!isExecuting) {
-			if (log.isDebugEnabled()) {
-				log.debug("Starting Auto Close Visits Task...");
-			}
+			log.debug("Starting Auto Close Visits Task...");
 			
 			startExecuting();
 			try {

--- a/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImpl.java
+++ b/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerServiceImpl.java
@@ -376,9 +376,7 @@ public class TimerSchedulerServiceImpl extends BaseOpenmrsService implements Sch
 	@Override
 	@Transactional(readOnly = true)
 	public TaskDefinition getTask(Integer id) {
-		if (log.isDebugEnabled()) {
-			log.debug("get task " + id);
-		}
+		log.debug("get task {}", id);
 		return getSchedulerDAO().getTask(id);
 	}
 	
@@ -390,9 +388,7 @@ public class TimerSchedulerServiceImpl extends BaseOpenmrsService implements Sch
 	@Override
 	@Transactional(readOnly = true)
 	public TaskDefinition getTaskByName(String name) {
-		if (log.isDebugEnabled()) {
-			log.debug("get task " + name);
-		}
+		log.debug("get task {}", name);
 		TaskDefinition foundTask = null;
 		try {
 			foundTask = getSchedulerDAO().getTaskByName(name);

--- a/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsClassLoader.java
@@ -84,9 +84,7 @@ public class OpenmrsClassLoader extends URLClassLoader {
 		
 		OpenmrsClassLoaderHolder.INSTANCE = this;
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Creating new OpenmrsClassLoader instance with parent: " + parent);
-		}
+		log.debug("Creating new OpenmrsClassLoader instance with parent: {}", parent);
 		
 		//disable caching so the jars aren't locked
 		//if performance is effected, this can be disabled in favor of
@@ -210,9 +208,7 @@ public class OpenmrsClassLoader extends URLClassLoader {
 	 */
 	@Override
 	public URL findResource(final String name) {
-		if (log.isTraceEnabled()) {
-			log.trace("finding resource: " + name);
-		}
+		log.trace("finding resource: {}", name);
 		
 		URL result;
 		for (ModuleClassLoader classLoader : ModuleFactory.getModuleClassLoaders()) {
@@ -544,24 +540,18 @@ public class OpenmrsClassLoader extends URLClassLoader {
 									}
 								} else {
 									field.set(null, null);
-									if (log.isDebugEnabled()) {
-										log.debug("Set field " + field.getName() + " to null in class " + clazz.getName());
-									}
+									log.debug("Set field {} to null in class {}", field.getName(), clazz.getName());
 								}
 							}
 							catch (Exception t) {
-								if (log.isDebugEnabled()) {
-									log.debug("Could not set field " + field.getName() + " to null in class "
+								log.debug("Could not set field " + field.getName() + " to null in class "
 											+ clazz.getName(), t);
-								}
 							}
 						}
 					}
 				}
 				catch (Exception t) {
-					if (log.isDebugEnabled()) {
-						log.debug("Could not clean fields for class " + clazz.getName(), t);
-					}
+					log.debug("Could not clean fields for class " + clazz.getName(), t);
 				}
 			}
 		}
@@ -599,26 +589,19 @@ public class OpenmrsClassLoader extends URLClassLoader {
 					if (null != value) {
 						Class<?> valueClass = value.getClass();
 						if (!loadedByThisOrChild(valueClass)) {
-							if (log.isDebugEnabled()) {
-								log.debug("Not setting field " + field.getName() + " to null in object of class "
-										+ instance.getClass().getName() + " because the referenced object was of type "
-										+ valueClass.getName() + " which was not loaded by this WebappClassLoader.");
-							}
+							log.debug("Not setting field {} to null in object of class {} because the referenced object was"
+									+ " of type {} which was not loaded by this WebappClassLoader.", 
+									new Object[] {field.getName(), instance.getClass().getName(), valueClass.getName() });
 						} else {
 							field.set(instance, null);
-							if (log.isDebugEnabled()) {
-								log.debug("Set field " + field.getName() + " to null in class "
-										+ instance.getClass().getName());
-							}
+							log.debug("Set field {} to null in class {}", field.getName(), instance.getClass().getName());
 						}
 					}
 				}
 			}
 			catch (Exception e) {
-				if (log.isDebugEnabled()) {
-					log.debug("Could not set field " + field.getName() + " to null in object instance of class "
+				log.debug("Could not set field " + field.getName() + " to null in object instance of class "
 							+ instance.getClass().getName(), e);
-				}
 			}
 		}
 	}
@@ -712,9 +695,7 @@ public class OpenmrsClassLoader extends URLClassLoader {
 		synchronized (ModuleClassLoader.class) {
 			libCacheFolder = new File(OpenmrsUtil.getApplicationDataDirectory(), LIBCACHESUFFIX);
 			
-			if (log.isDebugEnabled()) {
-				log.debug("libraries cache folder is " + libCacheFolder);
-			}
+			log.debug("libraries cache folder is {}", libCacheFolder);
 			
 			if (libCacheFolder.exists()) {
 				// clean up and empty the folder if it exists (and is not locked)
@@ -757,24 +738,18 @@ public class OpenmrsClassLoader extends URLClassLoader {
 			extForm = extForm.replaceFirst("jar:file:/", "").replaceAll("%20", " ");
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("url external form: " + extForm);
-		}
+		log.debug("url external form: {}", extForm);
 		
 		int i = extForm.indexOf("!");
 		String jarPath = extForm.substring(0, i);
 		String filePath = extForm.substring(i + 2); // skip over both the '!' and the '/'
 		
-		if (log.isDebugEnabled()) {
-			log.debug("jarPath: " + jarPath);
-			log.debug("filePath: " + filePath);
-		}
+		log.debug("jarPath: {}", jarPath);
+		log.debug("filePath: {}", filePath);
 		
 		File file = new File(folder, filePath);
 		
-		if (log.isDebugEnabled()) {
-			log.debug("absolute path: " + file.getAbsolutePath());
-		}
+		log.debug("absolute path: {}", file.getAbsolutePath());
 		
 		try {
 			// if the file has been expanded already, return that

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -905,9 +905,7 @@ public class OpenmrsUtil {
 			throw new IOException("Could not delete directory '" + dir.getAbsolutePath() + "' (not a directory)");
 		}
 		
-		if (log.isDebugEnabled()) {
-			log.debug("Deleting directory " + dir.getAbsolutePath());
-		}
+		log.debug("Deleting directory {}", dir.getAbsolutePath());
 		
 		File[] fileList = dir.listFiles();
 		if (fileList == null) {
@@ -920,9 +918,7 @@ public class OpenmrsUtil {
 			}
 			boolean success = f.delete();
 			
-			if (log.isDebugEnabled()) {
-				log.debug("   deleting " + f.getName() + " : " + (success ? "ok" : "failed"));
-			}
+			log.debug("   deleting {} : {}", f.getName(), (success ? "ok" : "failed"));
 			
 			if (!success) {
 				f.deleteOnExit();
@@ -936,7 +932,7 @@ public class OpenmrsUtil {
 			dir.deleteOnExit();
 		}
 		
-		if (success && log.isDebugEnabled()) {
+		if (success) {
 			log.debug("   ...and directory itself");
 		}
 		
@@ -2073,7 +2069,7 @@ public class OpenmrsUtil {
 		
 		// first look in the current directory (that java was started from)
 		String pathName = fileNameInTestMode != null ? fileNameInTestMode : defaultFileName;
-		log.debug("Attempting to look for properties file in current directory: " + pathName);
+		log.debug("Attempting to look for properties file in current directory: {}", pathName);
 		if (new File(pathName).exists()) {
 			return pathName;
 		} else {
@@ -2084,7 +2080,7 @@ public class OpenmrsUtil {
 		String envVarName = applicationName.toUpperCase() + "_RUNTIME_PROPERTIES_FILE";
 		String envFileName = System.getenv(envVarName);
 		if (envFileName != null) {
-			log.debug("Atempting to look for runtime properties from: " + pathName);
+			log.debug("Atempting to look for runtime properties from: {}", pathName);
 			if (new File(envFileName).exists()) {
 				return envFileName;
 			} else {
@@ -2092,20 +2088,18 @@ public class OpenmrsUtil {
 				        + envVarName + ")");
 			}
 		} else {
-			log.info("Couldn't find an environment variable named " + envVarName);
-			if (log.isDebugEnabled()) {
-				log.debug("Available environment variables are named: " + System.getenv().keySet());
-			}
+			log.info("Couldn't find an environment variable named {}", envVarName);
+			log.debug("Available environment variables are named: {}", System.getenv().keySet());
 		}
 		
 		// next look in the OpenMRS application data directory
 		File file = new File(getApplicationDataDirectory(), pathName);
 		pathName = file.getAbsolutePath();
-		log.debug("Attempting to look for property file from: " + pathName);
+		log.debug("Attempting to look for property file from: {}", pathName);
 		if (file.exists()) {
 			return pathName;
 		} else {
-			log.warn("Unable to find properties file: " + pathName);
+			log.warn("Unable to find properties file: {}", pathName);
 		}
 		
 		return null;

--- a/api/src/main/java/org/openmrs/validator/ConceptValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptValidator.java
@@ -194,9 +194,7 @@ public class ConceptValidator extends BaseCustomizableValidator implements Valid
 					        + "' is a duplicate name in locale '" + conceptNameLocale.toString() + "' for the same concept");
 				}
 				
-				if (log.isDebugEnabled()) {
-					log.debug("Valid name found: " + nameInLocale.getName());
-				}
+				log.debug("Valid name found: {}" + nameInLocale.getName());
 			}
 		}
 		

--- a/api/src/main/java/org/openmrs/validator/EncounterValidator.java
+++ b/api/src/main/java/org/openmrs/validator/EncounterValidator.java
@@ -40,9 +40,7 @@ public class EncounterValidator implements Validator {
 	 */
 	@Override
 	public boolean supports(Class<?> c) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".supports: " + c.getName());
-		}
+		log.debug("{}.supports: {}", getClass().getName(), c.getName());
 		return Encounter.class.isAssignableFrom(c);
 	}
 	
@@ -66,9 +64,7 @@ public class EncounterValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) throws APIException {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (obj == null || !(obj instanceof Encounter)) {
 			throw new IllegalArgumentException("The parameter obj should not be null and must be of type " + Encounter.class);

--- a/api/src/main/java/org/openmrs/validator/FieldValidator.java
+++ b/api/src/main/java/org/openmrs/validator/FieldValidator.java
@@ -36,9 +36,7 @@ public class FieldValidator implements Validator {
 	 */
 	@Override
 	public boolean supports(Class<?> c) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".supports: " + c.getName());
-		}
+		log.debug("{}.supports: {}", getClass().getName(), c.getName());
 		return Field.class.isAssignableFrom(c);
 	}
 	
@@ -62,9 +60,7 @@ public class FieldValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) throws APIException {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (obj == null || !(obj instanceof Field)) {
 			throw new IllegalArgumentException("The parameter obj should not be null and must be of type " + Field.class);

--- a/api/src/main/java/org/openmrs/validator/PatientProgramValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientProgramValidator.java
@@ -73,9 +73,7 @@ public class PatientProgramValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (obj == null) {
 			throw new IllegalArgumentException("The parameter obj should not be null");

--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -39,9 +39,7 @@ public class PatientValidator extends PersonValidator {
 	 */
 	@Override
 	public boolean supports(Class<?> c) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".supports: " + c.getName());
-		}
+		log.debug("{}.supports: {}", getClass().getName(), c.getName());
 		return Patient.class.isAssignableFrom(c);
 	}
 	
@@ -66,9 +64,7 @@ public class PatientValidator extends PersonValidator {
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (obj == null) {
 			return;

--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -59,9 +59,7 @@ public class PersonAddressValidator implements Validator {
 	@Override
 	public void validate(Object object, Errors errors) {
 		//TODO Validate other aspects of the personAddress object
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (object == null) {
 			throw new IllegalArgumentException("The personAddress object should not be null");

--- a/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
@@ -49,9 +49,7 @@ public class PersonNameValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object object, Errors errors) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		PersonName personName = (PersonName) object;
 		try {
 			// Validate that the person name object is not null

--- a/api/src/main/java/org/openmrs/validator/ProviderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ProviderValidator.java
@@ -38,9 +38,7 @@ public class ProviderValidator extends BaseCustomizableValidator implements Vali
 	 */
 	@Override
 	public boolean supports(Class<?> c) {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".supports: " + c.getName());
-		}
+		log.debug("{}.supports: {}", getClass().getName(), c.getName());
 		return Provider.class.isAssignableFrom(c);
 	}
 	
@@ -69,9 +67,7 @@ public class ProviderValidator extends BaseCustomizableValidator implements Vali
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) throws APIException {
-		if (log.isDebugEnabled()) {
-			log.debug(this.getClass().getName() + ".validate...");
-		}
+		log.debug("{}.validate...", getClass().getName());
 		
 		if (obj == null || !(obj instanceof Provider)) {
 			throw new IllegalArgumentException("The parameter obj should not be null and must be of type " + Provider.class);

--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -183,8 +183,7 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 		
 		Properties props = getRuntimeProperties();
 		
-		if (log.isDebugEnabled())
-			log.debug("props: " + props);
+		log.debug("props: {}", props);
 		
 		Context.setRuntimeProperties(props);
 		


### PR DESCRIPTION
## Description of what I changed
I replaced use of conditionals

```
if (log.isDebugEnabled()) {
  log.debug("Entry number: " + i + " is " + String.valueOf(entry[i]));
}
```

which are aimed at preventing to construct the debug message with slf4js parametrized messages

`log.debug("The entry is {}.", entry);`

**Note**:
- I replaced only at openmrs-api.
- I don't replace complex logging, like

```
if (log.isDebugEnabled()) {
    User user = Context.getAuthenticatedUser();
    log.debug("User " + user);
    if (user != null) {
	 log.debug("has roles " + user.getAllRoles());
    }
}
```

Why? See [this issue](https://issues.openmrs.org/browse/TRUNK-5427?jql=project%20%3D%20TRUNK%20AND%20text%20~%20%22AuthorizationAdvice%23before%22)

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5429 (sub-task of https://issues.openmrs.org/browse/TRUNK-5115)
## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
