### PR TITLE
TRUNK-5022:spring MVC configuration treats everything after the dot a…

### DIFF
--- a/web/src/main/resources/openmrs-servlet.xml
+++ b/web/src/main/resources/openmrs-servlet.xml
@@ -54,6 +54,8 @@
 	
 	<bean id="contentNegotiationManager"
 		  class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
+		  <property name="favorPathExtension" value="false"/>
+          <property name="favorParameter" value="true"/>
 		<property name="defaultContentType" value="application/json" />
 
 		<property name="mediaTypes">


### PR DESCRIPTION
Ticket ID:https://issues.openmrs.org/browse/TRUNK-5022

Description
I disabled the path extensions strategy and enabled path parameter strategy  and we already have our media types explicitly defined