### PR TITLE
TRUNK-5931: Using isEmpty() to check whether the collection is empty …

### DIFF
--- a/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
+++ b/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
@@ -143,7 +143,7 @@ public class ChangeLogDetective {
 				log.info("file '{}}' contains {} un-run change sets", filename, unrunChangeSets.size());
 				logUnRunChangeSetDetails(filename, unrunChangeSets);
 				
-				if (unrunChangeSets.size() > 0) {
+				if (!unrunChangeSets.isEmpty()) {
 					unrunLiquibaseUpdates.add(filename);
 				}
 			}

--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -663,7 +663,7 @@ public class DatabaseUpdater {
 		List<String> liquibaseUpdateFilenames = changeLogDetective.getUnrunLiquibaseUpdateFileNames(initialSnapshotVersion,
 		    CONTEXT, liquibaseProvider);
 		
-		if (liquibaseUpdateFilenames.size() > 0) {
+		if (!liquibaseUpdateFilenames.isEmpty()) {
 			return getUnrunDatabaseChanges(liquibaseUpdateFilenames.toArray(new String[0]));
 		}
 		


### PR DESCRIPTION
## Used isEmpty() to check whether the collection is empty or not.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-5931 

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. 
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.