### PR TITLE
TRUNK-5966: Correct next development version for 2.3.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.openmrs</groupId>
 	<artifactId>openmrs</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.3.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>OpenMRS</name>
 	<description>Master project for the modules of OpenMRS</description>


### PR DESCRIPTION
## Description of what I changed
I upgraded openmrs core 2.2.0  branch from version2.3.0-SNAPSHOT to 2.3.3-SNAPSHOT


## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5966