### PR TITLE
TRUNK-5000 - Allows first component to be an integer

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -540,9 +540,8 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 		// Care" as an internal openmrs location_id
 		try {
 			Integer locationId = Integer.valueOf(pointOfCare);
-			Location l = Context.getLocationService().getLocation(locationId);
-			if (l != null) {
-				return l.getLocationId();
+			if (locationId == null) throw new Exception();
+			return locationId;
 			}
 		
 		catch (Exception ex) {

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -544,7 +544,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 			if (l != null) {
 				return l.getLocationId();
 			}
-		}
+		
 		catch (Exception ex) {
 			if (facility == null) { // we have no tricks left up our sleeve, so
 				// throw an exception


### PR DESCRIPTION

## Description of what I changed
I enabled the component which should be "Point ofCare" to be treated as an internal openmrs location_id


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5000

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

