### PR TITLE
TRUNK-6038:Add Diagnosis Attribute to data model

### DIFF
--- a/api/src/main/java/org/openmrs/Diagnosis.java
+++ b/api/src/main/java/org/openmrs/Diagnosis.java
@@ -9,10 +9,15 @@
  */
 package org.openmrs;
 
+import org.hibernate.annotations.BatchSize;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
 import javax.persistence.AssociationOverride;
 import javax.persistence.AssociationOverrides;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -23,7 +28,12 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
  * Diagnosis class defines the identification of the nature of an illness or other problem by
@@ -34,7 +44,7 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "encounter_diagnosis")
-public class Diagnosis extends BaseFormRecordableOpenmrsData {
+public class Diagnosis extends BaseCustomizableData<DiagnosisAttribute> implements FormRecordable {
 	
 	private static final long serialVersionUID = 1L;
 	
@@ -67,7 +77,16 @@ public class Diagnosis extends BaseFormRecordableOpenmrsData {
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "patient_id")
 	private Patient patient;
-	
+
+	@Access(AccessType.PROPERTY)
+	@OneToMany(mappedBy = "diagnosis", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OrderBy("voided asc")
+	@BatchSize(size = 100)
+	private Set<DiagnosisAttribute> attributes = new LinkedHashSet<>();
+
+	@Column(name="form_namespace_and_path")
+	private String formNamespaceAndPath;
+
 	public Diagnosis() {
 	}
 	
@@ -77,15 +96,18 @@ public class Diagnosis extends BaseFormRecordableOpenmrsData {
 	 * @param certainty the certainty for the diagnosis
 	 * @param rank the rank of the diagnosis
 	 */
-	public Diagnosis(Encounter encounter, CodedOrFreeText diagnosis, ConditionVerificationStatus certainty, Integer rank,
-	    Patient patient) {
+	public Diagnosis(Integer diagnosisId, Encounter encounter, CodedOrFreeText diagnosis, Condition condition,
+			ConditionVerificationStatus certainty, Integer rank, Patient patient, String formNamespaceAndPath) {
+		this.diagnosisId = diagnosisId;
 		this.encounter = encounter;
 		this.diagnosis = diagnosis;
+		this.condition = condition;
 		this.certainty = certainty;
 		this.rank = rank;
 		this.patient = patient;
+		this.setFormNamespaceAndPath(getFormNamespaceAndPath());
 	}
-	
+
 	/**
 	 * Gets the diagnosis identifier.
 	 * 
@@ -230,5 +252,62 @@ public class Diagnosis extends BaseFormRecordableOpenmrsData {
 	 */
 	public void setPatient(Patient patient) {
 		this.patient = patient;
+	}
+
+	/**
+	 * Gets the form namespace and path
+	 *
+	 * @return Returns the formNamespaceAndPath.
+	 * @since 2.5.0
+	 */
+	public String getFormNamespaceAndPath() {
+		return formNamespaceAndPath;
+	}
+
+	/**
+	 * Sets the form namespace and path
+	 *
+	 * @param formNamespaceAndPath the form namespace and path to set
+	 * @since 2.5.0
+	 */
+	public void setFormNamespaceAndPath(String formNamespaceAndPath) {
+		this.formNamespaceAndPath = formNamespaceAndPath;
+	}
+
+	/**
+	 * Gets the namespace for the form field that was used to capture the details in the form
+	 *
+	 * @return the namespace
+	 * @since 2.5.0
+	 * <strong>Should</strong> return the namespace for a form field with or without a path otherwise null
+	 */
+	@Override
+	public String getFormFieldNamespace() {
+		return BaseFormRecordableOpenmrsData.getFormFieldNamespace(formNamespaceAndPath);
+	}
+
+	/**
+	 * Gets the path for the form field that was used to capture the details in the form
+	 *
+	 * @return the form field path
+	 * @since 2.5.0
+	 * <strong>Should</strong> return the path for a form field with or without a namespace otherwise null
+	 */
+	@Override
+	public String getFormFieldPath() {
+		return BaseFormRecordableOpenmrsData.getFormFieldPath(formNamespaceAndPath);
+	}
+
+	/**
+	 * Sets the namespace and path of the form field that was used to capture the details in the form.
+	 *
+	 * @param namespace the namespace of the form field
+	 * @param formFieldPath the path of the form field
+	 * @since 2.5.0
+	 * <strong>Should</strong> set the underlying formNamespaceAndPath in the correct pattern
+	 */
+	@Override
+	public void setFormField(String namespace, String formFieldPath) {
+		formNamespaceAndPath = BaseFormRecordableOpenmrsData.getFormNamespaceAndPath(namespace, formFieldPath);
 	}
 }

--- a/api/src/main/java/org/openmrs/Diagnosis.java
+++ b/api/src/main/java/org/openmrs/Diagnosis.java
@@ -87,6 +87,9 @@ public class Diagnosis extends BaseCustomizableData<DiagnosisAttribute> implemen
 	@Column(name="form_namespace_and_path")
 	private String formNamespaceAndPath;
 
+	/**
+	 * Default no-arg Constructor; instantiates a new Diagnosis without passing any initial values.
+	 */
 	public Diagnosis() {
 	}
 	
@@ -96,16 +99,30 @@ public class Diagnosis extends BaseCustomizableData<DiagnosisAttribute> implemen
 	 * @param certainty the certainty for the diagnosis
 	 * @param rank the rank of the diagnosis
 	 */
-	public Diagnosis(Integer diagnosisId, Encounter encounter, CodedOrFreeText diagnosis, Condition condition,
-			ConditionVerificationStatus certainty, Integer rank, Patient patient, String formNamespaceAndPath) {
-		this.diagnosisId = diagnosisId;
+	public Diagnosis(Encounter encounter, CodedOrFreeText diagnosis, ConditionVerificationStatus certainty, Integer rank,
+			Patient patient) {
 		this.encounter = encounter;
 		this.diagnosis = diagnosis;
-		this.condition = condition;
 		this.certainty = certainty;
 		this.rank = rank;
 		this.patient = patient;
-		this.setFormNamespaceAndPath(getFormNamespaceAndPath());
+	}
+
+	/**
+	 * @param encounter the encounter for this diagnosis
+	 * @param diagnosis the diagnosis to set
+	 * @param certainty the certainty for the diagnosis
+	 * @param rank the rank of the diagnosis
+	 * @param patient the patient diagnosed
+	 * @param formNamespaceAndPath the form namespace and path
+	 */
+	public Diagnosis(Encounter encounter, CodedOrFreeText diagnosis, ConditionVerificationStatus certainty, Integer rank, Patient patient, String formNamespaceAndPath) {
+		this.encounter = encounter;
+		this.diagnosis = diagnosis;
+		this.certainty = certainty;
+		this.rank = rank;
+		this.patient = patient;
+		this.formNamespaceAndPath = formNamespaceAndPath;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/DiagnosisAttribute.java
+++ b/api/src/main/java/org/openmrs/DiagnosisAttribute.java
@@ -1,0 +1,67 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import org.openmrs.attribute.Attribute;
+import org.openmrs.attribute.BaseAttribute;
+
+/**
+ * The DiagnosisAttribute, value for the {@link DiagnosisAttributeType} that is stored in a {@link Diagnosis}.
+ * @see Attribute
+ * @since 2.5.0
+ */
+public class DiagnosisAttribute extends BaseAttribute<DiagnosisAttributeType, Diagnosis> implements Attribute<DiagnosisAttributeType, Diagnosis> {
+	
+	private Integer diagnosisAttributeId;
+
+	/**
+	 * @return the diagnosisAttributeId
+	 */
+	public Integer getDiagnosisAttributeId() {
+		return diagnosisAttributeId;
+	}
+	
+	/**
+	 * @param diagnosisAttributeId the DiagnosisAttributeId to set
+	 */
+	public void setDiagnosisAttributeId(Integer diagnosisAttributeId) {
+		this.diagnosisAttributeId = diagnosisAttributeId;
+	}
+	
+	/**
+	 * @return the diagnosis
+	 */
+	public Diagnosis getDiagnosis() {
+		return getOwner();
+	}
+	
+	/**
+	 * @param diagnosis the diagnosis to set
+	 */
+	public void setDiagnosis(Diagnosis diagnosis) {
+		setOwner(diagnosis);
+	}
+	
+	/**
+	 * @see org.openmrs.OpenmrsObject#getId()
+	 */
+	@Override
+	public Integer getId() {
+		return getDiagnosisAttributeId();
+	}
+	
+	/**
+	 * @see org.openmrs.OpenmrsObject#setId(Integer)
+	 */
+	@Override
+	public void setId(Integer id) {
+		setDiagnosisAttributeId(id);
+	}
+}

--- a/api/src/main/java/org/openmrs/DiagnosisAttributeType.java
+++ b/api/src/main/java/org/openmrs/DiagnosisAttributeType.java
@@ -1,0 +1,54 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import org.openmrs.attribute.AttributeType;
+import org.openmrs.attribute.BaseAttributeType;
+
+/**
+ * The DiagnosisAttributeType extension to the {@link Diagnosis} class.
+ * @see AttributeType
+ * @since 2.5.0
+ */
+public class DiagnosisAttributeType extends BaseAttributeType<Diagnosis> implements AttributeType<Diagnosis> {
+
+	private Integer diagnosisAttributeTypeId;
+
+	/**
+	 * @see org.openmrs.OpenmrsObject#getId()
+	 */
+	@Override
+	public Integer getId() {
+		return getDiagnosisAttributeTypeId();
+	}
+
+	/**
+	 * @see org.openmrs.OpenmrsObject#setId(java.lang.Integer)
+	 */
+	@Override
+	public void setId(Integer id) {
+		setDiagnosisAttributeTypeId(id);
+	}
+
+	/**
+	 * @return the diagnosisAttributeTypeId
+	 */
+	public Integer getDiagnosisAttributeTypeId() {
+		return diagnosisAttributeTypeId;
+	}
+
+	/**
+	 * @param diagnosisAttributeTypeId the diagnosisAttributeTypeId to set
+	 */
+	public void setDiagnosisAttributeTypeId(Integer diagnosisAttributeTypeId) {
+		this.diagnosisAttributeTypeId = diagnosisAttributeTypeId;
+	}
+}
+

--- a/api/src/main/java/org/openmrs/api/DiagnosisService.java
+++ b/api/src/main/java/org/openmrs/api/DiagnosisService.java
@@ -17,7 +17,6 @@ import org.openmrs.Patient;
 import org.openmrs.Diagnosis;
 import org.openmrs.Visit;
 import org.openmrs.annotation.Authorized;
-import org.openmrs.api.db.DAOException;
 import org.openmrs.util.PrivilegeConstants;
 
 

--- a/api/src/main/java/org/openmrs/api/DiagnosisService.java
+++ b/api/src/main/java/org/openmrs/api/DiagnosisService.java
@@ -10,11 +10,14 @@
 
 package org.openmrs.api;
 
+import org.openmrs.DiagnosisAttribute;
+import org.openmrs.DiagnosisAttributeType;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.Diagnosis;
 import org.openmrs.Visit;
 import org.openmrs.annotation.Authorized;
+import org.openmrs.api.db.DAOException;
 import org.openmrs.util.PrivilegeConstants;
 
 
@@ -149,5 +152,95 @@ public interface DiagnosisService extends OpenmrsService {
 	 */
 	@Authorized(PrivilegeConstants.DELETE_DIAGNOSES)
 	void purgeDiagnosis(Diagnosis diagnosis) throws APIException;
-	
+
+	/**
+	 * Fetches all diagnosis attribute types including retired ones.
+	 *
+	 * @return all {@link DiagnosisAttributeType}s
+	 * @since 2.5.0
+	 * <strong>Should</strong> return all diagnosis attribute types including retired ones.
+	 */
+	@Authorized(PrivilegeConstants.GET_DIAGNOSES_ATTRIBUTE_TYPES)
+	List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes() throws APIException;
+
+	/**
+	 * Fetches a given diagnosis attribute type using the provided id
+	 *
+	 * @param id the id of the diagnosis attribute type to fetch
+	 * @return the {@link DiagnosisAttributeType} with the given id
+	 * @since 2.5.0
+	 * <strong>Should</strong> return the diagnosis attribute type with the given id
+	 * <strong>Should</strong> return null if no diagnosis attribute type exists with the given id
+	 */
+	@Authorized(PrivilegeConstants.GET_DIAGNOSES_ATTRIBUTE_TYPES)
+	DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id) throws APIException;
+
+	/**
+	 * Fetches a given diagnosis attribute type using the provided uuid
+	 * 
+	 * @param uuid the uuid of the diagnosis attribute type to fetch
+	 * @return the {@link DiagnosisAttributeType} with the given uuid
+	 * @since 2.5.0
+	 * <strong>Should</strong> return the diagnosis attribute type with the given uuid
+	 * <strong>Should</strong> return null if no diagnosis attribute type exists with the given uuid
+	 */
+	@Authorized(PrivilegeConstants.GET_DIAGNOSES_ATTRIBUTE_TYPES)
+	DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid) throws APIException;
+
+	/**
+	 * Creates or updates the given diagnosis attribute type in the database
+	 *
+	 * @param diagnosisAttributeType the diagnosis attribute type to save or update
+	 * @return the DiagnosisAttributeType created/saved
+	 * @since 2.5.0
+	 * <strong>Should</strong> create a new diagnosis attribute type
+	 * <strong>Should</strong> edit an existing diagnosis attribute type
+	 */
+	@Authorized(PrivilegeConstants.EDIT_DIAGNOSES)
+	DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException;
+
+	/**
+	 * Retires the given diagnosis attribute type in the database
+	 *
+	 * @param diagnosisAttributeType the diagnosis attribute type to retire
+	 * @param reason the reason why the diagnosis attribute type is being retired
+	 * @return the diagnosisAttributeType retired
+	 * @since 2.5.0
+	 * <strong>Should</strong> retire a diagnosis attribute type
+	 */
+	@Authorized(PrivilegeConstants.EDIT_DIAGNOSES)
+	DiagnosisAttributeType retireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType, String reason) throws APIException;
+
+	/**
+	 * Restores a diagnosis attribute type that was previously retired
+	 *
+	 * @param diagnosisAttributeType the diagnosis attribute type to unretire.
+	 * @return the DiagnosisAttributeType unretired
+	 * @since 2.5.0
+	 * <strong>Should</strong> unretire a retired diagnosis attribute type
+	 */
+	@Authorized(PrivilegeConstants.EDIT_DIAGNOSES)
+	DiagnosisAttributeType unretireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException;
+
+	/**
+	 * Completely removes a diagnosis attribute type from the database
+	 *
+	 * @param diagnosisAttributeType the diagnosis attribute type to purge
+	 * @since 2.5.0
+	 * <strong>Should</strong> completely remove a diagnosis attribute type
+	 */
+	@Authorized(PrivilegeConstants.DELETE_DIAGNOSES)
+	void purgeDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException;
+
+	/**
+	 * Fetches a given diagnosis attribute using the provided uuid
+	 *
+	 * @param uuid the uuid of the diagnosis attribute to fetch
+	 * @return the {@link DiagnosisAttribute} with the given uuid
+	 * @since 2.5.0
+	 * <strong>Should</strong> get the diagnosis attribute with the given uuid
+	 * <strong>Should</strong> return null if no diagnosis attribute has the given uuid
+	 */
+	@Authorized(PrivilegeConstants.GET_DIAGNOSES)
+	DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid) throws APIException;
 }

--- a/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/DiagnosisDAO.java
@@ -13,6 +13,8 @@ import java.util.Date;
 import java.util.List;
 
 import org.openmrs.Diagnosis;
+import org.openmrs.DiagnosisAttribute;
+import org.openmrs.DiagnosisAttributeType;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
@@ -77,4 +79,34 @@ public interface DiagnosisDAO {
 	 * @return all active diagnoses associated with the specified patient.
 	 */
 	List<Diagnosis> getActiveDiagnoses(Patient patient, Date fromDate);
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getAllDiagnosisAttributeTypes()
+	 */
+	List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes() throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeTypeById(Integer)
+	 */
+	DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id) throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeTypeByUuid(String)
+	 */
+	DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid) throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#saveDiagnosisAttributeType(DiagnosisAttributeType)
+	 */
+	DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#deleteDiagnosisAttributeType(DiagnosisAttributeType)
+	 */
+	void deleteDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws DAOException;
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeByUuid(String)
+	 */
+	DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid) throws DAOException;
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateDiagnosisDAO.java
@@ -14,13 +14,17 @@ import java.util.List;
 
 import org.hibernate.Query;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Restrictions;
 import org.openmrs.ConditionVerificationStatus;
 import org.openmrs.Diagnosis;
+import org.openmrs.DiagnosisAttribute;
+import org.openmrs.DiagnosisAttributeType;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.DiagnosisDAO;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.TypedQuery;
 
@@ -169,5 +173,63 @@ public class HibernateDiagnosisDAO implements DiagnosisDAO {
 	@Override
 	public void deleteDiagnosis(Diagnosis diagnosis) throws DAOException{
 		sessionFactory.getCurrentSession().delete(diagnosis);
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#getAllDiagnosisAttributeTypes()
+	 */
+	@SuppressWarnings("unchecked")
+	@Override
+	@Transactional(readOnly = true)
+	public List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes() throws DAOException {
+		return sessionFactory.getCurrentSession().createCriteria(DiagnosisAttributeType.class).list();
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosisAttributeTypeById(Integer) 
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id) throws DAOException {
+		return sessionFactory.getCurrentSession().get(DiagnosisAttributeType.class, id);
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosisAttributeTypeByUuid(String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid) throws DAOException {
+		return (DiagnosisAttributeType) sessionFactory.getCurrentSession().createCriteria(DiagnosisAttributeType.class).add(
+				Restrictions.eq("uuid", uuid)).uniqueResult();
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#saveDiagnosisAttributeType(DiagnosisAttributeType)
+	 */
+	@Override
+	@Transactional
+	public DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws DAOException {
+		sessionFactory.getCurrentSession().saveOrUpdate(diagnosisAttributeType);
+		return diagnosisAttributeType;
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#deleteDiagnosisAttributeType(DiagnosisAttributeType)
+	 */
+	@Override
+	@Transactional
+	public void deleteDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws DAOException {
+		sessionFactory.getCurrentSession().delete(diagnosisAttributeType);
+	}
+
+	/**
+	 * @see org.openmrs.api.db.DiagnosisDAO#getDiagnosisAttributeByUuid(String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid) throws DAOException {
+		return (DiagnosisAttribute) sessionFactory.getCurrentSession().createCriteria(DiagnosisAttribute.class).add(Restrictions.eq("uuid", uuid))
+				.uniqueResult();
 	}
 }

--- a/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/DiagnosisServiceImpl.java
@@ -11,11 +11,14 @@ package org.openmrs.api.impl;
 
 import org.openmrs.CodedOrFreeText;
 import org.openmrs.Diagnosis;
+import org.openmrs.DiagnosisAttribute;
+import org.openmrs.DiagnosisAttributeType;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.api.APIException;
 import org.openmrs.api.DiagnosisService;
+import org.openmrs.api.OpenmrsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DiagnosisDAO;
 import org.springframework.transaction.annotation.Transactional;
@@ -184,5 +187,73 @@ public class DiagnosisServiceImpl extends BaseOpenmrsService implements Diagnosi
 	 */
 	public void setDiagnosisDAO(DiagnosisDAO diagnosisDAO) {
 		this.diagnosisDAO = diagnosisDAO;
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getAllDiagnosisAttributeTypes()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes() throws APIException {
+		return diagnosisDAO.getAllDiagnosisAttributeTypes();
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeTypeById(Integer)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id) throws APIException {
+		return diagnosisDAO.getDiagnosisAttributeTypeById(id);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeTypeByUuid(String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid) throws APIException {
+		return diagnosisDAO.getDiagnosisAttributeTypeByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#saveDiagnosisAttributeType(DiagnosisAttributeType) 
+	 */
+	@Override
+	public DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException {
+		return diagnosisDAO.saveDiagnosisAttributeType(diagnosisAttributeType);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#retireDiagnosisAttributeType(DiagnosisAttributeType, String) 
+	 */
+	@Override
+	public DiagnosisAttributeType retireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType, String reason) throws APIException {
+		return Context.getDiagnosisService().saveDiagnosisAttributeType(diagnosisAttributeType);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#unretireDiagnosisAttributeType(DiagnosisAttributeType) 
+	 */
+	@Override
+	public DiagnosisAttributeType unretireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException {
+		return Context.getDiagnosisService().saveDiagnosisAttributeType(diagnosisAttributeType);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#purgeDiagnosisAttributeType(DiagnosisAttributeType) 
+	 */
+	@Override
+	public void purgeDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType) throws APIException {
+		diagnosisDAO.deleteDiagnosisAttributeType(diagnosisAttributeType);
+	}
+
+	/**
+	 * @see org.openmrs.api.DiagnosisService#getDiagnosisAttributeByUuid(String) 
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid) throws APIException {
+		return diagnosisDAO.getDiagnosisAttributeByUuid(uuid);
 	}
 }

--- a/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
+++ b/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
@@ -569,6 +569,9 @@ public class PrivilegeConstants {
 	@AddOnStartup(description = "Able to delete diagnoses")
 	public static final String DELETE_DIAGNOSES = "Delete Diagnoses";
 
+	@AddOnStartup(description = "Able to get diagnoses attribute types")
+	public static final String GET_DIAGNOSES_ATTRIBUTE_TYPES = "Get Diagnoses Attribute Types";
+
 	@AddOnStartup(description = "Able to get order set attribute types")
 	public static final String GET_ORDER_SET_ATTRIBUTE_TYPES = "Get Order Set Attribute Types";
 

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -41,6 +41,8 @@
 		<mapping resource="org/openmrs/api/db/hibernate/ConceptReferenceTerm.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/ConceptMapType.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/ConceptReferenceTermMap.hbm.xml" />
+		<mapping resource="org/openmrs/api/db/hibernate/DiagnosisAttribute.hbm.xml" />
+		<mapping resource="org/openmrs/api/db/hibernate/DiagnosisAttributeType.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/Drug.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/DrugIngredient.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/DrugReferenceMap.hbm.xml" />

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/DiagnosisAttribute.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/DiagnosisAttribute.hbm.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd" >
+
+<hibernate-mapping package="org.openmrs">
+
+	<class name="DiagnosisAttribute" table="diagnosis_attribute">
+
+		<id name="diagnosisAttributeId" type="int" column="diagnosis_attribute_id">
+			<generator class="native">
+				<param name="sequence">diagnosis_attribute_diagnosis_attribute_id_seq</param>
+			</generator>
+		</id>
+
+		<many-to-one name="diagnosis" class="Diagnosis" not-null="true" column="diagnosis_id" />
+
+		<many-to-one name="attributeType" class="DiagnosisAttributeType" not-null="true" column="attribute_type_id" />
+
+		<property name="valueReference" type="text" not-null="true" access="field" column="value_reference" length="65535" />
+
+		<many-to-one name="creator" class="User" not-null="true" column="creator" />
+
+		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" length="19" />
+
+		<many-to-one name="changedBy" class="User" column="changed_by" />
+
+		<property name="dateChanged" type="java.util.Date" column="date_changed" length="19" />
+
+		<property name="voided" type="java.lang.Boolean" column="voided" length="1" not-null="true" />
+
+		<many-to-one name="voidedBy" class="User" column="voided_by" />
+
+		<property name="dateVoided" type="java.util.Date" column="date_voided" length="19" />
+
+		<property name="voidReason" type="java.lang.String" column="void_reason" length="255" />
+
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" />
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/DiagnosisAttributeType.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/DiagnosisAttributeType.hbm.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs">
+
+	<class name="DiagnosisAttributeType" table="diagnosis_attribute_type">
+
+		<id name="diagnosisAttributeTypeId" type="int" column="diagnosis_attribute_type_id">
+			<generator class="native">
+				<param name="sequence">diagnosis_attribute_type_diagnosis_attribute_type_id_seq</param>
+			</generator>
+		</id>
+		
+		<property name="name" type="java.lang.String" column="name" not-null="true" length="255" />
+
+		<property name="description" type="java.lang.String" column="description" length="65535" />
+
+		<property name="datatypeClassname" type="java.lang.String" column="datatype" length="255" />
+
+		<property name="datatypeConfig" type="text" column="datatype_config" length="65535" />
+
+		<property name="preferredHandlerClassname" type="java.lang.String" column="preferred_handler" length="255" />
+
+		<property name="handlerConfig" type="text" column="handler_config" length="65535" />
+
+		<property name="minOccurs" type="int" column="min_occurs" length="11" not-null="true" />
+
+		<property name="maxOccurs" type="int" column="max_occurs" length="11" />
+
+		<many-to-one name="creator" class="User" not-null="true" column="creator" />
+
+		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" length="19" />
+
+		<many-to-one name="changedBy" class="User" column="changed_by" />
+
+		<property name="dateChanged" type="java.util.Date" column="date_changed" length="19" />
+
+		<property name="retired" type="java.lang.Boolean" column="retired" length="1" not-null="true" />
+
+		<many-to-one name="retiredBy" class="User" column="retired_by" />
+
+		<property name="dateRetired" type="java.util.Date" column="date_retired" length="19" />
+
+		<property name="retireReason" type="java.lang.String" column="retire_reason" length="255" />
+
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" />
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
@@ -285,4 +285,83 @@
 								 referencedTableName="concept" referencedColumnNames="concept_id" />
 	</changeSet>
 
+	<changeSet id="2021-24-10-1000-TRUNK-6038" author="miirochristopher">
+		<preConditions onFail="MARK_RAN" onFailMessage="Table diagnosis_attribute_type already exists">
+			<not>
+				<tableExists tableName="diagnosis_attribute_type" />
+			</not>
+		</preConditions>
+		<comment>Creating diagnosis_attribute_type table</comment>
+		<createTable tableName="diagnosis_attribute_type">
+			<column name="diagnosis_attribute_type_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+			<column name="name" type="varchar(255)">
+				<constraints nullable="false" unique="true"/>
+			</column>
+			<column name="description" type="varchar(1024)" />
+			<column name="datatype" type="varchar(255)" />
+			<column name="datatype_config" type="text" />
+			<column name="preferred_handler" type="varchar(255)" />
+			<column name="handler_config" type="text" />
+			<column name="min_occurs" type="int">
+				<constraints nullable="false" />
+			</column>
+			<column name="max_occurs" type="int"/>
+			<column name="creator" type="int">
+				<constraints nullable="false" />
+			</column>
+			<column name="date_created" type="datetime">
+				<constraints nullable="false" />
+			</column>
+			<column name="changed_by" type="int" />
+			<column name="date_changed" type="datetime" />
+			<column name="retired" type="boolean" defaultValueBoolean="false">
+				<constraints nullable="false" />
+			</column>
+			<column name="retired_by" type="int" />
+			<column name="date_retired" type="datetime" />
+			<column name="retire_reason" type="varchar(255)" />
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true" />
+			</column>
+		</createTable>
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_type_creator_fk" baseTableName="diagnosis_attribute_type" baseColumnNames="creator" referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_type_changed_by_fk" baseTableName="diagnosis_attribute_type" baseColumnNames="changed_by" referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_type_retired_by_fk" baseTableName="diagnosis_attribute_type" baseColumnNames="retired_by" referencedTableName="users" referencedColumnNames="user_id"/>
+	</changeSet>
+
+	<changeSet id="2021-24-10-1145-TRUNK-6038" author="miirochristopher">
+		<preConditions onFail="MARK_RAN" onFailMessage="Table diagnosis_attribute already exists">
+			<not>
+				<tableExists tableName="diagnosis_attribute" />
+			</not>
+		</preConditions>
+		<comment>Creating diagnosis_attribute table</comment>
+		<createTable tableName="diagnosis_attribute">
+			<column name="diagnosis_attribute_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+			<column name="diagnosis_id" type="int"><constraints nullable="false" /></column>
+			<column name="attribute_type_id" type="int"><constraints nullable="false" /></column>
+			<column name="value_reference" type="text"><constraints nullable="false" /></column>
+			<column name="uuid" type="char(38)"><constraints nullable="false" unique="true" /></column>
+			<column name="creator" type="int"><constraints nullable="false"/></column>
+			<column name="date_created" type="datetime"><constraints nullable="false"/></column>
+			<column name="changed_by" type="int"/>
+			<column name="date_changed" type="datetime" />
+			<column name="voided" type="boolean" defaultValueBoolean="false">
+				<constraints nullable="false"/>
+			</column>
+			<column name="voided_by" type="int" />
+			<column name="date_voided" type="datetime" />
+			<column name="void_reason" type="varchar(255)" />
+		</createTable>
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_diagnosis_fk" baseTableName="diagnosis_attribute" baseColumnNames="diagnosis_id" referencedTableName="encounter_diagnosis" referencedColumnNames="diagnosis_id" />
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_attribute_type_id_fk" baseTableName="diagnosis_attribute" baseColumnNames="attribute_type_id" referencedTableName="diagnosis_attribute_type" referencedColumnNames="diagnosis_attribute_type_id" />
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_creator_fk" baseTableName="diagnosis_attribute" baseColumnNames="creator" referencedTableName="users" referencedColumnNames="user_id" />
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_changed_by_fk" baseTableName="diagnosis_attribute" baseColumnNames="changed_by" referencedTableName="users" referencedColumnNames="user_id" />
+		<addForeignKeyConstraint constraintName="diagnosis_attribute_voided_by_fk" baseTableName="diagnosis_attribute" baseColumnNames="voided_by" referencedTableName="users" referencedColumnNames="user_id" />
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -521,8 +521,6 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		diagnosisService.save(diagnosis);
 		assertNotNull(diagnosis.getId(), "Successfully Saved Diagnosis");
 		Diagnosis savedDiagnosis = diagnosisService.getDiagnosisByUuid(UUID);
-		Set<DiagnosisAttributeType> savedDiagnosisAttributeTypes = savedDiagnosis.getAttributes().stream()
-				.map(DiagnosisAttribute::getAttributeType).collect(Collectors.toSet());
 		assertEquals(condition, savedDiagnosis.getCondition());
 		assertEquals(encounter, savedDiagnosis.getEncounter());
 		assertEquals(patient, savedDiagnosis.getPatient());
@@ -531,7 +529,6 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		assertEquals(false, savedDiagnosis.getVoided());
 		assertEquals(NAMESPACE + "^" + FORMFIELD_PATH, savedDiagnosis.getFormNamespaceAndPath());
 		assertThat(savedDiagnosis.getAttributes(), hasItem(diagnosisAttribute));
-		assertThat(savedDiagnosisAttributeTypes, contains(DIAGNOSIS_ATTRIBUTE_TYPE));
 	}
 
 	/**
@@ -541,12 +538,9 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	public void saveDiagnosis_shouldEditTheExistingDiagnosisRemovingTheAssociatedAttributesWhenRequired() {
 		final DiagnosisAttribute DIAGNOSIS_ATTRIBUTE = Context.getDiagnosisService()
 				.getDiagnosisAttributeByUuid("31f7c3cd-699b-4ed3-af10-563e024cae76");
-		final DiagnosisAttributeType DIAGNOSIS_ATTRIBUTE_TYPE = Context.getDiagnosisService()
-				.getDiagnosisAttributeTypeByUuid("949daf5b-a83e-4b65-b914-502a553243d3");
 		Diagnosis diagnosis = diagnosisService.getDiagnosis(1);
 		assertThat(diagnosis.getAttributes(), hasItem(DIAGNOSIS_ATTRIBUTE));
-		diagnosis.getAttributes()
-				 .removeIf(attribute -> attribute.getAttributeType().equals(DIAGNOSIS_ATTRIBUTE_TYPE));
+		diagnosis.getAttributes().remove(DIAGNOSIS_ATTRIBUTE);
 		diagnosisService.save(diagnosis);
 		Diagnosis editedDiagnosis = diagnosisService.getDiagnosis(1);
 		assertThat(editedDiagnosis.getAttributes(), not(hasItem(DIAGNOSIS_ATTRIBUTE)));

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.Condition;
 import org.openmrs.ConditionVerificationStatus;
 import org.openmrs.Diagnosis;
+import org.openmrs.DiagnosisAttribute;
 import org.openmrs.DiagnosisAttributeType;
 import org.openmrs.Encounter;
 import org.openmrs.Visit;
@@ -384,6 +385,7 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	@Test
 	public void purgeDiagnosisAttributeType_shouldCompletelyRemoveTheDiagnosisAttributeType() {
 		final int ORIGINAL_COUNT = diagnosisService.getAllDiagnosisAttributeTypes().size();
+		assertNotNull(diagnosisService.getDiagnosisAttributeTypeById(2));
 		diagnosisService.purgeDiagnosisAttributeType(diagnosisService.getDiagnosisAttributeTypeById(2));
 		assertNull(diagnosisService.getDiagnosisAttributeTypeById(2));
 		assertEquals(ORIGINAL_COUNT - 1, diagnosisService.getAllDiagnosisAttributeTypes().size());
@@ -470,8 +472,9 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void getDiagnosisAttributeByUuid_shouldGetTheDiagnosisAttributeWithTheProvidedUuid() {
-		assertEquals("2011-04-25", diagnosisService.getDiagnosisAttributeByUuid("31f7c3cd-699b-4ed3-af10-563e024cae76")
-				.getValueReference());
+		DiagnosisAttribute diagnosisAttribute = diagnosisService.getDiagnosisAttributeByUuid("31f7c3cd-699b-4ed3-af10-563e024cae76");
+		assertEquals("Testing Reference", diagnosisAttribute.getValueReference());
+		assertEquals(1, diagnosisAttribute.getId());
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -10,9 +10,15 @@
 package org.openmrs.api.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -24,7 +30,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
-import org.hamcrest.collection.IsEmptyCollection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Condition;
@@ -492,22 +497,21 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void saveDiagnosis_shouldSaveTheDiagnosisWithTheProvidedAttributes() {
-		final String NAMESPACE = "namespace", FORMFIELD_PATH = "formFieldPath";
+		final String NAMESPACE = "namespace";
+		final String FORMFIELD_PATH = "formFieldPath";
 		final DiagnosisAttributeType diagnosisAttributeType = Context.getDiagnosisService()
 				.getDiagnosisAttributeTypeByUuid("949daf5b-a83e-4b65-b914-502a553243d3");
 		DiagnosisAttribute diagnosisAttribute = new DiagnosisAttribute();
-		diagnosisAttribute.setId(2);
-		diagnosisAttribute.setUuid("3cc9ad27-a4e1-4a08-acd5-fb6b847d71d0");
 		diagnosisAttribute.setAttributeType(diagnosisAttributeType);
-		diagnosisAttribute.setCreator(diagnosisAttributeType.getCreator());
+		diagnosisAttribute.setCreator(Context.getUserService().getUser(1));
 		diagnosisAttribute.setVoided(false);
 		diagnosisAttribute.setValueReferenceInternal("Diagnosis Attribute Reference");
-		String uuid = "3c6422d8-7bdd-4e20-bd1b-a590f084db08";
+		final String UUID = "3c6422d8-7bdd-4e20-bd1b-a590f084db08";
 		Condition condition = conditionService.getConditionByUuid("2cc6880e-2c46-15e4-9038-a6c5e4d22fb7");
 		Encounter encounter = encounterService.getEncounterByUuid("y403fafb-e5e4-42d0-9d11-4f52e89d123r");
 		Patient patient = patientService.getPatient(2);
 		Diagnosis diagnosis = new Diagnosis();
-		diagnosis.setUuid(uuid);
+		diagnosis.setUuid(UUID);
 		diagnosis.setEncounter(encounter);
 		diagnosis.setCondition(condition);
 		diagnosis.setCertainty(ConditionVerificationStatus.CONFIRMED);
@@ -515,11 +519,10 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		diagnosis.setRank(1);
 		diagnosis.setVoided(false);
 		diagnosis.setFormField(NAMESPACE, FORMFIELD_PATH);
-		diagnosis.setAttribute(diagnosisAttribute);
+		diagnosis.addAttribute(diagnosisAttribute);
 		diagnosisService.save(diagnosis);
 		assertNotNull(diagnosis.getId(), "Successfully Saved Diagnosis");
-		Diagnosis savedDiagnosis = diagnosisService.getDiagnosisByUuid(uuid);
-		assertEquals(uuid, savedDiagnosis.getUuid());
+		Diagnosis savedDiagnosis = diagnosisService.getDiagnosisByUuid(UUID);
 		assertEquals(condition, savedDiagnosis.getCondition());
 		assertEquals(encounter, savedDiagnosis.getEncounter());
 		assertEquals(patient, savedDiagnosis.getPatient());
@@ -528,24 +531,42 @@ public class DiagnosisServiceImplTest extends BaseContextSensitiveTest {
 		assertEquals(false, savedDiagnosis.getVoided());
 		assertEquals(NAMESPACE + "^" + FORMFIELD_PATH, savedDiagnosis.getFormNamespaceAndPath());
 		assertThat(savedDiagnosis.getAttributes(), hasItem(diagnosisAttribute));
-		assertThat(diagnosisAttribute.getAttributeType().getName(), is("Differential Diagnosis"));
+		for (DiagnosisAttribute attribute : savedDiagnosis.getAttributes()) {
+			if (attribute.getAttributeType().equals(diagnosisAttributeType)) {
+				assertThat(attribute.getAttributeType().getName(), is("Differential Diagnosis"));
+			}
+		}
 	}
 
 	/**
-	 * @see org.openmrs.api.DiagnosisService#purgeDiagnosis(Diagnosis)
+	 * @see org.openmrs.api.DiagnosisService#save(Diagnosis)
 	 */
 	@Test
-	public void purgeDiagnosis_shouldPurgeTheDiagnosisAndTheAssociatedAttributes() {
-		final String uuid = "68802cce-6880-17e4-6880-a68804d22fb7";
+	public void saveDiagnosis_shouldEditTheExistingDiagnosisRemovingTheAssociatedAttributesWhenRequired() {
+		final int RANK = 5;
 		final DiagnosisAttribute diagnosisAttribute = Context.getDiagnosisService()
 				.getDiagnosisAttributeByUuid("31f7c3cd-699b-4ed3-af10-563e024cae76");
+		final DiagnosisAttributeType diagnosisAttributeType = Context.getDiagnosisService()
+				.getDiagnosisAttributeTypeByUuid("949daf5b-a83e-4b65-b914-502a553243d3");
 		Diagnosis diagnosis = diagnosisService.getDiagnosis(1);
-		assertEquals(uuid, diagnosis.getUuid());
-		assertThat(diagnosis.getAttributes(), hasItem(diagnosisAttribute));
-		assertThat(diagnosisAttribute.getAttributeType().getName(), is("Differential Diagnosis"));
-		diagnosisService.purgeDiagnosis(diagnosis);
-		assertNull(diagnosisService.getDiagnosisByUuid(uuid));
-		assertThat(diagnosisService.getDiagnoses(diagnosis.getPatient(),
-				diagnosis.getDateCreated()), is(IsEmptyCollection.empty()));
+		assertEquals(ConditionVerificationStatus.CONFIRMED, diagnosis.getCertainty());
+		assertEquals(1, diagnosis.getRank());
+		assertEquals(false, diagnosis.getVoided());
+		assertThat(diagnosis.getAttributes(),
+				both(hasItem(diagnosisAttribute)).and(contains(allOf(hasProperty("valueReference", is("Testing Reference"))))));
+		assertThat(diagnosis.getAttributes(),
+				both(hasItem(diagnosisAttribute)).and(contains(allOf(hasProperty("creator", is(Context.getUserService().getUser(1)))))));
+		assertThat(diagnosis.getAttributes(),
+				both(hasItem(diagnosisAttribute)).and(contains(allOf(hasProperty("voided", is(false))))));
+		diagnosis.setRank(RANK);
+		diagnosis.getAttributes()
+				 .removeIf(attribute -> attribute.getAttributeType().equals(diagnosisAttributeType));
+		diagnosisService.save(diagnosis);
+		Diagnosis editedDiagnosis = diagnosisService.getDiagnosis(1);
+		assertEquals(RANK, editedDiagnosis.getRank());
+		assertThat(editedDiagnosis.getAttributes(), not(hasItem(diagnosisAttribute)));
+		for (DiagnosisAttribute attribute : editedDiagnosis.getAttributes()) {
+			assertThat(attribute.getAttributeType().getName(), is(nullValue()));
+		}
 	}
 }

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 	
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 886;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 888;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 

--- a/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-DiagnosisAttributes.xml
+++ b/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-DiagnosisAttributes.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <diagnosis_attribute_type diagnosis_attribute_type_id="1" name="Differential Diagnosis" uuid="949daf5b-a83e-4b65-b914-502a553243d3" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="false" />
+  <diagnosis_attribute_type diagnosis_attribute_type_id="2" name="Pattern Recognition" uuid="96fc46dc-edd3-4f27-83b6-4a9f7b1f0a48" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="true" retired_by="1" date_retired="2005-01-01 02:00:00.0" retire_reason="Test Unretire" />
+  <diagnosis_attribute_type diagnosis_attribute_type_id="3" name="Diagnostic Criteria" uuid="9f41142f-a605-4247-9fa2-30ec8adcf7fb" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="false" />
+  <diagnosis_attribute diagnosis_attribute_id="1" diagnosis_id="1" attribute_type_id="1" value_reference="2011-04-25" uuid="31f7c3cd-699b-4ed3-af10-563e024cae76" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" />
+</dataset>

--- a/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-DiagnosisAttributes.xml
+++ b/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-DiagnosisAttributes.xml
@@ -14,5 +14,5 @@
   <diagnosis_attribute_type diagnosis_attribute_type_id="1" name="Differential Diagnosis" uuid="949daf5b-a83e-4b65-b914-502a553243d3" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="false" />
   <diagnosis_attribute_type diagnosis_attribute_type_id="2" name="Pattern Recognition" uuid="96fc46dc-edd3-4f27-83b6-4a9f7b1f0a48" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="true" retired_by="1" date_retired="2005-01-01 02:00:00.0" retire_reason="Test Unretire" />
   <diagnosis_attribute_type diagnosis_attribute_type_id="3" name="Diagnostic Criteria" uuid="9f41142f-a605-4247-9fa2-30ec8adcf7fb" creator="1" date_created="2005-01-01 00:00:00.0" min_occurs="0" retired="false" />
-  <diagnosis_attribute diagnosis_attribute_id="1" diagnosis_id="1" attribute_type_id="1" value_reference="2011-04-25" uuid="31f7c3cd-699b-4ed3-af10-563e024cae76" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" />
+  <diagnosis_attribute diagnosis_attribute_id="1" diagnosis_id="1" attribute_type_id="1" value_reference="Testing Reference" uuid="31f7c3cd-699b-4ed3-af10-563e024cae76" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" />
 </dataset>


### PR DESCRIPTION
## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6038

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. 
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.	

## Description of my changes.

Changed the Diagnosis class to extend `BaseCustomizableData<DiagnosisAttribute>` and implemented the `FormRecordable` interface.

Added the `String formNamespaceAndPath` field to the Diagnosis class and constructor and implemented the required methods from the `FormRecordable` interface. i.e `getFormFieldNamespace()`, `getFormFieldPath()` and `setFormField()`.

Created the `DiagnosisAttribute` and `DiagnosisAttributeType` classes with the required getter and setter methods. 

Added the required methods to the `DiagnosisService` interface.

`List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes()` 
`DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id)` 
`DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid)` 
`DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType)`
`DiagnosisAttributeType retireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType, String reason)`
`DiagnosisAttributeType unretireDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType)` 
`void purgeDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType)`
`DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid)`

Added the required methods to the `DiagnosisDAO` interface

`List<DiagnosisAttributeType> getAllDiagnosisAttributeTypes()`
`DiagnosisAttributeType getDiagnosisAttributeTypeById(Integer id)` 
`DiagnosisAttributeType getDiagnosisAttributeTypeByUuid(String uuid)` 
`DiagnosisAttributeType saveDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType)`
`void deleteDiagnosisAttributeType(DiagnosisAttributeType diagnosisAttributeType)`
`DiagnosisAttribute getDiagnosisAttributeByUuid(String uuid)`

Added the implementation of the methods in the `HibernateDiagnosisDAO` class

Added the implementation of the methods in the `DiagnosisServiceImpl` class

Added the `DiagnosisAttribute.hbm.xml` and `DiagnosisAttributeType.hbm.xml` class entries to the `hibernate.cfg.xml` file.

Added the `DiagnosisAttribute.hbm.xml` and `DiagnosisAttributeType.hbm.xml` files to `org/openmrs/api/db/hibernate/`

Added the `diagnosis_attribute_type` and `diagnosis_attribute` tables to `api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml`

Updated the `api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java` Incrementing the CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 887; 

Added the test dataset; `DiagnosisServiceImplTest-DiagnosisAttributes.xml` and tests for all the implementations in the `DiagnosisServiceImpl` class to the `DiagnosisServiceImplTest` class.