### PR TITLE
 TRUNK-5512: Upgrade com.h2database:h2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,7 @@
 			<dependency>
 				<groupId>com.h2database</groupId>
 				<artifactId>h2</artifactId>
-				<version>1.4.197</version>
+				<version>1.4.199</version>
 			</dependency>
 			<dependency>
 				<groupId>org.dbunit</groupId>


### PR DESCRIPTION

## Description of what I changed
  Upgraded library com.h2database:h2 from 1.4.197 - 1.4.199


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5512

