### PR TITLE
TRUNK-5491: PatientWorkflowState.toString should not hit the database

### DIFF
--- a/api/src/main/java/org/openmrs/ProgramWorkflowState.java
+++ b/api/src/main/java/org/openmrs/ProgramWorkflowState.java
@@ -50,7 +50,7 @@ public class ProgramWorkflowState extends BaseChangeableOpenmrsMetadata {
 	/** @see Object#toString() */
 	@Override
 	public String toString() {
-		return "State " + getConcept().getName() + " initial=" + getInitial() + " terminal=" + getTerminal();
+		return "State " + getConcept().toString() + " initial=" + getInitial() + " terminal=" + getTerminal();
 	}
 	
 	// ******************


### PR DESCRIPTION
https://issues.openmrs.org/browse/TRUNK-5491

**The problem**
While running tests for HTMLFormEntry, when one runs only the tests for EnrollProgramTagTest (rather than the full suite), all of the tests which attempt to modify entities in the database fail with `org.hibernate.AssertionFailure: null id in org.openmrs.PatientState entry (don't flush the Session after an exception occurs)`.

The failure occurs because of a log statement which logs the entity in [AuditableInterceptor](https://github.com/openmrs/openmrs-core/blob/9e474b6613b347a4fa68e08a4c6ac067f466dd1f/api/src/main/java/org/openmrs/api/db/hibernate/AuditableInterceptor.java#L108). This log statement ends up calling `org.openmrs.ProgramWorkflowState.toString`, which calls `Concept.getName()`, which apparently triggers a Hibernate flush. Hibernate gets mad that it's being flushed while it's trying to save an entity.

**The solution**
Simple `toString` methods. This one relies on the simplicity of `Concept.toString`.