### PR TITLE
TRUNK-4830 Avoid running legacy liquibase changesets

### DIFF
--- a/api/src/main/resources/liquibase-core-data.xml
+++ b/api/src/main/resources/liquibase-core-data.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!--
+	This file is provided to be backward compatible with build processes that continue to use 
+	api/src/main/resources/liquibase-core-data.xml to initialise the OpenMRS database.
+-->
+<databaseChangeLog 
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext 
+	    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog 
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+	<include file="org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-1.9.x.xml"/>
+	
+</databaseChangeLog>

--- a/api/src/main/resources/liquibase-schema-only.xml
+++ b/api/src/main/resources/liquibase-schema-only.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!--
+	This file is provided to be backward compatible with build processes that continue to use 
+	api/src/main/resources/liquibase-schema-only.xml to initialise the OpenMRS database.
+-->
+<databaseChangeLog 
+	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext 
+	    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog 
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+	
+	<include file="org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-1.9.x.xml"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
Re-introduce the legacy Liquibase changelog files to provide backwards compatibility for openmrs-standalone. 

see https://issues.openmrs.org/browse/TRUNK-4830

- [ x ] My pull request only contains **ONE single commit**
- [ x ] My IDE is configured to follow the [**code style**]
- [ n/a ] I have **added tests** to cover my changes. (If you refactored
- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ x ] All new and existing **tests passed**.
- [ x ] My pull request is **based on the latest changes** of the master branch.