### PR TITLE
FM2-184: Set context classloader to be module's classloader.

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -858,6 +858,7 @@ public class ModuleUtil {
 		for (Module module : startedModules) {
 			try {
 				if (module.getModuleActivator() != null) {
+					Thread.currentThread().setContextClassLoader(ModuleFactory.getModuleClassLoader(module));
 					module.getModuleActivator().willRefreshContext();
 				}
 			}


### PR DESCRIPTION
Backporting https://github.com/openmrs/openmrs-core/pull/3230 to 2.2.x.