### PR TITLE
TRUNK-5000 Allows first component to be an integer

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -539,12 +539,10 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 		// HACK: try to treat the first component (which should be "Point of
 		// Care" as an internal openmrs location_id
 		try {
-			Integer locationId = Integer.valueOf(pointOfCare);
-			Location l = Context.getLocationService().getLocation(locationId);
-			if (l != null) {
-				return l.getLocationId();
+			 Integer locationId = Integer.valueOf(pointOfCare);
+	            if (locationId == null) throw new Exception();
+	            return locationId;
 			}
-		}
 		catch (Exception ex) {
 			if (facility == null) { // we have no tricks left up our sleeve, so
 				// throw an exception


### PR DESCRIPTION

## Description of what I changed
I worked on the hack that allows first component to be an integer location.location_id


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5000


