### PR TITLE
TRUNK-4830 add missing junit dependency and fix unit tests

### DIFF
--- a/liquibase/pom.xml
+++ b/liquibase/pom.xml
@@ -51,6 +51,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junitVersion}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
 			<scope>test</scope>
 		</dependency>		
@@ -113,4 +118,5 @@
 			</plugin>
 		</plugins>
 	</build>
+		
 </project>

--- a/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,17 +49,17 @@ public class AbstractSnapshotTunerTest {
 	
 	@Test
 	public void shouldFindOpenMRSHeaderInFile() throws FileNotFoundException {
-		assertTrue(schemaOnlyTuner.isLicenseHeaderInFile(PATH_TO_TEST_RESOURCES + FILE_WITH_LICENSE_HEADER_MD));
+		assertTrue(schemaOnlyTuner.isLicenseHeaderInFile(PATH_TO_TEST_RESOURCES + File.separator + FILE_WITH_LICENSE_HEADER_MD));
 	}
 	
 	@Test
 	public void shouldDetectMissingOpenMRSHeaderInFile() throws FileNotFoundException {
-		assertFalse(schemaOnlyTuner.isLicenseHeaderInFile(PATH_TO_TEST_RESOURCES + FILE_WITHOUT_LICENSE_HEADER_MD));
+		assertFalse(schemaOnlyTuner.isLicenseHeaderInFile(PATH_TO_TEST_RESOURCES + File.separator + FILE_WITHOUT_LICENSE_HEADER_MD));
 	}
 	
 	@Test
 	public void shouldReadFile() throws FileNotFoundException {
-		assertTrue(schemaOnlyTuner.readFile(PATH_TO_TEST_RESOURCES + FILE_WITH_LICENSE_HEADER_MD)
+		assertTrue(schemaOnlyTuner.readFile(PATH_TO_TEST_RESOURCES + File.separator + FILE_WITH_LICENSE_HEADER_MD)
 		        .contains(HTTP_OPENMRS_ORG_LICENSE));
 	}
 	
@@ -84,7 +85,7 @@ public class AbstractSnapshotTunerTest {
 	@Test
 	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws IOException {
 		// given
-		Path sourcePath = Paths.get(PATH_TO_TEST_RESOURCES + FILE_WITHOUT_LICENSE_HEADER_MD);
+		Path sourcePath = Paths.get(PATH_TO_TEST_RESOURCES + File.separator + FILE_WITHOUT_LICENSE_HEADER_MD);
 		Path targetPath = tempDir.resolve("file-to-add-license-header-to.txt");
 		
 		Files.copy(sourcePath, targetPath, REPLACE_EXISTING);

--- a/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -66,7 +67,7 @@ public class CoreDataTunerTest {
 	@Test
 	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException {
 		// given
-		String sourcePath = PATH_TO_TEST_RESOURCES + LIQUIBASE_CORE_DATA_SNAPSHOT_XML;
+		String sourcePath = PATH_TO_TEST_RESOURCES + File.separator + LIQUIBASE_CORE_DATA_SNAPSHOT_XML;
 		String targetPath = tempDir.resolve("liquibase-core-data-UPDATED-SNAPSHOT.xml").toString();
 		
 		// when

--- a/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -60,7 +61,7 @@ public class SchemaOnlyTunerTest {
 	@Test
 	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException {
 		// given
-		String sourcePath = PATH_TO_TEST_RESOURCES + LIQUIBASE_SCHEMA_ONLY_SNAPSHOT_XML;
+		String sourcePath = PATH_TO_TEST_RESOURCES + File.separator + LIQUIBASE_SCHEMA_ONLY_SNAPSHOT_XML;
 		String targetPath = tempDir.resolve("liquibase-schema-only-UPDATED-SNAPSHOT.xml").toString();
 		
 		// when


### PR DESCRIPTION
## Description of what I changed
TRUNK-4830 add missing junit dependency and fix unit test in module liquibase

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
- [ x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [  ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ x ] All new and existing **tests passed**.
- [ x ] My pull request is **based on the latest changes** of the master branch.