### PR TITLE
TRUNK-5500:Upgrade org.apache.commons:commons-lang3 library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.6</version>
+				<version>3.9</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>


### PR DESCRIPTION

## Description of what I changed
Upgrade the org.apache.commons:commons-lang3 from 3.6.0 to 3.9.0 and handle any Backward Compatibility issues

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5500

