### PR TITLE
TRUNK-5875:Unit test files left in place

### DIFF
--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -65,6 +65,8 @@ import org.dbunit.operation.DatabaseOperation;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Environment;
 import org.hibernate.dialect.H2Dialect;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -122,6 +124,10 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 	protected static final String INITIAL_XML_DATASET_PACKAGE_PATH = "org/openmrs/include/initialInMemoryTestDataSet.xml";
 	
 	protected static final String EXAMPLE_XML_DATASET_PACKAGE_PATH = "org/openmrs/include/standardTestDataset.xml";
+	
+	
+	@ClassRule
+	public static TemporaryFolder tempappdir = TemporaryFolder.builder().assureDeletion().build();
 	
 	/**
 	 * cached runtime properties
@@ -348,26 +354,15 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 			//after that, just update, if there are any changes. This is for performance reasons.
 			runtimeProperties.setProperty(Environment.HBM2DDL_AUTO, "update");
 		}
-		
-		// we don't want to try to load core modules in tests
-		runtimeProperties.setProperty(ModuleConstants.IGNORE_CORE_MODULES_PROPERTY, "true");
-		
-		try {
-			File tempappdir = File.createTempFile("appdir-for-unit-tests-", "");
-			tempappdir.delete(); // so we can make it into a directory
-			tempappdir.mkdir(); // turn it into a directory
-			tempappdir.deleteOnExit(); // clean up when we're done with tests
-			
-			runtimeProperties.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, tempappdir
-			        .getAbsolutePath());
-			OpenmrsUtil.setApplicationDataDirectory(tempappdir.getAbsolutePath());
-		}
-		catch (IOException e) {
-			log.error("Unable to create temp dir", e);
-		}
-		
-		return runtimeProperties;
-	}
+	/** we don't want to try to load core modules in tests 
+	 * 
+	 */
+                runtimeProperties.setProperty(ModuleConstants.IGNORE_CORE_MODULES_PROPERTY, "true");
+				runtimeProperties.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, tempappdir
+					        .getAbsolutePath());
+					OpenmrsUtil.setApplicationDataDirectory(tempappdir.getAbsolutePath());
+					return runtimeProperties;
+			 }
 	
 	/**
 	 * This method provides the credentials to authenticate the user that is authenticated through the base setup.

--- a/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openmrs.ConceptName;
@@ -130,6 +131,9 @@ public abstract class BaseContextSensitiveTest {
 	 * cached runtime properties
 	 */
 	protected static Properties runtimeProperties;
+	
+	@TempDir
+	public static File tempappdir;
 	
 	/**
 	 * Used for username/password dialog
@@ -342,26 +346,16 @@ public abstract class BaseContextSensitiveTest {
 			runtimeProperties.setProperty(Environment.HBM2DDL_AUTO, "update");
 		}
 		
-		// we don't want to try to load core modules in tests
+	/** we don't want to try to load core modules in tests
+	 * 
+	 */
 		runtimeProperties.setProperty(ModuleConstants.IGNORE_CORE_MODULES_PROPERTY, "true");
-		
-		try {
-			File tempappdir = File.createTempFile("appdir-for-unit-tests-", "");
-			tempappdir.delete(); // so we can make it into a directory
-			tempappdir.mkdir(); // turn it into a directory
-			tempappdir.deleteOnExit(); // clean up when we're done with tests
-			
-			runtimeProperties.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, tempappdir
+		runtimeProperties.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, tempappdir
 			        .getAbsolutePath());
 			OpenmrsUtil.setApplicationDataDirectory(tempappdir.getAbsolutePath());
-		}
-		catch (IOException e) {
-			log.error("Unable to create temp dir", e);
-		}
-		
-		return runtimeProperties;
-	}
-	
+			return runtimeProperties;
+	  }
+	   
 	/**
 	 * This method provides the credentials to authenticate the user that is authenticated through the base setup.
 	 * This method can be overridden when setting up test application contexts that are *not* using the default authentication scheme.

--- a/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
@@ -35,6 +35,8 @@ import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,6 +65,9 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 	public static final String LIQUIBASE_UPDATE_TO_LATEST_XML = "liquibase-update-to-latest.xml";
 	
 	private DatabaseUpgradeTestUtil upgradeTestUtil;
+	
+	@ClassRule
+	public static TemporaryFolder tempappdir = TemporaryFolder.builder().assureDeletion().build();
 	
 	private static File testAppDataDir;
 	
@@ -119,10 +124,6 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 	
 	@BeforeAll
 	public static void beforeClass() throws IOException {
-		testAppDataDir = File.createTempFile("appdir-for-unit-tests", "");
-		testAppDataDir.delete();// so we can make turn it into a directory
-		testAppDataDir.mkdir();
-		
 		System.setProperty(OpenmrsConstants.APPLICATION_DATA_DIRECTORY_RUNTIME_PROPERTY, testAppDataDir.getAbsolutePath());
 		OpenmrsUtil.setApplicationDataDirectory(testAppDataDir.getAbsolutePath());
 	}


### PR DESCRIPTION

## Description of what I changed
I worked on the BaseContextSensitiveTest for JUnit 4 and JUnit5 to ensure it properly clean-up a directory after running the unit tests.

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5875

