### PR TITLE
TRUNK-5992: Order Service should always set autoExpireDate if duration is set.

### DIFF
--- a/api/src/main/java/org/openmrs/BaseDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/BaseDosingInstructions.java
@@ -1,0 +1,40 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import java.util.Date;
+
+import static org.apache.commons.lang3.time.DateUtils.addSeconds;
+
+/**
+ * @since 2.3.3
+ */
+public abstract class BaseDosingInstructions implements DosingInstructions {
+
+	/**
+	 * @see DosingInstructions#getAutoExpireDate(DrugOrder)
+	 */
+	@Override
+	public Date getAutoExpireDate(DrugOrder drugOrder) {
+		if (drugOrder.getDuration() == null || drugOrder.getDurationUnits() == null) {
+			return null;
+		}
+		String durationCode = Duration.getCode(drugOrder.getDurationUnits());
+		if (durationCode == null) {
+			return null;
+		}
+		Duration duration = new Duration(drugOrder.getDuration(), durationCode);
+		return aMomentBefore(duration.addToDate(drugOrder.getEffectiveStartDate(), drugOrder.getFrequency()));
+	}
+
+	private Date aMomentBefore(Date date) {
+		return addSeconds(date, -1);
+	}
+}

--- a/api/src/main/java/org/openmrs/BaseDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/BaseDosingInstructions.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import static org.apache.commons.lang3.time.DateUtils.addSeconds;
 
 /**
- * @since 2.3.3
+ * @since 2.3.4
  */
 public abstract class BaseDosingInstructions implements DosingInstructions {
 

--- a/api/src/main/java/org/openmrs/DosingInstructions.java
+++ b/api/src/main/java/org/openmrs/DosingInstructions.java
@@ -63,9 +63,7 @@ public interface DosingInstructions {
 	/**
 	 * Implementations of this interface may be able to infer the auto-expiration date from other
 	 * fields on the DrugOrder.  If the expiration date cannot be determined, then this method
-	 * may return null (i.e., null means duration of order is unknown).  In general, if a drug order
-	 * has non-zero refills, the auto-expiration date should <em>not</em> be set (even if it has
-	 * a known duration).
+	 * may return null (i.e., null means duration of order is unknown).
 	 */
 	public Date getAutoExpireDate(DrugOrder order);
 }

--- a/api/src/main/java/org/openmrs/FreeTextDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/FreeTextDosingInstructions.java
@@ -9,17 +9,16 @@
  */
 package org.openmrs;
 
-import java.util.Date;
-import java.util.Locale;
-
 import org.openmrs.api.APIException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 
+import java.util.Locale;
+
 /**
  * @since 1.10
  */
-public class FreeTextDosingInstructions implements DosingInstructions {
+public class FreeTextDosingInstructions extends BaseDosingInstructions {
 	
 	private String instructions;
 	
@@ -58,12 +57,6 @@ public class FreeTextDosingInstructions implements DosingInstructions {
 	public void validate(DrugOrder order, Errors errors) {
 		ValidationUtils.rejectIfEmpty(errors, "dosingInstructions",
 		    "DrugOrder.error.dosingInstructionsIsNullForDosingTypeFreeText");
-		
-	}
-	
-	@Override
-	public Date getAutoExpireDate(DrugOrder order) {
-		return null;
 	}
 	
 	public String getInstructions() {

--- a/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
@@ -9,19 +9,16 @@
  */
 package org.openmrs;
 
-import static org.apache.commons.lang3.time.DateUtils.addSeconds;
-
-import java.util.Date;
-import java.util.Locale;
-
 import org.openmrs.api.APIException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 
+import java.util.Locale;
+
 /**
  * @since 1.10
  */
-public class SimpleDosingInstructions implements DosingInstructions {
+public class SimpleDosingInstructions extends BaseDosingInstructions {
 	
 	private Double dose;
 	
@@ -132,25 +129,6 @@ public class SimpleDosingInstructions implements DosingInstructions {
 		}
 	}
 	
-	/**
-	 * @see DosingInstructions#getAutoExpireDate(DrugOrder)
-	 */
-	@Override
-	public Date getAutoExpireDate(DrugOrder drugOrder) {
-		if (drugOrder.getDuration() == null || drugOrder.getDurationUnits() == null) {
-			return null;
-		}
-		if (drugOrder.getNumRefills() != null && drugOrder.getNumRefills() > 0) {
-			return null;
-		}
-		String durationCode = Duration.getCode(drugOrder.getDurationUnits());
-		if (durationCode == null) {
-			return null;
-		}
-		Duration duration = new Duration(drugOrder.getDuration(), durationCode);
-		return aMomentBefore(duration.addToDate(drugOrder.getEffectiveStartDate(), drugOrder.getFrequency()));
-	}
-	
 	public Double getDose() {
 		return dose;
 	}
@@ -222,9 +200,4 @@ public class SimpleDosingInstructions implements DosingInstructions {
 	public void setAdministrationInstructions(String administrationInstructions) {
 		this.administrationInstructions = administrationInstructions;
 	}
-	
-	private Date aMomentBefore(Date date) {
-		return addSeconds(date, -1);
-	}
-	
 }

--- a/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
+++ b/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
@@ -26,8 +26,7 @@ import org.springframework.validation.Errors;
 public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 	
 	@Test
-	public void validate_shouldFailValidationIfAutoExpireDateIsNotSetAndDurationUnitsIsNotMappedToSNOMEDCTDuration()
-	        {
+	public void validate_shouldFailValidationIfAutoExpireDateIsNotSetAndDurationUnitsIsNotMappedToSNOMEDCTDuration() {
 		DrugOrder drugOrder = createValidDrugOrder();
 		drugOrder.setDuration(30);
 		Concept unMappedDurationUnits = new Concept();
@@ -93,16 +92,15 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 	}
 	
 	@Test
-	public void getAutoExpireDate_shouldNotInferAutoExpireDateWhenDrugOrderHasOneOrMoreRefill() throws ParseException {
+	public void getAutoExpireDate_shouldInferAutoExpireDateIfDurationIsSet() throws ParseException {
 		DrugOrder drugOrder = new DrugOrder();
-		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));
+		drugOrder.setDosingType(FreeTextDosingInstructions.class);
+		drugOrder.setDateActivated(createDateTime("2014-07-01 00:00:00"));
 		drugOrder.setDuration(30);
-		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_SECONDS_CODE));
+		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_DAYS_CODE));
 		drugOrder.setNumRefills(1);
-		
-		Date autoExpireDate = new SimpleDosingInstructions().getAutoExpireDate(drugOrder);
-		
-		assertEquals(null, autoExpireDate);
+		drugOrder.setAutoExpireDateBasedOnDuration();
+		assertEquals(createDateTime("2014-07-30 23:59:59"), drugOrder.getAutoExpireDate());
 	}
 	
 	@Test


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/TRUNK-5992

#### What I have done:

See Talk thread here:  https://talk.openmrs.org/t/duration-and-auto-expire-date-on-orders/32006/2

The effect of this is to set the autoExpireDate if both duration and durationUnits are specified.  Unlike the previous behavior, this will happen for both Simple _and_ FreeText Dosing Instructions and will also happen if refills are specified on the order.