### PR TITLE
TRUNK-5555: Fix validation message for length of ConceptDrug name

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ValidateUtil.java
+++ b/api/src/main/java/org/openmrs/validator/ValidateUtil.java
@@ -76,7 +76,7 @@ public class ValidateUtil {
 			Set<String> uniqueErrorMessages = new LinkedHashSet<>();
 			for (Object objerr : errors.getAllErrors()) {
 				ObjectError error = (ObjectError) objerr;
-				String message = Context.getMessageSourceService().getMessage(error.getCode());
+				String message = Context.getMessageSourceService().getMessage(error.getCode(), error.getArguments(), Context.getLocale());
 				if (error instanceof FieldError) {
 					message = ((FieldError) error).getField() + ": " + message;
 				}

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -834,7 +834,7 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 	public void savePatientProgram_shouldTestThrowPatientStateRequiresException() {
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("'PatientProgram(id=1, patient=Patient#2, program=Program(id=1, concept=Concept #1738, " +
-											"workflows=[ProgramWorkflow(id=1), ProgramWorkflow(id=2)]))' failed to validate with reason: states: {0} is required for a patient state");
+											"workflows=[ProgramWorkflow(id=1), ProgramWorkflow(id=2)]))' failed to validate with reason: states: State is required for a patient state");
 		PatientProgram patientProgram = pws.getPatientProgram(1);
 		for (PatientState state : patientProgram.getStates()) {
 			state.setState(null);

--- a/api/src/test/java/org/openmrs/validator/ValidateUtilTest.java
+++ b/api/src/test/java/org/openmrs/validator/ValidateUtilTest.java
@@ -12,12 +12,11 @@ package org.openmrs.validator;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
-import org.openmrs.Location;
-import org.openmrs.Patient;
-import org.openmrs.PatientIdentifierType;
+import org.openmrs.*;
 import org.openmrs.api.ValidationException;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.springframework.validation.BindException;
@@ -146,5 +145,19 @@ public class ValidateUtilTest extends BaseContextSensitiveTest {
 		}
 
 		ValidateUtil.setDisableValidation(prevVal);
+	}
+
+	/**
+	 * @see ValidateUtil#validate(Object)
+	 */
+	@Test
+	public void validate_shouldReturnThrowExceptionAlongWithAppropriateMessageIfTheObjectIsInvalid() {
+		Drug drug = new Drug();
+		Concept concept = new Concept();
+		drug.setName("Sucedáneo de leche humana de término de kcal 509-528/100g, lípidos 25.80-28.90/100g, proteínas 9.50-12.0/100g, hidrato de carbono 55.20-57.90/100g, polvo, envase de lata con 400 a 454 g y medida de 4.30 a 4.50 g. - envase con 400 a 454 g - - envase con 400 a 454 g");
+		drug.setConcept(concept);
+		
+		ValidationException exception = assertThrows(ValidationException.class, () -> ValidateUtil.validate(drug));
+		assertTrue(exception.getMessage().contains("failed to validate with reason: name: This value exceeds the maximum length of 255 permitted for this field."));
 	}
 }


### PR DESCRIPTION
## Description of what I changed
Made changes to ValidateUtil in order to be able to override dynamic placeholders in error messages. For eg., {0} should be replaced with the appropriate argument being passed for that attribute.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5555

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

  No? -> [read here](https://wiki.openmrs.org/display/docs/Pull+Request+Tips) on how to squash multiple commits into one

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

