### PR TITLE
TRUNK-5798, Add onDelete=CASCADE in liquibase changesets while creati…

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
@@ -5044,7 +5044,7 @@
         <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="concept_attribute" constraintName="concept_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-539">
-        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-540">
         <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_class" constraintName="concept_class_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" validate="true"/>
@@ -5437,7 +5437,7 @@
         <addForeignKeyConstraint baseColumnNames="parent" baseTableName="note" constraintName="note_hierarchy" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="note_id" referencedTableName="note" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-670">
-        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-671">
         <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="obs" constraintName="obs_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
@@ -5617,7 +5617,7 @@
         <addForeignKeyConstraint baseColumnNames="cause_of_death" baseTableName="person" constraintName="person_died_because" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-730">
-        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-731">
         <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="users" constraintName="person_id_for_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
@@ -5797,7 +5797,7 @@
         <addForeignKeyConstraint baseColumnNames="frequency" baseTableName="test_order" constraintName="test_order_frequency_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_frequency_id" referencedTableName="order_frequency" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-790">
-        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-791">
         <addForeignKeyConstraint baseColumnNames="specimen_source" baseTableName="test_order" constraintName="test_order_specimen_source_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>

--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
@@ -5044,7 +5044,7 @@
         <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="concept_attribute" constraintName="concept_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-539">
-        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-540">
         <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_class" constraintName="concept_class_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" validate="true"/>
@@ -5437,7 +5437,7 @@
         <addForeignKeyConstraint baseColumnNames="parent" baseTableName="note" constraintName="note_hierarchy" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="note_id" referencedTableName="note" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-670">
-        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-671">
         <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="obs" constraintName="obs_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
@@ -5617,7 +5617,7 @@
         <addForeignKeyConstraint baseColumnNames="cause_of_death" baseTableName="person" constraintName="person_died_because" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-730">
-        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-731">
         <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="users" constraintName="person_id_for_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" validate="true"/>
@@ -5797,7 +5797,7 @@
         <addForeignKeyConstraint baseColumnNames="frequency" baseTableName="test_order" constraintName="test_order_frequency_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_frequency_id" referencedTableName="order_frequency" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-790">
-        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" validate="true"/>
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" validate="true"/>
     </changeSet>
     <changeSet author="wolf (generated)" id="1582473628795-791">
         <addForeignKeyConstraint baseColumnNames="specimen_source" baseTableName="test_order" constraintName="test_order_specimen_source_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -108,4 +108,37 @@
 			SELECT setval('order_type_order_type_id_seq', (SELECT MAX(order_type_id) FROM order_type)+1);
 		</sql>
 	</changeSet> 
+	
+	<changeSet id="20200622-cascade_delete_concept_comlex" author="aman" dbms="postgresql">
+		<preConditions onFail="MARK_RAN">
+    	    <foreignKeyConstraintExists foreignKeyName="concept_attributes"/>
+		</preConditions>
+		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+   		<dropForeignKeyConstraint baseTableName="concept_complex" constraintName="concept_attributes"/>
+   		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>
+	</changeSet>
+	<changeSet id="20200622-cascade_delete_concept_numeric" author="aman" dbms="postgresql">
+		<preConditions onFail="MARK_RAN">
+   	    	<foreignKeyConstraintExists foreignKeyName="numeric_attributes"/>
+		</preConditions>
+		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+		<dropForeignKeyConstraint baseTableName="concept_numeric" constraintName="numeric_attributes"/>
+		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>   	
+	</changeSet>
+	<changeSet id="20200622-cascade_delete_patient" author="aman" dbms="postgresql">
+		<preConditions onFail="MARK_RAN">
+   		   <foreignKeyConstraintExists foreignKeyName="person_id_for_patient"/>
+		</preConditions>
+		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+   		<dropForeignKeyConstraint baseTableName="patient" constraintName="person_id_for_patient"/>
+		<addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person"/>
+	</changeSet>
+	<changeSet id="20200622-cascade_delete_test_order" author="aman" dbms="postgresql">
+		<preConditions onFail="MARK_RAN">
+	        <foreignKeyConstraintExists foreignKeyName="test_order_order_id_fk"/>
+		</preConditions>
+		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+    	<dropForeignKeyConstraint baseTableName="test_order" constraintName="test_order_order_id_fk"/>
+		<addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders"/>
+	</changeSet>
 </databaseChangeLog> 

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -113,7 +113,7 @@
 		<preConditions onFail="MARK_RAN">
     	    <foreignKeyConstraintExists foreignKeyName="concept_attributes"/>
 		</preConditions>
-		<comment>Updating Foreign Key concept_attributes To Add delete CASCADES</comment>
+		<comment>Updating foreign key concept_attributes to add delete CASCADES</comment>
    		<dropForeignKeyConstraint baseTableName="concept_complex" constraintName="concept_attributes"/>
    		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>
 	</changeSet>
@@ -121,7 +121,7 @@
 		<preConditions onFail="MARK_RAN">
    	    	<foreignKeyConstraintExists foreignKeyName="numeric_attributes"/>
 		</preConditions>
-		<comment>Updating Foreign Key numeric_attributes To Add delete CASCADES</comment>
+		<comment>Updating foreign key numeric_attributes to add delete CASCADES</comment>
 		<dropForeignKeyConstraint baseTableName="concept_numeric" constraintName="numeric_attributes"/>
 		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>   	
 	</changeSet>
@@ -129,7 +129,7 @@
 		<preConditions onFail="MARK_RAN">
    		   <foreignKeyConstraintExists foreignKeyName="person_id_for_patient"/>
 		</preConditions>
-		<comment>Updating Foreign Key person_id_for_patient To Add delete CASCADES</comment>
+		<comment>Updating foreign key person_id_for_patient to add delete CASCADES</comment>
    		<dropForeignKeyConstraint baseTableName="patient" constraintName="person_id_for_patient"/>
 		<addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person"/>
 	</changeSet>
@@ -137,7 +137,7 @@
 		<preConditions onFail="MARK_RAN">
 	        <foreignKeyConstraintExists foreignKeyName="test_order_order_id_fk"/>
 		</preConditions>
-		<comment>Updating Foreign Key test_order_order_id_fk To Add delete CASCADES</comment>
+		<comment>Updating foreign key test_order_order_id_fk to add delete CASCADES</comment>
     	<dropForeignKeyConstraint baseTableName="test_order" constraintName="test_order_order_id_fk"/>
 		<addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders"/>
 	</changeSet>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -113,7 +113,7 @@
 		<preConditions onFail="MARK_RAN">
     	    <foreignKeyConstraintExists foreignKeyName="concept_attributes"/>
 		</preConditions>
-		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+		<comment>Updating Foreign Key concept_attributes To Add delete CASCADES</comment>
    		<dropForeignKeyConstraint baseTableName="concept_complex" constraintName="concept_attributes"/>
    		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>
 	</changeSet>
@@ -121,7 +121,7 @@
 		<preConditions onFail="MARK_RAN">
    	    	<foreignKeyConstraintExists foreignKeyName="numeric_attributes"/>
 		</preConditions>
-		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+		<comment>Updating Foreign Key numeric_attributes To Add delete CASCADES</comment>
 		<dropForeignKeyConstraint baseTableName="concept_numeric" constraintName="numeric_attributes"/>
 		<addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept"/>   	
 	</changeSet>
@@ -129,7 +129,7 @@
 		<preConditions onFail="MARK_RAN">
    		   <foreignKeyConstraintExists foreignKeyName="person_id_for_patient"/>
 		</preConditions>
-		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+		<comment>Updating Foreign Key person_id_for_patient To Add delete CASCADES</comment>
    		<dropForeignKeyConstraint baseTableName="patient" constraintName="person_id_for_patient"/>
 		<addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person"/>
 	</changeSet>
@@ -137,7 +137,7 @@
 		<preConditions onFail="MARK_RAN">
 	        <foreignKeyConstraintExists foreignKeyName="test_order_order_id_fk"/>
 		</preConditions>
-		<comment>Updating Foreign Key To Add delete CASCADES</comment>
+		<comment>Updating Foreign Key test_order_order_id_fk To Add delete CASCADES</comment>
     	<dropForeignKeyConstraint baseTableName="test_order" constraintName="test_order_order_id_fk"/>
 		<addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders"/>
 	</changeSet>


### PR DESCRIPTION
…ng tables wherever necessary

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Added onDelete=CASCADE in liquibase schema files where necessary.
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5798

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

