### PR TITLE
TRUNK-5821: Adding indices to order_number and accession_number colum…

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -310,7 +310,7 @@
 			</and>
 		</preConditions>
 		<comment>Adding index to order_number column in Orders table</comment>
-		<createIndex  indexName="orders_order_number" tableName="orders" unique="true">
+		<createIndex  indexName="orders_order_number" tableName="orders">
 			<column   name="order_number"/>
 		</createIndex>
 	</changeSet>
@@ -325,7 +325,7 @@
 			</and>
 		</preConditions>
 		<comment>Adding index to accession_number column in Orders table</comment>
-		<createIndex  indexName="orders_accession_number"  tableName="orders" unique="true">
+		<createIndex  indexName="orders_accession_number"  tableName="orders">
 			<column   name="accession_number"/>
 		</createIndex>
 	</changeSet>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml
@@ -299,4 +299,34 @@
 		<addForeignKeyConstraint constraintName="order_group_attribute_changed_by_fk" baseTableName="order_group_attribute" baseColumnNames="changed_by" referencedTableName="users" referencedColumnNames="user_id" />
 		<addForeignKeyConstraint constraintName="order_group_attribute_voided_by_fk" baseTableName="order_group_attribute" baseColumnNames="voided_by" referencedTableName="users" referencedColumnNames="user_id" />
 	</changeSet>
+
+	<changeSet id="2020-08-29-2200-TRUNK-5821" author="miirochristopher">
+		<preConditions onFail="MARK_RAN" onFailMessage="Table orders does not exist or the index orders_order_number already exists.">
+			<tableExists tableName="orders"/>
+			<and>
+				<not>
+					<indexExists indexName="orders_order_number" />
+				</not>
+			</and>
+		</preConditions>
+		<comment>Adding index to order_number column in Orders table</comment>
+		<createIndex  indexName="orders_order_number" tableName="orders" unique="true">
+			<column   name="order_number"/>
+		</createIndex>
+	</changeSet>
+
+	<changeSet id="2020-08-30-100-TRUNK-5821" author="miirochristopher">
+		<preConditions onFail="MARK_RAN" onFailMessage="Table orders does not exist or the index orders_accession_number already exists.">
+			<tableExists tableName="orders"/>
+			<and>
+				<not>
+					<indexExists indexName="orders_accession_number" />
+				</not>
+			</and>
+		</preConditions>
+		<comment>Adding index to accession_number column in Orders table</comment>
+		<createIndex  indexName="orders_accession_number"  tableName="orders" unique="true">
+			<column   name="accession_number"/>
+		</createIndex>
+	</changeSet>
 </databaseChangeLog> 

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 
-	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 868;
+	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 	
 	
 	@BeforeEach


### PR DESCRIPTION
## Adding indices to order_number and accession_number columns in the orders table. 

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-5821

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. 
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.