### PR TITLE
Trunk-5331:Cohort membership should not require a startDate

### DIFF
--- a/api/src/main/java/org/openmrs/Cohort.java
+++ b/api/src/main/java/org/openmrs/Cohort.java
@@ -10,6 +10,7 @@
 package org.openmrs;
 
 import org.apache.commons.lang3.StringUtils;
+import org.openmrs.util.OpenmrsUtil;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -267,8 +268,19 @@ public class Cohort extends BaseChangeableOpenmrsData {
 		Cohort ret = new Cohort();
 		ret.setName("(" + (a == null ? "NULL" : a.getName()) + " * " + (b == null ? "NULL" : b.getName()) + ")");
 		if (a != null && b != null) {
-			ret.getMemberships().addAll(a.getMemberships());
-			ret.getMemberships().retainAll(b.getMemberships());
+			//loop between memberships and find the intersections
+			for (CohortMembership membershipA : a.getMemberships()) {
+				for (CohortMembership membershipB : b.getMemberships()) {
+					//add the membership with earliest date , if one date is null pick the other one
+					if (membershipA.getPatientId() == membershipB.getPatientId()) {
+						if (OpenmrsUtil.compareWithNullAsLatest(membershipA.getStartDate(), membershipB.getStartDate()) <= 0)
+							ret.addMembership(membershipB);
+						else
+							ret.addMembership(membershipA);
+						break;
+					}
+				}
+			}
 		}
 		return ret;
 	}

--- a/api/src/main/java/org/openmrs/CohortMembership.java
+++ b/api/src/main/java/org/openmrs/CohortMembership.java
@@ -41,7 +41,7 @@ public class CohortMembership extends BaseChangeableOpenmrsData implements Compa
 	}
 	
 	public CohortMembership(Integer patientId) {
-		this(patientId, new Date());
+		this(patientId, null);
 	}
 	
 	/**
@@ -51,7 +51,7 @@ public class CohortMembership extends BaseChangeableOpenmrsData implements Compa
 	 */
 	public boolean isActive(Date asOfDate) {
 		Date date = asOfDate == null ? new Date() : asOfDate;
-		return !this.getVoided() && OpenmrsUtil.compare(startDate, date) <= 0
+		return !this.getVoided() && OpenmrsUtil.compareWithNullAsEarliest(startDate, date) <= 0
 			&& OpenmrsUtil.compareWithNullAsLatest(date, endDate) <= 0;
 	}
 	

--- a/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
@@ -146,7 +146,7 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	@Override
 	@Transactional(readOnly = true)
 	public List<Cohort> getCohortsContainingPatientId(Integer patientId) {
-		return dao.getCohortsContainingPatientId(patientId, false, new Date());
+		return dao.getCohortsContainingPatientId(patientId, false, null);
 	}
 	
 	/**

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/CohortMembership.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/CohortMembership.hbm.xml
@@ -26,7 +26,7 @@
 		<property name="patientId" type="int" column="patient_id" not-null="true"/>
 
 		<property name="startDate" column="start_date"
-				  not-null="true" length="19" type="java.util.Date" />
+				 length="19" type="java.util.Date" />
 
 		<property name="endDate" column="end_date" length="19" type="java.util.Date"/>
 

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
@@ -109,5 +109,10 @@
 								 baseTableName="conditions" baseColumnNames="encounter_id"
 								 referencedTableName="encounter" referencedColumnNames="encounter_id" />
     </changeSet>
-    
+    <changeSet id="20190916-TRUNK-5331-cohort_member" author="gitacliff">
+		<comment>
+			Dropping not null constraint from cohort_member.start_date column
+		</comment>
+		<dropNotNullConstraint tableName="cohort_member" columnName="start_date" columnDataType="DATETIME" />
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
@@ -109,10 +109,5 @@
 								 baseTableName="conditions" baseColumnNames="encounter_id"
 								 referencedTableName="encounter" referencedColumnNames="encounter_id" />
     </changeSet>
-    <changeSet id="20190916-TRUNK-5331-cohort_member" author="gitacliff">
-		<comment>
-			Dropping not null constraint from cohort_member.start_date column
-		</comment>
-		<dropNotNullConstraint tableName="cohort_member" columnName="start_date" columnDataType="DATETIME" />
-	</changeSet>
+    
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -259,5 +259,10 @@
         <addForeignKeyConstraint constraintName="order_set_attribute_voided_by_fk" baseTableName="order_set_attribute" baseColumnNames="voided_by" referencedTableName="users" referencedColumnNames="user_id" />
     </changeSet>   
     
-
+    <changeSet id="20190916-TRUNK-5331-cohort_member" author="gitacliff">
+		<comment>
+			Dropping not null constraint from cohort_member.start_date column
+		</comment>
+		<dropNotNullConstraint tableName="cohort_member" columnName="start_date" columnDataType="DATETIME" />
+	</changeSet>
 </databaseChangeLog> 

--- a/api/src/test/java/org/openmrs/CohortTest.java
+++ b/api/src/test/java/org/openmrs/CohortTest.java
@@ -154,6 +154,147 @@ public class CohortTest {
 			assertTrue(m.getVoided() && m.getEndDate() != null);
 		});
 	}
+	@Test
+	public void intersect_shouldReturnEmptyIfCohortIsNull() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, null);
+		assertTrue(cohortIntersect.getMemberships().isEmpty());
+	}
+
+	@Test
+	public void intersect_shouldContainMembershipWhenStartDateIsNull() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setStartDate(startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		Date startDatee = null;
+		CohortMembership membershipTwo = new CohortMembership(7, startDatee);
+		membershipTwo.setStartDate(startDatee);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		assertTrue(cohortIntersect.getMemberships().contains(membershipTwo));
+		assertTrue(cohortIntersect.getMemberships().size() == 1);
+
+	}
+
+	@Test
+	public void intersect_shouldRetainMembershipsOfTheSamePatient() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setStartDate(startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		Date startDatee = dateFormat.parse("2019-08-18 00:00:00");
+		CohortMembership membershipTwo = new CohortMembership(7, startDatee);
+		membershipTwo.setStartDate(startDatee);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Date startDateee = dateFormat.parse("2019-08-18 00:00:00");
+		CohortMembership membershipThree = new CohortMembership(8, startDateee);
+		membershipTwo.setStartDate(startDateee);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipThree);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		assertTrue(cohortIntersect.contains(7));
+
+	}
+
+	@Test
+	public void intersect_shouldReturnMembershipOfCohortIfIsVoided() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setStartDate(startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		Date startDatee = dateFormat.parse("2019-08-18 00:00:00");
+		CohortMembership membershipTwo = new CohortMembership(7, startDatee);
+		membershipTwo.setStartDate(startDatee);
+		membershipTwo.setEndDate(endDate);
+		membershipTwo.setVoided(true);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		assertTrue(cohortIntersect.getMemberships(true).size() == 1);
+	}
+
+	@Test
+	public void intersect_shouldContainTheLatesttMemmbership() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setStartDate(startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		Date startDatee = dateFormat.parse("2019-08-18 00:00:00");
+		CohortMembership membershipTwo = new CohortMembership(7, startDatee);
+		membershipTwo.setStartDate(startDatee);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		assertTrue(cohortIntersect.getMemberships().contains(membershipTwo));
+
+	}
+
+	@Test
+	public void intersect_shouldFailWithNoPatientIdOfMembership() throws Exception {
+		SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		Date startDate = dateFormat.parse("2019-08-17 00:00:00");
+		Date endDate = dateFormat.parse("2019-09-17 00:00:00");
+
+		Cohort cohortOne = new Cohort(3);
+		CohortMembership membershipOne = new CohortMembership(7, startDate);
+		membershipOne.setStartDate(startDate);
+		membershipOne.setEndDate(endDate);
+		cohortOne.addMembership(membershipOne);
+
+		Cohort cohortTwo = new Cohort(4);
+		Date startDatee = dateFormat.parse("2019-08-18 00:00:00");
+		CohortMembership membershipTwo = new CohortMembership(0, startDatee);
+		membershipTwo.setStartDate(startDatee);
+		membershipTwo.setEndDate(endDate);
+		cohortTwo.addMembership(membershipTwo);
+
+		Cohort cohortIntersect = Cohort.intersect(cohortOne, cohortTwo);
+		assertTrue(cohortIntersect.size() == 0);
+	}
+
 
     @Test
     public void setMemberIds_shouldSupportLargeCohorts() {

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -702,7 +702,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		membership.setEndDate(endDate);
 		
 		List<Cohort> cohortsWithPatientAdded = service.getCohortsContainingPatientId(patient.getId());
-		assertEquals(0, cohortsWithPatientAdded.size());
+		assertEquals(1, cohortsWithPatientAdded.size());
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 
-	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 866;
+	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 867;
 	
 	
 	@BeforeEach


### PR DESCRIPTION
link:https://issues.openmrs.org/browse/TRUNK-5331
CohortMembership should not require a startDate

1-dropped the not-null constraint on CohortMembership.startDate
2-removed Java logic that defaults CohortMembership.startDate to new Date(), and instead default it to null.
3-Cohort.intersect should behave in a way that makes sense if you give it {Patient 123, startDate Jan 1} and {Patient 123, startDate Feb 15}.
I would be satisfied if the output is either a cohort with {Patient 123, startDate Feb 15}, or else a cohort with {Patient 123, startDate null}.
