### PR TITLE
TRUNK-5410: OrderGroupAttribute implementation

### DIFF
--- a/api/src/main/java/org/openmrs/OrderGroup.java
+++ b/api/src/main/java/org/openmrs/OrderGroup.java
@@ -35,6 +35,12 @@ public class OrderGroup extends BaseChangeableOpenmrsData {
 	
 	private OrderSet orderSet;
 	
+	private Concept orderGroupReason;
+	
+	private OrderGroup previousOrderGroup;
+	
+	private OrderGroup parentOrderGroup;
+
 	/**
 	 * Gets the orderGroupId
 	 *
@@ -207,5 +213,58 @@ public class OrderGroup extends BaseChangeableOpenmrsData {
 	public void setId(Integer id) {
 		setOrderGroupId(id);
 	}
-	
+
+	/**
+	 * Gets the orderGroupReason
+	 * 
+	 * @return the orderGroupReason
+	 */
+	public Concept getOrderGroupReason() {
+		return orderGroupReason;
+	}
+
+	/**
+	 * Sets the orderGroupReason
+	 * 
+	 * @param orderGroupReason the orderGroupReason to set
+	 */
+	public void setOrderGroupReason(Concept orderGroupReason) {
+		this.orderGroupReason = orderGroupReason;
+	}
+
+	/**
+	 * Gets the previousOrderGroup
+	 * 
+	 * @return the previousOrderGroup
+	 */
+	public OrderGroup getPreviousOrderGroup() {
+		return previousOrderGroup;
+	}
+
+	/**
+	 * Sets the previousOrderGroup
+	 * 
+	 * @param previousOrderGroup the previousOrderGroup to set
+	 */
+	public void setPreviousOrderGroup(OrderGroup previousOrderGroup) {
+		this.previousOrderGroup = previousOrderGroup;
+	}
+
+	/**
+	 * Gets the parentOrderGroup
+	 * 
+	 * @return the parentOrderGroup
+	 */
+	public OrderGroup getParentOrderGroup() {
+		return parentOrderGroup;
+	}
+
+	/**
+	 * Sets the parentOrderGroup
+	 * 
+	 * @param parentOrderGroup the parentOrderGroup to set
+	 */
+	public void setParentOrderGroup(OrderGroup parentOrderGroup) {
+		this.parentOrderGroup = parentOrderGroup;
+	}
 }

--- a/api/src/test/java/org/openmrs/OrderGroupTest.java
+++ b/api/src/test/java/org/openmrs/OrderGroupTest.java
@@ -31,4 +31,22 @@ public class OrderGroupTest {
         Assert.assertNotNull("should have orderGroup in order", orders.get(0).getOrderGroup());
         Assert.assertNotNull("should have orderGroup in order", orders.get(1).getOrderGroup());
     }
+
+	@Test
+	public void addOrderGroup_shouldLinkOtherOrderGroupAddOrderGroupReason() {
+
+		OrderGroup previousOrderGroup = new OrderGroup();
+		OrderGroup parentOrderGroup = new OrderGroup();
+		OrderGroup orderGroup = new OrderGroup();
+
+		Concept orderGroupReason = new Concept();
+
+		orderGroup.setPreviousOrderGroup(previousOrderGroup);
+		orderGroup.setParentOrderGroup(parentOrderGroup);
+		orderGroup.setOrderGroupReason(orderGroupReason);
+
+		Assert.assertNotNull("should have previousOrderGroup in orderGroup", orderGroup.getPreviousOrderGroup());
+		Assert.assertNotNull("should have parentOrderGroup in orderGroup", orderGroup.getParentOrderGroup());
+		Assert.assertNotNull("should have orderGroupReason in orderGroup", orderGroup.getOrderGroupReason());
+	}
 }


### PR DESCRIPTION
OrderGroups will also be extended via attributes to associate cycle number, the total number of cycles in the regimen, and the length of the regimen cycles.

Please refer to this Talk post for more detail: https://talk.openmrs.org/t/chemotherapy-ordering-data-design/19133