### PR TITLE
TRUNK-6063 - Fix to get broken unit test working in 2.4.x+

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -277,6 +277,11 @@
 		   <groupId>org.apache.lucene</groupId>
 		   <artifactId>lucene-analyzers-phonetic</artifactId>
 	   </dependency>
+	   <dependency>
+		   <groupId>com.sun.mail</groupId>
+		   <artifactId>javax.mail</artifactId>
+		   <scope>test</scope>
+	   </dependency>
    </dependencies>
    <build>
      <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -591,6 +591,12 @@
 				<artifactId>jaxb-impl</artifactId>
 			    <version>3.0.0-M4</version>
 			</dependency>
+			<dependency>
+				<groupId>com.sun.mail</groupId>
+				<artifactId>javax.mail</artifactId>
+				<version>1.6.2</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
I don't know what changed between the 2.3.x branch and the 2.4.x branch to make this happen, but I get a test failure in 2.4.x without this commit.  It seems that the java mail implementation does not exist, just the api, and this leads to a failure in this unit test:

```
[ERROR] Failures: 
[ERROR]   UserServiceTest.setUserActivationKey_shouldCreateUserActivationKey:1518 Unexpected exception type thrown ==> expected: <org.openmrs.notification.MessageException> but was: <java.lang.NoClassDefFoundError>
```

@dkayiwa  / @ibacher - this should fix the 2.4.x build
