### PR TITLE
Trunk-5551 Upgrade xerces:xercesImpl

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -205,12 +205,6 @@
        <dependency>
            <groupId>xerces</groupId>
            <artifactId>xercesImpl</artifactId>
-           <exclusions>
-           	<exclusion>
-           		<artifactId>xml-apis</artifactId>
-           		<groupId>xml-apis</groupId>
-           	</exclusion>
-           </exclusions>
        </dependency>
        <dependency>
            <groupId>javax.validation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
 			<dependency>
 				<groupId>xerces</groupId>
 				<artifactId>xercesImpl</artifactId>
-				<version>2.8.0</version>
+				<version>2.12.0</version>
 			</dependency>
 			<dependency>
 				<groupId>com.thoughtworks.xstream</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -25,12 +25,6 @@
       <dependency>
          <groupId>org.openmrs.api</groupId>
          <artifactId>openmrs-api</artifactId>
-         <exclusions>
-         	<exclusion>
-         		<artifactId>xml-apis</artifactId>
-         		<groupId>xml-apis</groupId>
-         	</exclusion>
-         </exclusions>
       </dependency>
       <dependency>
          <groupId>org.openmrs.test</groupId>


### PR DESCRIPTION
Trunk-5551 Upgraded xerces:xercesImpl

**Description of what I changed**
upgraded the library xerces:xercesImpl from 2.8.0 to 2.12.0
**Issue I worked on**
https://issues.openmrs.org/browse/TRUNK-5551

