### PR TITLE
TRUNK-5551:Upgrading xerces:xercesImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,7 +364,7 @@
 			<dependency>
 				<groupId>xerces</groupId>
 				<artifactId>xercesImpl</artifactId>
-				<version>2.8.0</version>
+				<version>2.9.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed
i tested out different upgrades for xerces:xercesImpl and the higher version that passed tests locally was 2.9.0


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5551


