### PR TITLE
TRUNK-5304: Upgrade from 1.10.6 to 1.11.8 fails because of inconsistent changeset

### DIFF
--- a/api/src/main/resources/liquibase-update-to-2.0.xml
+++ b/api/src/main/resources/liquibase-update-to-2.0.xml
@@ -9425,6 +9425,8 @@
 	</changeSet>
 
     <changeSet id="TRUNK-3422-20160216-1700" author="Wyclif" >
+		<validCheckSum>3:474feb8369313b4d680197f9bac6ec20</validCheckSum> <!-- old checksum -->
+		<validCheckSum>3:a517d5e30d3814f5b186cbc93aa359de</validCheckSum> <!-- checksum when "View" is replaced with "Get" -->
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
                 SELECT count(*) FROM privilege  WHERE privilege='Get Visits';
@@ -9439,6 +9441,8 @@
     </changeSet>
 
     <changeSet id="TRUNK-3422-20160216-1701" author="Wyclif" >
+		<validCheckSum>3:cc913159fdb532c487941d23ac9c79c9</validCheckSum> <!-- old checksum -->
+		<validCheckSum>3:e5e5b2b92bbceeb4041166cd3b86803e</validCheckSum> <!-- checksum when "View" is replaced with "Get" -->
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
                 SELECT count(*) FROM privilege  WHERE privilege='Get Providers';
@@ -9467,6 +9471,8 @@
     </changeSet>
 
     <changeSet id="TRUNK-3422-20160216-1703" author="PralayRamteke" >
+		<validCheckSum>3:693ea38e8702b7c1afef81ceefef9844</validCheckSum> <!-- old checksum -->
+		<validCheckSum>3:2188e5d96b696afc752217843a7fa697</validCheckSum> <!-- checksum when "View" is replaced with "Get" -->
         <preConditions onFail="MARK_RAN">
             <not>
                 <sqlCheck expectedResult="0">
@@ -9485,6 +9491,8 @@
     </changeSet>
 
     <changeSet id="TRUNK-3422-20160216-1704" author="PralayRamteke" >
+		<validCheckSum>3:b4caee668484f1d2759bbf3feeba2daa</validCheckSum> <!-- old checksum -->
+		<validCheckSum>3:13b334dbd8fba2fea886d1c9aab40e16</validCheckSum> <!-- checksum when "View" is replaced with "Get" -->
         <preConditions onFail="MARK_RAN">
             <not>
                 <sqlCheck expectedResult="0">


### PR DESCRIPTION
## Description of what I changed
I've modified bad changesets which caused ValidationError during upgrading following this <a href="https://wiki.openmrs.org/display/docs/How+to+Modify+a+Bad+Changeset">Wiki page</a>. 

Reopened the pull request because the first one wasn't based on master. It also needs to be backported to other versions after it's merged.

## Issue I worked on
JIRA: <a href="https://issues.openmrs.org/browse/TRUNK-5304">TRUNK-5304</a>

GCI: <a href="https://codein.withgoogle.com/dashboard/task-instances/4591487401590784/">Task Instance</a>

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**
- [x] My pull request only contains **ONE single commit**
- [x] My pull request is **based on the latest changes** of the master branch.