### PR TITLE
TRUNK-6004: Remove Redundant Comment TODO finish function

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -143,8 +143,7 @@ public class OpenmrsUtil {
 	 * @param newList
 	 * @return [List toAdd, List toDelete] with respect to origList
 	 */
-	public static <E> Collection<Collection<E>> compareLists(Collection<E> origList, Collection<E> newList) {
-		
+	public static <E> Collection<Collection<E>> compareLists(Collection<E> origList, Collection<E> newList) {	
 		Collection<Collection<E>> returnList = new ArrayList<>();
 		
 		Collection<E> toAdd = new LinkedList<>();

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -144,7 +144,6 @@ public class OpenmrsUtil {
 	 * @return [List toAdd, List toDelete] with respect to origList
 	 */
 	public static <E> Collection<Collection<E>> compareLists(Collection<E> origList, Collection<E> newList) {
-		// TODO finish function
 		
 		Collection<Collection<E>> returnList = new ArrayList<>();
 		


### PR DESCRIPTION
TRUNK-6004: Remove Redundant Comment TODO finish function
https://issues.openmrs.org/browse/TRUNK-6004
I removed the redundant comment TODO finish function.