### PR TITLE
TRUNK-6061 - Support setting mail configuration in runtime or system …

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -68,6 +68,7 @@ import org.openmrs.notification.mail.MailMessageSender;
 import org.openmrs.notification.mail.velocity.VelocityMessagePreparator;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.SchedulerUtil;
+import org.openmrs.util.ConfigUtil;
 import org.openmrs.util.DatabaseUpdateException;
 import org.openmrs.util.DatabaseUpdater;
 import org.openmrs.util.InputRequiredException;
@@ -594,30 +595,30 @@ public class Context {
 		if (mailSession == null) {
 			synchronized (Context.class) {
 				if (mailSession == null) {
-					AdministrationService adminService = getAdministrationService();
-
 					Properties props = new Properties();
-					props.setProperty("mail.transport.protocol", adminService.getGlobalProperty("mail.transport_protocol"));
-					props.setProperty("mail.smtp.host", adminService.getGlobalProperty("mail.smtp_host"));
-					props.setProperty("mail.smtp.port", adminService.getGlobalProperty("mail.smtp_port"));
-					props.setProperty("mail.from", adminService.getGlobalProperty("mail.from"));
-					props.setProperty("mail.debug", adminService.getGlobalProperty("mail.debug"));
-					props.setProperty("mail.smtp.auth", adminService.getGlobalProperty("mail.smtp_auth"));
-					props.setProperty(OpenmrsConstants.GP_MAIL_SMTP_STARTTLS_ENABLE, adminService.getGlobalProperty(OpenmrsConstants.GP_MAIL_SMTP_STARTTLS_ENABLE));
-
+					props.setProperty("mail.transport.protocol", ConfigUtil.getProperty("mail.transport_protocol"));
+					props.setProperty("mail.smtp.host", ConfigUtil.getProperty("mail.smtp_host"));
+					props.setProperty("mail.smtp.port", ConfigUtil.getProperty("mail.smtp_port"));
+					props.setProperty("mail.from", ConfigUtil.getProperty("mail.from"));
+					props.setProperty("mail.debug", ConfigUtil.getProperty("mail.debug"));
+					props.setProperty("mail.smtp.auth", ConfigUtil.getProperty("mail.smtp_auth"));
+					props.setProperty(
+						OpenmrsConstants.GP_MAIL_SMTP_STARTTLS_ENABLE,
+						ConfigUtil.getProperty(OpenmrsConstants.GP_MAIL_SMTP_STARTTLS_ENABLE)
+					);
 					Authenticator auth = new Authenticator() {
 
 						@Override
 						public PasswordAuthentication getPasswordAuthentication() {
-							return new PasswordAuthentication(getAdministrationService().getGlobalProperty("mail.user"),
-									getAdministrationService().getGlobalProperty("mail.password"));
+							return new PasswordAuthentication(
+								ConfigUtil.getProperty("mail.user"),
+								ConfigUtil.getProperty("mail.password")
+							);
 						}
 					};
-
 					mailSession = Session.getInstance(props, auth);
 				}
 			}
-
 		}
 		return mailSession;
 	}

--- a/api/src/main/java/org/openmrs/util/ConfigUtil.java
+++ b/api/src/main/java/org/openmrs/util/ConfigUtil.java
@@ -1,0 +1,113 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.GlobalPropertyListener;
+import org.openmrs.api.context.Context;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A utility class for working with configuration properties
+ */
+public class ConfigUtil implements GlobalPropertyListener {
+
+	/**
+	 * Cache of global property key/value pairs to enable lookups that do not require accessing the service each time
+	 */
+	private static final Map<String, String> globalPropertyCache = new HashMap<>();
+	
+	/**
+	 * Gets the value of the given OpenMRS global property
+	 */
+	public static String getGlobalProperty(String propertyName) {
+		if (globalPropertyCache.containsKey(propertyName)) {
+			return globalPropertyCache.get(propertyName);
+		}
+		String value = Context.getAdministrationService().getGlobalProperty(propertyName);
+		globalPropertyCache.put(propertyName, value);
+		return value;
+	}
+
+    /**
+	 * Returns the value of the given OpenMRS runtime property
+	 */
+	public static String getRuntimeProperty(String propertyName) {
+		return Context.getRuntimeProperties().getProperty(propertyName);
+	}
+
+	/**
+	 * Returns true if a runtime property with the given name has been defined, even if the value is empty
+	 */
+	public static boolean hasRuntimeProperty(String propertyName) {
+		return Context.getRuntimeProperties().containsKey(propertyName);
+	}
+
+	/**
+	 * Returns the value of the given OpenMRS system property
+	 */
+	public static String getSystemProperty(String propertyName) {
+		return System.getProperty(propertyName);
+	}
+
+	/**
+	 * Returns true if a system property with the given name has been defined, even if the value is empty
+	 */
+	public static boolean hasSystemProperty(String propertyName) {
+		return System.getProperties().containsKey(propertyName);
+	}
+
+	/**
+	 * Returns the value of the given configuration property.  This will check the OpenMRS global properties,
+	 * OpenMRS runtime properties, and any defined system properties.  In the event that a property is defined in 
+	 * multiple places, the order of precedence is system properties, then runtime properties, then global properties
+	 */
+	public static String getProperty(String propertyName) {
+		if (hasSystemProperty(propertyName)) {
+			return getSystemProperty(propertyName);
+		}
+		if (hasRuntimeProperty(propertyName)) {
+			return getRuntimeProperty(propertyName);
+		}
+		return getGlobalProperty(propertyName);
+	}
+
+	/**
+	 * Returns the value of the given configuration property.  This will check the OpenMRS global properties,
+	 * OpenMRS runtime properties, and any defined system properties.  In the event that a property is defined in 
+	 * multiple places, the order of precedence is system properties, then runtime properties, then global properties
+	 * If the value found is null, empty, or only whitespace, then the default value is returned
+	 */
+	public static String getProperty(String propertyName, String defaultValue) {
+		String value = getProperty(propertyName);
+		if (StringUtils.isBlank(value)) {
+			value = defaultValue;
+		}
+		return value;
+	}
+	
+	@Override
+	public void globalPropertyChanged(GlobalProperty newValue) {
+		globalPropertyCache.put(newValue.getProperty(), newValue.getPropertyValue());
+	}
+	
+	@Override
+	public void globalPropertyDeleted(String propertyName) {
+		globalPropertyCache.remove(propertyName);
+	}
+	
+	@Override
+	public boolean supportsPropertyName(String propertyName) {
+		return true;
+	}
+}

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -73,6 +73,7 @@
 
 	<bean id="localeUtility" class="org.openmrs.util.LocaleUtility"/>
 	<bean id="locationUtility" class="org.openmrs.util.LocationUtility"/>
+	<bean id="configUtilGlobalPropertyListener" class="org.openmrs.util.ConfigUtil"/>
 	<bean id="personNameGlobalPropertyListener" class="org.openmrs.api.impl.PersonNameGlobalPropertyListener"/>
 	<bean id="loggingConfigurationGlobalPropertyListener"
 		  class="org.openmrs.logging.LoggingConfigurationGlobalPropertyListener"/>
@@ -82,6 +83,7 @@
 			<list value-type="org.openmrs.api.GlobalPropertyListener">
 				<ref bean="localeUtility"/>
 				<ref bean="locationUtility"/>
+				<ref bean="configUtilGlobalPropertyListener"/>
 				<ref bean="personNameGlobalPropertyListener"/>
 				<ref bean="loggingConfigurationGlobalPropertyListener"/>
 				<ref bean="globalLocaleList"/>

--- a/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
@@ -1,0 +1,163 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavior-driven unit tests for {@link ConfigUtil} class
+ */
+public class ConfigUtilTest extends BaseContextSensitiveTest {
+
+	@Autowired 
+	@Qualifier("adminService")
+	AdministrationService administrationService;
+	
+	static {
+		System.setProperty("inRuntimeAndSystem", "system-property-value");
+		System.setProperty("inSystemNotRuntime", "system-property-value");
+		System.setProperty("emptyPropertyValue", "");
+	}
+
+	@Override
+	public Properties getRuntimeProperties() {
+		Properties p = super.getRuntimeProperties();
+		p.put("inRuntimeAndSystem", "runtime-property-value");
+		p.put("inRuntimeNotSystem", "runtime-property-value");
+		p.put("blankPropertyValue", " ");
+		return p;
+	}
+
+	@BeforeEach
+	public void setupProperties() {
+		administrationService.setGlobalProperty("mail.user", "user1@test.com");
+		administrationService.setGlobalProperty("mail.password", "Test123");
+		administrationService.setGlobalProperty("inRuntimeAndSystem", "global-property-value");
+		administrationService.setGlobalProperty("inRuntimeNotSystem", "global-property-value");
+		administrationService.setGlobalProperty("inSystemNotRuntime", "global-property-value");
+		administrationService.setGlobalProperty("inGlobalOnly", "global-property-value");
+	}
+
+	@Test
+	public void shouldGetGlobalProperty() {
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
+		assertThat(ConfigUtil.getGlobalProperty("mail.password"), is("Test123"));
+		assertThat(ConfigUtil.getGlobalProperty("mail.undefined"), nullValue());
+		assertThat(ConfigUtil.getGlobalProperty("inRuntimeAndSystem"), is("global-property-value"));
+		assertThat(ConfigUtil.getGlobalProperty("inRuntimeNotSystem"), is("global-property-value"));
+	}
+
+	@Test
+	public void shouldGetUpdatedGlobalPropertyIfChanged() {
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
+		administrationService.setGlobalProperty("mail.user", "user2@test.org");
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user2@test.org"));
+	}
+
+	@Test
+	public void shouldGetUpdatedGlobalPropertyIfDeleted() {
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
+		GlobalProperty p = administrationService.getGlobalPropertyObject("mail.user");
+		administrationService.purgeGlobalProperty(p);
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), nullValue());
+	}
+
+	@Test
+	public void shouldDetermineIfRuntimePropertyIsDefined() {
+		assertFalse(ConfigUtil.hasRuntimeProperty("undefined.property"));
+		int numMatches = 0;
+		for (String property : Context.getRuntimeProperties().stringPropertyNames()) {
+			assertTrue(ConfigUtil.hasRuntimeProperty(property));
+			numMatches++;
+		}
+		assertTrue(numMatches > 0);
+	}
+
+	@Test
+	public void shouldGetRuntimeProperty() {
+		assertThat(ConfigUtil.getRuntimeProperty("undefined.property"), nullValue());
+		int numMatches = 0;
+		Properties properties = Context.getRuntimeProperties();
+		for (String property : properties.stringPropertyNames()) {
+			assertThat(ConfigUtil.getRuntimeProperty(property), is(properties.getProperty(property)));
+			numMatches++;
+		}
+		assertTrue(numMatches > 0);
+		assertThat(ConfigUtil.getRuntimeProperty("inRuntimeAndSystem"), is("runtime-property-value"));
+		assertThat(ConfigUtil.getRuntimeProperty("inRuntimeNotSystem"), is("runtime-property-value"));
+	}
+
+	@Test
+	public void shouldDetermineIfSystemPropertyIsDefined() {
+		assertFalse(ConfigUtil.hasSystemProperty("undefined.property"));
+		int numMatches = 0;
+		for (String property : System.getProperties().stringPropertyNames()) {
+			assertTrue(ConfigUtil.hasSystemProperty(property));
+			numMatches++;
+		}
+		assertTrue(numMatches > 0);
+	}
+
+	@Test
+	public void shouldGetSystemProperty() {
+		assertThat(ConfigUtil.getSystemProperty("undefined.property"), nullValue());
+		int numMatches = 0;
+		Properties properties = System.getProperties();
+		for (String property : properties.stringPropertyNames()) {
+			assertThat(ConfigUtil.getSystemProperty(property), is(properties.getProperty(property)));
+			numMatches++;
+		}
+		assertTrue(numMatches > 0);
+		assertThat(ConfigUtil.getSystemProperty("inRuntimeAndSystem"), is("system-property-value"));
+	}
+
+	@Test
+	public void shouldReturnSystemPropertyOverRuntimeProperty() {
+		assertThat(ConfigUtil.getProperty("inRuntimeAndSystem"), is("system-property-value"));
+		assertThat(ConfigUtil.getProperty("inRuntimeNotSystem"), is("runtime-property-value"));
+	}
+
+	@Test
+	public void shouldReturnSystemPropertyOverGlobalProperty() {
+		assertThat(ConfigUtil.getProperty("inSystemNotRuntime"), is("system-property-value"));
+		assertThat(ConfigUtil.getProperty("inGlobalOnly"), is("global-property-value"));
+	}
+
+	@Test
+	public void shouldReturnRuntimePropertyOverGlobalProperty() {
+		assertThat(ConfigUtil.getProperty("inRuntimeNotSystem"), is("runtime-property-value"));
+		assertThat(ConfigUtil.getProperty("inGlobalOnly"), is("global-property-value"));
+	}
+
+	@Test
+	public void shouldReturnDefaultValueIfValueIsBlank() {
+		assertThat(ConfigUtil.getProperty("undefined.property"), nullValue());
+		assertThat(ConfigUtil.getProperty("undefined.property", "default"), is("default"));
+		assertThat(ConfigUtil.getProperty("emptyPropertyValue"), is(""));
+		assertThat(ConfigUtil.getProperty("emptyPropertyValue", "default"), is("default"));
+		assertThat(ConfigUtil.getProperty("blankPropertyValue"), is(" "));
+		assertThat(ConfigUtil.getProperty("blankPropertyValue", "default"), is("default"));
+	}
+}


### PR DESCRIPTION
This is a cherry-pick for the 2.4.x branch of the same features originally committed to 2.3.x here (073822f882d66301882ced310f34aae75707fa5e) but since the code is not 100% compatible, this has modifications to how this is setup in applicationContext-service.xml, and to making the Unit Test work with Junit 5 rather than Junit 4.  @dkayiwa I'm putting this in a new PR due to the above variations.  Would you mind having a look?
