### PR TITLE
TRUNK-5499-upgrade-hibernate-libraries

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -205,8 +205,8 @@
            <groupId>javax.validation</groupId>
            <artifactId>validation-api</artifactId>
        </dependency>
-       <dependency>
-			<groupId>org.hibernate</groupId>
+	   <dependency>
+			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 	   </dependency>
        <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1047,7 +1047,7 @@
 		<openmrs.version>${project.version}</openmrs.version>
 
 		<springVersion>4.1.4.RELEASE</springVersion>
-		<hibernateVersion>5.4.2.Final</hibernateVersion>
+		<hibernateVersion>4.3.10.Final</hibernateVersion>
 		<customArgLineForTesting/>
 
 		<sonar.host.url>https://sonar.openmrs.org</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -258,12 +258,12 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>4.2.0.Final</version>
+				<version>6.0.16.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-search-orm</artifactId>
-				<version>5.1.2.Final</version>
+				<version>5.11.1.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
@@ -1047,7 +1047,7 @@
 		<openmrs.version>${project.version}</openmrs.version>
 
 		<springVersion>4.1.4.RELEASE</springVersion>
-		<hibernateVersion>4.3.9.Final</hibernateVersion>
+		<hibernateVersion>5.4.2.Final</hibernateVersion>
 		<customArgLineForTesting/>
 
 		<sonar.host.url>https://sonar.openmrs.org</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
 				</exclusions>
 			</dependency>
 			<dependency>
-				<groupId>org.hibernate</groupId>
+				<groupId>org.hibernate.validator</groupId>
 				<artifactId>hibernate-validator</artifactId>
 				<version>6.0.16.Final</version>
 			</dependency>
@@ -1047,7 +1047,7 @@
 		<openmrs.version>${project.version}</openmrs.version>
 
 		<springVersion>4.1.4.RELEASE</springVersion>
-		<hibernateVersion>5.4.2.Final</hibernateVersion>
+		<hibernateVersion>5.1.0.Final</hibernateVersion>
 		<customArgLineForTesting/>
 
 		<sonar.host.url>https://sonar.openmrs.org</sonar.host.url>

--- a/pom.xml
+++ b/pom.xml
@@ -1047,7 +1047,7 @@
 		<openmrs.version>${project.version}</openmrs.version>
 
 		<springVersion>4.1.4.RELEASE</springVersion>
-		<hibernateVersion>5.1.0.Final</hibernateVersion>
+		<hibernateVersion>5.4.2.Final</hibernateVersion>
 		<customArgLineForTesting/>
 
 		<sonar.host.url>https://sonar.openmrs.org</sonar.host.url>


### PR DESCRIPTION
## Description of what I changed
I upgraded the Hibernate Library with the follwoing Sub Libraries

org.hibernate:hibernate-c3p0 … 4.3.9.Final -> 5.4.2.Final
 
org.hibernate:hibernate-core … 4.3.9.Final -> 5.4.2.Final
 
org.hibernate:hibernate-ehcache … 4.3.9.Final -> 5.4.2.Final
 
org.hibernate:hibernate-search-orm … 5.1.2.Final -> 5.11.1.Final
 
org.hibernate:hibernate-validator … 4.2.0.Final -> 6.0.16.Final

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5499

