### PR TITLE
TRUNK-5564:PersonAddressValidator - Throws exception instead of logging

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -64,7 +64,7 @@ public class PersonAddressValidator implements Validator {
 		}
 		
 		if (object == null) {
-			throw new IllegalArgumentException("The personAddress object should not be null");
+           errors.rejectValue("value", "error.null");
 		}
 		
 		PersonAddress personAddress = (PersonAddress) object;


### PR DESCRIPTION

## Description of what I changed

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5564
I coded the PersonAddressValidator in a way that avoids throwing exceptions
