### PR TITLE
FM2-184: Set context classloader to be module's classloader.

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -858,6 +858,7 @@ public class ModuleUtil {
 		for (Module module : startedModules) {
 			try {
 				if (module.getModuleActivator() != null) {
+					Thread.currentThread().setContextClassLoader(ModuleFactory.getModuleClassLoader(module));
 					module.getModuleActivator().willRefreshContext();
 				}
 			}


### PR DESCRIPTION
## Description of what I changed
Explicitly set the context classloader to be the module's classloader
before calling willRefreshContext.

## Issue I worked on
https://issues.openmrs.org/browse/FM2-184

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**]
- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> I'm not sure how this can be unit tested, tbh. 

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.