### PR TITLE
TRUNK-5151:Code in voidRelationship is not executed due to BaseVoidHandler

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -485,19 +485,10 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 	 */
 	@Override
 	public Relationship voidRelationship(Relationship relationship, String voidReason) throws APIException {
-		if (relationship.getVoided()) {
-			return relationship;
+		if (relationship == null) {
+		    return null;
 		}
-		
-		relationship.setVoided(true);
-		if (relationship.getVoidedBy() == null) {
-			relationship.setVoidedBy(Context.getAuthenticatedUser());
-		}
-		if (voidReason != null) {
-			relationship.setVoidReason(voidReason);
-		}
-		relationship.setDateVoided(new Date());
-		
+
 		return Context.getPersonService().saveRelationship(relationship);
 	}
 	


### PR DESCRIPTION
## Description of what I changed
 I removed 

```
if (relationship.getVoided()) {
			
return relationship;
		}
		
		relationship.setVoided(true);
		if (relationship.getVoidedBy() == null) {
			relationship.setVoidedBy(Context.getAuthenticatedUser());
		}
		if (voidReason != null) {
			relationship.setVoidReason(voidReason);
		}
		relationship.setDateVoided(new Date());
		
		return Context.getPersonService().saveRelationship(relationship);
```



 which is already  being called via AOP  the Relationship and  fixed the methods to effectively return null.


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5151