### PR TITLE
Revert "maven(deps): bump cargo-maven3-plugin from 1.9.8 to 1.9.9"

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -233,7 +233,7 @@
 		  <plugin>
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven3-plugin</artifactId>
-              <version>1.9.9</version>
+              <version>1.9.8</version>
               <configuration>
                   <container>
                       <containerId>tomcat9x</containerId>


### PR DESCRIPTION
Reverts openmrs/openmrs-core#3945 
Because of this error on startup: java.lang.NoClassDefFoundError: javax/security/auth/message/config/RegistrationListener