### PR TITLE
TRUNK-5672 | Add liquibase changesets to populate username for admin user

### DIFF
--- a/api/src/main/resources/liquibase-update-to-2.3.xml
+++ b/api/src/main/resources/liquibase-update-to-2.3.xml
@@ -108,4 +108,16 @@
 			<column name="description" type="varchar(1)" />
 		</createTable>
 	</changeSet>
+	<changeSet id="TRUNK-5672-201910211105" author="Mritunjay">
+		<preConditions onFail="MARK_RAN">
+			<sqlCheck expectedResult="0">
+				SELECT COUNT(*) FROM users where username = 'admin'
+			</sqlCheck>
+		</preConditions>
+		<comment>Populate username for admin user</comment>
+		<update tableName="users">
+			<column name="username" value="admin"/>
+			<where>system_id='admin'</where>
+		</update>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
As part of this PR following things are done:
- [x] Add a new file `liquibase-update-to-2.4.xml`.
- [x] Included the `liquibase-update-to-2.4.xml` in `liquibase-update-to-latest.xml` file.
- [x] Add the changeset to `liquibase-update-to-2.4.xml`.
- [x] Add the changeset to `liquibase-update-to-2.3.xml`.

Jira ticket: https://issues.openmrs.org/browse/TRUNK-5672
Talk Thread: https://talk.openmrs.org/t/admin-user-doesnt-have-a-username/25145/