### PR TITLE
TRUNK-6008: Fix HibernatePatientDAO.getDuplicatePatientsByAttributes

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -478,8 +478,8 @@ public class HibernatePatientDAO implements PatientDAO {
 				innerFields.add("person1." + attribute);
 			} else if (personNameFieldNames.contains(attribute)) {
 				if (!outerSelect.toString().contains("person_name")) {
-					outerSelect.append("inner join person_name t3 on t2.person_id = t3.person_id ");
-					innerSelect.append("inner join person_name pn1 on person1.person_id = pn1.person_id ");
+					outerSelect.append("inner join person_name t3 on t1.patient_id = t3.person_id ");
+					innerSelect.append("inner join person_name pn1 on p1.patient_id = pn1.person_id ");
 				}
 
 				//Since we are firing a native query get the actual table column name from the field name of the entity

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
@@ -12,9 +12,11 @@ package org.openmrs.api.db.hibernate;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.sql.Date;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,16 +26,21 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
 public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 
 	private HibernatePatientDAO hibernatePatientDao;
+	
+	private HibernatePersonDAO hibernatePersonDAO;
 
 	@BeforeEach
 	public void beforeEach() {
 		updateSearchIndex();
 		hibernatePatientDao = (HibernatePatientDAO) applicationContext.getBean("patientDAO");
+		hibernatePersonDAO = (HibernatePersonDAO) applicationContext.getBean("personDAO");
 	}
 
 	@Test
@@ -63,4 +70,116 @@ public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 		assertThat(identifierIds, hasItems(3, 4));
 	}
 
+	@Test
+	public void getDuplicatePatientsByAttributes_shouldNotReturnPatientsWithUniqueNames() {
+		// given
+		Person person1 = new Person();
+		person1.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person1 = hibernatePersonDAO.savePerson(person1);
+		hibernatePatientDao.savePatient(new Patient(person1));
+
+		Person person2 = new Person();
+		person2.addName(new PersonName("Ioan1", "Theo1", "Fletcher1"));
+		person2 = hibernatePersonDAO.savePerson(person2);
+		hibernatePatientDao.savePatient(new Patient(person2));
+
+		// when
+		List<Patient> duplicatePatients = hibernatePatientDao
+			.getDuplicatePatientsByAttributes(Arrays.asList("givenName", "middleName", "familyName"));
+
+		// then
+		assertThat(duplicatePatients.size(), equalTo(0));
+	}
+
+	@Test
+	public void getDuplicatePatientsByAttributes_shouldReturnPatientsWithDuplicatedAllNames() {
+		// given
+		Person person1 = new Person();
+		person1.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person1 = hibernatePersonDAO.savePerson(person1);
+		hibernatePatientDao.savePatient(new Patient(person1));
+
+		Person person2 = new Person();
+		person2.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person2 = hibernatePersonDAO.savePerson(person2);
+		hibernatePatientDao.savePatient(new Patient(person2));
+
+		// when
+		List<Patient> duplicatePatients = hibernatePatientDao
+			.getDuplicatePatientsByAttributes(Arrays.asList("givenName", "middleName", "familyName"));
+		
+		// then
+		assertThat(duplicatePatients.size(), equalTo(2));
+	}
+
+	@Test
+	public void getDuplicatePatientsByAttributes_shouldReturnPatientsWithDuplicatedFamilyNames() {
+		// given
+		Person person1 = new Person();
+		person1.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person1 = hibernatePersonDAO.savePerson(person1);
+		hibernatePatientDao.savePatient(new Patient(person1));
+
+		Person person2 = new Person();
+		person2.addName(new PersonName("Ioan1", "Theo1", "Fletcher"));
+		person2 = hibernatePersonDAO.savePerson(person2);
+		hibernatePatientDao.savePatient(new Patient(person2));
+
+		// when
+		List<Patient> duplicatePatients = hibernatePatientDao
+			.getDuplicatePatientsByAttributes(singletonList("familyName"));
+
+		// then
+		assertThat(duplicatePatients.size(), equalTo(2));
+	}
+
+	@Test
+	public void getDuplicatePatientsByAttributes_shouldReturnPatientsWithDuplicatedAllFields() {
+		// given
+		Person person1 = new Person();
+		person1.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person1.setGender("M");
+		person1.setBirthdate(Date.valueOf("2021-06-26"));
+		person1 = hibernatePersonDAO.savePerson(person1);
+		hibernatePatientDao.savePatient(new Patient(person1));
+
+		Person person2 = new Person();
+		person2.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person2.setGender("M");
+		person2.setBirthdate(Date.valueOf("2021-06-26"));
+		person2 = hibernatePersonDAO.savePerson(person2);
+		hibernatePatientDao.savePatient(new Patient(person2));
+
+		// when
+		List<Patient> duplicatePatients = hibernatePatientDao
+			.getDuplicatePatientsByAttributes(Arrays.asList("gender", "birthdate", "givenName", "middleName", "familyName"));
+
+		// then
+		assertThat(duplicatePatients.size(), equalTo(2));
+	}
+
+	@Test
+	public void getDuplicatePatientsByAttributes_shouldNotReturnPatientsWithDuplicatedAllFieldsBesidesGender() {
+		// given
+		Person person1 = new Person();
+		person1.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person1.setGender("M");
+		person1.setBirthdate(Date.valueOf("2021-06-26"));
+		person1 = hibernatePersonDAO.savePerson(person1);
+		hibernatePatientDao.savePatient(new Patient(person1));
+
+		Person person2 = new Person();
+		person2.addName(new PersonName("Ioan", "Theo", "Fletcher"));
+		person2.setGender("F");
+		person2.setBirthdate(Date.valueOf("2021-06-26"));
+		person2 = hibernatePersonDAO.savePerson(person2);
+		hibernatePatientDao.savePatient(new Patient(person2));
+
+		// when
+		List<Patient> duplicatePatients = hibernatePatientDao
+			.getDuplicatePatientsByAttributes(Arrays.asList("gender", "birthdate", "givenName", "middleName", "familyName"));
+
+		// then
+		assertThat(duplicatePatients.size(), equalTo(0));
+	}
 }


### PR DESCRIPTION
## Description of what I changed
Fixed issues with SQLException while trying to get patients with duplicated names. I've also added tests for this functionality.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6008

## Checklist: I completed these to help reviewers :)
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

