### PR TITLE
TRUNK-5877: Invalid discriminator for OrderSet

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSet.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderSet.hbm.xml
@@ -23,8 +23,6 @@
             </generator>
         </id>
 
-        <discriminator column="order_set_id" insert="false" />
-
         <property name="name" type="java.lang.String"
                   column="name" not-null="true" />
         <property name="description" type="java.lang.String"


### PR DESCRIPTION
This PR simply removes the discriminator property defined within the OrderSet.hbm.xml file. This property does not seem to be needed and prevents subclasses of OrderSet to be defined and saved due to it's presence in this file.