### PR TITLE
TRUNK-381: DaoAuthenticationScheme to return ContextDAO from Context.

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -202,10 +202,6 @@ public class Context {
 		catch(BeansException e){
 			log.error("Fatal error encountered when injecting the authentication scheme override. Sticking to OpenMRS default authentication scheme.");
 		}
-
-		if (authenticationScheme instanceof DaoAuthenticationScheme) {
-			((DaoAuthenticationScheme) authenticationScheme).setContextDao(getContextDAO());
-		}
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
+++ b/api/src/main/java/org/openmrs/api/context/DaoAuthenticationScheme.java
@@ -20,13 +20,7 @@ import org.openmrs.api.db.ContextDAO;
  */
 public abstract class DaoAuthenticationScheme implements AuthenticationScheme {
 	
-	private ContextDAO contextDao;
-	
 	public ContextDAO getContextDAO() {
-		return contextDao;
-	}
-	
-	public void setContextDao(ContextDAO contextDao) {
-		this.contextDao = contextDao;
+		return Context.getContextDAO();
 	}
 }


### PR DESCRIPTION
Back-ported from eac7f315a668bc2d02824a6f50c9ee2e817ddc9f
* TRUNK-381 : Context to be the single source of truth of the ContextDAO instance
* TRUNK-381 : Removing unused ContextDAO local variable

Ticket : https://issues.openmrs.org/browse/TRUNK-381