### PR TITLE
TRUNK-5521:Upgrade javax Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,18 +95,18 @@
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>
-				<version>3.0.1</version>
+				<version>4.0.1</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>jsp-api</artifactId>
-				<version>2.0</version>
+				<version>2.0.public_draft</version>
 			</dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>jstl</artifactId>
-				<version>1.1.2</version>
+				<version>1.2</version>
 			</dependency>
 			<dependency>
 				<groupId>taglibs</groupId>
@@ -374,7 +374,7 @@
 			<dependency>
 				<groupId>javax.mail</groupId>
 				<artifactId>mail</artifactId>
-				<version>1.4.1</version>
+				<version>1.5.0-b01</version>
 				<exclusions>
 					<exclusion>  <!-- declare the exclusion here -->
 						<groupId>javax.activation</groupId>
@@ -505,7 +505,7 @@
 			<dependency>
 				<groupId>javax.validation</groupId>
 				<artifactId>validation-api</artifactId>
-				<version>1.0.0.GA</version>
+				<version>2.0.1.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.codehaus.sonar-plugins.java</groupId>


### PR DESCRIPTION

## Description of what I changed
I upgraded library javax API sub-libraries below 
 # javax.mail:mail … 1.4.1 -> 1.5.0-b01
 #  javax.servlet:javax.servlet-api … 3.0.1 -> 4.0.1
 #  javax.servlet:jsp-api … 2.0 -> 2.0.public_draft
 #  javax.servlet:jstl … 1.1.2 -> 1.2
 # javax.validation:validation-api … 1.0.0.GA -> 2.0.1.Final

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5521

