### PR TITLE
TRUNK-4830 check for empty database before assessing database updates

### DIFF
--- a/api/src/test/java/org/openmrs/util/H2DatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/H2DatabaseIT.java
@@ -33,6 +33,8 @@ public class H2DatabaseIT implements LiquibaseProvider {
 	
 	private static final Logger log = LoggerFactory.getLogger(H2DatabaseIT.class);
 	
+	public static final String CONNECTION_URL = "jdbc:h2:mem:openmrs;DB_CLOSE_DELAY=-1";
+	
 	private static final String CONTEXT = "some context";
 	
 	protected static final String USER_NAME = "another_user";
@@ -96,7 +98,7 @@ public class H2DatabaseIT implements LiquibaseProvider {
 	}
 
 	protected Connection getConnection() throws SQLException {
-		Connection connection = DriverManager.getConnection("jdbc:h2:mem:openmrs;DB_CLOSE_DELAY=-1", USER_NAME, PASSWORD);
+		Connection connection = DriverManager.getConnection(CONNECTION_URL, USER_NAME, PASSWORD);
 		connection.setAutoCommit( false );
 		return connection;
 	}

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -51,6 +51,7 @@ import org.openmrs.util.MemoryLeakUtil;
 import org.openmrs.util.OpenmrsClassLoader;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.web.filter.initialization.DatabaseDetective;
 import org.openmrs.web.filter.initialization.InitializationFilter;
 import org.openmrs.web.filter.update.UpdateFilter;
 import org.slf4j.LoggerFactory;
@@ -211,6 +212,11 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	 */
 	private boolean setupNeeded() throws Exception {
 		if (!runtimePropertiesFound) {
+			return true;
+		}
+		
+		DatabaseDetective databaseDetective = new DatabaseDetective();
+		if (databaseDetective.isDatabaseEmpty(OpenmrsUtil.getRuntimeProperties(WebConstants.WEBAPP_NAME))) {
 			return true;
 		}
 		

--- a/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
@@ -1,0 +1,81 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.filter.initialization;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.openmrs.util.DatabaseUtil;
+
+public class DatabaseDetective {
+	
+	private static final String CONNECTION_URL = "connection.url";
+	
+	private static final String CONNECTION_USERNAME = "connection.username";
+	
+	private static final String CONNECTION_PASSWORD = "connection.password";
+	
+	/**
+	 * Check whether openmrs database is empty. Having just one non-liquibase table in the given
+	 * database qualifies this as a non-empty database.
+	 *
+	 * @param props the runtime properties
+	 * @return true if the openmrs database is empty or does not exist yet
+	 */
+	public boolean isDatabaseEmpty(Properties props) {
+		if (props == null) {
+			return true;
+		}
+		
+		Connection connection = null;
+		
+		try {
+			DatabaseUtil.loadDatabaseDriver(props.getProperty(CONNECTION_URL), null);
+			
+			connection = DriverManager.getConnection(props.getProperty(CONNECTION_URL), props
+			        .getProperty(CONNECTION_USERNAME), props.getProperty(CONNECTION_PASSWORD));
+			
+			DatabaseMetaData dbMetaData = connection.getMetaData();
+			
+			String[] types = { "TABLE" };
+			
+			//get all tables
+			ResultSet tbls = dbMetaData.getTables(null, null, null, types);
+			
+			while (tbls.next()) {
+				String tableName = tbls.getString("TABLE_NAME");
+				//if any table exist besides "liquibasechangelog" or "liquibasechangeloglock", return false
+				if (!("liquibasechangelog".equals(tableName.toLowerCase()))
+				        && !("liquibasechangeloglock".equals(tableName.toLowerCase()))) {
+					return false;
+				}
+			}
+			return true;
+		}
+		catch (Exception e) {
+			// consider the database to be empty
+			return true;
+		}
+		finally {
+			try {
+				if (connection != null) {
+					connection.close();
+				}
+			}
+			catch (Exception e) {
+				// consider the database to be empty
+				return true;
+			}
+		}
+	}
+}

--- a/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveIT.java
+++ b/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveIT.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.filter.initialization;
+
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.util.H2DatabaseIT;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class DatabaseDetectiveIT extends H2DatabaseIT {
+	
+	private static final String LIQUIBASE_SCHEMA_ONLY_1_9_X = "org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-1.9.x.xml";
+
+	private static final String LIQUIBASE_CHANGE_LOG_TABLES = "org/openmrs/liquibase/liquibase-changelog-tables.xml";
+
+	private DatabaseDetective databaseDetective;
+	
+	private Properties properties;
+	
+	@BeforeEach
+	public void setup() {
+		databaseDetective = new DatabaseDetective();
+
+		properties = new Properties();
+		properties.put("connection.url", super.CONNECTION_URL);
+		properties.put("connection.username", super.USER_NAME);
+		properties.put("connection.password", super.PASSWORD);
+	}
+	
+	@Test
+	public void shouldRecogniseDatabaseWithoutAnyTables() throws Exception {
+		assertTrue( databaseDetective.isDatabaseEmpty( properties ) );
+	}
+	
+	@Test
+	public void shouldIgnoreLiquibaseChangeLogTables() throws Exception {
+		updateDatabase( LIQUIBASE_CHANGE_LOG_TABLES );
+		DatabaseDetective databaseDetective = new DatabaseDetective();
+		assertTrue( databaseDetective.isDatabaseEmpty( properties ) );
+	}
+
+	@Test
+	public void shouldRecogniseDatabaseContainsOpenmrsTables() throws Exception {
+		updateDatabase( LIQUIBASE_SCHEMA_ONLY_1_9_X );
+		assertFalse( databaseDetective.isDatabaseEmpty( properties ) );
+	}
+}

--- a/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveTest.java
@@ -1,0 +1,37 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.filter.initialization;
+
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DatabaseDetectiveTest {
+
+	private DatabaseDetective databaseDetective;
+
+	@BeforeEach
+	public void setup() {
+		databaseDetective = new DatabaseDetective();
+	}
+	
+	@Test
+	public void shouldRecogniseNull() {
+		assertTrue(databaseDetective.isDatabaseEmpty(null));
+	}
+
+	@Test
+	public void shouldRecogniseInvalidConnectionParameters() {
+		Properties properties = new Properties();
+		assertTrue(databaseDetective.isDatabaseEmpty(properties));
+	}
+}

--- a/web/src/test/resources/org/openmrs/liquibase/liquibase-changelog-tables.xml
+++ b/web/src/test/resources/org/openmrs/liquibase/liquibase-changelog-tables.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+    
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext 
+    	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog 
+    	http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+	<changeSet author="wolf (hand-rolled)" id="1234567890123-1">
+		<preConditions onFail="MARK_RAN">
+			<not><tableExists tableName="liquibasechangelog"/></not>
+		</preConditions>
+		<createTable tableName="liquibasechangelog">
+			<column name="id" type="int"/>
+		</createTable>
+	</changeSet>
+	<changeSet author="wolf (hand-rolled)" id="1234567890123-2">
+		<preConditions onFail="MARK_RAN">
+			<not><tableExists tableName="liquibasechangeloglock"/></not>
+		</preConditions>
+		<createTable tableName="liquibasechangeloglock">
+			<column name="id" type="int"/>
+		</createTable>
+	</changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description of what I changed
Check for empty database before assessing database updates.

`org.openmrs.web.Listener#setupNeeded()` now checks for empty databases.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
- [ x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ x ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [ x ] All new and existing **tests passed**.

- [ x ] My pull request is **based on the latest changes** of the 2.4.x branch.