### PR TITLE
TRUNK-5876: Fix saveObs_shouldRetrieveCorrectMimetype tests on windows

### DIFF
--- a/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryStreamHandlerTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Obs;
@@ -73,7 +71,6 @@ public class BinaryStreamHandlerTest  extends BaseContextSensitiveTest {
     }
     	
 	@Test
-	@DisabledOnOs(WINDOWS)
 	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
 		
 		adminService.saveGlobalProperty(new GlobalProperty(
@@ -105,7 +102,7 @@ public class BinaryStreamHandlerTest  extends BaseContextSensitiveTest {
 			assertEquals(complexObs2.getComplexData().getMimeType(), mimetype);
 		} finally {
 			((InputStream) complexObs1.getComplexData().getData()).close();
-			((InputStream) complexObs1.getComplexData().getData()).close();
+			((InputStream) complexObs2.getComplexData().getData()).close();
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/MediaHandlerTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,7 +23,6 @@ import java.nio.file.Paths;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.io.TempDir;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Obs;
@@ -74,7 +72,6 @@ public class MediaHandlerTest extends BaseContextSensitiveTest {
     }
     
 	@Test
-	@DisabledOnOs(WINDOWS)
 	public void saveObs_shouldRetrieveCorrectMimetype() throws IOException {
 		
 		adminService.saveGlobalProperty(new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR,
@@ -106,7 +103,7 @@ public class MediaHandlerTest extends BaseContextSensitiveTest {
 			assertEquals("audio/mpeg", complexObs2.getComplexData().getMimeType());
 		} finally {
 			((InputStream) complexObs1.getComplexData().getData()).close();
-			((InputStream) complexObs1.getComplexData().getData()).close();
+			((InputStream) complexObs2.getComplexData().getData()).close();
 		}
 	}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

After an upgrade to junit 5 two tests were disabled due to an error affecting windows. The cause of the error is the same in both tests, a typo resulting in an attempt to close the same stream twice. This PR fixes that and enables the tests for windows again.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5876

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

