### PR TITLE
TRUNK-5497: Updated the mysql-connector-java from 5.1.45 to 8.0.16, m…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,13 +401,14 @@
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
-				<version>5.1.45</version>
+				<version>8.0.16</version>
 				<scope>runtime</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.mysql</groupId>
+				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-mxj</artifactId>
-				<version>5.0.11</version>
+				<version>5.0.12</version>
+				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>postgresql</groupId>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -151,26 +151,25 @@
              <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>mysql</groupId>
-                    <artifactId>mysql-connector-java</artifactId>
-                    <scope>runtime</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>com.mysql</groupId>
-                    <artifactId>mysql-connector-mxj</artifactId>
-                    <version>5.0.11</version>
-                    <scope>compile</scope>
-                </dependency>
-
-                <dependency>
-                    <groupId>com.mysql</groupId>
-                    <artifactId>mysql-connector-mxj-dbfiles</artifactId>
-                    <version>5.0.11</version>
-                    <scope>compile</scope>
-                </dependency>
+            <dependencies>           
+				<dependency>
+					<groupId>mysql</groupId>
+					<artifactId>mysql-connector-java</artifactId>
+					<version>8.0.16</version>
+					<scope>runtime</scope>
+				</dependency>
+				<dependency>
+					<groupId>mysql</groupId>
+					<artifactId>mysql-connector-mxj</artifactId>
+					<version>5.0.12</version>
+					<scope>compile</scope>
+				</dependency>
+				<dependency>
+					<groupId>mysql</groupId>
+					<artifactId>mysql-connector-mxj-db-files</artifactId>
+					<version>5.0.12</version>
+					<scope>compile</scope>
+				</dependency>
             </dependencies>
         </profile>
         


### PR DESCRIPTION
…ysql-connector-mxj from 5.0.11 to 5.0.12 and mysql-connector-mxj-db-files from 5.0.11 to 5.0.12

Upgrade MySQL version From 5.7 to 8.0
OpenMRS CoreTRUNK-5497 Upgrade MySQL version From 5.7 to 8
Updated the mysql-connector-java from 5.1.45 to 8.0.16, mysql-connector-mxj from 5.0.11 to 5.0.12 and mysql-connector-mxj-db-files from 5.0.11 to 5.0.12"
https://issues.openmrs.org/browse/TRUNK-5497?jql=assignee%20in%20(reagan)%20ORDER%20BY%20created%20DESC

