### PR TITLE
TRUNK-6044:Avoid using MySQL reserved word; rank as column name.

### DIFF
--- a/api/src/main/java/org/openmrs/Diagnosis.java
+++ b/api/src/main/java/org/openmrs/Diagnosis.java
@@ -71,7 +71,7 @@ public class Diagnosis extends BaseCustomizableData<DiagnosisAttribute> implemen
 	@Column(length = 50)
 	private ConditionVerificationStatus certainty;
 	
-	@Column(nullable = false)
+	@Column(name="dx_rank", nullable = false)
 	private Integer rank;
 	
 	@ManyToOne(optional = false)

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
@@ -376,4 +376,18 @@
 		                          onDelete="CASCADE"/>
 	</changeSet>
 
+	<changeSet id="2021-17-11-0222-TRUNK-6044" author="miirochristopher">
+		<preConditions onFail="MARK_RAN" onFailMessage="Table encounter_diagnosis or column rank does not exist.">
+			<tableExists tableName="encounter_diagnosis" />
+			<and>
+				<columnExists tableName="encounter_diagnosis" columnName="rank" />
+			</and>
+		</preConditions>
+		<comment>Renaming column rank to dx_rank because rank is a reserved word in MySQL 8.0.2 and later</comment>
+		<renameColumn columnDataType="int"
+		              newColumnName="dx_rank"
+		              oldColumnName="rank"
+		              tableName="encounter_diagnosis" />
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/DiagnosisServiceImplTest.java
@@ -10,7 +10,6 @@
 package org.openmrs.api.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -25,8 +24,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 	
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 889;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 890;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 

--- a/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml
+++ b/api/src/test/resources/org/openmrs/api/include/DiagnosisServiceImplTest-SetupDiagnosis.xml
@@ -25,14 +25,14 @@
 	<patient patient_id="2" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" 
 			 date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
 	<encounter_diagnosis diagnosis_id="1" encounter_id="6" patient_id="2" creator="1" date_created="2017-01-12 00:00:00"
-			   voided="false" rank="1" certainty="CONFIRMED" uuid="68802cce-6880-17e4-6880-a68804d22fb7"/>
+			   voided="false" dx_rank="1" certainty="CONFIRMED" uuid="68802cce-6880-17e4-6880-a68804d22fb7"/>
 	<encounter_diagnosis diagnosis_id="3" encounter_id="6" patient_id="2" creator="1" date_created="2016-01-12 00:00:00"
-						 voided="false" rank="2" certainty="CONFIRMED" uuid="688804ce-6880-8804-6880-a68804d88047"/>
+						 voided="false" dx_rank="2" certainty="CONFIRMED" uuid="688804ce-6880-8804-6880-a68804d88047"/>
 	<encounter_diagnosis diagnosis_id="2" encounter_id="5" patient_id="2" creator="1" date_created="2015-01-12 00:00:00"
-						 voided="false" rank="2" certainty="CONFIRMED" uuid="88042cce-8804-17e4-8804-a68804d22fb7"/>
+						 voided="false" dx_rank="2" certainty="CONFIRMED" uuid="88042cce-8804-17e4-8804-a68804d22fb7"/>
 	<encounter_diagnosis diagnosis_id="4" encounter_id="5" patient_id="2" creator="1" date_created="2015-01-12 00:00:00"
 						 voided="true" date_voided="2017-01-12 00:00:52" voided_by="1" void_reason="test reason" 
-						 rank="2" certainty="PROVISIONAL" uuid="77009cce-8804-17e4-8804-a68804d22fb7"/>
+						 dx_rank="2" certainty="PROVISIONAL" uuid="77009cce-8804-17e4-8804-a68804d22fb7"/>
 	<encounter encounter_id="16" encounter_type="1" patient_id="2" location_id="2" form_id="1"
 			   encounter_datetime="2008-08-19 00:00:00.0" creator="1" date_created="2008-08-19 12:34:40.0"
 			   voided="false" uuid="929809cc-8ef7-11e0-a7a1-91c116298e4b"/>

--- a/api/src/test/resources/org/openmrs/api/include/HibernateDiagnosisDAOTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/api/include/HibernateDiagnosisDAOTestDataset.xml
@@ -17,11 +17,11 @@
 	<encounter encounter_id="3" encounter_type="1" form_id="1" encounter_datetime="2012-01-01 02:00:00.0" patient_id="2" location_id="1" visit_id="7" creator="1" date_created="2012-01-01 02:00:00.0" voided="0" uuid="7fffd6b9-0970-4967-88c7-0b7b50f12bc6"/>
 	<encounter encounter_id="4" encounter_type="1" form_id="1" encounter_datetime="2012-01-01 02:00:00.0" patient_id="2" location_id="1" visit_id="8" creator="1" date_created="2012-01-01 02:00:00.0" voided="0" uuid="4fffd6b9-0970-4967-88c7-0b7b50112bc6"/>
 	<encounter_diagnosis diagnosis_id="1" creator="1" encounter_id="3" patient_id="2"
-						 date_created="2015-01-12 00:00:00.0" voided="false" uuid="4e663d66-6b78-11e0-93c3-18a905e044dc" rank="1" certainty="PROVISIONAL" />
+						 date_created="2015-01-12 00:00:00.0" voided="false" uuid="4e663d66-6b78-11e0-93c3-18a905e044dc" dx_rank="1" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="2" creator="1" encounter_id="3" patient_id="2"
-						 date_created="2013-01-11 03:00:00" voided="false" uuid="2cc6880e-2c46-15e4-9038-a6c5e4d22fb7" rank="1" certainty="PROVISIONAL" />
+						 date_created="2013-01-11 03:00:00" voided="false" uuid="2cc6880e-2c46-15e4-9038-a6c5e4d22fb7" dx_rank="1" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="3" creator="1" encounter_id="4 " patient_id="2"
-						 date_created="2015-03-12 00:00:00" voided="true" uuid="2fc6880e-2c46-15e4-d038-a6c5e4d22fb7" rank="4" certainty="PROVISIONAL" />
+						 date_created="2015-03-12 00:00:00" voided="true" uuid="2fc6880e-2c46-15e4-d038-a6c5e4d22fb7" dx_rank="4" certainty="PROVISIONAL" />
 	<encounter_diagnosis diagnosis_id="4" creator="1" encounter_id="4" patient_id="6"
-						 date_created="2015-01-12 00:40:00" voided="false" uuid="2dc6880e-2c46-15e4-9038-a6c5e4d21fb8" rank="2" certainty="CONFIRMED" />
+						 date_created="2015-01-12 00:40:00" voided="false" uuid="2dc6880e-2c46-15e4-9038-a6c5e4d21fb8" dx_rank="2" certainty="CONFIRMED" />
 </dataset>


### PR DESCRIPTION
## Description of what I changed
I added `name="dx_rank"` to the `rank` field in the Diagnosis class. 

I added the changeset to `liquibase-update-to-latest-2.5.x.xml` for renaming column rank to `dx_rank` because rank is a reserved word in MySQL 8.0.2 and later. 

I incremented the `CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X` to **890** in the `DatabaseUpdaterDatabaseIT` class. 

Modified dataset files `DiagnosisServiceImplTest-SetupDiagnosis.xml` and `HibernateDiagnosisDAOTestDataset.xml` to reflect the new column name so that the `DiagnosisServiceImplTests` and `HibernateDiagnosisDAOTests` would still pass. 

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6044

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. 
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.	