### PR TITLE
TRUNK-5728: Adding liquibase changeset that introduces 'encounter_id' column on conditions table to liquibase-update-to-latest-2.4.x.xml

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -64,5 +64,23 @@
 								 referencedTableName="order_group"
 								 referencedColumnNames="order_group_id" />
     </changeSet>
-	</databaseChangeLog> 
+    
+    <changeSet id="TRUNK-5728-2020-05-20" author="samuel34">
+    	<preConditions onFail="MARK_RAN">
+    		<not>
+    			<columnExists tableName="conditions" columnName="encounter_id"/>
+    		</not>
+    	</preConditions>
+    	<comment>Adding 'encounter_id' column to 'conditions' table</comment>
+    	<addColumn tableName="conditions">
+    		<column name="encounter_id" type="int">
+    			<constraints nullable="true" />
+    		</column>
+    	</addColumn>
+    	<addForeignKeyConstraint constraintName="conditions_encounter_id_fk"
+								 baseTableName="conditions" baseColumnNames="encounter_id"
+								 referencedTableName="encounter" referencedColumnNames="encounter_id" />
+    </changeSet>
+    
+</databaseChangeLog> 
 	


### PR DESCRIPTION
Followup commit for adding [this liquibase changeset](https://github.com/openmrs/openmrs-core/blob/master/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml#L96-L111) to liquibase-update-to-latest-2.4.x.xml 

See ticket for details: https://issues.openmrs.org/browse/TRUNK-5728