### PR TITLE
TRUNK-6073 Error when writing unit tests in a module that depends on 2.5.x

### DIFF
--- a/api/src/main/java/org/openmrs/logging/OpenmrsConfigurationFactory.java
+++ b/api/src/main/java/org/openmrs/logging/OpenmrsConfigurationFactory.java
@@ -84,7 +84,7 @@ public class OpenmrsConfigurationFactory extends ConfigurationFactory {
 	
 	@Override
 	public Configuration getConfiguration(LoggerContext loggerContext, ConfigurationSource source) {
-		switch (FilenameUtils.getExtension(source.getFile().getName()).toLowerCase(Locale.ROOT)) {
+		switch (FilenameUtils.getExtension(source.getLocation()).toLowerCase(Locale.ROOT)) {
 			case "xml":
 				return new OpenmrsXmlConfiguration(loggerContext, source);
 			case "yaml":


### PR DESCRIPTION
PR here for review @ibacher .  This got me past my blocker running unit tests.  Defer to you on whether this looks good based on your original work.  This is written against the 2.5.x branch, so should be merged there and then up-ported to master.  Not sure if it also needs backporting down to 2.4.x, or what maintenance lines this new class applies to.
