### PR TITLE
EMPT-111: Server logging for deleted patient

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -312,6 +312,7 @@ public class HibernatePatientDAO implements PatientDAO {
 	 */
         @Override
 	public void deletePatient(Patient patient) throws DAOException {
+		log.info("deleted patient " + patient.getId());
 		HibernatePersonDAO.deletePersonAndAttributes(sessionFactory, patient);
 	}
 	


### PR DESCRIPTION
Add a `log.info()` to patient deletion so removal can be tracked.