### PR TITLE
TRUNK-5557: Improve performance of ConceptService.getConceptsByMapping

### DIFF
--- a/api/src/main/java/org/openmrs/api/ConceptService.java
+++ b/api/src/main/java/org/openmrs/api/ConceptService.java
@@ -1025,6 +1025,28 @@ public interface ConceptService extends OpenmrsService {
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired) throws APIException;
+
+	/**
+	 * Looks up concepts via {@link ConceptMap} This will return the list of ids for all
+	 * {@link Concept}s which contain a {@link ConceptMap} entry whose <code>sourceCode</code> is
+	 * equal to the passed <code>conceptCode</code> and whose {@link ConceptSource} has either a
+	 * <code>name</code> or <code>hl7Code</code> that is equal to the passed
+	 * <code>mappingCode</code>
+	 *
+	 * @param code the code associated with a concept within a given {@link ConceptSource}
+	 * @param sourceName the name or hl7Code of the {@link ConceptSource} to check
+	 * @param includeRetired whether or not to include retired concepts
+	 * @return the list ids for all non-voided {@link Concept}s that have the given mapping, or an empty List if none found
+	 * @throws APIException if the specified source+code maps to more than one concept
+	 * @should get concepts with given code and and source hl7 code
+	 * @should get concepts with given code and source name
+	 * @should return empty list if source code does not exist
+	 * @should return empty list if mapping does not exist
+	 * @should include retired concepts
+	 * @since 2.3
+	 */
+	@Authorized(PrivilegeConstants.GET_CONCEPTS)
+	public List<Integer> getConceptIdsByMapping(String code, String sourceName, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get all the concept name tags defined in the database, included voided ones

--- a/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
@@ -324,6 +324,11 @@ public interface ConceptDAO {
 	 * @see org.openmrs.api.ConceptService#getConceptsByMapping(java.lang.String, java.lang.String)
 	 */
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired);
+
+	/**
+	 * @see org.openmrs.api.ConceptService#getConceptIdsByMapping(String, String, boolean)
+	 */
+	public List<Integer> getConceptIdsByMapping(String code, String sourceName, boolean includeRetired);
 	
 	/**
 	 * @param uuid

--- a/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
@@ -322,7 +322,10 @@ public interface ConceptDAO {
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptsByMapping(java.lang.String, java.lang.String)
+	 * This method has been deprecated in favor of getConceptIdsByMapping, which
+	 * is used by the ConceptService to leverage caching of results
 	 */
+	@Deprecated
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired);
 
 	/**

--- a/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ConceptDAO.java
@@ -322,8 +322,8 @@ public interface ConceptDAO {
 	
 	/**
 	 * @see org.openmrs.api.ConceptService#getConceptsByMapping(java.lang.String, java.lang.String)
-	 * This method has been deprecated in favor of getConceptIdsByMapping, which
-	 * is used by the ConceptService to leverage caching of results
+	 * 
+	 * @deprecated As of 2.5.0, this method has been deprecated in favor of {@link #getConceptIdsByMapping(String, String, boolean)}
 	 */
 	@Deprecated
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -471,7 +471,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 	}
 	
 	/**
-	 * @see org.openmrs.api.db.ConceptDAO#getConceptDatatypes(java.lang.String)
+	 * @param name the name of the ConceptDatatype
+	 * @return a List of ConceptDatatype whose names start with the passed name
 	 */
 	@SuppressWarnings("unchecked")
 	public List<ConceptDatatype> getConceptDatatypes(String name) throws DAOException {
@@ -1022,6 +1023,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired) {
 		Criteria criteria = createSearchConceptMapCriteria(code, sourceName, includeRetired);
 		criteria.setProjection(Projections.property("concept"));

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -817,7 +817,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 	/**
 	 * returns a list of n-generations of parents of a concept in a concept set
 	 * 
-	 * @param Concept current
+	 * @param current
 	 * @return List&lt;Concept&gt;
 	 * @throws DAOException
 	 */
@@ -1016,54 +1016,29 @@ public class HibernateConceptDAO implements ConceptDAO {
 		}
 		
 	}
-	
+
 	/**
 	 * @see org.openmrs.api.db.ConceptDAO#getConceptsByMapping(String, String, boolean)
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
 	public List<Concept> getConceptsByMapping(String code, String sourceName, boolean includeRetired) {
-		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ConceptMap.class);
-		
-		// make this criteria return a list of concepts
+		Criteria criteria = createSearchConceptMapCriteria(code, sourceName, includeRetired);
 		criteria.setProjection(Projections.property("concept"));
-		
-		//join to the conceptReferenceTerm table
-		criteria.createAlias("conceptReferenceTerm", "term");
-		
-		// match the source code to the passed code
-		if (Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive()) {
-			criteria.add(Restrictions.eq("term.code", code).ignoreCase());
-		} else {
-			criteria.add(Restrictions.eq("term.code", code));
-		}
-		
-		// join to concept reference source and match to the h17Code or source name
-		criteria.createAlias("term.conceptSource", "source");
-		if (Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive()) {
-			criteria.add(Restrictions.or(Restrictions.eq("source.name", sourceName).ignoreCase(), Restrictions.eq(
-			    "source.hl7Code", sourceName).ignoreCase()));
-		} else {
-			criteria.add(Restrictions.or(Restrictions.eq("source.name", sourceName), Restrictions.eq("source.hl7Code",
-			    sourceName)));
-		}
-		
-		criteria.createAlias("concept", "concept");
-		
-		if (!includeRetired) {
-			// ignore retired concepts
-			criteria.add(Restrictions.eq("concept.retired", false));
-		} else {
-			// sort retired concepts to the end of the list
-			criteria.addOrder(Order.asc("concept.retired"));
-		}
-		
-		// we only want distinct concepts
-		criteria.setResultTransformer(DistinctRootEntityResultTransformer.INSTANCE);
-		
 		return (List<Concept>) criteria.list();
 	}
-	
+
+	/**
+	 * @see org.openmrs.api.db.ConceptDAO#getConceptIdsByMapping(String, String, boolean)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public List<Integer> getConceptIdsByMapping(String code, String sourceName, boolean includeRetired) {
+		Criteria criteria = createSearchConceptMapCriteria(code, sourceName, includeRetired);
+		criteria.setProjection(Projections.property("concept.conceptId"));
+		return (List<Integer>) criteria.list();
+	}
+
 	/**
 	 * @see org.openmrs.api.db.ConceptDAO#getConceptByUuid(java.lang.String)
 	 */
@@ -2073,5 +2048,44 @@ public class HibernateConceptDAO implements ConceptDAO {
 			searchCriteria.add(Restrictions.eq("drug.retired", false));
 		}
 		return searchCriteria;
+	}
+
+	private Criteria createSearchConceptMapCriteria(String code, String sourceName, boolean includeRetired) {
+		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ConceptMap.class);
+
+		//join to the conceptReferenceTerm table
+		criteria.createAlias("conceptReferenceTerm", "term");
+
+		// match the source code to the passed code
+		if (Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive()) {
+			criteria.add(Restrictions.eq("term.code", code).ignoreCase());
+		} else {
+			criteria.add(Restrictions.eq("term.code", code));
+		}
+
+		// join to concept reference source and match to the h17Code or source name
+		criteria.createAlias("term.conceptSource", "source");
+		if (Context.getAdministrationService().isDatabaseStringComparisonCaseSensitive()) {
+			criteria.add(Restrictions.or(Restrictions.eq("source.name", sourceName).ignoreCase(), Restrictions.eq(
+					"source.hl7Code", sourceName).ignoreCase()));
+		} else {
+			criteria.add(Restrictions.or(Restrictions.eq("source.name", sourceName), Restrictions.eq("source.hl7Code",
+					sourceName)));
+		}
+
+		criteria.createAlias("concept", "concept");
+
+		if (!includeRetired) {
+			// ignore retired concepts
+			criteria.add(Restrictions.eq("concept.retired", false));
+		} else {
+			// sort retired concepts to the end of the list
+			criteria.addOrder(Order.asc("concept.retired"));
+		}
+
+		// we only want distinct concepts
+		criteria.setResultTransformer(DistinctRootEntityResultTransformer.INSTANCE);
+
+		return criteria;
 	}
 }

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -112,6 +112,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
      * <strong>Should</strong> force set flag if set members exist
 	 */
 	@Override
+	@CacheEvict(value = CONCEPT_IDS_BY_MAPPING_CACHE_NAME, allEntries = true)
 	public Concept saveConcept(Concept concept) throws APIException {
 		ensureConceptMapTypeIsSet(concept);
 
@@ -295,8 +296,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			
 			concept.setRetired(true);
 			concept.setRetireReason(reason);
-			return dao.saveConcept(concept);
-			
+			return Context.getConceptService().saveConcept(concept);
 		}
 		
 		return concept;
@@ -953,8 +953,8 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 * @see org.openmrs.api.ConceptService#purgeConceptSource(org.openmrs.ConceptSource)
 	 */
 	@Override
+	@CacheEvict(value = CONCEPT_IDS_BY_MAPPING_CACHE_NAME, allEntries = true)
 	public ConceptSource purgeConceptSource(ConceptSource cs) throws APIException {
-		
 		return dao.deleteConceptSource(cs);
 	}
 	
@@ -964,7 +964,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	@Override
 	public ConceptSource retireConceptSource(ConceptSource cs, String reason) throws APIException {
 		// retireReason is automatically set in BaseRetireHandler
-		return dao.saveConceptSource(cs);
+		return Context.getConceptService().saveConceptSource(cs);
 	}
 	
 	/**
@@ -1503,6 +1503,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 	 * @see ConceptService#updateConceptIndexes()
 	 */
 	@Override
+	@CacheEvict(value = CONCEPT_IDS_BY_MAPPING_CACHE_NAME, allEntries = true)
 	public void updateConceptIndexes() throws APIException {
 		Context.updateSearchIndexForType(ConceptName.class);
 	}

--- a/api/src/main/resources/ehcache-api.xml
+++ b/api/src/main/resources/ehcache-api.xml
@@ -33,4 +33,11 @@
         <persistence strategy="none"/>
     </cache>
 
+    <cache name="conceptIdsByMapping"
+           maxElementsInMemory="10000"
+           eternal="true"
+           memoryStoreEvictionPolicy="LRU">
+        <persistence strategy="localTempSwap"/>
+    </cache>
+
 </ehcache>

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import net.sf.ehcache.Ehcache;
 import org.apache.commons.collections.CollectionUtils;
 import org.dbunit.dataset.IDataSet;
 import org.junit.jupiter.api.AfterEach;
@@ -82,6 +84,11 @@ import org.openmrs.util.ConceptMapTypeComparator;
 import org.openmrs.util.DateUtil;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.ehcache.EhCacheCache;
+import org.springframework.cache.interceptor.SimpleKey;
 import org.springframework.validation.Errors;
 
 /**
@@ -102,6 +109,8 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 
 	protected static final String CONCEPT_ATTRIBUTE_TYPE_XML = "org/openmrs/api/include/ConceptServiceTest-conceptAttributeType.xml";
 
+	@Autowired
+	CacheManager cacheManager;
 	
 	/**
 	 * Run this before each unit test in this class. The "@Before" method in
@@ -708,6 +717,58 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 	public void getConceptByMapping_shouldIgnoreCase() {
 		Concept concept = conceptService.getConceptByMapping("wgt234", "sstrm");
 		assertEquals(5089, concept.getId().intValue());
+	}
+
+	/**
+	 * @see ConceptService#getConceptByMapping(String,String)
+	 */
+	@Test
+	public void getConceptIdsByMapping_shouldPopulateCache() {
+		Cache cache = cacheManager.getCache("conceptIdsByMapping");
+		Ehcache ehcache = ((EhCacheCache) cache).getNativeCache();
+		cache.clear();
+		assertThat(ehcache.getSize(), is(0));
+		conceptService.getConceptIdsByMapping("wgt234", "sstrm", true);
+		assertThat(ehcache.getSize(), is(1));
+		List<SimpleKey> keys = ehcache.getKeys();
+		assertThat(keys.size(), is(1));
+		SimpleKey foundKey = keys.get(0);
+		SimpleKey expectedKey = new SimpleKey("wgt234", "sstrm", true);
+		assertThat(foundKey.toString(), equalTo(expectedKey.toString()));;
+	}
+
+	/**
+	 * @see ConceptService#getConceptByMapping(String,String)
+	 */
+	@Test
+	public void shouldEvictConceptIdsIfSourceOrTermsAreUpdated() {
+		Cache cache = cacheManager.getCache("conceptIdsByMapping");
+		Ehcache ehcache = ((EhCacheCache) cache).getNativeCache();
+		ConceptSource cs = conceptService.getConceptSourceByHL7Code("SSTRM");
+		ConceptReferenceTerm crt = conceptService.getConceptReferenceTermByCode("WGT234", cs);
+		ConceptReferenceTerm dummyTerm = new ConceptReferenceTerm(cs, "DUMMY", "DummyTerm");
+		conceptService.saveConceptReferenceTerm(dummyTerm);
+		assertThat(ehcache.getSize(), is(0));
+
+		// Update Concept Source
+		conceptService.getConceptIdsByMapping(crt.getCode(), cs.getHl7Code(), true);
+		assertThat(ehcache.getSize(), is(1));
+		cs.setDateChanged(new Date());
+		conceptService.saveConceptSource(cs);
+		assertThat(ehcache.getSize(), is(0));
+
+		// Save Concept Reference Term
+		conceptService.getConceptIdsByMapping(crt.getCode(), cs.getHl7Code(), true);
+		assertThat(ehcache.getSize(), is(1));
+		crt.setDateChanged(new Date());
+		conceptService.saveConceptReferenceTerm(crt);
+		assertThat(ehcache.getSize(), is(0));
+
+		// purgeConceptReferenceTerm
+		conceptService.getConceptIdsByMapping(crt.getCode(), cs.getHl7Code(), true);
+		assertThat(ehcache.getSize(), is(1));
+		conceptService.purgeConceptReferenceTerm(dummyTerm);
+		assertThat(ehcache.getSize(), is(0));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/cache/OpenmrsCacheManagerFactoryBeanTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/OpenmrsCacheManagerFactoryBeanTest.java
@@ -10,7 +10,8 @@
 package org.openmrs.api.cache;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 import java.util.Collection;
@@ -26,10 +27,10 @@ public class OpenmrsCacheManagerFactoryBeanTest extends BaseContextSensitiveTest
     CacheManager cacheManager;
     
     @Test
-    public void shouldContainsThreeCacheConfigurations(){
-        Collection<String> cacheNames = cacheManager.getCacheNames();
-        assertThat(cacheNames.size(), is(3));
-        cacheNames.forEach(cn ->
-                assertThat(cn, anyOf(is("conceptDatatype"), is("subscription"), is("userSearchLocales"))));
+    public void shouldContainSpecificCacheConfigurations(){
+        String[] expectedCaches = {"conceptDatatype", "subscription", "userSearchLocales", "conceptIdsByMapping"};
+        Collection<String> actualCaches = cacheManager.getCacheNames();
+        assertThat(actualCaches.size(), is(expectedCaches.length));
+        assertThat(actualCaches, containsInAnyOrder(expectedCaches));
     }
 }


### PR DESCRIPTION
…g using spring cache

Based on feedback from @rkorytkowski , here is an attempt at solving the same problem using a Spring cache.  This actually does perform better than the earlier Lucene approach (and could likely be improved further in the future).

This adds one new service method to retrieve concept ids by mapping, the results of which are cached.  This is done this way as only service methods have the cache annotation picked up, and also I wanted to avoid caching any Hibernate-managed objects to avoid any lazy loading exceptions.

This has the implementation of the List<Concept> getConceptsByMapping iterate across the conceptIds returned by List<Integer> getConceptIdsByMapping, and load the matching concepts.

Performance testing shows considerable improvement.  Testing the loading of a large htmlform with a lot of concept lookups by mapping shows:

Prior to change:  47-49 seconds
After change:  3-5 seconds

@rkorytkowski curious on your feedback on this - your prior comments were very helpful, thank you!