### PR TITLE
TRUNK-5991 - Loosen validation requirement for quantity, units, and r…

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -368,6 +368,8 @@ public final class OpenmrsConstants {
 	public static final String GLOBAL_PROPERTY_PATIENT_IDENTIFIER_TYPES_LOCKED = "patientIdentifierTypes.locked";
 	
 	public static final String GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_DRUG = "drugOrder.requireDrug";
+
+	public static final String GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_OUTPATIENT_QUANTITY = "drugOrder.requireOutpatientQuantity";
 	
 	public static final String DEFAULT_ADDRESS_TEMPLATE = "<org.openmrs.layout.address.AddressTemplate>\n"
 	        + "    <nameMappings class=\"properties\">\n"
@@ -1034,6 +1036,9 @@ public final class OpenmrsConstants {
 		
 		props.add(new GlobalProperty(GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_DRUG, "false",
 		        "Set to value true if you need to specify a formulation(Drug) when creating a drug order."));
+
+		props.add(new GlobalProperty(GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_OUTPATIENT_QUANTITY, "true",
+			"true/false whether to require quantity, quantityUnits, and numRefills for outpatient drug orders"));
 		
 		props.add(new GlobalProperty(GLOBAL_PROPERTY_PERSON_ATRIBUTE_TYPES_LOCKED, "false",
 		        "Set to a value of true if you do not want allow editing person attribute types, else set to false."));

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -140,8 +140,12 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 	private void validateFieldsForOutpatientCareSettingType(DrugOrder order, Errors errors) {
 		if (order.getAction() != Order.Action.DISCONTINUE && order.getCareSetting() != null
 		        && order.getCareSetting().getCareSettingType().equals(CareSetting.CareSettingType.OUTPATIENT)) {
-			ValidationUtils.rejectIfEmpty(errors, "quantity", "DrugOrder.error.quantityIsNullForOutPatient");
-			ValidationUtils.rejectIfEmpty(errors, "numRefills", "DrugOrder.error.numRefillsIsNullForOutPatient");
+			boolean requireQuantity = Context.getAdministrationService().getGlobalPropertyValue(
+				OpenmrsConstants.GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_OUTPATIENT_QUANTITY, true);
+			if (requireQuantity) {
+				ValidationUtils.rejectIfEmpty(errors, "quantity", "DrugOrder.error.quantityIsNullForOutPatient");
+				ValidationUtils.rejectIfEmpty(errors, "numRefills", "DrugOrder.error.numRefillsIsNullForOutPatient");
+			}
 		}
 	}
 	

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -169,6 +169,27 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(inPatientOrder, InpatientOrderErrors);
 		Assert.assertFalse(InpatientOrderErrors.hasFieldErrors("numRefills"));
 	}
+
+	/**
+	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldNotFailValidationIfQuantityAndNumRefillsAreNullIfConfiguredToNotRequire() {
+		AdministrationService as = Context.getAdministrationService();
+		as.setGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_DRUG_ORDER_REQUIRE_OUTPATIENT_QUANTITY, "false");
+		
+		DrugOrder OutpatientOrder = new DrugOrder();
+		OutpatientOrder.setCareSetting(Context.getOrderService().getCareSetting(1));
+		OutpatientOrder.setQuantity(null);
+		OutpatientOrder.setQuantityUnits(null);
+		OutpatientOrder.setNumRefills(null);
+		Errors OutpatientOrderErrors = new BindException(OutpatientOrder, "order");
+		new DrugOrderValidator().validate(OutpatientOrder, OutpatientOrderErrors);
+		Assert.assertTrue(OutpatientOrder.getCareSetting().getCareSettingType() == CareSetting.CareSettingType.OUTPATIENT);
+		Assert.assertFalse(OutpatientOrderErrors.hasFieldErrors("quantity"));
+		Assert.assertFalse(OutpatientOrderErrors.hasFieldErrors("quantityUnits"));
+		Assert.assertFalse(OutpatientOrderErrors.hasFieldErrors("numRefills"));
+	}
 	
 	/**
 	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)


### PR DESCRIPTION
…efills on outpatient drug orders

Per ticket comments, this:
* Adds a new global property:  "drugOrder.requireOutpatientQuantity" which defaults to true (for backwards-compatibility)
* Modifies the DrugOrderValidator.validateFieldsForOutpatientCareSettingType method to no longer require quantity, quantityUnits, and numRefills for OUTPATIENT care settings, if this global property value is set to false.

NOTE:  This PR is issued against the core 2.3.x branch.  Once approved and merged, we need to up-port it to later branches/master