### PR TITLE
TRUNK-4830 refactor legacy Liquibase changelog files

### DIFF
--- a/api/src/main/java/org/openmrs/BaseChangeableOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseChangeableOpenmrsData.java
@@ -16,5 +16,4 @@ import java.util.Date;
  * 
  * @since 2.2
  */
-public abstract class BaseChangeableOpenmrsData extends BaseOpenmrsData {
-}
+public abstract class BaseChangeableOpenmrsData extends BaseOpenmrsData {}

--- a/api/src/main/java/org/openmrs/BaseChangeableOpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseChangeableOpenmrsMetadata.java
@@ -16,5 +16,4 @@ import java.util.Date;
  * 
  * @since 2.2
  */
-public abstract class BaseChangeableOpenmrsMetadata extends BaseOpenmrsMetadata {
-}
+public abstract class BaseChangeableOpenmrsMetadata extends BaseOpenmrsMetadata {}

--- a/api/src/main/resources/liquibase-core-data.xml
+++ b/api/src/main/resources/liquibase-core-data.xml
@@ -23,6 +23,6 @@
 		http://www.liquibase.org/xml/ns/dbchangelog 
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-	<include file="org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-1.9.x.xml"/>
+	<include file="org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-2.3.x.xml"/>
 	
 </databaseChangeLog>

--- a/api/src/main/resources/liquibase-update-to-latest-from-1.9.x.xml
+++ b/api/src/main/resources/liquibase-update-to-latest-from-1.9.x.xml
@@ -11,8 +11,7 @@
 
 -->
 <!--
-	This file is provided to be backward compatible with build processes that continue to use 
-	api/src/main/resources/liquibase-schema-only.xml to initialise the OpenMRS database.
+	This file is used by the org.openmrs.util.databasechange.Database1_9_7UpgradeIT integration test.
 -->
 <databaseChangeLog 
 	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
@@ -22,7 +21,12 @@
 	    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
 		http://www.liquibase.org/xml/ns/dbchangelog 
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-	
-	<include file="org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml"/>
+
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-1.9.x.xml"/>
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.0.x.xml"/>
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.1.x.xml"/>
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.2.x.xml"/>
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml"/>
+	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml"/>
 
 </databaseChangeLog>

--- a/api/src/main/resources/liquibase-update-to-latest.xml
+++ b/api/src/main/resources/liquibase-update-to-latest.xml
@@ -10,6 +10,10 @@
     graphic logo is a trademark of OpenMRS Inc.
 
 -->
+<!--
+	This file is provided to be backward compatible with build processes that continue to use 
+	api/src/main/resources/liquibase-schema-only.xml to initialise the OpenMRS database.
+-->
 <databaseChangeLog 
 	xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -19,11 +23,6 @@
 		http://www.liquibase.org/xml/ns/dbchangelog 
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-1.9.x.xml"/>
-	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.0.x.xml"/>
-	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.1.x.xml"/>
-	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.2.x.xml"/>
-	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.3.x.xml"/>
 	<include file="org/openmrs/liquibase/updates/liquibase-update-to-latest-2.4.x.xml"/>
 
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/Database1_9_7UpgradeIT.java
@@ -9,16 +9,6 @@
  */
 package org.openmrs.util.databasechange;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -32,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
@@ -45,6 +34,16 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests database upgrade from OpenMRS 1.9.7.
@@ -60,12 +59,11 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 	
 	public final static String DATABASE_PATH = TEST_DATA_DIR + "openmrs-1.9.7.h2.db";
 	
-	public static final String LIQUIBASE_UPDATE_TO_LATEST_XML = "liquibase-update-to-latest.xml";
+	public static final String LIQUIBASE_UPDATE_TO_LATEST_XML = "liquibase-update-to-latest-from-1.9.x.xml";
 	
 	private DatabaseUpgradeTestUtil upgradeTestUtil;
 	
 	private static File testAppDataDir;
-	
 	
 	private Map<String, String> row(String... values) {
 		Map<String, String> row = new HashMap<>();
@@ -228,7 +226,7 @@ public class Database1_9_7UpgradeIT extends BaseContextSensitiveTest {
 		createOrderEntryUpgradeFileWithTestData("1/day\\ x\\ 7\\ days/week=113\n2/day\\ x\\ 7\\ days/week=114");
 		
 		String errorMsgSubString1 = "liquibase.exception.MigrationFailedException: Migration failed for change set liquibase-update-to-latest.xml::201401101647-TRUNK-4187::wyclif";
-		IOException exception =assertThrows(IOException.class, () -> upgradeTestUtil.upgrade());
+		IOException exception = assertThrows(IOException.class, () -> upgradeTestUtil.upgrade());
 		assertThat(exception.getMessage(), startsWith(errorMsgSubString1));
 	}
 	

--- a/api/src/test/java/org/openmrs/util/databasechange/DatabaseUpgradeTestUtil.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/DatabaseUpgradeTestUtil.java
@@ -217,17 +217,17 @@ public class DatabaseUpgradeTestUtil {
 	}
 	
 	public void upgrade() throws IOException, SQLException {
-		upgrade("liquibase-update-to-latest.xml");
+		upgrade("liquibase-update-to-latest-from-1.9.x.xml");
 	}
 	
 	public void upgrade(String filename) throws IOException, SQLException {
 		try {
 			Liquibase liquibase = new Liquibase(filename, new ClassLoaderResourceAccessor(getClass().getClassLoader()),
 			        liqubaseConnection);
-
+			
 			DataTypeFactory dataTypeFactory = DataTypeFactory.getInstance();
-			dataTypeFactory.register( MySQLBooleanType.class );
-
+			dataTypeFactory.register(MySQLBooleanType.class);
+			
 			liquibase.update("");
 			
 			connection.commit();

--- a/liquibase/README.md
+++ b/liquibase/README.md
@@ -23,7 +23,8 @@ of `openmrs-api`:
 
 * `openmrs-core/api/src/main/resources`
 
-**Since** the introduction of snapshots, the respective change log files are no longer stored in the resource folder 
+**Since** the introduction of snapshots, the respective change log files are no longer stored in 
+`openmrs-core/api/src/main/resources` 
 but in the following subfolders:
 
 *  `openmrs-core/api/src/main/resources/org/openmrs/liquibase/snapshots` contains all Liquibase snapshot files.
@@ -79,8 +80,15 @@ a **snapshot** generated from OpenMRS 4.7.x.
 * `org/openmrs/liquibase/updates/liquibase-update-to-latest-4.8.x.xml` contains database changes introduced by 
 OpenMRS 4.8.x
 
-### Further Liquibase files 
-* `liquibase-update-to-latest.xml` is used by integration tests and includes references to 
+### Further Liquibase files
+The folder `openmrs-core/api/src/main/resources` contains further Liquibase files: 
+* `liquibase-schema-only.xml` references the latest snapshot file for creating the OpenMRS schema and continues to
+be used by other OpenMRS projects, e.g. openmrs-standalone.   
+* `liquibase-core-data.xml` references the latest snapshot file for OpenMRS data and continues to
+be used by other OpenMRS projects, e.g. openmrs-standalone.   
+* `liquibase-update-to-latest.xml` references the latest update file for the OpenMRS database and continues to
+be used by other OpenMRS projects, e.g. openmrs-standalone.   
+* `liquibase-update-to-latest-from-1.9.x.xml` is used by integration tests and includes references to 
 multiple `org/openmrs/liquibase/updates/liquibase-update-to-latest-a.b.x.xml` files.
   
 * `liquibase-empty-changelog.xml` is used as a default Liquibase file by the org.openmrs.util.DatabaseUpdater class.
@@ -266,9 +274,16 @@ sets that are introduced
 * *after* OpenMRS version 2.2 was created 
 * and *before* OpenMRS version 2.3 will be created
 
-Include the new file in `resources/liquibase-update-to-latest.xml`, it is used by integration tests (as mentioned above).
+Include the new file in `resources/liquibase-update-to-latest-from-1.9.x.xml`, it is used by integration tests (as mentioned above).
 
-#### Step 3 - Make OpenMRS aware of the new versions
+#### Step 3 - Update references in legacy Liquibase change log files
+The following files in `openmrs-core/api/src/main/resources` contain references to the latest Liquibase snapshot and 
+update change logs and need to be updated after the new change log files were added:
+* `liquibase-schema-only.xml`
+* `liquibase-core-data.xml`
+* `liquibase-update-to-latest.xml`
+
+#### Step 4 - Make OpenMRS aware of the new versions
 New snapshot and update versions need to be added to the `org.openmrs.liquibase.ChangeLogVersions` class. 
 
 After adding the new change log files and updating the `ChangeLogVersions` class, run the 
@@ -276,7 +291,7 @@ test `org.openmrs.liquibase.ChangeLogVersionsTest` to ensure that the definition
 change log files are in sync. The test fails if either versions are missing in the `ChangeLogVersions` class or if 
 change log files are missing in the resource folder.
 
-#### Step 4 - Validate Hibernate mappings
+#### Step 5 - Validate Hibernate mappings
 
 Run `org.openmrs.util.databasechange.ValidateHibernateMappingsDatabaseIT` to check whether the data types in the new 
 liquibase files are compatible with the data types specified in the Hibernate mappings. 
@@ -286,7 +301,7 @@ The test can be run in two ways:
 * By running `mvn clean test -Pskip-default-test -Pintegration-test -Dtest=ValidateHibernateMappingsIT2` in the console
 * Alternatively, by running the test in IntelliJ or another IDE 
 
-#### Step 5 - Build and initialise OpenMRS with the new snapshot and update files
+#### Step 6 - Build and initialise OpenMRS with the new snapshot and update files
 Drop your local OpenMRS database and build and initialise OpenMRS as described in the section "How to generate 
 Liquibase snapshots".
 


### PR DESCRIPTION
## Description of what I changed

OpenMRS components such as openmrs-standalone continue to use legacy Liquibase change log files in their build process. 

The legacy Liquibase change log files are:

- api/src/main/resources/liquibase-schema-only.xml
- api/src/main/resources/liquibase-core-data.xml
- api/src/main/resources/liquibase-update-to-latest.xml

This pull request ensures that the legacy Liquibase change log files reference the **latest** snapshot files.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
- [ x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [  ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [ x ] All new and existing **tests passed**.

- [ x ] My pull request is **based on the latest changes** of the master branch.
