### PR TITLE
TRUNK-4830: Use 1.9.x as default snapshot version

### DIFF
--- a/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
+++ b/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
@@ -36,6 +36,8 @@ public class ChangeLogDetective {
 	
 	private static final String BEN = "ben";
 	
+	private static final String DEFAULT_SNAPSHOT_VERSION = "1.9.x";
+	
 	private static final String DISABLE_FOREIGN_KEY_CHECKS = "disable-foreign-key-checks";
 	
 	private static final String ENABLE_FOREIGN_KEY_CHECKS = "enable-foreign-key-checks";
@@ -57,7 +59,7 @@ public class ChangeLogDetective {
 	 * database. The version is needed to determine which Liquibase update files need to be checked for
 	 * un-run change sets and may need to be (re-)run to apply the latest changes to the OpenMRS
 	 * database.
-	 *
+	 * 
 	 * @param liquibaseProvider provides access to a Liquibase instance
 	 * @return the version of the Liquibase snapshot that had been used to initialise the OpenMRS
 	 *         database
@@ -100,7 +102,8 @@ public class ChangeLogDetective {
 				if (liquibase != null) {
 					try {
 						liquibase.close();
-					} catch ( Exception e ) {
+					}
+					catch (Exception e) {
 						// ignore exceptions triggered by closing liquibase a second time 
 					}
 				}
@@ -113,8 +116,11 @@ public class ChangeLogDetective {
 			}
 		}
 		
-		throw new IllegalStateException(
-		        "identifying the snapshot version that had been used to initialize the OpenMRS database failed as no candidate change set resulted in zero un-run changes");
+		log.info(
+		    "the snapshot version that had been used to initialize the OpenMRS database could not be identified, falling back to the default version '{}'",
+		    DEFAULT_SNAPSHOT_VERSION);
+		
+		return DEFAULT_SNAPSHOT_VERSION;
 	}
 	
 	/**
@@ -152,7 +158,8 @@ public class ChangeLogDetective {
 			if (liquibase != null) {
 				try {
 					liquibase.close();
-				} catch ( Exception e ) {
+				}
+				catch (Exception e) {
 					// ignore exceptions triggered by closing liquibase a second time 
 				}
 			}
@@ -188,16 +195,16 @@ public class ChangeLogDetective {
 		}
 		return false;
 	}
-
+	
 	/**
 	 * Logs un-run change sets no more than a given number and only for the 1.9.x Liquibase snapshots.
 	 * 
-	 * @return a boolean value indicating whether the change sets were logged. The value is used for testing.
+	 * @return a boolean value indicating whether the change sets were logged. The value is used for
+	 *         testing.
 	 */
 	boolean logUnRunChangeSetDetails(String filename, List<ChangeSet> changeSets) {
-		if (changeSets.size() < MAX_NUMBER_OF_CHANGE_SETS_TO_LOG
-		        && (filename.contains(LIQUIBASE_CORE_DATA_1_9_X_FILENAME)
-		                || filename.contains(LIQUIBASE_SCHEMA_ONLY_1_9_X_FILENAME))) {
+		if (changeSets.size() < MAX_NUMBER_OF_CHANGE_SETS_TO_LOG && (filename.contains(LIQUIBASE_CORE_DATA_1_9_X_FILENAME)
+		        || filename.contains(LIQUIBASE_SCHEMA_ONLY_1_9_X_FILENAME))) {
 			for (ChangeSet changeSet : changeSets) {
 				log.info("file '{}' contains un-run change set with id '{}' by author '{}'", filename, changeSet.getId(),
 				    changeSet.getAuthor());

--- a/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/liquibase/ChangeLogDetectiveDatabaseIT.java
@@ -9,22 +9,21 @@
  */
 package org.openmrs.liquibase;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.util.List;
 import java.util.Map;
-
 import org.junit.jupiter.api.Test;
 import org.openmrs.util.H2DatabaseIT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class ChangeLogDetectiveDatabaseIT extends H2DatabaseIT {
 	
 	private static final Logger log = LoggerFactory.getLogger(ChangeLogDetectiveDatabaseIT.class);
-	
+
+	private static final String VERSION_1_9_X = "1.9.x";
+
 	private static final String VERSION_2_1_X = "2.1.x";
 	
 	
@@ -45,15 +44,13 @@ public class ChangeLogDetectiveDatabaseIT extends H2DatabaseIT {
 	}
 	
 	@Test
-	public void shouldRecogniseThatAllSnapshotsContainUnrunChangeSets() throws Exception {
+	public void shouldReturnDefaultSnapshotVersion() throws Exception {
 		ChangeLogDetective changeLogDetective = new ChangeLogDetective();
-		try {
-			changeLogDetective.getInitialLiquibaseSnapshotVersion("some context", this);
-			fail("IllegalStateException was expected but not raised");
-		}
-		catch (IllegalStateException ise) {
-			assertTrue(true, "IllegalStateException was raised as expected");
-		}
+
+		String expected = VERSION_1_9_X;
+		String actual = changeLogDetective.getInitialLiquibaseSnapshotVersion("some context", this);
+
+		assertEquals(expected, actual);
 	}
 	
 	@Test


### PR DESCRIPTION
## Description of what I changed

Use 1.9.x as default snapshot version if the snapshot version that was used to initialise OpenMRS cannot be identified.

This change [fixes an issue regarding the Platform 2.4 Release](https://talk.openmrs.org/t/platform-2-4-release-to-dos-and-release-discussions-thread/30616). Please search for:

_all the PIH EMR instances were initialized with OpenMRS 1.9 or later, but some of our other instances (and many others) date back to way before that_

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
- [ x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ x ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [ x ] All new and existing **tests passed**.

- [ x ] My pull request is **based on the latest changes** of the master branch.


