### PR TITLE
TRUNK-6030: Validating input String in the Allergen field

### DIFF
--- a/api/src/main/java/org/openmrs/validator/AllergyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AllergyValidator.java
@@ -94,6 +94,12 @@ public class AllergyValidator implements Validator {
 					errors.rejectValue("allergen", "allergyapi.message.duplicateAllergen", new Object[] { name }, null);
 				}
 			}
+
+			if(StringUtils.isNotBlank(allergen.getNonCodedAllergen())){
+				if (NumberUtils.isParsable(allergen.getNonCodedAllergen())) {
+					errors.rejectValue("allergen", "error.allergyapi.allergen.nonCodedAllergen.cannotBeNumeric");
+				}
+			}
 		}
 	}
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -93,6 +93,7 @@ error.email.invalid =Invalid Email address
 error.activationkey.invalid =Invalid user activation Key
 error.usernameOrEmail.notNullOrBlank =Username Or email cannot be null or blank
 error.allergyapi.allergy.ReactionNonCoded.cannotBeNumeric=Reaction Non-coded must not be only a number
+error.allergyapi.allergen.nonCodedAllergen.cannotBeNumeric=Non-coded Allergen must not be only a number
 
 general.at=at
 general.with=with

--- a/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
@@ -191,4 +191,13 @@ public class AllergyValidatorTest extends BaseContextMockTest {
 		validator.validate(allergy, errors);
 		assertTrue(errors.hasErrors());
 	}
+	
+	@Test
+	public void validate_shouldRejectNumericAllergenValue() {
+		Allergen allergen = new Allergen(AllergenType.DRUG, null , "45" );
+		allergy.setAllergen(allergen);
+		Errors errors = new BindException(allergy,"allergy");
+		validator.validate(allergy, errors);
+		assertTrue(errors.hasErrors());
+	}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
After my changes, now our user is not allowed to enter any numeric or symbolic value in the Other Allergen section
 

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6030

## Steps to Implement the changes
* Build mvn clean install Openmrs-core
* Copy your openmrs. war file
* Give it a version like openmrs-2.4.0.war
* Then mvn openmrs-sdk:run to run the server

Thank you
