### PR TITLE
TRUNK-4946:Discard all changes to an object when retiring/voiding/unretiring/unvoiding it

### DIFF
--- a/api/src/main/java/org/openmrs/api/handler/BaseRetireHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseRetireHandler.java
@@ -15,6 +15,7 @@ import org.openmrs.Retireable;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
+import org.openmrs.api.context.Context;
 
 /**
  * This is the default class for all retire* actions that take place on all services. The
@@ -54,7 +55,10 @@ public class BaseRetireHandler implements RetireHandler<Retireable> {
 	 */
 	@Override
 	public void handle(Retireable retireableObject, User retiringUser, Date retireDate, String retireReason) {
-		
+		// reload object from database if it has been saved before
+		if (retireableObject.getId() != null) {
+			Context.refreshEntity(retireableObject);
+		}
 		// skip over doing retire stuff if already retired
 		if (!retireableObject.getRetired() || retireableObject.getRetiredBy() == null) {
 			

--- a/api/src/main/java/org/openmrs/api/handler/BaseUnretireHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseUnretireHandler.java
@@ -15,6 +15,7 @@ import org.openmrs.Retireable;
 import org.openmrs.User;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
+import org.openmrs.api.context.Context;
 
 /**
  * This is the super interface for all unretire* actions that take place on all services. The
@@ -50,7 +51,10 @@ public class BaseUnretireHandler implements UnretireHandler<Retireable> {
 	 */
 	@Override
 	public void handle(Retireable retireableObject, User retiringUser, Date origParentRetiredDate, String unused) {
-		
+		  // reload object from database if it has been saved before
+	    if (retireableObject.getId() != null) {  
+	        Context.refreshEntity(retireableObject);    
+	    }
 		// only act on retired objects
 		if (retireableObject.getRetired()
 		        && (origParentRetiredDate == null || origParentRetiredDate.equals(retireableObject.getDateRetired()))) {

--- a/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
@@ -52,7 +52,7 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 	 */
 	@Override
 	public void handle(Voidable voidableObject, User voidingUser, Date origParentVoidedDate, String unused) {
-		
+
 		// reload object from database if it has been saved before
 		if (voidableObject.getId() != null) {
 			Context.refreshEntity(voidableObject);

--- a/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
@@ -11,10 +11,13 @@ package org.openmrs.api.handler;
 
 import java.util.Date;
 
+
 import org.openmrs.User;
 import org.openmrs.Voidable;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
+import org.openmrs.api.context.Context;
+
 
 /**
  * This is the super interface for all unvoid* actions that take place on all services. The
@@ -50,6 +53,10 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 	@Override
 	public void handle(Voidable voidableObject, User voidingUser, Date origParentVoidedDate, String unused) {
 		
+		// reload object from database if it has been saved before
+		if (voidableObject.getId() != null) {
+			Context.refreshEntity(voidableObject);
+		
 		// only operate on voided objects
 		if (voidableObject.getVoided()
 		        && (origParentVoidedDate == null || origParentVoidedDate.equals(voidableObject.getDateVoided()))) {
@@ -59,7 +66,9 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 			voidableObject.setVoidedBy(null);
 			voidableObject.setDateVoided(null);
 			voidableObject.setVoidReason(null);
-		}
+		    }
+	    }
 	}
-	
+ 
 }
+	

--- a/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseUnvoidHandler.java
@@ -56,6 +56,7 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 		// reload object from database if it has been saved before
 		if (voidableObject.getId() != null) {
 			Context.refreshEntity(voidableObject);
+		}
 		
 		// only operate on voided objects
 		if (voidableObject.getVoided()
@@ -66,9 +67,6 @@ public class BaseUnvoidHandler implements UnvoidHandler<Voidable> {
 			voidableObject.setVoidedBy(null);
 			voidableObject.setDateVoided(null);
 			voidableObject.setVoidReason(null);
-		    }
 	    }
 	}
- 
-}
-	
+}	

--- a/api/src/main/java/org/openmrs/api/handler/BaseVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/BaseVoidHandler.java
@@ -15,6 +15,8 @@ import org.openmrs.User;
 import org.openmrs.Voidable;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
+import org.openmrs.api.context.Context;
+
 
 /**
  * This is the super interface for all void* actions that take place on all services. The
@@ -54,6 +56,11 @@ public class BaseVoidHandler implements VoidHandler<Voidable> {
 	 */
 	@Override
 	public void handle(Voidable voidableObject, User voidingUser, Date voidedDate, String voidReason) {
+		
+		// reload object from database if it has been saved before
+		if (voidableObject.getId() != null) {
+			Context.refreshEntity(voidableObject);
+		}
 		
 		// skip over all work if the object is already voided
 		if (!voidableObject.getVoided() || voidableObject.getVoidedBy() == null) {

--- a/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
@@ -17,11 +17,11 @@ import org.openmrs.Location;
 import org.openmrs.Retireable;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
-
+import org.openmrs.test.BaseContextSensitiveTest;
 /**
  * Tests for the {@link BaseRetireHandler} class.
  */
-public class BaseRetireHandlerTest {
+public class BaseRetireHandlerTest extends BaseContextSensitiveTest  {
 	
 	/**
 	 * @see BaseRetireHandler#handle(Retireable,User,Date,String)

--- a/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
@@ -122,7 +122,7 @@ public class BaseRetireHandlerTest {
 		Assert.assertEquals("THE REASON", retireable.getRetireReason());
 	}
 	@Test
-	public void handle_shoudNotUpdateFieldBesidesRetireableFields() {
+	public void handle_shouldNotUpdateFieldBesidesRetireableFields() {
 		RetireHandler<Retireable> handler = new BaseRetireHandler();
 		Location retireable = Context.getLocationService().getLocation(1);
 		Assert.assertNotEquals("NOT SET", retireable.getAddress1());

--- a/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseRetireHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.openmrs.Location;
 import org.openmrs.Retireable;
 import org.openmrs.User;
+import org.openmrs.api.context.Context;
 
 /**
  * Tests for the {@link BaseRetireHandler} class.
@@ -119,6 +120,20 @@ public class BaseRetireHandlerTest {
 		retireable.setRetired(true);
 		handler.handle(retireable, null, null, "THE REASON");
 		Assert.assertEquals("THE REASON", retireable.getRetireReason());
+	}
+	@Test
+	public void handle_shoudNotUpdateFieldBesidesRetireableFields() {
+		RetireHandler<Retireable> handler = new BaseRetireHandler();
+		Location retireable = Context.getLocationService().getLocation(1);
+		Assert.assertNotEquals("NOT SET", retireable.getAddress1());
+		
+		retireable.setAddress1("NOT SET");
+		Assert.assertEquals("NOT SET", retireable.getAddress1());
+		
+		retireable.setRetired(true);
+		handler.handle(retireable, null, null, "THE REASON");
+		
+		Assert.assertNotEquals("NOT SET", retireable.getAddress1());
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/api/handler/BaseUnretireHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseUnretireHandlerTest.java
@@ -16,11 +16,14 @@ import org.junit.Test;
 import org.openmrs.Location;
 import org.openmrs.Retireable;
 import org.openmrs.User;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.LocationService;
+import org.openmrs.test.BaseContextSensitiveTest;
 
 /**
  * Tests the {@link BaseUnretireHandler} class.
  */
-public class BaseUnretireHandlerTest {
+public class BaseUnretireHandlerTest extends BaseContextSensitiveTest {
 	
 	/**
 	 * @see BaseUnretireHandler#handle(Retireable,User,Date,String)
@@ -101,4 +104,30 @@ public class BaseUnretireHandlerTest {
 		Assert.assertTrue(retireable.getRetired());
 	}
 	
+	/**
+	 * @see BaseUnretireHandler#handle(Retireable,User,Date,String)
+	 */
+	@Test
+	public void handle_shoudNotUpdateFieldBesidesRetireableFields() {
+		RetireHandler<Retireable> handler = new BaseRetireHandler();
+	        
+	        LocationService locationService = Context.getLocationService();
+	        
+	        // retire the location
+		Location retireable = locationService.getLocation(1);
+		retireable.setRetired(true);
+		retireable.setRetireReason("test");
+	        locationService.saveLocation(retireable);
+	        
+	        retireable = locationService.getLocation(1);
+		Assert.assertNotEquals("NOT SET", retireable.getAddress1());
+		
+		retireable.setAddress1("NOT SET");
+		Assert.assertEquals("NOT SET", retireable.getAddress1());
+		
+		retireable.setRetired(false);
+		handler.handle(retireable, null, null, "THE REASON");
+		
+		Assert.assertNotEquals("NOT SET", retireable.getAddress1());
+	}
 }

--- a/api/src/test/java/org/openmrs/api/handler/BaseUnretireHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseUnretireHandlerTest.java
@@ -108,7 +108,7 @@ public class BaseUnretireHandlerTest extends BaseContextSensitiveTest {
 	 * @see BaseUnretireHandler#handle(Retireable,User,Date,String)
 	 */
 	@Test
-	public void handle_shoudNotUpdateFieldBesidesRetireableFields() {
+	public void handle_shouldNotUpdateFieldBesidesRetireableFields() {
 		RetireHandler<Retireable> handler = new BaseRetireHandler();
 	        
 	        LocationService locationService = Context.getLocationService();

--- a/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseUnvoidHandlerTest.java
@@ -16,11 +16,12 @@ import org.junit.Test;
 import org.openmrs.Person;
 import org.openmrs.User;
 import org.openmrs.Voidable;
-
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseContextSensitiveTest;
 /**
  * Tests the {@link BaseUnvoidHandler} class.
  */
-public class BaseUnvoidHandlerTest {
+public class BaseUnvoidHandlerTest extends BaseContextSensitiveTest {
 	
 	/**
 	 * @see BaseUnvoidHandler#handle(Voidable,User,Date,String)
@@ -100,4 +101,27 @@ public class BaseUnvoidHandlerTest {
 		handler.handle(voidable, null, new Date(), "SOME REASON");
 		Assert.assertTrue(voidable.getVoided());
 	}
+	
+	/**
+	 * @see BaseUnvoidHandler#handle(Voidable,User,Date,String)
+	 */
+	@Test
+	public void handle_shouldNotUpdateFieldBesidesVoidFields() {
+		VoidHandler<Voidable> handler = new BaseVoidHandler();
+		Person voidable = Context.getPersonService().getPerson(1);
+		Assert.assertNotEquals("NOT SET", voidable.getGender());
+
+		voidable.setVoided(true);
+		voidable.setVoidReason("test");
+		Context.getPersonService().savePerson(voidable);
+
+		voidable.setGender("NOT SET");
+		Assert.assertEquals("NOT SET", voidable.getGender());
+
+		voidable.setVoided(false);
+		handler.handle(voidable, null, null, "THE REASON");
+
+		Assert.assertNotEquals("NOT SET", voidable.getGender());
+	}
 }
+

--- a/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
@@ -16,11 +16,16 @@ import org.junit.Test;
 import org.openmrs.Person;
 import org.openmrs.User;
 import org.openmrs.Voidable;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.openmrs.api.context.ServiceContext.getService;
+
+
 
 /**
  * Tests for the {@link BaseVoidHandler} class.
  */
-public class BaseVoidHandlerTest {
+public class BaseVoidHandlerTest extends BaseContextSensitiveTest  {
 	
 	/**
 	 * @see BaseVoidHandler#handle(Voidable,User,Date,String)
@@ -121,4 +126,24 @@ public class BaseVoidHandlerTest {
 		handler.handle(voidable, null, null, "THE REASON");
 		Assert.assertEquals("THE REASON", voidable.getVoidReason());
 	}
+	
+	/**
+	 * @see BaseUnvoidHandler#handle(Voidable,User,Date,String)
+	 */
+	@Test
+	public void handle_shoudNotUpdateFieldBesidesVoidFields() {  
+	  VoidHandler<Voidable> handler = new BaseVoidHandler();   
+	  Person voidable = Context.getPersonService().getPerson(1);                                        
+	  Assert.assertNotEquals("NOT SET", voidable.getGender());
+
+	  voidable.setGender("NOT SET");
+	  Assert.assertEquals("NOT SET", voidable.getGender());
+
+	  voidable.setVoided(true);
+	  handler.handle(voidable, null, null, "THE REASON");
+
+	  Assert.assertNotEquals("NOT SET", voidable.getGender());
+	 }
+
 }
+

--- a/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
@@ -18,7 +18,7 @@ import org.openmrs.User;
 import org.openmrs.Voidable;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.BaseContextSensitiveTest;
-import org.openmrs.api.context.ServiceContext.getService;
+
 
 
 

--- a/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/BaseVoidHandlerTest.java
@@ -131,7 +131,7 @@ public class BaseVoidHandlerTest extends BaseContextSensitiveTest  {
 	 * @see BaseUnvoidHandler#handle(Voidable,User,Date,String)
 	 */
 	@Test
-	public void handle_shoudNotUpdateFieldBesidesVoidFields() {  
+	public void handle_shouldNotUpdateFieldBesidesVoidFields() {  
 	  VoidHandler<Voidable> handler = new BaseVoidHandler();   
 	  Person voidable = Context.getPersonService().getPerson(1);                                        
 	  Assert.assertNotEquals("NOT SET", voidable.getGender());


### PR DESCRIPTION

## Description of what I changed
I refactored the AOP methods for retireXXX(), unretireXXX(), voidXXX(), and unvoidXXX() methods to discard any changes to the object and only save changes to the voided/retired, voidedBy/retiredBy, dateVoided/dateRetirede and voidReason/retireReasom fields and also I included a unit test to prove that changes made to an object (other than to void/retire fields) when retiring, voiding, unretiring, or unvoiding are lost.

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-4946

