### PR TITLE
TRUNK-5469 Use simpler call to get a String's substring

### DIFF
--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
@@ -65,7 +65,7 @@ public class OpenmrsProfileExcludeFilter implements TypeFilter {
 
 		for (String moduleAndVersion : modules) {
 			if ("!".equals(moduleAndVersion.substring(0, 1))) {
-				if (ModuleFactory.isModuleStarted(moduleAndVersion.substring(1, moduleAndVersion.length()))) {
+				if (ModuleFactory.isModuleStarted(moduleAndVersion.substring(1))) {
 					return false;
 				}
 			}

--- a/api/src/main/java/org/openmrs/patient/impl/BaseHyphenatedIdentifierValidator.java
+++ b/api/src/main/java/org/openmrs/patient/impl/BaseHyphenatedIdentifierValidator.java
@@ -70,7 +70,7 @@ public abstract class BaseHyphenatedIdentifierValidator implements IdentifierVal
 		
 		int computedCheckDigit = getCheckDigit(idWithoutCheckDigit);
 		
-		String checkDigit = identifier.substring(identifier.indexOf("-") + 1, identifier.length());
+		String checkDigit = identifier.substring(identifier.indexOf("-") + 1);
 		
 		if (checkDigit.length() != 1) {
 			throw new UnallowedIdentifierException("Identifier must have a check digit of length 1.");

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswersEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswersEditor.java
@@ -220,7 +220,7 @@ public class ConceptAnswersEditor extends PropertyEditorSupport {
 	 */
 	private Integer getDrugId(String conceptId) {
 		if (conceptId.contains("^")) {
-			return Integer.valueOf(conceptId.substring(conceptId.indexOf("^") + 1, conceptId.length()));
+			return Integer.valueOf(conceptId.substring(conceptId.indexOf("^") + 1));
 		}
 		
 		return null;

--- a/api/src/test/java/org/openmrs/patient/impl/VerhoeffIdentifierValidatorTest.java
+++ b/api/src/test/java/org/openmrs/patient/impl/VerhoeffIdentifierValidatorTest.java
@@ -161,7 +161,7 @@ public class VerhoeffIdentifierValidatorTest {
 					}
 				}
 				// Shuffle the allowed identifier string around so that first character becomes last.
-				allowedIdentifier = allowedIdentifier.substring(1, allowedIdentifier.length()) + allowedIdentifier.charAt(0);
+				allowedIdentifier = allowedIdentifier.substring(1) + allowedIdentifier.charAt(0);
 			}
 		}
 		assertTrue(failures + " transposed digits were not detected:\n" + failureMsg, failures == 0);


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Using *String*'s simpler method to get a substring starting at position *n* and finishing at the end of the string.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5469

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [X] My pull request only contains **ONE single commit**

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [X] All new and existing **tests passed**.

- [X] My pull request is **based on the latest changes** of the master branch.