### PR TITLE
TRUNK-5999: Add more filtering options to Diagnosis service

### DIFF
--- a/api/src/main/java/org/openmrs/api/DiagnosisService.java
+++ b/api/src/main/java/org/openmrs/api/DiagnosisService.java
@@ -69,13 +69,12 @@ public interface DiagnosisService extends OpenmrsService {
 	List<Diagnosis> getDiagnoses(Patient patient, Date fromDate);
 
 	/**
-	 * Gets diagnoses for an Encounter. When specified, this method only returns
-	 * primary or confirmed diagnoses.
+	 * Gets diagnoses for an Encounter.
 	 *
 	 * @param encounter the encounter for which to fetch diagnoses
 	 * @param primaryOnly whether to return only primary diagnoses
 	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @return the list of diagnoses for the given encounter
 	 * 
 	 * @since 2.5.0
 	 */
@@ -83,13 +82,12 @@ public interface DiagnosisService extends OpenmrsService {
 	List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
 	
 	/**
-	 * Gets diagnoses for a Visit. When specified, this method only returns
-	 * primary or confirmed diagnoses.
+	 * Gets diagnoses for a Visit.
 	 *
 	 * @param visit the visit for which to fetch diagnoses
 	 * @param primaryOnly whether to return only primary diagnoses
 	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given visit
+	 * @return the list of diagnoses for the given visit
 	 * 
 	 * @since 2.5.0
 	 */

--- a/api/src/main/java/org/openmrs/api/DiagnosisService.java
+++ b/api/src/main/java/org/openmrs/api/DiagnosisService.java
@@ -76,9 +76,11 @@ public interface DiagnosisService extends OpenmrsService {
 	 * @param primaryOnly whether to return only primary diagnoses
 	 * @param confirmedOnly whether to return only confirmed diagnoses
 	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * 
+	 * @since 2.5.0
 	 */
 	@Authorized({ PrivilegeConstants.GET_DIAGNOSES })
-	List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
+	List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
 	
 	/**
 	 * Gets diagnoses for a Visit. When specified, this method only returns
@@ -87,16 +89,18 @@ public interface DiagnosisService extends OpenmrsService {
 	 * @param visit the visit for which to fetch diagnoses
 	 * @param primaryOnly whether to return only primary diagnoses
 	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @return the list of (primary, confirmed) diagnoses for the given visit
+	 * 
+	 * @since 2.5.0
 	 */
 	@Authorized({ PrivilegeConstants.GET_DIAGNOSES })
-	List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
+	List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
 
 
 	/**
 	 * Finds the primary diagnoses for a given encounter
 	 *
-	 * @deprecated since 2.5.0, use {@link #getDiagnosesForEncounter}
+	 * @deprecated since 2.5.0, use {@link #getDiagnosesByEncounter}
 	 * 
 	 * @param encounter the encounter whose diagnoses we are to get
 	 * @return the list of diagnoses in the given encounter

--- a/api/src/main/java/org/openmrs/api/DiagnosisService.java
+++ b/api/src/main/java/org/openmrs/api/DiagnosisService.java
@@ -13,6 +13,7 @@ package org.openmrs.api;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.Diagnosis;
+import org.openmrs.Visit;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.util.PrivilegeConstants;
 
@@ -68,11 +69,39 @@ public interface DiagnosisService extends OpenmrsService {
 	List<Diagnosis> getDiagnoses(Patient patient, Date fromDate);
 
 	/**
+	 * Gets diagnoses for an Encounter. When specified, this method only returns
+	 * primary or confirmed diagnoses.
+	 *
+	 * @param encounter the encounter for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 */
+	@Authorized({ PrivilegeConstants.GET_DIAGNOSES })
+	List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
+	
+	/**
+	 * Gets diagnoses for a Visit. When specified, this method only returns
+	 * primary or confirmed diagnoses.
+	 *
+	 * @param visit the visit for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 */
+	@Authorized({ PrivilegeConstants.GET_DIAGNOSES })
+	List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
+
+
+	/**
 	 * Finds the primary diagnoses for a given encounter
+	 *
+	 * @deprecated since 2.5.0, use {@link #getDiagnosesForEncounter}
 	 * 
 	 * @param encounter the encounter whose diagnoses we are to get
 	 * @return the list of diagnoses in the given encounter
 	 */
+	@Deprecated
 	List<Diagnosis> getPrimaryDiagnoses(Encounter encounter);
 
 	/**

--- a/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
@@ -61,7 +61,7 @@ public interface DiagnosisDAO {
 	/**
 	 * Gets all diagnoses for a given encounter
 	 *
-	 * @deprecated since 2.5.0, use {@link #getDiagnosesForEncounter}
+	 * @deprecated since 2.5.0, use {@link #getDiagnosesByEncounter}
 	 *
 	 * @param encounter the encounter for which to fetch diagnoses
 	 * @return the list of (primary, confirmed) diagnoses for the given encounter
@@ -70,26 +70,14 @@ public interface DiagnosisDAO {
 	List<Diagnosis> getDiagnoses(Encounter encounter);
 	
 	/**
-	 * Gets diagnoses for an Encounter. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param encounter the encounter for which to fetch diagnoses
-	 * @param primaryOnly whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
-	List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
+	List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
 
 	/**
-	 * Gets diagnoses for a Visit. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param visit the visit for which to fetch diagnoses
-	 * @param primaryOnly whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given visit
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosesByVisit(Visit, boolean, boolean)
 	 */
-	List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
+	List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
 
 	/**
 	 * Gets all active diagnoses related to the specified patient.

--- a/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.openmrs.Diagnosis;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
+import org.openmrs.Visit;
 
 /**
  * This interface defines database methods for diagnosis objects.
@@ -56,22 +57,39 @@ public interface DiagnosisDAO {
 	 * @throws DAOException exception thrown if error occurs while deleting the diagnosis
 	 */
 	void deleteDiagnosis(Diagnosis diagnosis) throws DAOException;
-	
+
 	/**
 	 * Gets all diagnoses for a given encounter
 	 *
-	 * @param encounter the specific encounter to get the diagnoses for.
-	 * @return list of diagnoses for an encounter
+	 * @deprecated since 2.5.0, use {@link #getDiagnosesForEncounter}
+	 *
+	 * @param encounter the encounter for which to fetch diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
 	 */
+	@Deprecated
 	List<Diagnosis> getDiagnoses(Encounter encounter);
+	
+	/**
+	 * Gets diagnoses for an Encounter. When specified, this method only returns
+	 * primary or confirmed diagnoses.
+	 *
+	 * @param encounter the encounter for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 */
+	List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly);
 
 	/**
-	 * Gets primary diagnoses for a given encounter
+	 * Gets diagnoses for a Visit. When specified, this method only returns
+	 * primary or confirmed diagnoses.
 	 *
-	 * @param encounter the specific encounter to get the primary diagnoses for.
-	 * @return list of primary diagnoses for an encounter
+	 * @param visit the visit for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given visit
 	 */
-	List<Diagnosis> getPrimaryDiagnoses(Encounter encounter);
+	List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly);
 
 	/**
 	 * Gets all active diagnoses related to the specified patient.

--- a/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
@@ -57,17 +57,6 @@ public interface DiagnosisDAO {
 	 * @throws DAOException exception thrown if error occurs while deleting the diagnosis
 	 */
 	void deleteDiagnosis(Diagnosis diagnosis) throws DAOException;
-
-	/**
-	 * Gets all diagnoses for a given encounter
-	 *
-	 * @deprecated since 2.5.0, use {@link #getDiagnosesByEncounter}
-	 *
-	 * @param encounter the encounter for which to fetch diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
-	 */
-	@Deprecated
-	List<Diagnosis> getDiagnoses(Encounter encounter);
 	
 	/**
 	 * @see org.openmrs.api.DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
@@ -30,9 +30,10 @@ import javax.persistence.TypedQuery;
  *
  * @see DiagnosisDAO
  * @see org.openmrs.api.DiagnosisService
+ *
  */
 public class HibernateDiagnosisDAO implements DiagnosisDAO {
-
+	
 	/**
 	 * Hibernate session factory
 	 */
@@ -74,15 +75,15 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	@Override
 	public List<Diagnosis> getActiveDiagnoses(Patient patient, Date fromDate) {
 		String fromDateCriteria = "";
-		if (fromDate != null) {
+		if(fromDate != null){
 			fromDateCriteria = " and d.dateCreated >= :fromDate ";
 		}
 		Query query = sessionFactory.getCurrentSession().createQuery(
-			"from Diagnosis d where d.patient.patientId = :patientId and d.voided = false "
-				+ fromDateCriteria
+			"from Diagnosis d where d.patient.patientId = :patientId and d.voided = false " 
+				+ fromDateCriteria  
 				+ " order by d.dateCreated desc");
 		query.setInteger("patientId", patient.getId());
-		if (fromDate != null) {
+		if(fromDate != null){
 			query.setDate("fromDate", fromDate);
 		}
 		return query.list();
@@ -95,11 +96,11 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 * @return list of diagnoses for an encounter
 	 */
 	@Override
-	public List<Diagnosis> getDiagnoses(Encounter encounter) {
+	public List<Diagnosis> getDiagnoses(Encounter encounter){
 		Query query = sessionFactory.getCurrentSession().createQuery(
 			"from Diagnosis d where d.encounter.encounterId = :encounterId order by dateCreated desc");
 		query.setInteger("encounterId", encounter.getId());
-		return query.list();
+		return query.list();	
 	}
 
 	/**
@@ -112,7 +113,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 * @return the list of (primary, confirmed) diagnoses for the given encounter
 	 */
 	@Override
-	public List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
+	public List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
 		String queryString = "from Diagnosis d where d.encounter.id = :encounterId";
 		if (primaryOnly) {
 			queryString += " and d.rank = :rankId";
@@ -143,7 +144,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 * @return the list of (primary, confirmed) diagnoses for the given visit
 	 */
 	@Override
-	public List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
+	public List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
 		String queryString = "from Diagnosis d where d.encounter.visit.id = :visitId";
 		if (primaryOnly) {
 			queryString += " and d.rank = :rankId";
@@ -166,7 +167,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 
 	/**
 	 * Gets a diagnosis from database using the diagnosis id
-	 *
+	 * 
 	 * @param diagnosisId the id of the diagnosis to look for
 	 * @return the diagnosis with the given diagnosis id
 	 */
@@ -174,7 +175,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	public Diagnosis getDiagnosisById(Integer diagnosisId) {
 		return (Diagnosis) sessionFactory.getCurrentSession().get(Diagnosis.class, diagnosisId);
 	}
-
+	
 	/**
 	 * Gets the diagnosis attached to the specified UUID.
 	 *
@@ -182,18 +183,17 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 * @return the diagnosis associated with the UUID.
 	 */
 	@Override
-	public Diagnosis getDiagnosisByUuid(String uuid) {
+	public Diagnosis getDiagnosisByUuid(String uuid){
 		return (Diagnosis) sessionFactory.getCurrentSession().createQuery("from Diagnosis d where d.uuid = :uuid")
 			.setString("uuid", uuid).uniqueResult();
 	}
 
 	/**
-	 * Completely remove a diagnosis from the database.
-	 *
+	 * Completely remove a diagnosis from the database. 
 	 * @param diagnosis diagnosis to remove from the database
 	 */
 	@Override
-	public void deleteDiagnosis(Diagnosis diagnosis) throws DAOException {
+	public void deleteDiagnosis(Diagnosis diagnosis) throws DAOException{
 		sessionFactory.getCurrentSession().delete(diagnosis);
 	}
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
@@ -90,20 +90,6 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	}
 
 	/**
-	 * Gets all diagnoses for a given encounter
-	 *
-	 * @param encounter the specific encounter to get the diagnoses for.
-	 * @return list of diagnoses for an encounter
-	 */
-	@Override
-	public List<Diagnosis> getDiagnoses(Encounter encounter){
-		Query query = sessionFactory.getCurrentSession().createQuery(
-			"from Diagnosis d where d.encounter.encounterId = :encounterId order by dateCreated desc");
-		query.setInteger("encounterId", encounter.getId());
-		return query.list();	
-	}
-
-	/**
 	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Override

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
@@ -104,13 +104,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	}
 
 	/**
-	 * Gets diagnoses for an Encounter. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param encounter     the encounter for which to fetch diagnoses
-	 * @param primaryOnly   whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Override
 	public List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
@@ -135,13 +129,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	}
 
 	/**
-	 * Gets diagnoses for an Encounter. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param visit     the visit for which to fetch diagnoses
-	 * @param primaryOnly   whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given visit
+	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosesByVisit(Visit, boolean, boolean)
 	 */
 	@Override
 	public List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
@@ -94,7 +94,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 */
 	@Override
 	public List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
-		String queryString = "from Diagnosis d where d.encounter.id = :encounterId";
+		String queryString = "from Diagnosis d where d.encounter.encounterId = :encounterId";
 		if (primaryOnly) {
 			queryString += " and d.rank = :rankId";
 		}
@@ -119,7 +119,7 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	 */
 	@Override
 	public List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
-		String queryString = "from Diagnosis d where d.encounter.visit.id = :visitId";
+		String queryString = "from Diagnosis d where d.encounter.visit.visitId = :visitId";
 		if (primaryOnly) {
 			queryString += " and d.rank = :rankId";
 		}

--- a/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
@@ -79,33 +79,21 @@ public class DiagnosisServiceImpl extends BaseOpenmrsService implements Diagnosi
 	}
 
 	/**
-	 * Gets diagnoses for an Encounter. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param encounter the encounter for which to fetch diagnoses
-	 * @param primaryOnly whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
-		return diagnosisDAO.getDiagnosesForEncounter(encounter, primaryOnly, confirmedOnly);
+	public List<Diagnosis> getDiagnosesByEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
+		return diagnosisDAO.getDiagnosesByEncounter(encounter, primaryOnly, confirmedOnly);
 	}
-	
+
 	/**
-	 * Gets diagnoses for a Visit. When specified, this method only returns
-	 * primary or confirmed diagnoses.
-	 *
-	 * @param visit the visit for which to fetch diagnoses
-	 * @param primaryOnly whether to return only primary diagnoses
-	 * @param confirmedOnly whether to return only confirmed diagnoses
-	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosesByVisit(Visit, boolean, boolean) 
 	 */
 	@Override
 	@Transactional(readOnly = true)
-	public List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
-		return diagnosisDAO.getDiagnosesForVisit(visit, primaryOnly, confirmedOnly);
+	public List<Diagnosis> getDiagnosesByVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
+		return diagnosisDAO.getDiagnosesByVisit(visit, primaryOnly, confirmedOnly);
 	}
 
 	/**
@@ -113,14 +101,14 @@ public class DiagnosisServiceImpl extends BaseOpenmrsService implements Diagnosi
 	 * The diagnosis order is identified using the integer rank value. The diagnosis rank is thus:
 	 * 1 - PRIMARY (Primary diagnosis)
 	 * 2 - SECONDARY (Secondary diagnosis)
-	 * 
+	 *
 	 * @param encounter the encounter whose diagnoses we are to get
 	 * @return the list of diagnoses in the given encounter whose rank is 1 (Primary diagnosis)
 	 */
 	@Override
 	@Transactional(readOnly = true)
 	public List<Diagnosis> getPrimaryDiagnoses(Encounter encounter) {
-		return diagnosisDAO.getDiagnosesForEncounter(encounter, true, false);
+		return diagnosisDAO.getDiagnosesByEncounter(encounter, true, false);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
@@ -13,13 +13,13 @@ import org.openmrs.CodedOrFreeText;
 import org.openmrs.Diagnosis;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
+import org.openmrs.Visit;
 import org.openmrs.api.APIException;
 import org.openmrs.api.DiagnosisService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DiagnosisDAO;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Iterator;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -79,18 +79,48 @@ public class DiagnosisServiceImpl extends BaseOpenmrsService implements Diagnosi
 	}
 
 	/**
+	 * Gets diagnoses for an Encounter. When specified, this method only returns
+	 * primary or confirmed diagnoses.
+	 *
+	 * @param encounter the encounter for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Diagnosis> getDiagnosesForEncounter(Encounter encounter, boolean primaryOnly, boolean confirmedOnly) {
+		return diagnosisDAO.getDiagnosesForEncounter(encounter, primaryOnly, confirmedOnly);
+	}
+	
+	/**
+	 * Gets diagnoses for a Visit. When specified, this method only returns
+	 * primary or confirmed diagnoses.
+	 *
+	 * @param visit the visit for which to fetch diagnoses
+	 * @param primaryOnly whether to return only primary diagnoses
+	 * @param confirmedOnly whether to return only confirmed diagnoses
+	 * @return the list of (primary, confirmed) diagnoses for the given encounter
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Diagnosis> getDiagnosesForVisit(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
+		return diagnosisDAO.getDiagnosesForVisit(visit, primaryOnly, confirmedOnly);
+	}
+
+	/**
 	 * Finds the primary diagnoses for a given encounter
 	 * The diagnosis order is identified using the integer rank value. The diagnosis rank is thus:
 	 * 1 - PRIMARY (Primary diagnosis)
 	 * 2 - SECONDARY (Secondary diagnosis)
-	 *
+	 * 
 	 * @param encounter the encounter whose diagnoses we are to get
 	 * @return the list of diagnoses in the given encounter whose rank is 1 (Primary diagnosis)
 	 */
 	@Override
 	@Transactional(readOnly = true)
 	public List<Diagnosis> getPrimaryDiagnoses(Encounter encounter) {
-		return diagnosisDAO.getPrimaryDiagnoses(encounter);
+		return diagnosisDAO.getDiagnosesForEncounter(encounter, true, false);
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
@@ -17,6 +17,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.CodedOrFreeText;
@@ -28,6 +29,7 @@ import org.openmrs.Diagnosis;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.User;
+import org.openmrs.Visit;
 import org.openmrs.api.db.DiagnosisDAO;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,15 +44,14 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 	@BeforeEach
 	public void setUp() {
 		executeDataSet(DIAGNOSIS_XML);
-
 	}
-
+	
 	@Test
 	public void shouldSaveDiagnosis() {
 		CodedOrFreeText codedOrFreeText = new CodedOrFreeText(new Concept(4),
 			new ConceptName(5089), "non coded");
 		int diagnosisId = 5;
-		
+
 		Diagnosis diagnosis = new Diagnosis();
 		diagnosis.setEncounter(new Encounter(3));
 		diagnosis.setRank(2);
@@ -67,7 +68,7 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 		diagnosisDAO.saveDiagnosis(diagnosis);
 
 		Diagnosis savedDiagnosis = diagnosisDAO.getDiagnosisById(diagnosisId);
-		
+
 		assertEquals(diagnosis.getUuid(), savedDiagnosis.getUuid());
 		assertEquals(diagnosis.getVoided(), savedDiagnosis.getVoided());
 		assertEquals(diagnosis.getRank(), savedDiagnosis.getRank());
@@ -92,13 +93,13 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void shouldGetActiveDiagnosesWithFromDate() {
-		Calendar calendar = new GregorianCalendar(2014,1,1,13,24,56);
-		assertEquals(1, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size()); 
+		Calendar calendar = new GregorianCalendar(2014, 1, 1, 13, 24, 56);
+		assertEquals(1, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size());
 	}
 
 	@Test
 	public void shouldGetActiveDiagnosesWithDifferentFromDate() {
-		Calendar calendar = new GregorianCalendar(2012,1,3,13,32,36);
+		Calendar calendar = new GregorianCalendar(2012, 1, 3, 13, 32, 36);
 		assertEquals(2, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size());
 	}
 
@@ -114,9 +115,40 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldGetPrimaryDiagnoses() {
-		assertEquals(2, diagnosisDAO.getPrimaryDiagnoses(new Encounter(3)).size());
-		assertEquals(0, diagnosisDAO.getPrimaryDiagnoses(new Encounter(4)).size());
+	public void shouldGetDiagnosesForEncounter() {
+		assertEquals(2, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), false, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(9), false, false).size());
+	}
+
+	@Test
+	public void shouldGetPrimaryDiagnosesForEncounter() {
+		assertEquals(2, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), true, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(4), true, false).size());
+	}
+	
+	@Test
+	public void shouldGetConfirmedDiagnosesForEncounter() {
+		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), false, true).size());
+		assertEquals(1, diagnosisDAO.getDiagnosesForEncounter(new Encounter(4), false, true).size());
+	}
+	
+	@Test 
+	public void shouldGetDiagnosesForVisit() {
+		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(7), false, false).size());
+		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(8), false, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(9), false, false).size());
+	}
+	
+	@Test
+	public void shouldGetPrimaryDiagnosesForVisit() {
+		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(7), true, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(8), true, false).size());
+	}
+	
+	@Test
+	public void shouldGetConfirmedDiagnosesForVisit() {
+		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(7), false, true).size());
+		assertEquals(1, diagnosisDAO.getDiagnosesForVisit(new Visit(8), false, true).size());
 	}
 
 	@Test
@@ -125,6 +157,6 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 		Diagnosis diagnosis = diagnosisDAO.getDiagnosisByUuid(uuid);
 		assertNotNull(diagnosis);
 		diagnosisDAO.deleteDiagnosis(diagnosis);
-		assertNull(diagnosisDAO.getDiagnosisByUuid(uuid)); 
+		assertNull(diagnosisDAO.getDiagnosisByUuid(uuid));
 	}
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
@@ -17,7 +17,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.CodedOrFreeText;
@@ -44,14 +43,15 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 	@BeforeEach
 	public void setUp() {
 		executeDataSet(DIAGNOSIS_XML);
+
 	}
-	
+
 	@Test
 	public void shouldSaveDiagnosis() {
 		CodedOrFreeText codedOrFreeText = new CodedOrFreeText(new Concept(4),
 			new ConceptName(5089), "non coded");
 		int diagnosisId = 5;
-
+		
 		Diagnosis diagnosis = new Diagnosis();
 		diagnosis.setEncounter(new Encounter(3));
 		diagnosis.setRank(2);
@@ -68,7 +68,7 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 		diagnosisDAO.saveDiagnosis(diagnosis);
 
 		Diagnosis savedDiagnosis = diagnosisDAO.getDiagnosisById(diagnosisId);
-
+		
 		assertEquals(diagnosis.getUuid(), savedDiagnosis.getUuid());
 		assertEquals(diagnosis.getVoided(), savedDiagnosis.getVoided());
 		assertEquals(diagnosis.getRank(), savedDiagnosis.getRank());
@@ -93,13 +93,13 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void shouldGetActiveDiagnosesWithFromDate() {
-		Calendar calendar = new GregorianCalendar(2014, 1, 1, 13, 24, 56);
-		assertEquals(1, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size());
+		Calendar calendar = new GregorianCalendar(2014,1,1,13,24,56);
+		assertEquals(1, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size()); 
 	}
 
 	@Test
 	public void shouldGetActiveDiagnosesWithDifferentFromDate() {
-		Calendar calendar = new GregorianCalendar(2012, 1, 3, 13, 32, 36);
+		Calendar calendar = new GregorianCalendar(2012,1,3,13,32,36);
 		assertEquals(2, diagnosisDAO.getActiveDiagnoses(new Patient(2), calendar.getTime()).size());
 	}
 
@@ -115,40 +115,40 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldGetDiagnosesForEncounter() {
-		assertEquals(2, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), false, false).size());
-		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(9), false, false).size());
+	public void shouldGetDiagnosesByEncounter() {
+		assertEquals(2, diagnosisDAO.getDiagnosesByEncounter(new Encounter(3), false, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesByEncounter(new Encounter(9), false, false).size());
 	}
 
 	@Test
-	public void shouldGetPrimaryDiagnosesForEncounter() {
-		assertEquals(2, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), true, false).size());
-		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(4), true, false).size());
+	public void shouldGetPrimaryDiagnosesByEncounter() {
+		assertEquals(2, diagnosisDAO.getDiagnosesByEncounter(new Encounter(3), true, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesByEncounter(new Encounter(4), true, false).size());
 	}
 	
 	@Test
-	public void shouldGetConfirmedDiagnosesForEncounter() {
-		assertEquals(0, diagnosisDAO.getDiagnosesForEncounter(new Encounter(3), false, true).size());
-		assertEquals(1, diagnosisDAO.getDiagnosesForEncounter(new Encounter(4), false, true).size());
+	public void shouldGetConfirmedDiagnosesByEncounter() {
+		assertEquals(0, diagnosisDAO.getDiagnosesByEncounter(new Encounter(3), false, true).size());
+		assertEquals(1, diagnosisDAO.getDiagnosesByEncounter(new Encounter(4), false, true).size());
 	}
 	
 	@Test 
-	public void shouldGetDiagnosesForVisit() {
-		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(7), false, false).size());
-		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(8), false, false).size());
-		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(9), false, false).size());
+	public void shouldGetDiagnosesByVisit() {
+		assertEquals(2, diagnosisDAO.getDiagnosesByVisit(new Visit(7), false, false).size());
+		assertEquals(2, diagnosisDAO.getDiagnosesByVisit(new Visit(8), false, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesByVisit(new Visit(9), false, false).size());
 	}
 	
 	@Test
-	public void shouldGetPrimaryDiagnosesForVisit() {
-		assertEquals(2, diagnosisDAO.getDiagnosesForVisit(new Visit(7), true, false).size());
-		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(8), true, false).size());
+	public void shouldGetPrimaryDiagnosesByVisit() {
+		assertEquals(2, diagnosisDAO.getDiagnosesByVisit(new Visit(7), true, false).size());
+		assertEquals(0, diagnosisDAO.getDiagnosesByVisit(new Visit(8), true, false).size());
 	}
 	
 	@Test
-	public void shouldGetConfirmedDiagnosesForVisit() {
-		assertEquals(0, diagnosisDAO.getDiagnosesForVisit(new Visit(7), false, true).size());
-		assertEquals(1, diagnosisDAO.getDiagnosesForVisit(new Visit(8), false, true).size());
+	public void shouldGetConfirmedDiagnosesByVisit() {
+		assertEquals(0, diagnosisDAO.getDiagnosesByVisit(new Visit(7), false, true).size());
+		assertEquals(1, diagnosisDAO.getDiagnosesByVisit(new Visit(8), false, true).size());
 	}
 
 	@Test
@@ -157,6 +157,6 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 		Diagnosis diagnosis = diagnosisDAO.getDiagnosisByUuid(uuid);
 		assertNotNull(diagnosis);
 		diagnosisDAO.deleteDiagnosis(diagnosis);
-		assertNull(diagnosisDAO.getDiagnosisByUuid(uuid));
+		assertNull(diagnosisDAO.getDiagnosisByUuid(uuid)); 
 	}
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAOTest.java
@@ -109,12 +109,6 @@ public class HibernateDiagnosisDAOTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldGetDiagnoses() {
-		assertEquals(2, diagnosisDAO.getDiagnoses(new Encounter(3)).size());
-		assertEquals(0, diagnosisDAO.getDiagnoses(new Encounter(9)).size());
-	}
-
-	@Test
 	public void shouldGetDiagnosesByEncounter() {
 		assertEquals(2, diagnosisDAO.getDiagnosesByEncounter(new Encounter(3), false, false).size());
 		assertEquals(0, diagnosisDAO.getDiagnosesByEncounter(new Encounter(9), false, false).size());

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -26,11 +26,13 @@ import org.openmrs.Condition;
 import org.openmrs.ConditionVerificationStatus;
 import org.openmrs.Diagnosis;
 import org.openmrs.Encounter;
+import org.openmrs.Visit;
 import org.openmrs.Patient;
 import org.openmrs.api.ConditionService;
 import org.openmrs.api.DiagnosisService;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.PatientService;
+import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
@@ -41,34 +43,38 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 
 	protected static final String DIAGNOSIS_XML = "org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml";
-	
+
 	private DiagnosisService diagnosisService;
+	private VisitService visitService;
 	private PatientService patientService;
 	private EncounterService encounterService;
 	private ConditionService conditionService;
 
 	@BeforeEach
-	public void setUp (){
-		if(diagnosisService == null){
+	public void setUp() {
+		if (diagnosisService == null) {
 			diagnosisService = Context.getDiagnosisService();
 		}
-		if(patientService == null){
+		if (patientService == null) {
 			patientService = Context.getPatientService();
 		}
-		if(conditionService == null){
+		if (conditionService == null) {
 			conditionService = Context.getConditionService();
 		}
-		if(encounterService == null){
+		if (encounterService == null) {
 			encounterService = Context.getEncounterService();
+		}
+		if (visitService == null) {
+			visitService = Context.getVisitService();
 		}
 		executeDataSet(DIAGNOSIS_XML);
 	}
 
 	/**
-	 * @see DiagnosisService#save(Diagnosis) 
+	 * @see DiagnosisService#save(Diagnosis)
 	 */
 	@Test
-	public void saveDiagnosis_shouldSaveNewDiagnosis(){
+	public void saveDiagnosis_shouldSaveNewDiagnosis() {
 		String uuid = "a303bbfb-w5w4-25d1-9f11-4f33f99d456r";
 		Condition condition = conditionService.getConditionByUuid("2cc6880e-2c46-15e4-9038-a6c5e4d22fb7");
 		Encounter encounter = encounterService.getEncounterByUuid("y403fafb-e5e4-42d0-9d11-4f52e89d123r");
@@ -81,9 +87,9 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		diagnosis.setPatient(patient);
 		diagnosis.setRank(2);
 		diagnosisService.save(diagnosis);
-		
+
 		Diagnosis savedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
-		
+
 		assertEquals(uuid, savedDiagnosis.getUuid());
 		assertEquals(condition, savedDiagnosis.getCondition());
 		assertEquals(encounter, savedDiagnosis.getEncounter());
@@ -97,7 +103,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void getDiagnosisByUuid_shouldFindDiagnosisGivenValidUuid() {
-		String uuid="68802cce-6880-17e4-6880-a68804d22fb7";
+		String uuid = "68802cce-6880-17e4-6880-a68804d22fb7";
 		Diagnosis diagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertEquals(uuid, diagnosis.getUuid());
 	}
@@ -115,10 +121,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getPrimaryDiagnoses(Encounter) 
+	 * @see DiagnosisService#getPrimaryDiagnoses(Encounter)
 	 */
 	@Test
-	public void getPrimaryDiagnoses_shouldGetPrimaryDiagnoses(){
+	public void getPrimaryDiagnoses_shouldGetPrimaryDiagnoses() {
 		Encounter encounter = encounterService.getEncounterByUuid("y403fafb-e5e4-42d0-9d11-4f52e89d123r");
 		List<Diagnosis> diagnoses = diagnosisService.getPrimaryDiagnoses(encounter);
 		assertEquals(1, diagnoses.size());
@@ -128,10 +134,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnoses(Patient, Date) 
+	 * @see DiagnosisService#getDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDate(){
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDate() {
 		Calendar calendar = new GregorianCalendar(2015, 12, 1, 0, 0, 0);
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, calendar.getTime());
@@ -144,7 +150,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#getDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDifferentDate(){
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDifferentDate() {
 		Calendar calendar = new GregorianCalendar(2016, 12, 1, 0, 0, 0);
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, calendar.getTime());
@@ -156,7 +162,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#getDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithoutDate(){
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithoutDate() {
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, null);
 		assertEquals(3, diagnoses.size());
@@ -166,13 +172,13 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getUniqueDiagnoses(Patient, Date) 
+	 * @see DiagnosisService#getUniqueDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getUniqueDiagnoses_shouldGetUniqueDiagnosesOfPatient(){
+	public void getUniqueDiagnoses_shouldGetUniqueDiagnosesOfPatient() {
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getUniqueDiagnoses(patient, new Date(0));
-		
+
 		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
 		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
 		assertEquals(new Integer(1), diagnoses.get(0).getDiagnosisId());
@@ -181,10 +187,95 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForEncounter_shouldGetDiagnosesForEncounter() {
+		Encounter encounter = encounterService.getEncounter(5);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, false, false);
+
+		assertEquals(2, diagnoses.size());
+		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+		assertEquals("77009cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(1).getUuid());
+		assertEquals(ConditionVerificationStatus.PROVISIONAL, diagnoses.get(1).getCertainty());
+	}
+
+	/**
+	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForEncounter_shouldGetPrimaryDiagnosesForEncounter() {
+		Encounter encounter = encounterService.getEncounter(6);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, true, false);
+
+		assertEquals(1, diagnoses.size());
+		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+		assertEquals(1, diagnoses.get(0).getRank());
+	}
+
+	/**
+	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForEncounter_shouldGetConfirmedDiagnosesForEncounter() {
+		Encounter encounter = encounterService.getEncounter(5);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, false, true);
+
+		assertEquals(1, diagnoses.size());
+		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+	}
+
+	/**
+	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForVisit_shouldGetDiagnosesForEncounter() {
+		Visit visit = visitService.getVisit(7);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, false, false);
+
+		assertEquals(2, diagnoses.size());
+		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+		assertEquals("77009cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(1).getUuid());
+		assertEquals(ConditionVerificationStatus.PROVISIONAL, diagnoses.get(1).getCertainty());
+
+	}
+
+	/**
+	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForVisit_shouldGetPrimaryDiagnosesForEncounter() {
+		Visit visit = visitService.getVisit(8);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, true, false);
+
+		assertEquals(1, diagnoses.size());
+		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+		assertEquals(1, diagnoses.get(0).getRank());
+	}
+
+	/**
+	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 */
+	@Test
+	public void getDiagnosesForVisit_shouldGetConfirmedDiagnosesForEncounter() {
+		Visit visit = visitService.getVisit(7);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, false, true);
+
+		assertEquals(1, diagnoses.size());
+		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+	}
+
+	/**
 	 * @see DiagnosisService#voidDiagnosis(Diagnosis, String)
 	 */
 	@Test
-	public void voidDiagnosis_shouldVoidDiagnosisSuccessfully(){
+	public void voidDiagnosis_shouldVoidDiagnosisSuccessfully() {
 		String voidReason = "void reason";
 		String uuid = "688804ce-6880-8804-6880-a68804d88047";
 		Diagnosis nonVoidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
@@ -204,17 +295,17 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#unvoidDiagnosis(Diagnosis)
 	 */
 	@Test
-	public void unvoidDiagnosis_shouldUnvoidDiagnosisSuccessfully(){
+	public void unvoidDiagnosis_shouldUnvoidDiagnosisSuccessfully() {
 		String uuid = "77009cce-8804-17e4-8804-a68804d22fb7";
 		Diagnosis voidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertTrue(voidedDiagnosis.getVoided());
 		assertNotNull(voidedDiagnosis.getVoidReason());
 		assertNotNull(voidedDiagnosis.getDateVoided());
 		assertNotNull(voidedDiagnosis.getVoidedBy());
-		
+
 		diagnosisService.unvoidDiagnosis(voidedDiagnosis);
-		
-		Diagnosis unVoidedDiagnosis= diagnosisService.getDiagnosisByUuid(uuid);
+
+		Diagnosis unVoidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertEquals(ConditionVerificationStatus.PROVISIONAL, unVoidedDiagnosis.getCertainty());
 		assertEquals(uuid, unVoidedDiagnosis.getUuid());
 		assertFalse(unVoidedDiagnosis.getVoided());
@@ -224,7 +315,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#purgeDiagnosis(Diagnosis) 
+	 * @see DiagnosisService#purgeDiagnosis(Diagnosis)
 	 */
 	@Test
 	public void purgeDiagnosis_shouldPurgeDiagnosis() {
@@ -235,5 +326,5 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		Diagnosis purgedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertNull(purgedDiagnosis);
 	}
-	
+
 }

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -41,9 +41,7 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
  * would span implementations should go on the {@link org.openmrs.api.DiagnosisService}.
  */
 public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
-
 	protected static final String DIAGNOSIS_XML = "org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml";
-
 	private DiagnosisService diagnosisService;
 	private VisitService visitService;
 	private PatientService patientService;
@@ -51,17 +49,17 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	private ConditionService conditionService;
 
 	@BeforeEach
-	public void setUp() {
-		if (diagnosisService == null) {
+	public void setUp (){
+		if(diagnosisService == null){
 			diagnosisService = Context.getDiagnosisService();
 		}
-		if (patientService == null) {
+		if(patientService == null){
 			patientService = Context.getPatientService();
 		}
-		if (conditionService == null) {
+		if(conditionService == null){
 			conditionService = Context.getConditionService();
 		}
-		if (encounterService == null) {
+		if(encounterService == null){
 			encounterService = Context.getEncounterService();
 		}
 		if (visitService == null) {
@@ -71,10 +69,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#save(Diagnosis)
+	 * @see DiagnosisService#save(Diagnosis) 
 	 */
 	@Test
-	public void saveDiagnosis_shouldSaveNewDiagnosis() {
+	public void saveDiagnosis_shouldSaveNewDiagnosis(){
 		String uuid = "a303bbfb-w5w4-25d1-9f11-4f33f99d456r";
 		Condition condition = conditionService.getConditionByUuid("2cc6880e-2c46-15e4-9038-a6c5e4d22fb7");
 		Encounter encounter = encounterService.getEncounterByUuid("y403fafb-e5e4-42d0-9d11-4f52e89d123r");
@@ -87,9 +85,9 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		diagnosis.setPatient(patient);
 		diagnosis.setRank(2);
 		diagnosisService.save(diagnosis);
-
+		
 		Diagnosis savedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
-
+		
 		assertEquals(uuid, savedDiagnosis.getUuid());
 		assertEquals(condition, savedDiagnosis.getCondition());
 		assertEquals(encounter, savedDiagnosis.getEncounter());
@@ -103,7 +101,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void getDiagnosisByUuid_shouldFindDiagnosisGivenValidUuid() {
-		String uuid = "68802cce-6880-17e4-6880-a68804d22fb7";
+		String uuid="68802cce-6880-17e4-6880-a68804d22fb7";
 		Diagnosis diagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertEquals(uuid, diagnosis.getUuid());
 	}
@@ -121,10 +119,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getPrimaryDiagnoses(Encounter)
+	 * @see DiagnosisService#getPrimaryDiagnoses(Encounter) 
 	 */
 	@Test
-	public void getPrimaryDiagnoses_shouldGetPrimaryDiagnoses() {
+	public void getPrimaryDiagnoses_shouldGetPrimaryDiagnoses(){
 		Encounter encounter = encounterService.getEncounterByUuid("y403fafb-e5e4-42d0-9d11-4f52e89d123r");
 		List<Diagnosis> diagnoses = diagnosisService.getPrimaryDiagnoses(encounter);
 		assertEquals(1, diagnoses.size());
@@ -134,10 +132,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnoses(Patient, Date)
+	 * @see DiagnosisService#getDiagnoses(Patient, Date) 
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDate() {
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDate(){
 		Calendar calendar = new GregorianCalendar(2015, 12, 1, 0, 0, 0);
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, calendar.getTime());
@@ -150,7 +148,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#getDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDifferentDate() {
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithDifferentDate(){
 		Calendar calendar = new GregorianCalendar(2016, 12, 1, 0, 0, 0);
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, calendar.getTime());
@@ -162,7 +160,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#getDiagnoses(Patient, Date)
 	 */
 	@Test
-	public void getDiagnoses_shouldGetDiagnosesOfPatientWithoutDate() {
+	public void getDiagnoses_shouldGetDiagnosesOfPatientWithoutDate(){
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getDiagnoses(patient, null);
 		assertEquals(3, diagnoses.size());
@@ -172,13 +170,13 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getUniqueDiagnoses(Patient, Date)
+	 * @see DiagnosisService#getUniqueDiagnoses(Patient, Date) 
 	 */
 	@Test
-	public void getUniqueDiagnoses_shouldGetUniqueDiagnosesOfPatient() {
+	public void getUniqueDiagnoses_shouldGetUniqueDiagnosesOfPatient(){
 		Patient patient = patientService.getPatient(2);
 		List<Diagnosis> diagnoses = diagnosisService.getUniqueDiagnoses(patient, new Date(0));
-
+		
 		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
 		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
 		assertEquals(new Integer(1), diagnoses.get(0).getDiagnosisId());
@@ -187,12 +185,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForEncounter_shouldGetDiagnosesForEncounter() {
+	public void getDiagnosesByEncounter_shouldGetDiagnosesForEncounter() {
 		Encounter encounter = encounterService.getEncounter(5);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, false, false);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByEncounter(encounter, false, false);
 
 		assertEquals(2, diagnoses.size());
 		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -202,12 +200,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForEncounter_shouldGetPrimaryDiagnosesForEncounter() {
+	public void getDiagnosesByEncounter_shouldGetPrimaryDiagnosesForEncounter() {
 		Encounter encounter = encounterService.getEncounter(6);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, true, false);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByEncounter(encounter, true, false);
 
 		assertEquals(1, diagnoses.size());
 		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -216,12 +214,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForEncounter(Encounter, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByEncounter(Encounter, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForEncounter_shouldGetConfirmedDiagnosesForEncounter() {
+	public void getDiagnosesByEncounter_shouldGetConfirmedDiagnosesForEncounter() {
 		Encounter encounter = encounterService.getEncounter(5);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForEncounter(encounter, false, true);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByEncounter(encounter, false, true);
 
 		assertEquals(1, diagnoses.size());
 		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -229,12 +227,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByVisit(Visit, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForVisit_shouldGetDiagnosesForEncounter() {
+	public void getDiagnosesByVisit_shouldGetDiagnosesForEncounter() {
 		Visit visit = visitService.getVisit(7);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, false, false);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByVisit(visit, false, false);
 
 		assertEquals(2, diagnoses.size());
 		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -245,12 +243,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByVisit(Visit, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForVisit_shouldGetPrimaryDiagnosesForEncounter() {
+	public void getDiagnosesByVisit_shouldGetPrimaryDiagnosesForEncounter() {
 		Visit visit = visitService.getVisit(8);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, true, false);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByVisit(visit, true, false);
 
 		assertEquals(1, diagnoses.size());
 		assertEquals("68802cce-6880-17e4-6880-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -259,12 +257,12 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#getDiagnosesForVisit(Visit, boolean, boolean)
+	 * @see DiagnosisService#getDiagnosesByVisit(Visit, boolean, boolean)
 	 */
 	@Test
-	public void getDiagnosesForVisit_shouldGetConfirmedDiagnosesForEncounter() {
+	public void getDiagnosesByVisit_shouldGetConfirmedDiagnosesForEncounter() {
 		Visit visit = visitService.getVisit(7);
-		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesForVisit(visit, false, true);
+		List<Diagnosis> diagnoses = diagnosisService.getDiagnosesByVisit(visit, false, true);
 
 		assertEquals(1, diagnoses.size());
 		assertEquals("88042cce-8804-17e4-8804-a68804d22fb7", diagnoses.get(0).getUuid());
@@ -275,7 +273,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#voidDiagnosis(Diagnosis, String)
 	 */
 	@Test
-	public void voidDiagnosis_shouldVoidDiagnosisSuccessfully() {
+	public void voidDiagnosis_shouldVoidDiagnosisSuccessfully(){
 		String voidReason = "void reason";
 		String uuid = "688804ce-6880-8804-6880-a68804d88047";
 		Diagnosis nonVoidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
@@ -295,17 +293,17 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 * @see DiagnosisService#unvoidDiagnosis(Diagnosis)
 	 */
 	@Test
-	public void unvoidDiagnosis_shouldUnvoidDiagnosisSuccessfully() {
+	public void unvoidDiagnosis_shouldUnvoidDiagnosisSuccessfully(){
 		String uuid = "77009cce-8804-17e4-8804-a68804d22fb7";
 		Diagnosis voidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertTrue(voidedDiagnosis.getVoided());
 		assertNotNull(voidedDiagnosis.getVoidReason());
 		assertNotNull(voidedDiagnosis.getDateVoided());
 		assertNotNull(voidedDiagnosis.getVoidedBy());
-
+		
 		diagnosisService.unvoidDiagnosis(voidedDiagnosis);
-
-		Diagnosis unVoidedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
+		
+		Diagnosis unVoidedDiagnosis= diagnosisService.getDiagnosisByUuid(uuid);
 		assertEquals(ConditionVerificationStatus.PROVISIONAL, unVoidedDiagnosis.getCertainty());
 		assertEquals(uuid, unVoidedDiagnosis.getUuid());
 		assertFalse(unVoidedDiagnosis.getVoided());
@@ -315,7 +313,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see DiagnosisService#purgeDiagnosis(Diagnosis)
+	 * @see DiagnosisService#purgeDiagnosis(Diagnosis) 
 	 */
 	@Test
 	public void purgeDiagnosis_shouldPurgeDiagnosis() {
@@ -326,5 +324,5 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		Diagnosis purgedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
 		assertNull(purgedDiagnosis);
 	}
-
+	
 }

--- a/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml
+++ b/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml
@@ -11,9 +11,14 @@
 
 -->
 <dataset>
-	<encounter encounter_id="6" encounter_type="1" patient_id="2" location_id="2" form_id="1" 
-			   encounter_datetime="2008-08-19 00:00:00.0" creator="1" date_created="2008-08-19 12:34:40.0" 
-			   voided="false" uuid="y403fafb-e5e4-42d0-9d11-4f52e89d123r"/>
+	<visit visit_id="7" patient_id="2" visit_type_id="1" date_started="2008-01-01 02:00:00.0" creator="1" date_created="2008-01-01 00:00:00.0" voided="0" uuid="a2c3868a-6b90-11e0-93c3-18a905e044dc" />
+	<visit visit_id="8" patient_id="2" visit_type_id="1" date_started="2008-01-01 02:00:00.0" creator="1" date_created="2008-01-01 00:00:00.0" voided="0" uuid="f2c3848a-6b90-11e0-93c3-18a905e044dc" />
+	<encounter encounter_id="5" encounter_type="1" patient_id="2" location_id="2" form_id="1"
+			   encounter_datetime="2008-08-19 00:00:00.0" creator="1" date_created="2008-08-19 12:34:40.0"
+			   voided="false" uuid="f403fafb-b5e4-42d0-9d11-4f52e89d123r" visit_id="7"/>
+	<encounter encounter_id="6" encounter_type="1" patient_id="2" location_id="2" form_id="1"
+			   encounter_datetime="2008-08-19 00:00:00.0" creator="1" date_created="2008-08-19 12:34:40.0"
+			   voided="false" uuid="y403fafb-e5e4-42d0-9d11-4f52e89d123r" visit_id="8"/>
 	<conditions condition_id="1" patient_id="2" clinical_status="INACTIVE" creator="1" date_created="2015-01-12 00:00:00" 
 			   voided="false" onset_date="2017-01-12 00:00:00" end_date="2017-01-15 00:00:00" verification_status="PROVISIONAL" 
 			   uuid="2cc6880e-2c46-15e4-9038-a6c5e4d22fb7"/>

--- a/api/src/test/resources/org/openmrs/api/include/HibernateDiagnosisDAOTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/api/include/HibernateDiagnosisDAOTestDataset.xml
@@ -12,10 +12,14 @@
 -->
 
 <dataset>
+	<visit visit_id="7" patient_id="2" visit_type_id="1" date_started="2012-01-01 02:00:00.0" creator="1" date_created="2012-01-01 00:00:00.0" voided="0" uuid="a2c3868a-6b90-11e0-93c3-18a905e044dc" />
+	<visit visit_id="8" patient_id="2" visit_type_id="1" date_started="2012-01-01 02:00:00.0" creator="1" date_created="2012-01-01 00:00:00.0" voided="0" uuid="a2c3848a-6b90-11e0-93c3-18a905e044dc" />
+	<encounter encounter_id="3" encounter_type="1" form_id="1" encounter_datetime="2012-01-01 02:00:00.0" patient_id="2" location_id="1" visit_id="7" creator="1" date_created="2012-01-01 02:00:00.0" voided="0" uuid="7fffd6b9-0970-4967-88c7-0b7b50f12bc6"/>
+	<encounter encounter_id="4" encounter_type="1" form_id="1" encounter_datetime="2012-01-01 02:00:00.0" patient_id="2" location_id="1" visit_id="8" creator="1" date_created="2012-01-01 02:00:00.0" voided="0" uuid="4fffd6b9-0970-4967-88c7-0b7b50112bc6"/>
 	<encounter_diagnosis diagnosis_id="1" creator="1" encounter_id="3" patient_id="2"
 						 date_created="2015-01-12 00:00:00.0" voided="false" uuid="4e663d66-6b78-11e0-93c3-18a905e044dc" rank="1" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="2" creator="1" encounter_id="3" patient_id="2"
-						 date_created="2013-01-12 03:00:00" voided="false" uuid="2cc6880e-2c46-15e4-9038-a6c5e4d22fb7" rank="1" certainty="PROVISIONAL" />
+						 date_created="2013-01-11 03:00:00" voided="false" uuid="2cc6880e-2c46-15e4-9038-a6c5e4d22fb7" rank="1" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="3" creator="1" encounter_id="4 " patient_id="2"
 						 date_created="2015-03-12 00:00:00" voided="true" uuid="2fc6880e-2c46-15e4-d038-a6c5e4d22fb7" rank="4" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="4" creator="1" encounter_id="4" patient_id="6"


### PR DESCRIPTION
## Description of what I changed
Creates two new methods in the `DiagnosisService` and corresponding DAOs:
- `getDiagnosesByEncounter`
- `getDiagnosesByVisit`

Each of these methods can filter by diagnoses that are primary or confirmed.

This backports the behaviour for `Visit`s in https://github.com/icrc-psousa/openmrs-module-emrapi/blob/RA-1714/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/EmrDiagnosisDAOImpl2_2.java into `openmrs-core` and introduces the same behaviour with regard to `Encounter`s.

This PR deprecates `DiagnosisService#getPrimaryDiagnoses` as the behaviour is now contained in `DiagnosisService#getDiagnosesByEncounter` which allows filtering for primary diagnoses; the same goes for `DiagnosisDAO#getDiagnoses`. I did not remove the methods for backwards compatibility reasons.

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-5999

## Checklist: I completed these to help reviewers :)
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [X] I ran `mvn clean package` right before creating this pull request and

- [X] All new and existing **tests passed**.

- [X] My pull request is **based on the latest changes** of the master branch.