### PR TITLE
TRUNK-5499-Upgrading the Hibernate Library from 4.3.9.Final to 4.3.10.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -258,12 +258,12 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>4.2.0.Final</version>
+				<version>6.0.16.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-search-orm</artifactId>
-				<version>5.1.2.Final</version>
+				<version>5.3.0.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
@@ -1047,7 +1047,7 @@
 		<openmrs.version>${project.version}</openmrs.version>
 
 		<springVersion>4.1.4.RELEASE</springVersion>
-		<hibernateVersion>4.3.9.Final</hibernateVersion>
+		<hibernateVersion>4.3.10.Final</hibernateVersion>
 		<customArgLineForTesting/>
 
 		<sonar.host.url>https://sonar.openmrs.org</sonar.host.url>


### PR DESCRIPTION
## Description of what I changed

I upgraded the Hibernate  version from 4.3.9.Final to 4.3.10.Final
thus  upgrading the following 3 Sub Libraries

org.hibernate:hibernate-c3p0 … 4.3.9.Final -> 4.3.10.Final

org.hibernate:hibernate-core … 4.3.9.Final -> 4.3.10.Final

org.hibernate:hibernate-ehcache … 4.3.9.Final ->  4.3.10.Final

also I upgraded

org.hibernate:hibernate-validator … 4.2.0.Final -> 6.0.16.Final
org.hibernate:hibernate-search-orm … 5.1.2.Final -> 5.3.0.Final



## Issue I worked on
I have worked on this issue 
https://issues.openmrs.org/browse/TRUNK-5499

