### PR TITLE
TRUNK-4830 Avoid running legacy liquibase changesets

### DIFF
--- a/liquibase/README.md
+++ b/liquibase/README.md
@@ -102,7 +102,7 @@ The pom file of the openmrs-liquibase module contains a template for generating 
 #### Step 1 - Drop your local OpenMRS schema
 E.g. by running the script `openmrs-core/liquibase/scripts/drop_openmrs_schema.sql`:
 
-	mysql -u root -p openmrs < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
+	mysql -u root -p < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
 	
 Take care **not** to run this script on a production database.
 
@@ -221,14 +221,16 @@ Change the username and password of the user with `name="system_id"` and  `value
 #### Step 1 - Drop your local OpenMRS schema
 E.g. by running the script `drop_openmrs_schema.sql`:
 
-	mysql -u root -p openmrs < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
+	mysql -u root -p < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
 	
 Again, take care **not** to run this script on a production database.
 
 #### Step 2 - Create an empty OpenMRS database
 E.g. by running the script `create_openmrs_database.sql`:
 
-	mysql -u root -p openmrs < openmrs-core/liquibase/scripts/create_openmrs_database.sql
+	mysql -u root -p < openmrs-core/liquibase/scripts/create_openmrs_database.sql
+	
+The script creates the openmrs database and the tables `liquibasechangelog` and `liquibasechangeloglock`.
 	
 #### Step 3 - Use the snapshots to update the OpenMRS database 
 Execute
@@ -303,7 +305,7 @@ This section describes how these tests were conducted, so that they can be repea
 #### Step 1 - Drop your local OpenMRS schema
 E.g. by running the script `drop_openmrs_schema.sql`:
 
-	mysql -u root -p openmrs < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
+	mysql -u root -p < openmrs-core/liquibase/scripts/drop_openmrs_schema.sql
 	
 Take care **not** to run this script on a production database.
 

--- a/liquibase/scripts/create_openmrs_database.sql
+++ b/liquibase/scripts/create_openmrs_database.sql
@@ -9,3 +9,34 @@
 --
 create database openmrs;
 show databases;
+
+use openmrs;
+
+DROP TABLE IF EXISTS `liquibasechangelog`;
+CREATE TABLE `liquibasechangelog` (
+  `ID` varchar(255) NOT NULL,
+  `AUTHOR` varchar(255) NOT NULL,
+  `FILENAME` varchar(255) NOT NULL,
+  `DATEEXECUTED` datetime NOT NULL,
+  `ORDEREXECUTED` int(11) NOT NULL,
+  `EXECTYPE` varchar(10) NOT NULL,
+  `MD5SUM` varchar(35) DEFAULT NULL,
+  `DESCRIPTION` varchar(255) DEFAULT NULL,
+  `COMMENTS` varchar(255) DEFAULT NULL,
+  `TAG` varchar(255) DEFAULT NULL,
+  `LIQUIBASE` varchar(20) DEFAULT NULL,
+  `CONTEXTS` varchar(255) DEFAULT NULL,
+  `LABELS` varchar(255) DEFAULT NULL,
+  `DEPLOYMENT_ID` varchar(10) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `liquibasechangeloglock`;
+CREATE TABLE `liquibasechangeloglock` (
+  `ID` int(11) NOT NULL,
+  `LOCKED` tinyint(1) NOT NULL,
+  `LOCKGRANTED` datetime DEFAULT NULL,
+  `LOCKEDBY` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+show tables;


### PR DESCRIPTION
Here comes another by-product of my work on the reference application and the SDK.

I noted that the tables `liquibasechangelog` and `liquibasechangeloglock` need to be created to be able to test changelog files as described in the section _"How to test Liquibase snapshots"_ of the `liquibase/README.md` file.

see https://issues.openmrs.org/browse/TRUNK-4830

- [ x  ] My pull request only contains **ONE single commit**
- [ x ] My IDE is configured to follow the [**code style**]
- [  n/a ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [ n/a ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ n/a ] All new and existing **tests passed**.
- [ x ] My pull request is **based on the latest changes** of the master branch .