### PR TITLE
TRUNK-5528:Upgrade org.apache.lucene sub Libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,17 +263,17 @@
 			<dependency>
 				<groupId>org.hibernate</groupId>
 				<artifactId>hibernate-search-orm</artifactId>
-				<version>5.3.0.Final</version>
+				<version>5.5.8.Final</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-queryparser</artifactId>
-				<version>4.10.4</version>
+				<version>5.3.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-queries</artifactId>
-				<version>4.10.4</version>
+				<version>5.3.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.liquibase</groupId>


### PR DESCRIPTION
Description of what I changed

I upgraded library org.apache.lucene sub Libraries

    org.apache.lucene:lucene-queries … 4.10.4 -> 5.3.1
    org.apache.lucene:lucene-queryparser … 4.10.4 -> 5.3.1

Issue I worked on

https://issues.openmrs.org/browse/TRUNK-5528


