### PR TITLE
TRUNK-5546;Upgrade library org.mockito:mockito-core from 1.10.19 to 2.27.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,9 +462,9 @@
 				<version>4.12</version>
 			</dependency>
 			<dependency>
-				<groupId>org.mockito</groupId>
-				<artifactId>mockito-core</artifactId>
-				<version>1.10.19</version>
+			    <groupId>org.mockito</groupId>
+			    <artifactId>mockito-core</artifactId>
+			    <version>2.27.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.powermock</groupId>


### PR DESCRIPTION
TRUNK-5546;Upgrade library org.mockito:mockito-core from 1.10.19 to 2.27.0
Upgraded library org.mockito:mockito-core from 1.10.19 to 2.27.0