### PR TITLE
TRUNK-6069 - Password reset email should be localized to the user

### DIFF
--- a/api/src/main/java/org/openmrs/api/UserService.java
+++ b/api/src/main/java/org/openmrs/api/UserService.java
@@ -10,6 +10,7 @@
 package org.openmrs.api;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.openmrs.Person;
@@ -566,4 +567,10 @@ public interface UserService extends OpenmrsService {
 	 * @param newPassword the new password
 	 */
 	public void changePasswordUsingActivationKey(String activationKey, String newPassword);
+
+	/**
+	 * @param user the User whose Locale to retrieve
+	 * @return the default Locale of the given user, or the system locale if unspecified
+	 */
+	Locale getDefaultLocaleForUser(User user);
 }

--- a/api/src/main/java/org/openmrs/api/UserService.java
+++ b/api/src/main/java/org/openmrs/api/UserService.java
@@ -571,6 +571,7 @@ public interface UserService extends OpenmrsService {
 	/**
 	 * @param user the User whose Locale to retrieve
 	 * @return the default Locale of the given user, or the system locale if unspecified
+	 * @since 2.3.6
 	 */
 	Locale getDefaultLocaleForUser(User user);
 }

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -767,9 +767,10 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	}
 
 	/**
-	 * @return the default locale for the given User, or the default system locale if none configured
+	 * @see UserService#getDefaultLocaleForUser(User) 
 	 */
-	private Locale getDefaultLocaleForUser(User user) {
+	@Override
+	public Locale getDefaultLocaleForUser(User user) {
 		Locale locale = null;
 		if (user != null) {
 			try {

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -9,19 +9,10 @@
  */
 package org.openmrs.api.impl;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Person;
 import org.openmrs.Privilege;
-import org.openmrs.PrivilegeListener;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.annotation.Authorized;
@@ -39,6 +30,7 @@ import org.openmrs.api.db.UserDAO;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.notification.MessageException;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
+import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
@@ -46,9 +38,17 @@ import org.openmrs.util.RoleConstants;
 import org.openmrs.util.Security;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Default implementation of the user service. This class should not be used on its own. The current
@@ -747,16 +747,44 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 		
 		MessageSourceService messages = Context.getMessageSourceService();
 		AdministrationService adminService = Context.getAdministrationService();
+		Locale locale = getDefaultLocaleForUser(user);
+		
 		String link = adminService.getGlobalProperty(OpenmrsConstants.GP_HOST_URL)
 		        .replace("{activationKey}", token);
-		String msg = messages.getMessage("mail.passwordreset.content").replace("{name}", user.getUsername())
+		
+		String sender = adminService.getGlobalProperty("mail.from");
+		
+		String subject = messages.getMessage("mail.passwordreset.subject",null, locale);
+		
+		String msg = messages.getMessage("mail.passwordreset.content", null, locale)
+				.replace("{name}", user.getUsername())
 		        .replace("{link}", link)
 		        .replace("{time}", String.valueOf(getValidTime() / 60000));
-		Context.getMessageService().sendMessage(user.getEmail(),
-		    adminService.getGlobalProperty("mail.from"),
-		    messages.getMessage("mail.passwordreset.subject"), msg);
+		
+		Context.getMessageService().sendMessage(user.getEmail(), sender, subject, msg);
 		
 		return user;
+	}
+
+	/**
+	 * @return the default locale for the given User, or the default system locale if none configured
+	 */
+	private Locale getDefaultLocaleForUser(User user) {
+		Locale locale = null;
+		if (user != null) {
+			try {
+				String preferredLocale = user.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE);
+				if (StringUtils.isNotBlank(preferredLocale)) {
+					locale = LocaleUtility.fromSpecification(preferredLocale);
+				}
+			} catch (Exception e) {
+				log.warn("Unable to parse user locale into a Locale", e);
+			}
+		}
+		if (locale == null) {
+			locale = Context.getLocale();
+		}
+		return locale;
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -9,22 +9,6 @@
  */
 package org.openmrs.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.openmrs.test.TestUtil.containsId;
-
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,6 +36,23 @@ import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 import org.openmrs.util.Security;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.openmrs.test.TestUtil.containsId;
 
 /**
  * TODO add more tests to cover the methods in <code>UserService</code>
@@ -1394,14 +1395,9 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void setUserActivationKey_shouldCreateUserActivationKey() throws Exception {
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
+		User createdUser = createTestUser();
 		Context.getAdministrationService().setGlobalProperty(OpenmrsConstants.GP_HOST_URL,
 		    "http://localhost:8080/openmrs/admin/users/changePassword.form/{activationKey}");
-		User createdUser = userService.createUser(u, "Openmr5xy");
 		assertNull(dao.getLoginCredential(createdUser).getActivationKey());
 		expectedException.expect(MessageException.class);
 		assertEquals(createdUser, userService.setUserActivationKey(createdUser));
@@ -1410,12 +1406,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test 
 	public void getUserByActivationKey_shouldGetUserByActivationKey(){
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
-		User createdUser = userService.createUser(u, "Openmr5xy");
+		User createdUser = createTestUser();
 		String key="h4ph0fpNzQCIPSw8plJI";
 		int validTime = 10*60*1000; //equivalent to 10 minutes for token to be valid
 		Long tokenTime = System.currentTimeMillis() + validTime;
@@ -1427,12 +1418,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void getUserByActivationKey_shouldReturnNullIfTokenTimeExpired(){
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
-		User createdUser = userService.createUser(u, "Openmr5xy");
+		User createdUser = createTestUser();
 		String key="h4ph0fpNzQCIPSw8plJI";
 		int validTime = 10*60*1000; //equivalent to 10 minutes for token to be valid
 		Long tokenTime = System.currentTimeMillis() - validTime;
@@ -1444,12 +1430,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void changePasswordUsingActivationKey_shouldUpdatePasswordIfActivationKeyIsCorrect() {
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
-		User createdUser = userService.createUser(u, "Openmr5xy");
+		User createdUser = createTestUser();
 		String key = "h4ph0fpNzQCIPSw8plJI";
 		int validTime = 10 * 60 * 1000; //equivalent to 10 minutes for token to be valid
 		Long tokenTime = System.currentTimeMillis() + validTime;
@@ -1468,12 +1449,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void changePasswordUsingActivationKey_shouldNotUpdatePasswordIfActivationKeyIsIncorrect() {
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
-		User createdUser = userService.createUser(u, "Openmr5xy");
+		User createdUser = createTestUser();
 		String key = "wrongactivationkeyin";
 		Context.authenticate(createdUser.getUsername(), "Openmr5xy");
 		expectedException.expect(InvalidActivationKeyException.class);
@@ -1484,12 +1460,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void changePasswordUsingActivationKey_shouldNotUpdatePasswordIfActivationKeyExpired() {
-		User u = new User();
-		u.setPerson(new Person());
-		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
-		u.setUsername("bwolfe");
-		u.getPerson().setGender("M");
-		User createdUser = userService.createUser(u, "Openmr5xy");
+		User createdUser = createTestUser();
 		String key = "h4ph0fpNzQCIPSw8plJI";
 		int validTime = 10 * 60 * 1000; //equivalent to 10 minutes for token to be valid
 		Long tokenTime = System.currentTimeMillis() - validTime;
@@ -1504,5 +1475,32 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 		expectedException.expectMessage(messages.getMessage("activation.key.not.correct"));
 		
 		userService.changePasswordUsingActivationKey(key, "Pa55w0rd");
+	}
+	
+	@Test
+	public void getDefaultLocaleForUser_shouldReturnSystemLocaleIfNoUserLocaleConfigured() {
+		User createdUser = createTestUser();
+		assertEquals("", createdUser.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE));
+		assertEquals(Context.getLocale(), Context.getUserService().getDefaultLocaleForUser(createdUser));
+	}
+
+	@Test
+	public void getDefaultLocaleForUser_shouldReturnDefaultLocaleForUserIfConfigured() {
+		User createdUser = createTestUser();
+		createdUser.setUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE, "en");
+		Context.getUserService().saveUser(createdUser);
+		assertEquals(Locale.ENGLISH, Context.getUserService().getDefaultLocaleForUser(createdUser));
+		createdUser.setUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE, "fr");
+		Context.getUserService().saveUser(createdUser);
+		assertEquals(Locale.FRENCH, Context.getUserService().getDefaultLocaleForUser(createdUser));
+	}
+
+	private User createTestUser() {
+		User u = new User();
+		u.setPerson(new Person());
+		u.addName(new PersonName("Benjamin", "A", "Wolfe"));
+		u.setUsername("bwolfe");
+		u.getPerson().setGender("M");
+		return userService.createUser(u, "Openmr5xy");
 	}
 }


### PR DESCRIPTION
This PR is against the 2.3.x branch, and ensures that the user's default locale is used to generate the localized email subject and message that is sent out in response to a password reset request.