### PR TITLE
TRUNK-5544:Upgraded the javassist from 3.22.0-GA to 3.25.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
 			<dependency>
 				<groupId>org.javassist</groupId>
 				<artifactId>javassist</artifactId>
-				<version>3.22.0-GA</version>
+				<version>3.25.0-GA</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>


### PR DESCRIPTION
Upgrade library org.javassist:javassist from 3.22.0-GA to 3.25.0-GA
TRUNK-5544:Upgrade org.javassist:javassist
I upgraded the org.javassist:javassist library from 3.22.0-GA to 3.25.0-GA

I also included the mysql connector in my api pom with the scope as test because the tests fail with out it...errors shown here https://pastebin.com/nNxrKv1d
https://issues.openmrs.org/browse/TRUNK-5544