### PR TITLE
TRUNK-5875:Unit test files left in place

### DIFF
--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -43,6 +43,7 @@ import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -353,10 +354,17 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 		runtimeProperties.setProperty(ModuleConstants.IGNORE_CORE_MODULES_PROPERTY, "true");
 		
 		try {
-			File tempappdir = File.createTempFile("appdir-for-unit-tests-", "");
+			final File tempappdir = File.createTempFile("appdir-for-unit-tests-", "");
 			tempappdir.delete(); // so we can make it into a directory
 			tempappdir.mkdir(); // turn it into a directory
-			tempappdir.deleteOnExit(); // clean up when we're done with tests
+			// clean up when we're done with tests
+			Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+				try {
+					FileUtils.deleteDirectory(tempappdir);
+				}
+				catch (IOException ignored) {
+				}
+			}));
 			
 			runtimeProperties.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, tempappdir
 			        .getAbsolutePath());

--- a/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.ConceptName;
@@ -92,6 +93,7 @@ import org.springframework.test.context.TestExecutionListeners;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 import org.xml.sax.InputSource;
+
 
 /**
  * This is the base for spring/context tests. Tests that NEED to use calls to the Context class and
@@ -130,6 +132,9 @@ public abstract class BaseContextSensitiveTest {
 	 * cached runtime properties
 	 */
 	protected static Properties runtimeProperties;
+	
+	@TempDir
+	public static File tempappdir;
 	
 	/**
 	 * Used for username/password dialog

--- a/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
@@ -122,7 +122,13 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		testAppDataDir = File.createTempFile("appdir-for-unit-tests", "");
 		testAppDataDir.delete();// so we can make turn it into a directory
 		testAppDataDir.mkdir();
-		
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			try {
+				FileUtils.deleteDirectory(testAppDataDir);
+			}
+			catch (IOException ignored) {
+			}
+		}));
 		System.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, testAppDataDir.getAbsolutePath());
 		OpenmrsUtil.setApplicationDataDirectory(testAppDataDir.getAbsolutePath());
 	}


### PR DESCRIPTION

## Description of what I changed:
I worked on the deleteOnExit() in the BaseContextSensitiveTest to ensure it properly clean-up a directory after running the unit tests.

## Issue I worked on:
https://issues.openmrs.org/browse/TRUNK-5875