### PR TITLE
TRUNK-4986:Upgrade liquibase to 3.5.x version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
 			<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
-				<version>2.0.5</version>
+				<version>3.5.5</version>
 			</dependency>
 			<dependency>
 				<groupId>org.openmrs.liquibase.ext</groupId>


### PR DESCRIPTION
Description of what I changed
I Upgraded liquibase to 3.5.5 version


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-4986?filter=-1


