### PR TITLE
TRUNK-5134: Replace path constructions using separator char

### DIFF
--- a/liquibase/src/main/java/org/openmrs/liquibase/Main.java
+++ b/liquibase/src/main/java/org/openmrs/liquibase/Main.java
@@ -9,23 +9,24 @@
  */
 package org.openmrs.liquibase;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
+
 import org.dom4j.DocumentException;
 
 public class Main {
 	
-	public static final String LIQUIBASE_CORE_DATA_SOURCE_PATH = "." + File.separator + "snapshots" + File.separator
-	        + "liquibase-core-data-SNAPSHOT.xml";
+	public static final String LIQUIBASE_CORE_DATA_SOURCE_PATH = Paths
+	        .get(".", "snapshots", "liquibase-core-data-SNAPSHOT.xml").toString();
 	
-	public static final String LIQUIBASE_CORE_DATA_TARGET_PATH = "." + File.separator + "snapshots" + File.separator
-	        + "liquibase-core-data-UPDATED-SNAPSHOT.xml";
+	public static final String LIQUIBASE_CORE_DATA_TARGET_PATH = Paths
+	        .get(".", "snapshots", "liquibase-core-data-UPDATED-SNAPSHOT.xml").toString();
 	
-	public static final String LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH = "." + File.separator + "snapshots" + File.separator
-	        + "liquibase-schema-only-SNAPSHOT.xml";
+	public static final String LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH = Paths
+	        .get(".", "snapshots", "liquibase-schema-only-SNAPSHOT.xml").toString();
 	
-	public static final String LIQUIBASE_SCHEMA_ONLY_TARGET_PATH = "." + File.separator + "snapshots" + File.separator
-	        + "liquibase-schema-only-UPDATED-SNAPSHOT.xml";
+	public static final String LIQUIBASE_SCHEMA_ONLY_TARGET_PATH = Paths
+	        .get(".", "snapshots", "liquibase-schema-only-UPDATED-SNAPSHOT.xml").toString();
 	
 	private static CoreDataTuner coreDataTuner;
 	
@@ -37,10 +38,9 @@ public class Main {
 	}
 	
 	public static void main(String[] args) throws DocumentException, IOException {
-		coreDataTuner.addLicenseHeaderToFileIfNeeded( LIQUIBASE_CORE_DATA_SOURCE_PATH );
+		coreDataTuner.addLicenseHeaderToFileIfNeeded(LIQUIBASE_CORE_DATA_SOURCE_PATH);
 		coreDataTuner.createUpdatedChangeLogFile(LIQUIBASE_CORE_DATA_SOURCE_PATH, LIQUIBASE_CORE_DATA_TARGET_PATH);
-
-		schemaOnlyTuner.addLicenseHeaderToFileIfNeeded( LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH );
+		schemaOnlyTuner.addLicenseHeaderToFileIfNeeded(LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH);
 		schemaOnlyTuner.createUpdatedChangeLogFile(LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH, LIQUIBASE_SCHEMA_ONLY_TARGET_PATH);
 	}
 	

--- a/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
@@ -9,21 +9,21 @@
  */
 package org.openmrs.liquibase;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class AbstractSnapshotTunerTest {
 	
@@ -33,8 +33,7 @@ public class AbstractSnapshotTunerTest {
 	
 	private static final String HTTP_OPENMRS_ORG_LICENSE = "http://openmrs.org/license";
 	
-	private static String PATH_TO_TEST_RESOURCES = "src" + File.separator + "test" + File.separator + "resources"
-	        + File.separator;
+	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 	
 	/*
 	 * An instance of org.openmrs.liquibase.SchemaOnlyTuner is used to test behaviour implemented in the 
@@ -76,7 +75,7 @@ public class AbstractSnapshotTunerTest {
 		
 		//  when
 		String actual = schemaOnlyTuner
-		        .addLicenseHeaderToFileContent(PATH_TO_TEST_RESOURCES + File.separator + FILE_WITHOUT_LICENSE_HEADER_MD);
+		        .addLicenseHeaderToFileContent(Paths.get(PATH_TO_TEST_RESOURCES, FILE_WITHOUT_LICENSE_HEADER_MD).toString());
 		
 		// then
 		assertTrue(actual.contains(HTTP_OPENMRS_ORG_LICENSE));

--- a/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
@@ -9,13 +9,20 @@
  */
 package org.openmrs.liquibase;
 
-import java.io.File;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
@@ -26,24 +33,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 public class CoreDataTunerTest {
 	
-	private static final String LIQUIBASE_CORE_DATA_SNAPSHOT_XML = "org" + File.separator + "openmrs" + File.separator
-	        + "liquibase" + File.separator + "snapshots" + File.separator + "core-data" + File.separator
-	        + "liquibase-core-data-SNAPSHOT.xml";
+	private static final String LIQUIBASE_CORE_DATA_SNAPSHOT_XML = Paths
+	        .get("org", "openmrs", "liquibase", "snapshots", "core-data", "liquibase-core-data-SNAPSHOT.xml").toString();
 	
-	private static final String LIQUIBASE_CORE_DATA_UPDATED_SNAPSHOT_XML = "org" + File.separator + "openmrs"
-	        + File.separator + "liquibase" + File.separator + "snapshots" + File.separator + "core-data" + File.separator
-	        + "liquibase-core-data-UPDATED-SNAPSHOT.xml";
+	private static final String LIQUIBASE_CORE_DATA_UPDATED_SNAPSHOT_XML = Paths
+	        .get("org", "openmrs", "liquibase", "snapshots", "core-data", "liquibase-core-data-UPDATED-SNAPSHOT.xml")
+	        .toString();
 	
-	private static String PATH_TO_TEST_RESOURCES = "src" + File.separator + "test" + File.separator + "resources"
-	        + File.separator;
+	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 	
 	public static final int TWENTY_FIVE = 25;
 	

--- a/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
@@ -9,12 +9,20 @@
  */
 package org.openmrs.liquibase;
 
-import java.io.File;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.DocumentHelper;
@@ -25,25 +33,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-
 public class SchemaOnlyTunerTest {
 	
-	private static final String LIQUIBASE_SCHEMA_ONLY_SNAPSHOT_XML = "org" + File.separator + "openmrs" + File.separator
-	        + "liquibase" + File.separator + "snapshots" + File.separator + "schema-only" + File.separator
-	        + "liquibase-schema-only-SNAPSHOT.xml";
+	private static final String LIQUIBASE_SCHEMA_ONLY_SNAPSHOT_XML = Paths
+	        .get("org", "openmrs", "liquibase", "snapshots", "schema-only", "liquibase-schema-only-SNAPSHOT.xml").toString();
 	
-	private static final String LIQUIBASE_SCHEMA_ONLY_UPDATED_SNAPSHOT_XML = "org" + File.separator + "openmrs"
-	        + File.separator + "liquibase" + File.separator + "snapshots" + File.separator + "schema-only" + File.separator
-	        + "liquibase-schema-only-UPDATED-SNAPSHOT.xml";
+	private static final String LIQUIBASE_SCHEMA_ONLY_UPDATED_SNAPSHOT_XML = Paths
+	        .get("org", "openmrs", "liquibase", "snapshots", "schema-only", "liquibase-schema-only-UPDATED-SNAPSHOT.xml")
+	        .toString();
 	
-	private static String PATH_TO_TEST_RESOURCES = "src" + File.separator + "test" + File.separator + "resources"
-	        + File.separator;
+	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 	
 	private Document document;
 	


### PR DESCRIPTION
## Description of what I changed
 liquibase package changes for replacing path constructions using separator char


## Issue I worked on 
see https://issues.openmrs.org/browse/TRUNK-5134

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task --> 
<!--- If you forgot a task please follow the instructions below -->
- [x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

