### PR TITLE
TRUNK-6081: Add not null constraint to encounter_diagnosis.dx_rank

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.6.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.6.x.xml
@@ -128,5 +128,10 @@
         	CREATE FUNCTION UUID() RETURNS UUID LANGUAGE SQL AS $$ SELECT uuid_generate_v1() $$;
         </sql>
     </changeSet>
+
+	<changeSet id="TRUNK-6081-2022-11-21" author="wikumChamith">
+		<comment>Adding not null constraint to encounter_diagnosis.dx_rank. TRUNK-6081</comment>
+		<addNotNullConstraint tableName="encounter_diagnosis" columnName="dx_rank" columnDataType="int"/>
+	</changeSet>
 	
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -30,7 +30,7 @@ public class DatabaseUpdaterDatabaseIT extends H2DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 	
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 892;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 893;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 


### PR DESCRIPTION


## Description of what I changed
Java field Diagnosis.rank is marked as not nullable via the JPA annotations but encounter_diagnosis.dx_rank column is missing the not null constraint in the database. So this adds not null constraint to encounter_diagnosis.dx_rank column.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6081

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

