### PR TITLE
GCI-241:Lazy initialization of static serviceContext should be synchr…

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -240,14 +240,12 @@ public class Context {
 	 * @return the current ServiceContext
 	 */
 	static ServiceContext getServiceContext() {
-		if (serviceContext == null) {
 			synchronized (Context.class) {
 				if (serviceContext == null) {
 					log.error("serviceContext is null.  Creating new ServiceContext()");
 					serviceContext = ServiceContext.getInstance();
 				}
 			}
-		}
 		log.trace("serviceContext: {}", serviceContext);
 
 		return ServiceContext.getInstance();


### PR DESCRIPTION

## Description of what I changed
Since the method body was already synchronized, I remove the outer if (serviceContext == null) because it was duplicated in the inner block.


## Issue I worked on
https://issues.openmrs.org/browse/GCI-241






