### PR TITLE
TRUNK-6010: HibernatePatientDAOTest should test getting duplicated patients by identifier and includeVoided

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -10,6 +10,7 @@
 package org.openmrs.api.db.hibernate;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -435,7 +436,6 @@ public class HibernatePatientDAO implements PatientDAO {
 	private String getDuplicatePatientsSQLString(List<String> attributes) {
 		StringBuilder outerSelect = new StringBuilder("select distinct t1.patient_id from patient t1 ");
 		final String t5 = " = t5.";
-		
 		Set<String> patientFieldNames = OpenmrsUtil.getDeclaredFields(Patient.class);
 		Set<String> personFieldNames = OpenmrsUtil.getDeclaredFields(Person.class);
 		Set<String> personNameFieldNames = OpenmrsUtil.getDeclaredFields(PersonName.class);
@@ -461,7 +461,9 @@ public class HibernatePatientDAO implements PatientDAO {
 				whereConditions.add(" t1." + attribute + t5 + attribute);
 				innerFields.add("p1." + attribute);
 			} else if (personFieldNames.contains(attribute)) {
-				if (!outerSelect.toString().contains("person")) {
+				// check if outerSelect contains 'person' word, surrounded by spaces.
+				// otherwise it will wrongly match for example: 'person_name' etc.
+				if (!Arrays.asList(outerSelect.toString().split("\\s+")).contains("person")) {
 					outerSelect.append("inner join person t2 on t1.patient_id = t2.person_id ");
 					innerSelect.append("inner join person person1 on p1.patient_id = person1.person_id ");
 				}

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernatePatientDAOTest.java
@@ -29,6 +29,7 @@ import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.Person;
 import org.openmrs.PersonName;
+import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
 public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
@@ -240,8 +241,8 @@ public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 		patient2.setVoided(true);
 		hibernatePatientDao.savePatient(patient2);
 
-		// update voided patients, doesn't update them without this line
-		hibernatePatientDao.getAllPatients(true);
+		// flush DB session to persist voiding patients
+		Context.flushSession();
 
 		// when
 		List<String> attributes = Arrays.asList("gender", "identifier", "birthdate", "givenName", "middleName", "familyName");
@@ -275,8 +276,8 @@ public class HibernatePatientDAOTest extends BaseContextSensitiveTest {
 		patient2.setVoided(true);
 		hibernatePatientDao.savePatient(patient2);
 
-		// update voided patients, doesn't update them without this line
-		hibernatePatientDao.getAllPatients(true);
+		// flush DB session to persist voiding patients
+		Context.flushSession();
 
 		// when
 		List<String> attributes = Arrays.asList("gender", "identifier", "birthdate", "givenName", "middleName", "familyName", "includeVoided");


### PR DESCRIPTION
## Description of what I changed
This PR fixes `HibernatePatientDAO.getDuplicatePatientsByAttributes` method by sorting passed attributes before building an SQL query. It also adds more unit tests for `identifier` and `includeVoided` attributes. It also adds random order to passed attributes in tests to make sure they aren't flaky.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6010

## Checklist: I completed these to help reviewers :)
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

