### PR TITLE
Trunk 5546: upgrading mockito-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.8.0</version>
+                <version>2.12.0</version>
             </dependency>
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,7 @@
 			<dependency>
 				<groupId>org.mockito</groupId>
 				<artifactId>mockito-core</artifactId>
-				<version>1.9.5</version>
+				<version>2.27.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.powermock</groupId>


### PR DESCRIPTION

## Description of what I changed
upgraded mockito-core from 1.9.5  to the latest which is 2.27.0

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5546

