### PR TITLE
TRUNK-4253  PatientService.savePatient isn't threadsafe and can allow duplicate patient identifiers

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -124,7 +124,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 			patient.getPatientIdentifier().setPreferred(true);
 		}
 
-		if (!patient.getVoided()) {
+		if (!patient.getVoided() && patient.getIdentifiers().size() == 1) {
 			checkPatientIdentifiers(patient);
 		}
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -117,14 +117,14 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#savePatient(org.openmrs.Patient)
 	 */
 	@Override
-	public Patient savePatient(Patient patient) throws APIException {
+	public synchronized Patient savePatient(Patient patient) throws APIException {
 		requireAppropriatePatientModificationPrivilege(patient);
 
 		if (!patient.getVoided() && patient.getIdentifiers().size() == 1) {
 			patient.getPatientIdentifier().setPreferred(true);
 		}
 
-		if (!patient.getVoided() && patient.getIdentifiers().size() == 1) {
+		if (!patient.getVoided()) {
 			checkPatientIdentifiers(patient);
 		}
 


### PR DESCRIPTION
# TRUNK-4253 :PatientService.savePatient isn't threadsafe and can allow duplicate patient identifiers

## Description of what I changed
i have add synchronize to before savePatient() method


