### PR TITLE
TRUNK-5920 - Saving Order Groups fails to validate underlying Orders

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -112,7 +112,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		List<Order> orders = orderGroup.getOrders();
 		for (Order order : orders) {
 			if (order.getId() == null) {
-				saveOrder(order, null);
+				Context.getOrderService().saveOrder(order, null);
 			}
 		}
 		return orderGroup;

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -38,6 +38,7 @@ import org.openmrs.Patient;
 import org.openmrs.Provider;
 import org.openmrs.SimpleDosingInstructions;
 import org.openmrs.TestOrder;
+import org.openmrs.api.builder.DrugOrderBuilder;
 import org.openmrs.api.builder.OrderBuilder;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.OrderServiceImpl;
@@ -3760,5 +3761,56 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		expectedException.expect(APIException.class);
 		expectedException.expectMessage("Cannot add a member which is out of range of the list");
 		secondSavedOrderGroup.addOrder(newOrderWithInvalidPosition, secondSavedOrderGroup.getOrders().size() + 1);
+	}
+
+	/**
+	 * @see OrderService#saveOrder(Order, OrderContext)
+	 */
+	@Test
+	public void saveOrderGroup_shouldFailValidationIfAnyOrdersFailValidation() {
+		executeDataSet(ORDER_SET);
+
+		Encounter encounter = encounterService.getEncounter(3);
+		OrderContext context = new OrderContext();
+		
+		// First we confirm that saving a Drug Order on it's own with missing required fields will fail validation
+
+		DrugOrder drugOrder = new DrugOrderBuilder().withPatient(encounter.getPatient().getPatientId())
+			.withEncounter(encounter.getEncounterId()).withCareSetting(1).withOrderer(1)
+			.withOrderType(1).withDrug(2)
+			.withUrgency(Order.Urgency.ROUTINE).withDateActivated(new Date())
+			.build();
+		
+		Exception expectedValidationError = null;
+		try {
+			Context.getOrderService().saveOrder(drugOrder, context);
+		}
+		catch (Exception e) {
+			expectedValidationError = e;
+		}
+		
+		Assert.assertNotNull(expectedValidationError);
+		Assert.assertEquals(ValidationException.class, expectedValidationError.getClass());
+		Assert.assertTrue(expectedValidationError.getMessage().contains("Dose is required"));
+
+		// Next, add this to an Order Group and save it within that group, and it should also fail
+		
+		OrderSet orderSet = Context.getOrderSetService().getOrderSet(2000);
+		OrderGroup orderGroup = new OrderGroup();
+		orderGroup.setOrderSet(orderSet);
+		orderGroup.setPatient(encounter.getPatient());
+		orderGroup.setEncounter(encounter);
+		orderGroup.addOrder(drugOrder);
+		drugOrder.setOrderGroup(orderGroup);
+
+		expectedValidationError = null;
+		try {
+			Context.getOrderService().saveOrderGroup(orderGroup);
+		}
+		catch (Exception e) {
+			expectedValidationError = e;
+		}
+
+		Assert.assertNotNull("Validation should cause order group to fail to save", expectedValidationError);
 	}
 }

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -3803,14 +3803,15 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		orderGroup.addOrder(drugOrder);
 		drugOrder.setOrderGroup(orderGroup);
 
-		expectedValidationError = null;
+		Exception expectedGroupValidationError = null;
 		try {
 			Context.getOrderService().saveOrderGroup(orderGroup);
 		}
 		catch (Exception e) {
-			expectedValidationError = e;
+			expectedGroupValidationError = e;
 		}
 
-		Assert.assertNotNull("Validation should cause order group to fail to save", expectedValidationError);
+		Assert.assertNotNull("Validation should cause order group to fail to save", expectedGroupValidationError);
+		Assert.assertEquals(expectedValidationError.getMessage(), expectedGroupValidationError.getMessage());
 	}
 }


### PR DESCRIPTION
This commit ensures that AOP validation checks are not bypassed by ensuring that Orders are saved via the full call to Context.getOrderService() rather than directly.