### PR TITLE
TRUNK-6001: Drop non-null constraint from column cohort_member.start_date

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
@@ -18,12 +18,14 @@
 	    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
 		http://www.liquibase.org/xml/ns/dbchangelog 
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
-
-	<!--
-		The empty change set is needed for integration tests. It can be removed if this file contains other change sets.
-	-->
-	<changeSet id="42ddb873-f064-4418-a6c0-6c09426c4832" author="wschlegel">
-		<comment>Empty change set for integration tests.</comment>
+	
+	
+	<changeSet author="rasztabigab" id="TRUNK-6001">
+		<preConditions onFail="MARK_RAN">
+			<columnExists tableName="cohort_member" columnName="start_date"/>
+		</preConditions>
+		<comment>Delete non-null constraint from column cohort_member.start_date</comment>
+		<dropNotNullConstraint columnDataType="datetime" columnName="start_date" tableName="cohort_member"/>
 	</changeSet>
 	
 </databaseChangeLog>


### PR DESCRIPTION
## Description of what I changed
Dropped non-null constraint from column cohort_member.start_date

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6001

## Checklist: I completed these to help reviewers :)
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

