### PR TITLE
TRUNK-6078: Custom changeset classes in modules fail on 2.5.x+

### DIFF
--- a/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
+++ b/api/src/main/java/org/openmrs/util/DatabaseUpdater.java
@@ -208,6 +208,8 @@ public class DatabaseUpdater {
 			cl = OpenmrsClassLoader.getInstance();
 		}
 		
+		Thread.currentThread().setContextClassLoader(cl);
+		
 		log.debug("Setting up liquibase object to run changelog: {}", changeLogFile);
 		Liquibase liquibase = getLiquibase(changeLogFile, cl);
 		


### PR DESCRIPTION
This PR is against the 2.5.x branch.  Once approved and merged it will need to be ported to the master branch.
