### PR TITLE
TRUNK-5208:ModuleUtil compareVersions should sort a SNAPSHOT version as "less than" 

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -85,7 +85,12 @@ public final class OpenmrsConstants {
 	 * @see #OPENMRS_VERSION
 	 */
 	private static String getBuildVersion() {
-		return getOpenmrsProperty("openmrs.version.long");
+		String longVersion = getOpenmrsProperty("openmrs.version.long");
+		if (longVersion != null && !longVersion.isEmpty() && !longVersion.contains("${")) {
+			return longVersion;
+		}
+		
+		return null;
 	}
 	
 	/**
@@ -96,7 +101,12 @@ public final class OpenmrsConstants {
 	 * @see #OPENMRS_VERSION
 	 */
 	private static String getBuildVersionShort() {
-		return getOpenmrsProperty("openmrs.version.short");
+		String shortVersion = getOpenmrsProperty("openmrs.version.short");
+		if (shortVersion != null && !shortVersion.isEmpty() && !shortVersion.contains("${")) {
+			return shortVersion;
+		}
+		
+		return null;
 	}
 	
 	private static String getVersion() {

--- a/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
@@ -545,26 +545,20 @@ public class ModuleUtilTest extends BaseContextSensitiveTest {
 	}
 	
 	private JarFile loadModuleJarFile(String moduleId, String version) throws IOException {
-		InputStream moduleStream = null;
-		File tempFile = null;
-		OutputStream tempFileStream = null;
-		JarFile jarFile = null;
-		try {
-			moduleStream = getClass().getClassLoader().getResourceAsStream(
-			    "org/openmrs/module/include/" + moduleId + "-" + version + ".omod");
+		File tempFile = File.createTempFile("moduleTest", "omod");
+		JarFile jarFile;
+
+		try (InputStream moduleStream = getClass().getClassLoader().getResourceAsStream(
+			"org/openmrs/module/include/" + moduleId + "-" + version + ".omod");
+		     OutputStream tempFileStream = new FileOutputStream(tempFile)) {
 			assertNotNull(moduleStream);
-			tempFile = File.createTempFile("moduleTest", "omod");
-			tempFileStream = new FileOutputStream(tempFile);
 			IOUtils.copy(moduleStream, tempFileStream);
 			jarFile = new JarFile(tempFile);
 		}
 		finally {
-			IOUtils.closeQuietly(moduleStream);
-			IOUtils.closeQuietly(tempFileStream);
-			if (tempFile != null) {
-				tempFile.delete();
-			}
+			tempFile.delete();
 		}
+
 		return jarFile;
 	}
 	


### PR DESCRIPTION

## Description of what I changed
I replaced the custom version ordering code with SemVer 

## Issue I worked on


https://issues.openmrs.org/browse/TRUNK-5208