### PR TITLE
TRUNK-381 : Follow up commit to fix bug due to context refresh to suc…

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -202,10 +202,6 @@ public class Context {
 		catch(BeansException e){
 			log.error("Fatal error encountered when injecting the authentication scheme override. Sticking to OpenMRS default authentication scheme.");
 		}
-
-		if (authenticationScheme instanceof DaoAuthenticationScheme) {
-			((DaoAuthenticationScheme) authenticationScheme).setContextDao(getContextDAO());
-		}
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
+++ b/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
@@ -23,10 +23,6 @@ public abstract class DaoAuthenticationScheme implements AuthenticationScheme {
 	private ContextDAO contextDao;
 	
 	public ContextDAO getContextDAO() {
-		return contextDao;
-	}
-	
-	public void setContextDao(ContextDAO contextDao) {
-		this.contextDao = contextDao;
+		return Context.getContextDAO();
 	}
 }

--- a/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
+++ b/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
@@ -20,8 +20,6 @@ import org.openmrs.api.db.ContextDAO;
  */
 public abstract class DaoAuthenticationScheme implements AuthenticationScheme {
 	
-	private ContextDAO contextDao;
-	
 	public ContextDAO getContextDAO() {
 		return Context.getContextDAO();
 	}


### PR DESCRIPTION
Ticket : https://issues.openmrs.org/browse/TRUNK-381

Pass the ContextDAO instance on than save it in an authenticationScheme instance which has been causing context refresh vs existing browser session issue, evident when logging out and then in without clean the browser session.