### PR TITLE
TRUNK-5675  Lucene Analyzer Defs should be provided programatically

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
@@ -17,56 +17,12 @@ import javax.persistence.MappedSuperclass;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
-import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
-import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
-import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
-import org.apache.lucene.analysis.ngram.NGramFilterFactory;
-import org.apache.lucene.analysis.standard.ClassicFilterFactory;
 import org.hibernate.Hibernate;
-import org.hibernate.search.annotations.AnalyzerDef;
-import org.hibernate.search.annotations.AnalyzerDefs;
-import org.hibernate.search.annotations.Parameter;
-import org.hibernate.search.annotations.TokenFilterDef;
-import org.hibernate.search.annotations.TokenizerDef;
-import org.openmrs.api.db.hibernate.search.LuceneAnalyzers;
 
 /**
  * This is the base implementation of the {@link OpenmrsObject} interface.<br>
  * It implements the uuid variable that all objects are expected to have.
  */
-@AnalyzerDefs({
-		@AnalyzerDef(name = LuceneAnalyzers.PHRASE_ANALYZER,
-				tokenizer = @TokenizerDef(factory = KeywordTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class)
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.EXACT_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class)
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.START_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class),
-						@TokenFilterDef(factory = EdgeNGramFilterFactory.class, params = {
-								@Parameter(name = "minGramSize", value = "2"),
-								@Parameter(name = "maxGramSize", value = "20") })
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.ANYWHERE_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class),
-						@TokenFilterDef(factory = NGramFilterFactory.class, params = {
-								@Parameter(name = "minGramSize", value = "2"),
-								@Parameter(name = "maxGramSize", value = "20") })
-				})
-})
 @MappedSuperclass
 public abstract class BaseOpenmrsObject implements Serializable, OpenmrsObject {
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
@@ -1,0 +1,59 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.db.hibernate.search;
+
+import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
+import org.apache.lucene.analysis.ngram.NGramFilterFactory;
+import org.apache.lucene.analysis.standard.ClassicFilterFactory;
+import org.hibernate.search.annotations.Factory;
+import org.hibernate.search.cfg.SearchMapping;
+
+/**
+ * Provides a Lucene SearchMapping for any objects in openmrs-core.
+ * 
+ * Objects such as PersonName can use the analyzers provided by this mapping to make their fields searchable.
+ * This class defines some default analyzers:
+ * 	phraseAnalyzer, which allows searching for an entire phrase, including whitespace
+ * 	startAnalyzer, which allows searching for tokens that match at the beginning
+ * 	exactAnalyzer, which allows searching for tokens that are identical
+ * 	anywhereAnalyzer, which allows searching for text within tokens
+ *
+ * @since 2.4.0
+ */
+public class LuceneAnalyzerFactory {
+	@Factory
+	public SearchMapping getSearchMapping() {
+		SearchMapping mapping = new SearchMapping();
+		mapping
+			.analyzerDef(LuceneAnalyzers.PHRASE_ANALYZER, KeywordTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class);
+		mapping.analyzerDef(LuceneAnalyzers.EXACT_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class);
+		mapping.analyzerDef(LuceneAnalyzers.START_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class)
+			.filter(EdgeNGramFilterFactory.class)
+                .param("minGramSize", "2")
+                .param("maxGramSize", "20");
+		mapping.analyzerDef(LuceneAnalyzers.ANYWHERE_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class)
+			.filter(NGramFilterFactory.class)
+			.param("minGramSize", "2")
+			.param("maxGramSize", "20");
+		return mapping;
+	}
+}
+

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -18,6 +18,8 @@
 
 	<session-factory>
         <property name="javax.persistence.validation.mode">none</property>
+		<property name="hibernate.search.model_mapping">org.openmrs.api.db.hibernate.search.LuceneAnalyzerFactory</property>
+		
 		<!-- API -->
 
 		<mapping resource="org/openmrs/api/db/hibernate/AllergyReaction.hbm.xml" />


### PR DESCRIPTION
TRUNK-5675 Lucene Analyzer Defs should be provided programatically
https://issues.openmrs.org/browse/TRUNK-5675

Moves the Lucene Analyzer Definitions out of BaseOpenmrsObject annotations and into a factory class.

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.  (maven does auto-formatting, we should just get that working if it isn't presently...)
- [ ] I have **added tests** to cover my changes. (this is a refactor)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.