### PR TITLE
TRUNK-4830 Avoid running legacy liquibase changesets

### DIFF
--- a/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveTest.java
+++ b/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveTest.java
@@ -85,7 +85,7 @@ public class ChangeLogDetectiveTest {
 		boolean actual = changeLogDetective.isVintageChangeSet("any_filename", changeSet);
 		assertFalse(actual);
 	}
-
+	
 	/*
 	 * The vintage change sets to ignore were authored by a person called Ben, this test is about all the
 	 * other change sets authored by Ben.
@@ -133,5 +133,42 @@ public class ChangeLogDetectiveTest {
 		List<ChangeSet> expected = changeSets;
 		
 		assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void shouldLogSmallNumberOfUnrunChangeSets() {
+		ChangeLogDetective changeLogDetective = new ChangeLogDetective();
+		
+		// log up to 9 change sets
+		List<ChangeSet> changeSets = Arrays.asList(mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class),
+		    mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class),
+		    mock(ChangeSet.class), mock(ChangeSet.class));
+		
+		assertTrue(changeLogDetective.logUnRunChangeSetDetails("liquibase-core-data-1.9.x.xml", changeSets));
+		assertTrue(changeLogDetective.logUnRunChangeSetDetails("liquibase-schema-only-1.9.x.xml", changeSets));
+	}
+	
+	@Test
+	public void shouldNotLogLargeNumberOfUnrunChangeSets() {
+		ChangeLogDetective changeLogDetective = new ChangeLogDetective();
+		
+		// do not log 10 or more change sets
+		List<ChangeSet> changeSets = Arrays.asList(mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class),
+		    mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class),
+		    mock(ChangeSet.class), mock(ChangeSet.class), mock(ChangeSet.class));
+		
+		assertFalse(changeLogDetective.logUnRunChangeSetDetails("liquibase-core-data-1.9.x.xml", changeSets));
+		assertFalse(changeLogDetective.logUnRunChangeSetDetails("liquibase-schema-only-1.9.x.xml", changeSets));
+	}
+	
+	@Test
+	public void shouldNotLogUnrunChangeSetsFromOtherChangeLogFile() {
+		ChangeLogDetective changeLogDetective = new ChangeLogDetective();
+		
+		List<ChangeSet> changeSets = Arrays.asList(mock(ChangeSet.class), mock(ChangeSet.class));
+		
+		assertFalse(changeLogDetective.logUnRunChangeSetDetails("liquibase-core-data-2.2.x.xml", changeSets));
+		assertFalse(changeLogDetective.logUnRunChangeSetDetails("liquibase-schema-only-2.2.x.xml", changeSets));
+		assertFalse(changeLogDetective.logUnRunChangeSetDetails("any_filename", changeSets));
 	}
 }


### PR DESCRIPTION
Log details of un-run change sets.

This pull request provides additional logging when the OpenMRS database is updated. The additional log entries are limited to no more than 10 and un-run change sets are logged for 1.9.x Liquibase snapshot files only.

The additional logging was used to debug the database initialisation of the reference application and will help when other users report similar issues.

- [ x ] My pull request only contains **ONE single commit**
- [ x ] My IDE is configured to follow the [**code style**]- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ x ] All new and existing **tests passed**.
- [ x ] My pull request is **based on the latest changes** of the master branch.

