### PR TITLE
TRUNK-6070 Back port to 2.5.x [Add Patient Program to Patient Identifier]

### DIFF
--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -343,7 +343,7 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 	/**
 	 * This method sets the patient program on a patient Identifier
 	 * @since 2.3.6
-	 * @param patientProgram The patientProgram to set.
+	 * @param patientProgram The patient program to set.
 	 */
 	public void setPatientProgram(PatientProgram patientProgram) {
 		this.patientProgram = patientProgram;

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -68,7 +68,6 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 
 	private PatientProgram patientProgram;
 	
-
 	@Field
 	private Boolean preferred = false;
 	

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -66,6 +66,9 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 	
 	private Location location;
 
+	private PatientProgram patientProgram;
+	
+
 	@Field
 	private Boolean preferred = false;
 	
@@ -327,5 +330,24 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 			
 			return retValue;
 		}
+	}
+
+
+	/**
+	 * Gets patient program associated to the identifier in context
+	 * @since 2.3.6
+	 * @return patientProgram the patient program associated to an identifier
+	 */
+	public PatientProgram getPatientProgram() {
+		return patientProgram;
+	}
+
+	/**
+	 * This method sets the patient program on a patient Identifier
+	 * @since 2.3.6
+	 * @param patientProgram The patientProgram to set.
+	 */
+	public void setPatientProgram(PatientProgram patientProgram) {
+		this.patientProgram = patientProgram;
 	}
 }

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -330,8 +330,7 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 			return retValue;
 		}
 	}
-
-
+	
 	/**
 	 * Gets patient program associated to the identifier in context
 	 * @since 2.3.6

--- a/api/src/main/java/org/openmrs/api/PatientService.java
+++ b/api/src/main/java/org/openmrs/api/PatientService.java
@@ -20,6 +20,7 @@ import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
+import org.openmrs.PatientProgram;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.db.PatientDAO;
 import org.openmrs.comparator.PatientIdentifierTypeDefaultComparator;
@@ -844,4 +845,13 @@ public interface PatientService extends OpenmrsService {
 	 * @throws PatientIdentifierTypeLockedException
 	 */
 	public void checkIfPatientIdentifierTypesAreLocked() throws PatientIdentifierTypeLockedException;
+
+	/**
+	 * Get all patientIdentifiers that are associated to the patient program
+	 * @param patientProgram the patientProgram to be used to fetch the associated identifiers
+	 * @return PatientIdentifiers matching the patient program
+	 * @since 2.3.6
+	 */
+	@Authorized({PrivilegeConstants.GET_PATIENT_IDENTIFIERS})
+	public List<PatientIdentifier> getPatientIdentifiersByPatientProgram(PatientProgram patientProgram);
 }

--- a/api/src/main/java/org/openmrs/api/db/PatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/PatientDAO.java
@@ -17,6 +17,7 @@ import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
+import org.openmrs.PatientProgram;
 import org.openmrs.api.PatientService;
 
 /**
@@ -296,5 +297,12 @@ public interface PatientDAO {
 	 * @return the saved allergy
 	 */
 	public Allergy saveAllergy(Allergy allergy);
+
+	/**
+	 * Gets a List of Patient Identifiers associated to a program 
+	 * @param patientProgram the program that matches the patientIdentifier
+	 * @return patient identifier or null
+	 */
+	public List getPatientIdentifierByProgram(PatientProgram patientProgram);
 	
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -995,7 +995,6 @@ public class HibernatePatientDAO implements PatientDAO {
     	return allergy;
     }
 
-
     /**
      * @see org.openmrs.api.db.PatientDAO#getPatientIdentifierByProgram(org.openmrs.PatientProgram)
      */

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -37,6 +37,7 @@ import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PatientIdentifierType.UniquenessBehavior;
+import org.openmrs.PatientProgram;
 import org.openmrs.Person;
 import org.openmrs.PersonAttribute;
 import org.openmrs.PersonName;
@@ -992,5 +993,16 @@ public class HibernatePatientDAO implements PatientDAO {
     public Allergy saveAllergy(Allergy allergy) {
     	sessionFactory.getCurrentSession().save(allergy);
     	return allergy;
+    }
+
+
+    /**
+     * @see org.openmrs.api.db.PatientDAO#getPatientIdentifierByProgram(org.openmrs.PatientProgram)
+     */
+    public List<PatientIdentifier> getPatientIdentifierByProgram(PatientProgram patientProgram) {
+
+        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(PatientIdentifier.class);
+        criteria.add(Restrictions.eq("patientProgram", patientProgram));
+        return criteria.list();
     }
 }

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -1631,4 +1631,11 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 			throw new PatientIdentifierTypeLockedException();
 		}
 	}
+
+	/**
+	 * @see PatientService#getPatientIdentifiersByPatientProgram(org.openmrs.PatientProgram)
+	 */
+	public List<PatientIdentifier> getPatientIdentifiersByPatientProgram(PatientProgram patientProgram) {
+		return dao.getPatientIdentifierByProgram(patientProgram);
+	}
 }

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/PatientIdentifier.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/PatientIdentifier.hbm.xml
@@ -30,6 +30,7 @@
 		<many-to-one name="identifierType" class="org.openmrs.PatientIdentifierType" column="identifier_type"/>
 
 		<many-to-one name="location" class="org.openmrs.Location" column="location_id" not-null="false"/>
+		<many-to-one name="patientProgram" class="org.openmrs.PatientProgram" column="patient_program_id" not-null="false"/>
 		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" />
 		<property name="dateVoided" type="java.util.Date" column="date_voided"/>
 		<property name="preferred" type="boolean" not-null="true" />

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.5.x.xml
@@ -390,4 +390,18 @@
 		              tableName="encounter_diagnosis" />
 	</changeSet>
 
+	<changeSet id="TRUNK-6070-2022-03-10" author="slubwama">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<columnExists tableName="patient_identifier" columnName="patient_program_id"/>
+			</not>
+		</preConditions>
+		<comment>Adding 'patient_program_id' column to 'patient_identifier' table</comment>
+		<addColumn tableName="patient_identifier">
+			<column name="patient_program_id" type="int">
+				<constraints nullable="true" />
+			</column>
+		</addColumn>
+		<addForeignKeyConstraint constraintName="patient_identifier_program_id_fk" baseTableName="patient_identifier" baseColumnNames="patient_program_id" referencedTableName="patient_program" referencedColumnNames="patient_program_id" />
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -3298,7 +3298,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// get the first patient
 		Collection<Patient> panPatients = patientService.getPatients("Pan", null, null, false);
 
-		assertFalse( panPatients.isEmpty(),"The patient List should not be null");
+		assertFalse(panPatients.isEmpty(), "The patient List should not be null");
 
 		Patient patient = panPatients.iterator().next();
 

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -92,7 +92,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	
 	// Datasets
 	protected static final String CREATE_PATIENT_XML = "org/openmrs/api/include/PatientServiceTest-createPatient.xml";
-	
+
+	protected static final String CREATE_PATIENT_WITH_PATIENT_IDENTIFIER_PROGRAM_XML = "org/openmrs/api/include/PatientServiceTest-createPatientWithPatientProgramIdentifier.xml";
+
 	protected static final String CREATE_PATIENT_VALID_IDENT_XML = "org/openmrs/api/include/PatientServiceTest-createPatientValidIdent.xml";
 	
 	protected static final String JOHN_PATIENTS_XML = "org/openmrs/api/include/PatientServiceTest-lotsOfJohns.xml";
@@ -3279,6 +3281,37 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertEquals(8, encounterService.getEncounter(57).getAllObs(true).size());
 		assertEquals(1, encounterService.getEncounter(57).getObsAtTopLevel(false).size());
 		assertEquals(2, encounterService.getEncounter(57).getObsAtTopLevel(true).size());
+	}
+
+
+	/**
+	 * Gets the patient , then sees if it can get the patient identifier by the patient program as well
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void getPatientIdentifiersByPatientProgram_shouldGetPatientsByIdentifierByProgram() throws Exception {
+
+		executeDataSet(CREATE_PATIENT_WITH_PATIENT_IDENTIFIER_PROGRAM_XML);
+		updateSearchIndex();
+
+		// get the first patient
+		Collection<Patient> panPatients = patientService.getPatients("Pan", null, null, false);
+
+		assertFalse( panPatients.isEmpty(),"The patient List should not be null");
+
+		Patient patient = panPatients.iterator().next();
+
+		assertEquals(patient.getActiveIdentifiers().size(), 2);
+
+		PatientProgram patientProgram = Context.getProgramWorkflowService().getPatientProgramByUuid("e2d4c2f9-d4d6-4dc7-8b4a-b4073dd6e097");
+
+		assertNotNull(patientProgram, "Test Patient Program not found");
+
+		List<PatientIdentifier> patientIdentifier = Context.getPatientService().getPatientIdentifiersByPatientProgram(patientProgram);
+
+		assertEquals(patientIdentifier.size(), 1);
+		assertEquals(patientIdentifier.iterator().next().getIdentifier(), "XXXCCCAAA11");
 	}
 
 }

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 	
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 890;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 891;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-createPatientWithPatientProgramIdentifier.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-createPatientWithPatientProgramIdentifier.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+
+	<concept  concept_id="99423"  retired="0"    datatype_id="2"  class_id="5"  is_set="0"  creator="1"  date_created="2012-08-04 10:37:44"  version="NULL" uuid="e44c8c4c-db50-4d1e-9d6e-092d3b31cfd6"/>
+	<concept  concept_id="160541"  retired="0"    datatype_id="4"  class_id="11"  is_set="0"  creator="1"  date_created="2012-06-14 16:17:34"  version="NULL" uuid="6887de6f-269f-4ff0-b776-c649802605fe"/>
+	<concept_name  concept_name_id="4671"  concept_id="99423"  name="Test Outcome"  locale="en"  locale_preferred="0"  creator="1"  date_created="2012-08-04 10:37:44"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="94671810-97d4-435f-bcdc-a16ea930296d"/>
+	<concept_name  concept_name_id="108877"  concept_id="160541"  name="Test Program"  locale="en"  locale_preferred="0"  creator="1"  date_created="2012-06-14 16:17:34"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="bcdb7243-5aa6-4d48-8645-5a5c2fd05749"/>
+
+	<program  program_id="15"  concept_id="160541"  outcomes_concept_id="99423"  creator="1"  date_created="2022-03-17 10:35:51"  changed_by="1"  date_changed="2022-03-17 10:35:51"  retired="0"  name="Test Program"  description="Program where patients are treated and monitored"  uuid="9dc21a72-0971-11e7-8037-507b9dc4c741"/>
+	<location location_id="1" name="Test Location" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3c8"/>
+	
+	<patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2005-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>
+
+	<person  person_id="1011"  gender="M"  birthdate="1988-08-11"  birthdate_estimated="0"  dead="0" creator="1"  date_created="2022-04-06 12:10:20"  voided="0"  uuid="6bae5d91-3e39-4451-bb76-20b7b73b9e51"  deathdate_estimated="0" />
+	<patient  patient_id="1011"  creator="1"  date_created="2022-04-06 12:10:20" voided="0"  allergy_status="Unknown"/>
+	<person_name  person_name_id="1015"  preferred="1"  person_id="1011"  given_name="Peter"   family_name="Pan"  creator="1"  date_created="2022-04-06 12:10:20"  voided="0"  uuid="a8084d64-4616-482c-a658-d8abfab41912"/>
+
+	<patient_program  patient_program_id="15"  patient_id="1011"  program_id="15"  date_enrolled="2022-04-06 00:00:00" location_id="1"  creator="1"  date_created="2022-04-06 12:13:49"  voided="0" uuid="e2d4c2f9-d4d6-4dc7-8b4a-b4073dd6e097"/>
+	
+	<patient_identifier  patient_identifier_id="52072"  patient_id="1011"  identifier="10V6D5"  identifier_type="1"  preferred="1"  location_id="1"  creator="1"  date_created="2022-04-06 12:10:20"  voided="0"   uuid="c5414864-bb83-44f6-b404-7ed61ae8af9e"/>
+	<patient_identifier  patient_identifier_id="52073"  patient_id="1011"  identifier="XXXCCCAAA11"  identifier_type="5"  preferred="0" creator="1"  date_created="2022-04-06 12:12:27"   voided="0" patient_program_id="15"  uuid="bf6819f4-f13d-4379-924b-f1f2cf88051b"/>
+	
+</dataset>


### PR DESCRIPTION
Back Port to 2.5.x
Ticket
https://issues.openmrs.org/browse/TRUNK-6070
Add a patient program to the patient identifier to create a connection between a patient identifier and a patient program
Create a method to allow getting a patient identifier by a patient program.

PR to Master https://github.com/openmrs/openmrs-core/pull/4044