### PR TITLE
TRUNK-5728: Using a unique FK constraint name for the 'encounter_id' column in the 'conditions' table

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml
@@ -105,7 +105,7 @@
     			<constraints nullable="true" />
     		</column>
     	</addColumn>
-    	<addForeignKeyConstraint constraintName="encounter_id_fk"
+    	<addForeignKeyConstraint constraintName="conditions_encounter_id_fk"
 								 baseTableName="conditions" baseColumnNames="encounter_id"
 								 referencedTableName="encounter" referencedColumnNames="encounter_id" />
     </changeSet>


### PR DESCRIPTION
This is a small followup commit on [work done on linking Conditions to an Encounter](https://github.com/openmrs/openmrs-core/commit/53e4d9ce7b94b4c6e7cb0f7b817244664d3c0124).

See ticket for details: https://issues.openmrs.org/browse/TRUNK-5728