### PR TITLE
TRUNK-5935: Utility classes should not have public constructors

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -48,6 +48,12 @@ public class Daemon {
 	protected static final ThreadLocal<User> daemonThreadUser = new ThreadLocal<>();
 	
 	/**
+	 * Protected constructor to override the default constructor to prevent it from being instantiated.
+	 */
+	protected Daemon() {
+	}
+	
+	/**
 	 * @see #startModule(Module, boolean, AbstractRefreshableApplicationContext)
 	 */
 	public static Module startModule(Module module) throws ModuleException {

--- a/api/src/main/java/org/springframework/core/JdkVersion.java
+++ b/api/src/main/java/org/springframework/core/JdkVersion.java
@@ -121,6 +121,12 @@ public abstract class JdkVersion {
 	}
 	
 	/**
+	 * Private constructor to override the default constructor to prevent it from being instantiated.
+	 */
+	private JdkVersion() {
+	}
+	
+	/**
 	 * Return the full Java version string, as returned by
 	 * {@code System.getProperty("java.version")}.
 	 * @return the full Java version string


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
I have overwritten the default constructors to prevent the creation of an instance of the utility class.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5935

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

