### PR TITLE
TRUNK-5897: Remove discriminator from OrderGroup.hbm.xml

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderGroup.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderGroup.hbm.xml
@@ -23,8 +23,6 @@
             </generator>
         </id>
 
-        <discriminator column="order_group_id" insert="false" />
-
         <many-to-one name="orderSet" class="OrderSet">
             <column name="order_set_id"/>
         </many-to-one>


### PR DESCRIPTION
Removes incorrect discriminator column from OrderGroup.hbm.xml

This is the same fix that we had to make to OrderSet.hbm.xml in TRUNK-5877, likely introduced incorrectly at the same time.