### PR TITLE
TRUNK-5528:Upgrade org.apache.lucene sub Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,12 +268,12 @@
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-queryparser</artifactId>
-				<version>4.10.4</version>
+				<version>8.1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-queries</artifactId>
-				<version>4.10.4</version>
+				<version>8.1.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.liquibase</groupId>


### PR DESCRIPTION

## Description of what I changed


I upgraded library org.apache.lucene sub Libraries 

1. org.apache.lucene:lucene-queries … 4.10.4 -> 8.1.0
2.  org.apache.lucene:lucene-queryparser … 4.10.4 -> 8.1.0


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5528


