### PR TITLE
TRUNK-4830 Avoid running legacy liquibase changesets

### DIFF
--- a/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveDatabaseIT.java
@@ -1,4 +1,3 @@
-
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -10,10 +9,8 @@
  */
 package org.openmrs.liquibase;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
-import liquibase.exception.LiquibaseException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -79,14 +76,5 @@ public class ChangeLogDetectiveDatabaseIT extends H2DatabaseIT {
 		List<String> actual = changeLogDetective.getUnrunLiquibaseUpdateFileNames(VERSION_2_1_X, "some context", this);
 		
 		assertEquals(expected, actual);
-	}
-	
-	private void updateDatabase(List<String> filenames) throws SQLException, LiquibaseException {
-		log.info("liquibase files used for creating and updating the OpenMRS database are: " + filenames);
-		
-		for (String filename : filenames) {
-			log.info("updating database with '{}'", filename);
-			this.updateDatabase(filename);
-		}
 	}
 }

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -1,0 +1,59 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openmrs.liquibase.ChangeLogVersionFinder;
+
+import static org.junit.Assert.assertEquals;
+
+public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
+	
+	private static final String VERSION_2_1_X = "2.1.x";
+	
+	/*
+	 * This is the number of change sets defined by the Liquibase snapshot files 2.1.x and all Liquibase update
+	 * files with versions greater than 2.1.x.
+	 * 
+	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
+	 */
+	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 863;
+	
+	@Rule
+	public ExpectedException expectedException = ExpectedException.none();
+	
+	@Before
+	public void setup() {
+		DatabaseUpdater.setLiquibaseProvider(this);
+	}
+	
+	@After
+	public void tearDown() {
+		DatabaseUpdater.unsetLiquibaseProvider();
+	}
+	
+	@Test
+	public void should() throws Exception {
+		ChangeLogVersionFinder changeLogVersionFinder = new ChangeLogVersionFinder();
+		Map<String, List<String>> snapshotCombinations = changeLogVersionFinder.getSnapshotCombinations();
+		updateDatabase(snapshotCombinations.get(VERSION_2_1_X));
+		
+		List<DatabaseUpdater.OpenMRSChangeSet> actual = DatabaseUpdater.getDatabaseChanges();
+		
+		assertEquals(CHANGE_SET_COUNT_FOR_2_1_X, actual.size());
+		
+	}
+}

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterTest.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterTest.java
@@ -11,12 +11,16 @@ package org.openmrs.util;
 
 import liquibase.exception.LockException;
 import org.junit.Test;
+import org.openmrs.liquibase.LiquibaseProvider;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.mockito.Mockito.verify;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 /**
  * Tests methods on the {@link DatabaseUpdater} class. This class expects /metadata/model to be on
@@ -68,5 +72,14 @@ public class DatabaseUpdaterTest extends BaseContextSensitiveTest {
 		catch (RuntimeException re) {
 			assertTrue(re.getCause() instanceof IllegalArgumentException);
 		}
+	}
+	
+	@Test
+	public void shouldReturnInjectedLiquibaseProvider() throws Exception {
+		LiquibaseProvider liquibaseProvider = mock(LiquibaseProvider.class);
+		DatabaseUpdater.setLiquibaseProvider(liquibaseProvider);
+		DatabaseUpdater.getLiquibase( "filename" );
+		verify(liquibaseProvider, times(1)).getLiquibase("filename");
+		DatabaseUpdater.unsetLiquibaseProvider();
 	}
 }

--- a/api/src/test/java/org/openmrs/util/databasechange/ValidateHibernateMappingsDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/ValidateHibernateMappingsDatabaseIT.java
@@ -9,12 +9,10 @@
  */
 package org.openmrs.util.databasechange;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.persistence.Entity;
-import liquibase.exception.LiquibaseException;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
@@ -39,7 +37,7 @@ public class ValidateHibernateMappingsDatabaseIT extends H2DatabaseIT {
 	public ExpectedException expectedException = ExpectedException.none();
 	
 	@Test
-	public void shouldValidateHibernateMappings() throws SQLException, LiquibaseException, ClassNotFoundException {
+	public void shouldValidateHibernateMappings() throws Exception {
 		/*
 		 * Drop all database objects before running the test as previously run tests may have left tables behind.
 		 */


### PR DESCRIPTION
## Description of what I changed
restored DatabaseUpdater#getDatabaseChanges method

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
- [ x ] My IDE is configured to follow the [**code style**]
- [ x ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests
- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ x ] All new and existing **tests passed**.
- [ x ] My pull request is **based on the latest changes** of the master branch.
