### PR TITLE
TRUNK-6021: Validating input String in the reaction field | Allergy UI

### DIFF
--- a/api/src/main/java/org/openmrs/validator/AllergyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AllergyValidator.java
@@ -50,6 +50,7 @@ public class AllergyValidator implements Validator {
 	 * <strong>Should</strong> reject a duplicate allergen
 	 * <strong>Should</strong> reject a duplicate non coded allergen
 	 * <strong>Should</strong> pass for a valid allergy
+	 * <strong>Should</strong> reject numeric values and symbols on reactionNonCoded
 	 */
 	@Override
 	public void validate(Object target, Errors errors) {
@@ -62,6 +63,11 @@ public class AllergyValidator implements Validator {
 		
 		Allergy allergy = (Allergy) target;
 		
+		if (allergy.getReactionNonCoded() != null) {
+			if (!allergy.getReactionNonCoded().matches("[a-zA-Z]+$")) {
+				errors.rejectValue("reactionNonCoded", "error.allergyapi.validateInputString");
+			}
+		}
 		if (allergy.getAllergen() == null) {
 			errors.rejectValue("allergen", "allergyapi.allergen.required");
 		} else {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -92,6 +92,7 @@ error.rank.notPositiveInteger=Rank can only be a positive integer
 error.email.invalid =Invalid Email address
 error.activationkey.invalid =Invalid user activation Key
 error.usernameOrEmail.notNullOrBlank =Username Or email cannot be null or blank
+error.allergyapi.validateInputString=Other Reaction must not contain a number or symbol
 
 general.at=at
 general.with=with

--- a/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
@@ -22,12 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.openmrs.Allergen;
-import org.openmrs.AllergenType;
-import org.openmrs.Allergies;
-import org.openmrs.Allergy;
-import org.openmrs.Concept;
-import org.openmrs.Patient;
+import org.openmrs.*;
 import org.openmrs.api.PatientService;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.test.jupiter.BaseContextMockTest;
@@ -177,5 +172,19 @@ public class AllergyValidatorTest extends BaseContextMockTest {
 		validator.validate(allergy, errors);
 		
 		assertFalse(errors.hasErrors());
+	}
+
+	@Test
+	public void valid_shouldRejectNumericReactionValue() throws Exception {
+		Allergy allergy = new Allergy();
+		AllergyReaction reaction = new AllergyReaction();
+		String nonCoded = "sometext";
+		reaction.setReactionNonCoded(nonCoded);
+		allergy.addReaction(reaction);
+		Errors errors = new BindException(allergy, "allergy");
+		
+		validator.validate(allergy, errors);
+		
+		assertTrue(errors.hasErrors());
 	}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
I found out that Allergy UI was transferred to  Core 
After my changes, now our user is not allowed to enter any numeric or symbolic value in the Other reaction section
 

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6021

## Steps to Implement the changes
* Build mvn clean install Openmrs-core
* Copy your openmrs. war file
* Give it a version like openmrs-2.4.0.war
* Then mvn openmrs-sdk:run to run the server

Done the needful After closing the one which had much spaces formatting
Thank you

