### PR TITLE
TRUNK-5000 : Get rid of Get rid of hack that allows first component t…

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -543,7 +543,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 	            if (locationId == null) throw new Exception();
 	            return locationId;
 			}
-		}
+	
 		catch (Exception ex) {
 			if (facility == null) { // we have no tricks left up our sleeve, so
 				// throw an exception

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -539,10 +539,9 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 		// HACK: try to treat the first component (which should be "Point of
 		// Care" as an internal openmrs location_id
 		try {
-			Integer locationId = Integer.valueOf(pointOfCare);
-			Location l = Context.getLocationService().getLocation(locationId);
-			if (l != null) {
-				return l.getLocationId();
+			 Integer locationId = Integer.valueOf(pointOfCare);
+	            if (locationId == null) throw new Exception();
+	            return locationId;
 			}
 		}
 		catch (Exception ex) {


### PR DESCRIPTION
**Description of what I changed**
 To treat the first component (which should be "Point ofCare" as an internal openmrs location_id

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5000


