### PR TITLE
Backport to 2.3.x: TRUNK-5675 "Lucene Analyzer Defs should be provided programatically" and TRUNK-5681 "Patient search should be insensitive to accents"

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
@@ -17,56 +17,12 @@ import javax.persistence.MappedSuperclass;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
-import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
-import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
-import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
-import org.apache.lucene.analysis.ngram.NGramFilterFactory;
-import org.apache.lucene.analysis.standard.ClassicFilterFactory;
 import org.hibernate.Hibernate;
-import org.hibernate.search.annotations.AnalyzerDef;
-import org.hibernate.search.annotations.AnalyzerDefs;
-import org.hibernate.search.annotations.Parameter;
-import org.hibernate.search.annotations.TokenFilterDef;
-import org.hibernate.search.annotations.TokenizerDef;
-import org.openmrs.api.db.hibernate.search.LuceneAnalyzers;
 
 /**
  * This is the base implementation of the {@link OpenmrsObject} interface.<br>
  * It implements the uuid variable that all objects are expected to have.
  */
-@AnalyzerDefs({
-		@AnalyzerDef(name = LuceneAnalyzers.PHRASE_ANALYZER,
-				tokenizer = @TokenizerDef(factory = KeywordTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class)
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.EXACT_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class)
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.START_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class),
-						@TokenFilterDef(factory = EdgeNGramFilterFactory.class, params = {
-								@Parameter(name = "minGramSize", value = "2"),
-								@Parameter(name = "maxGramSize", value = "20") })
-				}),
-		@AnalyzerDef(name = LuceneAnalyzers.ANYWHERE_ANALYZER,
-				tokenizer = @TokenizerDef(factory = WhitespaceTokenizerFactory.class),
-				filters = {
-						@TokenFilterDef(factory = ClassicFilterFactory.class),
-						@TokenFilterDef(factory = LowerCaseFilterFactory.class),
-						@TokenFilterDef(factory = NGramFilterFactory.class, params = {
-								@Parameter(name = "minGramSize", value = "2"),
-								@Parameter(name = "maxGramSize", value = "20") })
-				})
-})
 @MappedSuperclass
 public abstract class BaseOpenmrsObject implements Serializable, OpenmrsObject {
 	

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
@@ -1,0 +1,59 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.db.hibernate.search;
+
+import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
+import org.apache.lucene.analysis.ngram.NGramFilterFactory;
+import org.apache.lucene.analysis.standard.ClassicFilterFactory;
+import org.hibernate.search.annotations.Factory;
+import org.hibernate.search.cfg.SearchMapping;
+
+/**
+ * Provides a Lucene SearchMapping for any objects in openmrs-core.
+ * 
+ * Objects such as PersonName can use the analyzers provided by this mapping to make their fields searchable.
+ * This class defines some default analyzers:
+ * 	phraseAnalyzer, which allows searching for an entire phrase, including whitespace
+ * 	startAnalyzer, which allows searching for tokens that match at the beginning
+ * 	exactAnalyzer, which allows searching for tokens that are identical
+ * 	anywhereAnalyzer, which allows searching for text within tokens
+ *
+ * @since 2.4.0
+ */
+public class LuceneAnalyzerFactory {
+	@Factory
+	public SearchMapping getSearchMapping() {
+		SearchMapping mapping = new SearchMapping();
+		mapping
+			.analyzerDef(LuceneAnalyzers.PHRASE_ANALYZER, KeywordTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class);
+		mapping.analyzerDef(LuceneAnalyzers.EXACT_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class);
+		mapping.analyzerDef(LuceneAnalyzers.START_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class)
+			.filter(EdgeNGramFilterFactory.class)
+                .param("minGramSize", "2")
+                .param("maxGramSize", "20");
+		mapping.analyzerDef(LuceneAnalyzers.ANYWHERE_ANALYZER, WhitespaceTokenizerFactory.class)
+			.filter(ClassicFilterFactory.class)
+			.filter(LowerCaseFilterFactory.class)
+			.filter(NGramFilterFactory.class)
+			.param("minGramSize", "2")
+			.param("maxGramSize", "20");
+		return mapping;
+	}
+}
+

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/LuceneAnalyzerFactory.java
@@ -12,6 +12,7 @@ package org.openmrs.api.db.hibernate.search;
 import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
 import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
 import org.apache.lucene.analysis.ngram.NGramFilterFactory;
 import org.apache.lucene.analysis.standard.ClassicFilterFactory;
@@ -37,19 +38,23 @@ public class LuceneAnalyzerFactory {
 		mapping
 			.analyzerDef(LuceneAnalyzers.PHRASE_ANALYZER, KeywordTokenizerFactory.class)
 			.filter(ClassicFilterFactory.class)
-			.filter(LowerCaseFilterFactory.class);
+			.filter(LowerCaseFilterFactory.class)
+			.filter(ASCIIFoldingFilterFactory.class);
 		mapping.analyzerDef(LuceneAnalyzers.EXACT_ANALYZER, WhitespaceTokenizerFactory.class)
 			.filter(ClassicFilterFactory.class)
-			.filter(LowerCaseFilterFactory.class);
+			.filter(LowerCaseFilterFactory.class)
+			.filter(ASCIIFoldingFilterFactory.class);
 		mapping.analyzerDef(LuceneAnalyzers.START_ANALYZER, WhitespaceTokenizerFactory.class)
 			.filter(ClassicFilterFactory.class)
 			.filter(LowerCaseFilterFactory.class)
+			.filter(ASCIIFoldingFilterFactory.class)
 			.filter(EdgeNGramFilterFactory.class)
                 .param("minGramSize", "2")
                 .param("maxGramSize", "20");
 		mapping.analyzerDef(LuceneAnalyzers.ANYWHERE_ANALYZER, WhitespaceTokenizerFactory.class)
 			.filter(ClassicFilterFactory.class)
 			.filter(LowerCaseFilterFactory.class)
+			.filter(ASCIIFoldingFilterFactory.class)
 			.filter(NGramFilterFactory.class)
 			.param("minGramSize", "2")
 			.param("maxGramSize", "20");

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -18,6 +18,8 @@
 
 	<session-factory>
         <property name="javax.persistence.validation.mode">none</property>
+		<property name="hibernate.search.model_mapping">org.openmrs.api.db.hibernate.search.LuceneAnalyzerFactory</property>
+		
 		<!-- API -->
 
 		<mapping resource="org/openmrs/api/db/hibernate/AllergyReaction.hbm.xml" />

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -100,6 +100,8 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	
 	protected static final String FIND_PATIENTS_XML = "org/openmrs/api/include/PatientServiceTest-findPatients.xml";
 	
+	protected static final String FIND_PATIENTS_ACCENTS_XML = "org/openmrs/api/include/PatientServiceTest-findPatientsAccents.xml";
+	
 	private static final String PATIENT_RELATIONSHIPS_XML = "org/openmrs/api/include/PersonServiceTest-createRelationship.xml";
 	
 	private static final String ENCOUNTERS_FOR_VISITS_XML = "org/openmrs/api/include/PersonServiceTest-encountersForVisits.xml";
@@ -748,7 +750,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
-	 * @see PatientService#getPatients(String,String,List<QPatientIdentifierType ;>,null)
+	 * @see PatientService#getPatients(String, String, List, boolean) 
 	 */
 	@Test
 	public void getPatients_shouldSearchFamilyName2WithName() throws Exception {
@@ -1136,7 +1138,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
-	 * @see PatientService#getAllPatientIdentifierTypes(null)
+	 * @see PatientService#getAllPatientIdentifierTypes(boolean) 
 	 */
 	@Test
 	public void getAllPatientIdentifierTypes_shouldFetchPatientIdentifierTypesIncludingRetiredWhenIncludeRetiredIsTrue()
@@ -1156,7 +1158,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	}
 	
 	/**
-	 * @see PatientService#getAllPatientIdentifierTypes(null)
+	 * @see PatientService#getAllPatientIdentifierTypes(boolean)
 	 */
 	@Test
 	public void getAllPatientIdentifierTypes_shouldFetchPatientIdentifierTypesExcludingRetiredWhenIncludeRetiredIsFalse()
@@ -1943,6 +1945,54 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		    patients.contains(patientService.getPatient(3)));
 	}
 	
+	@SkipBaseSetup
+	@Test
+	public void getPatients_shouldIgnoreAccentsWhenMatchingName() throws Exception {
+		initializeInMemoryDatabase();
+		executeDataSet(FIND_PATIENTS_ACCENTS_XML);
+		authenticate();
+		updateSearchIndex();
+		
+		List<Patient> patients = patientService.getPatients("Jose", null, null, false);
+		assertTrue("search term without accent did not find patient first name with accent",
+			patients.contains(patientService.getPatient(202)));
+		assertTrue("search term without accent did not find patient middle name with accent",
+			patients.contains(patientService.getPatient(205)));
+		
+		patients = patientService.getPatients("Úrsula", null, null, false);
+		assertTrue("search term with accent did not find matching name",
+			patients.contains(patientService.getPatient(203)));
+		assertTrue("search term with accent did not find matching name",
+			patients.contains(patientService.getPatient(204)));
+
+		patients = patientService.getPatients("Ho Xuan Huong", null, null, false);
+		assertTrue("three-term search did not find Vietnamese-accented name",
+			patients.contains(patientService.getPatient(208)));
+		
+		patients = patientService.getPatients("Hưong", null, null, false);
+		assertTrue("did not find a name with a partially accented search term",
+			patients.contains(patientService.getPatient(208)));
+
+		patients = patientService.getPatients("Ὀδυσσεύς", null, null, false);
+		assertTrue("did not find a Greek name that should have matched exactly",
+			patients.contains(patientService.getPatient(207)));
+		
+		// This is more to document behavior than to assert that this should necessarily behave this way
+		patients = patientService.getPatients("Amarantá", null, null, false);
+		assertFalse("unexpectedly found a patient using a search term with an extraneous accent",
+			patients.contains(patientService.getPatient(204)));
+
+		// This is more to document behavior than to assert that this should necessarily behave this way
+		patients = patientService.getPatients("Οδυσσευς", null, null, false);
+		assertFalse("unexpectedly found an accented Greek name by searching for its un-accented equivalent",
+			patients.contains(patientService.getPatient(207)));
+
+		// This is more to document behavior than to assert that this should necessarily behave this way
+		patients = patientService.getPatients("Dost", null, null, false);
+		assertFalse("unexpectedly found a Russian name with an ASCII search",
+			patients.contains(patientService.getPatient(209)));
+	}
+
 	@SkipBaseSetup
 	@Test
 	public void purgePatient_shouldDeletePatientFromDatabase() throws Exception {

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-findPatientsAccents.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-findPatientsAccents.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <person person_id="202" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="8e84200d-016e-4360-9f32-1065ba0b0960"/>
+  <person person_id="203" gender="F" dead="true" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="c7a3851e-58db-4527-b5cd-8e257b4150d8"/>
+  <person person_id="204" gender="F" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="6d350f8c-a6cd-455d-ae93-900d1cd2ce3c"/>
+  <person person_id="205" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="fc867923-30fe-4468-8fce-98bb950f5396"/>
+  <person person_id="206" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="0eee8f7c-cf38-4509-ba1d-12ca6ceeee22"/>
+  <person person_id="207" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="07fffd72-0faf-4cc6-b44b-3bf0f8bb01d0"/>
+  <person person_id="208" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="f5a56825-f56f-4e06-91a3-246ef8344a34"/>
+  <person person_id="209" gender="M" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="238344fa-b39c-48eb-96a9-8e74461501ed"/>
+  <person_name person_name_id="202" preferred="true" person_id="202" given_name="José" middle_name="Arcadio" family_name="Buendía" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="62775ec1-be49-4996-9335-2b435fc897e9"/>
+  <person_name person_name_id="203" preferred="true" person_id="203" given_name="Úrsula" middle_name="" family_name="Iguarán" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="97246256-cdfe-4491-ab9b-67a5f3ede414"/>
+  <person_name person_name_id="204" preferred="true" person_id="204" prefix="Amaranta" given_name="Úrsula" middle_name="" family_name="Buendía" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="4d00ca4c-2d21-48b1-87e0-f860e4c8c78b"/>
+  <person_name person_name_id="205" preferred="true" person_id="205" given_name="Aureliano" middle_name="José" family_name="Buendía" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="052b7ac8-519e-46b5-86c8-1dba8610998d"/>
+  <person_name person_name_id="206" preferred="true" person_id="206" given_name="Arcadio" middle_name="" family_name="Buendía" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="d22de1cf-268f-4cf4-aedb-b5b655618ac6"/>
+  <person_name person_name_id="207" preferred="true" person_id="207" given_name="Ὀδυσσεύς" middle_name="" family_name="Ιθάκη" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="de7a20f9-ea09-4c25-8afb-8aeb9613f4ef"/>
+  <person_name person_name_id="208" preferred="true" person_id="208" given_name="Hồ" middle_name="Xuân" family_name="Hương" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="4347cd6e-e636-41d4-88ce-e8e1bf850803"/>
+  <person_name person_name_id="209" preferred="true" person_id="209" given_name="Фёдор" middle_name="Михайлович" family_name="Достоевский" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="23366143-4132-4625-a043-d9328b4b7b6d"/>
+  <patient patient_id="202" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="203" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="204" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="205" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="206" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="207" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="208" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+  <patient patient_id="209" creator="1" date_created="2005-01-01 00:00:00.0" voided="false"/>
+</dataset>


### PR DESCRIPTION
Backport to 2.3.x:
TRUNK-5675 "Lucene Analyzer Defs should be provided programatically"
TRUNK-5681 "Patient search should be insensitive to accents"

https://issues.openmrs.org/browse/TRUNK-5675 and
https://issues.openmrs.org/browse/TRUNK-5681

#3049