### PR TITLE
TRUNK-6006:  OrderService prevents saving Order Frequencies

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -824,11 +824,6 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	 */
 	@Override
 	public OrderFrequency saveOrderFrequency(OrderFrequency orderFrequency) throws APIException {
-		if (orderFrequency.getOrderFrequencyId() != null
-				&& dao.isOrderFrequencyInUse(orderFrequency)) {		
-			throw new CannotUpdateObjectInUseException("Order.frequency.cannot.edit");
-		}
-		
 		return dao.saveOrderFrequency(orderFrequency);
 	}
 	

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -1497,20 +1497,6 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see OrderService#saveOrderFrequency(OrderFrequency)
-	 */
-	@Test
-	public void saveOrderFrequency_shouldNotAllowEditingAnExistingOrderFrequencyThatIsInUse() {
-		OrderFrequency orderFrequency = orderService.getOrderFrequency(1);
-		assertNotNull(orderFrequency);
-
-		orderFrequency.setFrequencyPerDay(4d);
-		expectedException.expect(CannotUpdateObjectInUseException.class);
-		expectedException.expectMessage("Order.frequency.cannot.edit");
-		orderService.saveOrderFrequency(orderFrequency);
-	}
-
-	/**
 	 * @see OrderService#purgeOrderFrequency(OrderFrequency)
 	 */
 	@Test


### PR DESCRIPTION
This PR is against the 2.3.x branch.  If approved, I will up-port to 2.4.x and master.  This removes the validation within the Order Service that prevents saving an Order Frequency if it is in use.  See TRUNK-6006 for details.