### PR TITLE
TRUNK-4830: Backporting liquibase-schema-only-2.3.x.xml + liquibase-core-data-2.3.x.xml to Core 2.3.x.

### DIFF
--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-2.3.x.xml
@@ -1,0 +1,3623 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    
+	<changeSet author="wolf (generated)" id="1582473679024-17">
+		<insert tableName="person">
+			<column name="person_id" valueNumeric="1"/>
+			<column name="gender" value="M"/>
+			<column name="birthdate"/>
+			<column name="birthdate_estimated" valueBoolean="false"/>
+			<column name="dead" valueBoolean="false"/>
+			<column name="death_date"/>
+			<column name="cause_of_death"/>
+			<column name="creator"/>
+			<column name="date_created" valueDate="2005-01-01T00:00:00"/>
+			<column name="changed_by"/>
+			<column name="date_changed"/>
+			<column name="voided" valueBoolean="false"/>
+			<column name="voided_by"/>
+			<column name="date_voided"/>
+			<column name="void_reason"/>
+			<column name="uuid" value="5f87c042-6814-11e8-923f-e9a88dcb533f"/>
+			<column name="deathdate_estimated" valueBoolean="false"/>
+			<column name="birthtime"/>
+			<column name="cause_of_death_non_coded"/>
+		</insert>
+	</changeSet>
+	<changeSet author="wolf (generated)" id="1582473679024-27">
+		<insert tableName="users">
+			<column name="user_id" valueNumeric="1"/>
+			<column name="system_id" value="admin"/>
+			<column name="username" value=""/>
+			<column name="password" value="4a1750c8607dfa237de36c6305715c223415189"/>
+			<column name="salt" value="c788c6ad82a157b712392ca695dfcf2eed193d7f"/>
+			<column name="secret_question"/>
+			<column name="secret_answer"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2005-01-01T00:00:00"/>
+			<column name="changed_by" valueNumeric="1"/>
+			<column name="date_changed" valueDate="2018-06-04T18:31:16"/>
+			<column name="person_id" valueNumeric="1"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="82f18b44-6814-11e8-923f-e9a88dcb533f"/>
+			<column name="activation_key"/>
+			<column name="email"/>
+		</insert>
+		<insert tableName="users">
+			<column name="user_id" valueNumeric="2"/>
+			<column name="system_id" value="daemon"/>
+			<column name="username" value="daemon"/>
+			<column name="password"/>
+			<column name="salt"/>
+			<column name="secret_question"/>
+			<column name="secret_answer"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2010-04-26T13:25:00"/>
+			<column name="changed_by"/>
+			<column name="date_changed"/>
+			<column name="person_id" valueNumeric="1"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="A4F30A1B-5EB9-11DF-A648-37A07F9C90FB"/>
+			<column name="activation_key"/>
+			<column name="email"/>
+		</insert>
+	</changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-1">
+        <insert tableName="care_setting">
+            <column name="care_setting_id" valueNumeric="1"/>
+            <column name="name" value="Outpatient"/>
+            <column name="description" value="Out-patient care setting"/>
+            <column name="care_setting_type" value="OUTPATIENT"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2013-12-27T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="uuid" value="6f0c9a92-6f24-11e3-af88-005056821db0"/>
+        </insert>
+        <insert tableName="care_setting">
+            <column name="care_setting_id" valueNumeric="2"/>
+            <column name="name" value="Inpatient"/>
+            <column name="description" value="In-patient care setting"/>
+            <column name="care_setting_type" value="INPATIENT"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2013-12-27T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="uuid" value="c365e560-c3ec-11e3-9c1a-0800200c9a66"/>
+        </insert>
+    </changeSet>
+	<changeSet author="wolf (generated)" id="1582473679024-3">
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="1"/>
+			<column name="name" value="Test"/>
+			<column name="description" value="Acq. during patient encounter (vitals, labs, etc.)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4907b2-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="2"/>
+			<column name="name" value="Procedure"/>
+			<column name="description" value="Describes a clinical procedure"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d490bf4-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="3"/>
+			<column name="name" value="Drug"/>
+			<column name="description" value="Drug"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d490dfc-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="4"/>
+			<column name="name" value="Diagnosis"/>
+			<column name="description" value="Conclusion drawn through findings"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4918b0-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="5"/>
+			<column name="name" value="Finding"/>
+			<column name="description" value="Practitioner observation/finding"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d491a9a-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="6"/>
+			<column name="name" value="Anatomy"/>
+			<column name="description" value="Anatomic sites / descriptors"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d491c7a-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="7"/>
+			<column name="name" value="Question"/>
+			<column name="description" value="Question (eg, patient history, SF36 items)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d491e50-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="8"/>
+			<column name="name" value="LabSet"/>
+			<column name="description" value="Term to describe laboratory sets"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492026-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="9"/>
+			<column name="name" value="MedSet"/>
+			<column name="description" value="Term to describe medication sets"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4923b4-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="10"/>
+			<column name="name" value="ConvSet"/>
+			<column name="description" value="Term to describe convenience sets"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492594-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="11"/>
+			<column name="name" value="Misc"/>
+			<column name="description" value="Terms which don't fit other categories"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-03-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492774-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="12"/>
+			<column name="name" value="Symptom"/>
+			<column name="description" value="Patient-reported observation"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-10-04T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492954-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="13"/>
+			<column name="name" value="Symptom/Finding"/>
+			<column name="description" value="Observation that can be reported from patient or found on exam"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-10-04T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492b2a-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="14"/>
+			<column name="name" value="Specimen"/>
+			<column name="description" value="Body or fluid specimen"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-12-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492d0a-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="15"/>
+			<column name="name" value="Misc Order"/>
+			<column name="description" value="Orderable items which aren't tests or drugs"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2005-02-17T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d492ee0-c2cc-11de-8d13-0010c6dffd0f"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+		<insert tableName="concept_class">
+			<column name="concept_class_id" valueNumeric="16"/>
+			<column name="name" value="Frequency"/>
+			<column name="description" value="A class for order frequencies"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2014-03-06T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8e071bfe-520c-44c0-a89b-538e9129b42a"/>
+			<column name="date_changed"/>
+			<column name="changed_by"/>
+		</insert>
+	</changeSet>
+	<changeSet author="wolf (generated)" id="1582473679024-4">
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="1"/>
+			<column name="name" value="Numeric"/>
+			<column name="hl7_abbreviation" value="NM"/>
+			<column name="description" value="Numeric value, including integer or float (e.g., creatinine, weight)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a4488-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="2"/>
+			<column name="name" value="Coded"/>
+			<column name="hl7_abbreviation" value="CWE"/>
+			<column name="description" value="Value determined by term dictionary lookup (i.e., term identifier)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a48b6-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="3"/>
+			<column name="name" value="Text"/>
+			<column name="hl7_abbreviation" value="ST"/>
+			<column name="description" value="Free text"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a4ab4-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="4"/>
+			<column name="name" value="N/A"/>
+			<column name="hl7_abbreviation" value="ZZ"/>
+			<column name="description" value="Not associated with a datatype (e.g., term answers, sets)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-02-02T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a4c94-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="5"/>
+			<column name="name" value="Document"/>
+			<column name="hl7_abbreviation" value="RP"/>
+			<column name="description" value="Pointer to a binary or text-based document (e.g., clinical document, RTF, XML, EKG, image, etc.) stored in complex_obs table"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-04-15T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a4e74-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="6"/>
+			<column name="name" value="Date"/>
+			<column name="hl7_abbreviation" value="DT"/>
+			<column name="description" value="Absolute date"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-07-22T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a505e-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="7"/>
+			<column name="name" value="Time"/>
+			<column name="hl7_abbreviation" value="TM"/>
+			<column name="description" value="Absolute time of day"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-07-22T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a591e-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="8"/>
+			<column name="name" value="Datetime"/>
+			<column name="hl7_abbreviation" value="TS"/>
+			<column name="description" value="Absolute date and time"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-07-22T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a5af4-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="10"/>
+			<column name="name" value="Boolean"/>
+			<column name="hl7_abbreviation" value="BIT"/>
+			<column name="description" value="Boolean value (yes/no, true/false)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2004-08-26T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a5cca-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="11"/>
+			<column name="name" value="Rule"/>
+			<column name="hl7_abbreviation" value="ZZ"/>
+			<column name="description" value="Value derived from other data"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2006-09-11T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a5e96-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="12"/>
+			<column name="name" value="Structured Numeric"/>
+			<column name="hl7_abbreviation" value="SN"/>
+			<column name="description" value="Complex numeric values possible (ie, &lt;5, 1-10, etc.)"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2005-08-06T00:00:00"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a606c-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+		<insert tableName="concept_datatype">
+			<column name="concept_datatype_id" valueNumeric="13"/>
+			<column name="name" value="Complex"/>
+			<column name="hl7_abbreviation" value="ED"/>
+			<column name="description" value="Complex value.  Analogous to HL7 Embedded Datatype"/>
+			<column name="creator" valueNumeric="1"/>
+			<column name="date_created" valueDate="2008-05-28T12:25:34"/>
+			<column name="retired" valueBoolean="false"/>
+			<column name="retired_by"/>
+			<column name="date_retired"/>
+			<column name="retire_reason"/>
+			<column name="uuid" value="8d4a6242-c2cc-11de-8d13-0010c6dffd0f"/>
+		</insert>
+	</changeSet>	
+    <changeSet author="wolf (generated)" id="1582473679024-2">
+        <insert tableName="concept">
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="short_name" value=""/>
+            <column name="description" value=""/>
+            <column name="form_text"/>
+            <column name="datatype_id" valueNumeric="4"/>
+            <column name="class_id" valueNumeric="11"/>
+            <column name="is_set" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="version"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="cf82933b-3f3f-45e7-a5ab-5d31aaee3da3"/>
+        </insert>
+        <insert tableName="concept">
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="short_name" value=""/>
+            <column name="description" value=""/>
+            <column name="form_text"/>
+            <column name="datatype_id" valueNumeric="4"/>
+            <column name="class_id" valueNumeric="11"/>
+            <column name="is_set" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="version"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="488b58ff-64f5-4f8a-8979-fa79940b1594"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-5">
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="1"/>
+            <column name="name" value="SAME-AS"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="35543629-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="2"/>
+            <column name="name" value="NARROWER-THAN"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="43ac5109-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="3"/>
+            <column name="name" value="BROADER-THAN"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="4b9d9421-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="4"/>
+            <column name="name" value="Associated finding"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="55e02065-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="5"/>
+            <column name="name" value="Associated morphology"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="605f4a61-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="6"/>
+            <column name="name" value="Associated procedure"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="6eb1bfce-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="7"/>
+            <column name="name" value="Associated with"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="781bdc8f-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="8"/>
+            <column name="name" value="Causative agent"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="808f9e19-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="9"/>
+            <column name="name" value="Finding site"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="889c3013-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="10"/>
+            <column name="name" value="Has specimen"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="929600b9-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="11"/>
+            <column name="name" value="Laterality"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="999c6fc0-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="12"/>
+            <column name="name" value="Severity"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="false"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="a0e52281-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="13"/>
+            <column name="name" value="Access"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="f9e90b29-7d8c-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="14"/>
+            <column name="name" value="After"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="01b60e29-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="15"/>
+            <column name="name" value="Clinical course"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="5f7c3702-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="16"/>
+            <column name="name" value="Component"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="67debecc-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="17"/>
+            <column name="name" value="Direct device"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="718c00da-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="18"/>
+            <column name="name" value="Direct morphology"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="7b9509cb-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="19"/>
+            <column name="name" value="Direct substance"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="82bb495d-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="20"/>
+            <column name="name" value="Due to"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8b77f7d3-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="21"/>
+            <column name="name" value="Episodicity"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="94a81179-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="22"/>
+            <column name="name" value="Finding context"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="9d23c22e-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="23"/>
+            <column name="name" value="Finding informer"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="a4524368-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="24"/>
+            <column name="name" value="Finding method"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="af089254-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="25"/>
+            <column name="name" value="Has active ingredient"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="b65aa605-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="26"/>
+            <column name="name" value="Has definitional manifestation"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="c2b7b2fa-7d8d-11e1-909d-c80aa9edcf4"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="27"/>
+            <column name="name" value="Has dose form"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="cc3878e6-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="28"/>
+            <column name="name" value="Has focus"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="d67c5840-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="29"/>
+            <column name="name" value="Has intent"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="de2fb2c5-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="30"/>
+            <column name="name" value="Has interpretation"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="e758838b-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="31"/>
+            <column name="name" value="Indirect device"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="ee63c142-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="32"/>
+            <column name="name" value="Indirect morphology"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="f4f36681-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="33"/>
+            <column name="name" value="Interprets"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="fc7f5fed-7d8d-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="34"/>
+            <column name="name" value="Measurement method"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="06b11d79-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="35"/>
+            <column name="name" value="Method"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="0efb4753-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="36"/>
+            <column name="name" value="Occurrence"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="16e7b617-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="37"/>
+            <column name="name" value="Part of"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="1e82007b-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="38"/>
+            <column name="name" value="Pathological process"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="2969915e-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="39"/>
+            <column name="name" value="Priority"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="32d57796-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="40"/>
+            <column name="name" value="Procedure context"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="3f11904c-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="41"/>
+            <column name="name" value="Procedure device"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="468c4aa3-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="42"/>
+            <column name="name" value="Procedure morphology"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="5383e889-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="43"/>
+            <column name="name" value="Procedure site"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="5ad2655d-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="44"/>
+            <column name="name" value="Procedure site - Direct"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="66085196-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="45"/>
+            <column name="name" value="Procedure site - Indirect"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="7080e843-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="46"/>
+            <column name="name" value="Property"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="76bfb796-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="47"/>
+            <column name="name" value="Recipient category"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="7e7d00e4-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="48"/>
+            <column name="name" value="Revision status"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="851e14c1-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="49"/>
+            <column name="name" value="Route of administration"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8ee5b13d-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="50"/>
+            <column name="name" value="Scale type"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="986acf48-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="51"/>
+            <column name="name" value="Specimen procedure"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="a6937642-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="52"/>
+            <column name="name" value="Specimen source identity"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="b1d6941e-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="53"/>
+            <column name="name" value="Specimen source morphology"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="b7c793c1-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="54"/>
+            <column name="name" value="Specimen source topography"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="be9f9eb8-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="55"/>
+            <column name="name" value="Specimen substance"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="c8f2bacb-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="56"/>
+            <column name="name" value="Subject of information"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="d0664c4f-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="57"/>
+            <column name="name" value="Subject relationship context"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="dace9d13-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="58"/>
+            <column name="name" value="Surgical approach"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="e3cd666d-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="59"/>
+            <column name="name" value="Temporal context"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="ed96447d-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="60"/>
+            <column name="name" value="Time aspect"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="f415bcce-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="61"/>
+            <column name="name" value="Using access device"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="fa9538a9-7d8e-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="62"/>
+            <column name="name" value="Using device"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="06588655-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="63"/>
+            <column name="name" value="Using energy"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="0c2ae0bc-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="64"/>
+            <column name="name" value="Using substance"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="13d2c607-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="65"/>
+            <column name="name" value="IS A"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="1ce7a784-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="66"/>
+            <column name="name" value="MAY BE A"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="267812a3-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="67"/>
+            <column name="name" value="MOVED FROM"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="2de3168e-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="68"/>
+            <column name="name" value="MOVED TO"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="32f0fd99-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="69"/>
+            <column name="name" value="REPLACED BY"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="3b3b9a7d-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+        <insert tableName="concept_map_type">
+            <column name="concept_map_type_id" valueNumeric="70"/>
+            <column name="name" value="WAS A"/>
+            <column name="description"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="is_hidden" valueBoolean="true"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="41a034da-7d8f-11e1-909d-c80aa9edcf4e"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-6">
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="1"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Verdadeiro"/>
+            <column name="locale" value="pt"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="7561f550-ccee-43b6-bcf4-269992d6c284"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="2"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Sim"/>
+            <column name="locale" value="pt"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="89522273-55b5-4c4a-8e0b-cc7a66f3f3aa"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="3"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="True"/>
+            <column name="locale" value="en"/>
+            <column name="locale_preferred" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type" value="FULLY_SPECIFIED"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="111eb000-3113-4d74-9d9b-98ae5d566a98"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="4"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Yes"/>
+            <column name="locale" value="en"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="a31778d2-53ab-4c4b-a333-a0149d1c25c6"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="5"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Vero"/>
+            <column name="locale" value="it"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="a069d777-3999-4bb4-8217-d4fae1f337bc"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="6"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Sì"/>
+            <column name="locale" value="it"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="f16c811c-d970-4f02-be47-0c7afea9eddc"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="7"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Vrai"/>
+            <column name="locale" value="fr"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="bb75175c-5d1b-492a-8c38-98506e2e6b2d"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="8"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Oui"/>
+            <column name="locale" value="fr"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="c4c4b0f6-c80c-410b-9f48-72b683072184"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="9"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Verdadero"/>
+            <column name="locale" value="es"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="bf9ace2a-ff96-44fc-b529-172f5c3ac0b0"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="10"/>
+            <column name="concept_id" valueNumeric="1"/>
+            <column name="name" value="Sí"/>
+            <column name="locale" value="es"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="b58d53a3-c6dd-469a-8db1-0a80dfe4c542"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="11"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Falso"/>
+            <column name="locale" value="pt"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="2553457e-849d-4a5c-9824-2f0a9ba79461"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="12"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Não"/>
+            <column name="locale" value="pt"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="38a0828c-c54e-4bdb-8217-defb0fdfc4b6"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="13"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="False"/>
+            <column name="locale" value="en"/>
+            <column name="locale_preferred" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type" value="FULLY_SPECIFIED"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="ac6d888e-dc00-4402-9a2a-576438161f96"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="14"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="No"/>
+            <column name="locale" value="en"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="17a5cdd3-a0a9-406a-b39f-5cd7e8d634c4"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="15"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Falso"/>
+            <column name="locale" value="it"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="026e4e70-28c5-458d-8bbf-be7abaf09519"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="16"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="No"/>
+            <column name="locale" value="it"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="23851ffa-da5d-4086-8107-e0318b4d26eb"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="17"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Faux"/>
+            <column name="locale" value="fr"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="5709a1b5-b3de-472f-bf7a-eb57c5cb7144"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="18"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Non"/>
+            <column name="locale" value="fr"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="3990b17b-22a0-4b66-9d06-1645030e6b60"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="19"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="Falso"/>
+            <column name="locale" value="es"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="ae3cf994-72e1-471d-9af0-96dace0b6787"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="concept_name">
+            <column name="concept_name_id" valueNumeric="20"/>
+            <column name="concept_id" valueNumeric="2"/>
+            <column name="name" value="No"/>
+            <column name="locale" value="es"/>
+            <column name="locale_preferred" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:29:58"/>
+            <column name="concept_name_type"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="uuid" value="72071f05-d7e2-4687-ac2e-c7d9809d888a"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-7">
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="1"/>
+            <column name="word" value="A"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f45540-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="2"/>
+            <column name="word" value="AND"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f469ae-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="3"/>
+            <column name="word" value="AT"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f47070-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="4"/>
+            <column name="word" value="BUT"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f476c4-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="5"/>
+            <column name="word" value="BY"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f47d04-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="6"/>
+            <column name="word" value="FOR"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f4834e-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="7"/>
+            <column name="word" value="HAS"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f48a24-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="8"/>
+            <column name="word" value="OF"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f49064-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="9"/>
+            <column name="word" value="THE"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f496ae-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+        <insert tableName="concept_stop_word">
+            <column name="concept_stop_word_id" valueNumeric="10"/>
+            <column name="word" value="TO"/>
+            <column name="locale" value="en"/>
+            <column name="uuid" value="f5f49cda-e2a7-11df-87ae-18a905e044dc"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-8">
+        <insert tableName="encounter_role">
+            <column name="encounter_role_id" valueNumeric="1"/>
+            <column name="name" value="Unknown"/>
+            <column name="description" value="Unknown encounter role for legacy providers with no encounter role set"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2011-08-18T14:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="a0b03050-c99b-11e0-9572-0800200c9a66"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-9">
+        <insert tableName="field_type">
+            <column name="field_type_id" valueNumeric="1"/>
+            <column name="name" value="Concept"/>
+            <column name="description" value=""/>
+            <column name="is_set" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-02-22T00:00:00"/>
+            <column name="uuid" value="8d5e7d7c-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="field_type">
+            <column name="field_type_id" valueNumeric="2"/>
+            <column name="name" value="Database element"/>
+            <column name="description" value=""/>
+            <column name="is_set" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-02-22T00:00:00"/>
+            <column name="uuid" value="8d5e8196-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="field_type">
+            <column name="field_type_id" valueNumeric="3"/>
+            <column name="name" value="Set of Concepts"/>
+            <column name="description" value=""/>
+            <column name="is_set" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-02-22T00:00:00"/>
+            <column name="uuid" value="8d5e836c-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="field_type">
+            <column name="field_type_id" valueNumeric="4"/>
+            <column name="name" value="Miscellaneous Set"/>
+            <column name="description" value=""/>
+            <column name="is_set" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-02-22T00:00:00"/>
+            <column name="uuid" value="8d5e852e-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="field_type">
+            <column name="field_type_id" valueNumeric="5"/>
+            <column name="name" value="Section"/>
+            <column name="description" value=""/>
+            <column name="is_set" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-02-22T00:00:00"/>
+            <column name="uuid" value="8d5e86fa-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-11">
+        <insert tableName="hl7_source">
+            <column name="hl7_source_id" valueNumeric="1"/>
+            <column name="name" value="LOCAL"/>
+            <column name="description" value=""/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2006-09-01T00:00:00"/>
+            <column name="uuid" value="8d6b8bb6-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-14">
+        <insert tableName="location">
+            <column name="location_id" valueNumeric="1"/>
+            <column name="name" value="Unknown Location"/>
+            <column name="description"/>
+            <column name="address1" value=""/>
+            <column name="address2" value=""/>
+            <column name="city_village" value=""/>
+            <column name="state_province" value=""/>
+            <column name="postal_code" value=""/>
+            <column name="country" value=""/>
+            <column name="latitude"/>
+            <column name="longitude"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-09-22T00:00:00"/>
+            <column name="county_district"/>
+            <column name="address3"/>
+            <column name="address4"/>
+            <column name="address5"/>
+            <column name="address6"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="parent_location"/>
+            <column name="uuid" value="8d6c993e-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="address7"/>
+            <column name="address8"/>
+            <column name="address9"/>
+            <column name="address10"/>
+            <column name="address11"/>
+            <column name="address12"/>
+            <column name="address13"/>
+            <column name="address14"/>
+            <column name="address15"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-15">
+        <insert tableName="order_type">
+            <column name="order_type_id" valueNumeric="2"/>
+            <column name="name" value="Drug Order"/>
+            <column name="description" value="An order for a medication to be given to the patient"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2010-05-12T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="131168f4-15f5-102d-96e4-000c29c2a5d7"/>
+            <column name="java_class_name" value="org.openmrs.DrugOrder"/>
+            <column name="parent"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+        </insert>
+        <insert tableName="order_type">
+            <column name="order_type_id" valueNumeric="3"/>
+            <column name="name" value="Test Order"/>
+            <column name="description" value="Order type for test orders"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2014-03-09T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="52a447d3-a64a-11e3-9aeb-50e549534c5e"/>
+            <column name="java_class_name" value="org.openmrs.TestOrder"/>
+            <column name="parent"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-16">
+        <insert tableName="patient_identifier_type">
+            <column name="patient_identifier_type_id" valueNumeric="1"/>
+            <column name="name" value="OpenMRS Identification Number"/>
+            <column name="description" value="Unique number used in OpenMRS"/>
+            <column name="format" value=""/>
+            <column name="check_digit" valueBoolean="true"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-09-22T00:00:00"/>
+            <column name="required" valueBoolean="false"/>
+            <column name="format_description"/>
+            <column name="validator" value="org.openmrs.patient.impl.LuhnIdentifierValidator"/>
+            <column name="location_behavior"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d793bee-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="uniqueness_behavior"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="patient_identifier_type">
+            <column name="patient_identifier_type_id" valueNumeric="2"/>
+            <column name="name" value="Old Identification Number"/>
+            <column name="description" value="Number given out prior to the OpenMRS system (No check digit)"/>
+            <column name="format" value=""/>
+            <column name="check_digit" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-09-22T00:00:00"/>
+            <column name="required" valueBoolean="false"/>
+            <column name="format_description"/>
+            <column name="validator"/>
+            <column name="location_behavior"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d79403a-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="uniqueness_behavior"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-18">
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="1"/>
+            <column name="name" value="Race"/>
+            <column name="description" value="Group of persons related by common descent or heredity"/>
+            <column name="format" value="java.lang.String"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="6.0"/>
+            <column name="uuid" value="8d871386-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="2"/>
+            <column name="name" value="Birthplace"/>
+            <column name="description" value="Location of persons birth"/>
+            <column name="format" value="java.lang.String"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="0.0"/>
+            <column name="uuid" value="8d8718c2-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="3"/>
+            <column name="name" value="Citizenship"/>
+            <column name="description" value="Country of which this person is a member"/>
+            <column name="format" value="java.lang.String"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="1.0"/>
+            <column name="uuid" value="8d871afc-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="4"/>
+            <column name="name" value="Mother's Name"/>
+            <column name="description" value="First or last name of this person's mother"/>
+            <column name="format" value="java.lang.String"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="5.0"/>
+            <column name="uuid" value="8d871d18-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="5"/>
+            <column name="name" value="Civil Status"/>
+            <column name="description" value="Marriage status of this person"/>
+            <column name="format" value="org.openmrs.Concept"/>
+            <column name="foreign_key" valueNumeric="1054"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="2.0"/>
+            <column name="uuid" value="8d871f2a-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="6"/>
+            <column name="name" value="Health District"/>
+            <column name="description" value="District/region in which this patient' home health center resides"/>
+            <column name="format" value="java.lang.String"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="4.0"/>
+            <column name="uuid" value="8d872150-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="person_attribute_type">
+            <column name="person_attribute_type_id" valueNumeric="7"/>
+            <column name="name" value="Health Center"/>
+            <column name="description" value="Specific Location of this person's home health center."/>
+            <column name="format" value="org.openmrs.Location"/>
+            <column name="foreign_key" valueNumeric="0"/>
+            <column name="searchable" valueBoolean="false"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="edit_privilege"/>
+            <column name="sort_weight" valueNumeric="3.0"/>
+            <column name="uuid" value="8d87236c-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-19">
+        <insert tableName="person_name">
+            <column name="person_name_id" valueNumeric="1"/>
+            <column name="preferred" valueBoolean="true"/>
+            <column name="person_id" valueNumeric="1"/>
+            <column name="prefix"/>
+            <column name="given_name" value="Super"/>
+            <column name="middle_name" value=""/>
+            <column name="family_name_prefix"/>
+            <column name="family_name" value="User"/>
+            <column name="family_name2"/>
+            <column name="family_name_suffix"/>
+            <column name="degree"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2005-01-01T00:00:00"/>
+            <column name="voided" valueBoolean="false"/>
+            <column name="voided_by"/>
+            <column name="date_voided"/>
+            <column name="void_reason"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="uuid" value="5f897a68-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-20">
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Allergies"/>
+            <column name="description" value="Add allergies"/>
+            <column name="uuid" value="8d04fc61-45de-4d16-a2f7-39ccbda88739"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Cohorts"/>
+            <column name="description" value="Able to add a cohort to the system"/>
+            <column name="uuid" value="5f8a2896-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Concept Proposals"/>
+            <column name="description" value="Able to add concept proposals to the system"/>
+            <column name="uuid" value="5f8a2a1c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Encounters"/>
+            <column name="description" value="Able to add patient encounters"/>
+            <column name="uuid" value="5f8a2a8a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add HL7 Inbound Archive"/>
+            <column name="description" value="Able to add an HL7 archive item"/>
+            <column name="uuid" value="3192b2c9-3844-42f7-8e8e-f8964768ca26"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add HL7 Inbound Exception"/>
+            <column name="description" value="Able to add an HL7 error item"/>
+            <column name="uuid" value="e41c644c-1866-4572-a78d-6bfe36dd6a4b"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add HL7 Inbound Queue"/>
+            <column name="description" value="Able to add an HL7 Queue item"/>
+            <column name="uuid" value="b20ee658-9faa-4c6a-bc95-b5a9a4bfa4c2"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add HL7 Source"/>
+            <column name="description" value="Able to add an HL7 Source"/>
+            <column name="uuid" value="b8a2625f-3130-4b15-a3ba-907600d1bb03"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Observations"/>
+            <column name="description" value="Able to add patient observations"/>
+            <column name="uuid" value="5f8a2ada-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Orders"/>
+            <column name="description" value="Able to add orders"/>
+            <column name="uuid" value="5f8a2b7a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Patient Identifiers"/>
+            <column name="description" value="Able to add patient identifiers"/>
+            <column name="uuid" value="5f8a2bc0-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Patient Programs"/>
+            <column name="description" value="Able to add patients to programs"/>
+            <column name="uuid" value="5f8a2c10-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Patients"/>
+            <column name="description" value="Able to add patients"/>
+            <column name="uuid" value="5f8a2c56-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add People"/>
+            <column name="description" value="Able to add person objects"/>
+            <column name="uuid" value="5f8a2c92-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Problems"/>
+            <column name="description" value="Add problems"/>
+            <column name="uuid" value="2f6d256a-1f73-4776-ad5b-f94c80f7beea"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Relationships"/>
+            <column name="description" value="Able to add relationships"/>
+            <column name="uuid" value="5f8a2cce-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Report Objects"/>
+            <column name="description" value="Able to add report objects"/>
+            <column name="uuid" value="5f8a2cf6-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Reports"/>
+            <column name="description" value="Able to add reports"/>
+            <column name="uuid" value="5f8a2d32-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Users"/>
+            <column name="description" value="Able to add users to OpenMRS"/>
+            <column name="uuid" value="5f8a2d5a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Add Visits"/>
+            <column name="description" value="Able to add visits"/>
+            <column name="uuid" value="65d14b28-3989-11e6-899a-a4d646d86a8a"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Assign System Developer Role"/>
+            <column name="description" value="Able to assign System Developer role"/>
+            <column name="uuid" value="09cbaabc-ae63-44ed-9d4d-34ec6610e0a5"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Configure Visits"/>
+            <column name="description" value="Able to choose encounter visit handler and enable/disable encounter visits"/>
+            <column name="uuid" value="d7899df6-68d7-49f1-bc3a-a1a64be157d6"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Cohorts"/>
+            <column name="description" value="Able to add a cohort to the system"/>
+            <column name="uuid" value="5f8a2d8c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Concept Proposals"/>
+            <column name="description" value="Able to delete concept proposals from the system"/>
+            <column name="uuid" value="5f8a2dbe-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Conditions"/>
+            <column name="description" value="Able to delete conditions"/>
+            <column name="uuid" value="ef725ffa-2d14-41d8-b655-2d2430963b21"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Diagnoses"/>
+            <column name="description" value="Able to delete diagnoses"/>
+            <column name="uuid" value="a7882352-41b4-4da7-b422-84470ede7052"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Encounters"/>
+            <column name="description" value="Able to delete patient encounters"/>
+            <column name="uuid" value="5f8a2de6-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete HL7 Inbound Archive"/>
+            <column name="description" value="Able to delete/retire an HL7 archive item"/>
+            <column name="uuid" value="7cd1f479-4e6a-422d-8b4d-7a7e5758d253"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete HL7 Inbound Exception"/>
+            <column name="description" value="Able to delete an HL7 archive item"/>
+            <column name="uuid" value="25109fd5-edd1-4d11-84fe-a50b4001b50b"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete HL7 Inbound Queue"/>
+            <column name="description" value="Able to delete an HL7 Queue item"/>
+            <column name="uuid" value="0e39bf44-a08b-4d61-9d20-08d2cc0ab51e"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Notes"/>
+            <column name="description" value="Able to delete patient notes"/>
+            <column name="uuid" value="ff39bade-4ea2-463b-8a66-ff4b26f85f25"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Observations"/>
+            <column name="description" value="Able to delete patient observations"/>
+            <column name="uuid" value="5f8a2e18-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Orders"/>
+            <column name="description" value="Able to delete orders"/>
+            <column name="uuid" value="5f8a2e40-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Patient Identifiers"/>
+            <column name="description" value="Able to delete patient identifiers"/>
+            <column name="uuid" value="5f8a2e72-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Patient Programs"/>
+            <column name="description" value="Able to delete patients from programs"/>
+            <column name="uuid" value="5f8a2ea4-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Patients"/>
+            <column name="description" value="Able to delete patients"/>
+            <column name="uuid" value="5f8a2ecc-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete People"/>
+            <column name="description" value="Able to delete objects"/>
+            <column name="uuid" value="5f8a2efe-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Relationships"/>
+            <column name="description" value="Able to delete relationships"/>
+            <column name="uuid" value="5f8a2f26-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Report Objects"/>
+            <column name="description" value="Able to delete report objects"/>
+            <column name="uuid" value="5f8a2f58-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Reports"/>
+            <column name="description" value="Able to delete reports"/>
+            <column name="uuid" value="5f8a2f8a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Users"/>
+            <column name="description" value="Able to delete users in OpenMRS"/>
+            <column name="uuid" value="5f8a2fb2-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Delete Visits"/>
+            <column name="description" value="Able to delete visits"/>
+            <column name="uuid" value="02d02051-931b-4325-88d9-bf1a6cc85f5d"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Allergies"/>
+            <column name="description" value="Able to edit allergies"/>
+            <column name="uuid" value="507e9f66-ee25-4113-a55a-4b050022f55a"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Cohorts"/>
+            <column name="description" value="Able to add a cohort to the system"/>
+            <column name="uuid" value="5f8a2fe4-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Concept Proposals"/>
+            <column name="description" value="Able to edit concept proposals in the system"/>
+            <column name="uuid" value="5f8a300c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Conditions"/>
+            <column name="description" value="Able to edit conditions"/>
+            <column name="uuid" value="910ec2ec-a87b-4528-ad5c-02c500068bf0"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Diagnoses"/>
+            <column name="description" value="Able to edit diagnoses"/>
+            <column name="uuid" value="107f5169-77a2-48d3-9f69-9f2ca9b419ca"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Encounters"/>
+            <column name="description" value="Able to edit patient encounters"/>
+            <column name="uuid" value="5f8a303e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Notes"/>
+            <column name="description" value="Able to edit patient notes"/>
+            <column name="uuid" value="888fe070-549c-429a-9784-edbaf42e3229"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Observations"/>
+            <column name="description" value="Able to edit patient observations"/>
+            <column name="uuid" value="5f8a3066-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Orders"/>
+            <column name="description" value="Able to edit orders"/>
+            <column name="uuid" value="5f8a308e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Patient Identifiers"/>
+            <column name="description" value="Able to edit patient identifiers"/>
+            <column name="uuid" value="5f8a30c0-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Patient Programs"/>
+            <column name="description" value="Able to edit patients in programs"/>
+            <column name="uuid" value="5f8a30e8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Patients"/>
+            <column name="description" value="Able to edit patients"/>
+            <column name="uuid" value="5f8a311a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit People"/>
+            <column name="description" value="Able to edit person objects"/>
+            <column name="uuid" value="5f8a3142-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Problems"/>
+            <column name="description" value="Able to edit problems"/>
+            <column name="uuid" value="5131daf7-2c4d-4c2b-8f6e-bf7cf8290444"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Relationships"/>
+            <column name="description" value="Able to edit relationships"/>
+            <column name="uuid" value="5f8a3174-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Report Objects"/>
+            <column name="description" value="Able to edit report objects"/>
+            <column name="uuid" value="5f8a319c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Reports"/>
+            <column name="description" value="Able to edit reports"/>
+            <column name="uuid" value="5f8a31ce-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit User Passwords"/>
+            <column name="description" value="Able to change the passwords of users in OpenMRS"/>
+            <column name="uuid" value="5f8a31f6-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Users"/>
+            <column name="description" value="Able to edit users in OpenMRS"/>
+            <column name="uuid" value="5f8a3228-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Edit Visits"/>
+            <column name="description" value="Able to edit visits"/>
+            <column name="uuid" value="14f4da3c-d1e1-4571-b379-0b533496f5b7"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Form Entry"/>
+            <column name="description" value="Allows user to access Form Entry pages/functions"/>
+            <column name="uuid" value="5f8a3250-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Allergies"/>
+            <column name="description" value="Able to get allergies"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a220"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Care Settings"/>
+            <column name="description" value="Able to get Care Settings"/>
+            <column name="uuid" value="1ab26030-a207-4a22-be52-b40be3e401dd"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Attribute Types"/>
+            <column name="description" value="Able to get concept attribute types"/>
+            <column name="uuid" value="498317ea-e55f-4488-9e87-0db1349c3d11"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Classes"/>
+            <column name="description" value="Able to get concept classes"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a238"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Datatypes"/>
+            <column name="description" value="Able to get concept datatypes"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a237"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Map Types"/>
+            <column name="description" value="Able to get concept map types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a230"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Proposals"/>
+            <column name="description" value="Able to get concept proposals to the system"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a250"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Reference Terms"/>
+            <column name="description" value="Able to get concept reference terms"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a229"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concept Sources"/>
+            <column name="description" value="Able to get concept sources"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a231"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Concepts"/>
+            <column name="description" value="Able to get concept entries"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a251"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Conditions"/>
+            <column name="description" value="Able to get conditions"/>
+            <column name="uuid" value="6b470c18-04e8-42c5-bc34-0ac871a0beb6"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Database Changes"/>
+            <column name="description" value="Able to get database changes from the admin screen"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a222"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Diagnoses"/>
+            <column name="description" value="Able to get diagnoses"/>
+            <column name="uuid" value="77b0b402-c928-4811-b084-f0ef7087a49c"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Encounter Roles"/>
+            <column name="description" value="Able to get encounter roles"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a210"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Encounter Types"/>
+            <column name="description" value="Able to get encounter types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a247"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Encounters"/>
+            <column name="description" value="Able to get patient encounters"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a248"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Field Types"/>
+            <column name="description" value="Able to get field types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a234"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Forms"/>
+            <column name="description" value="Able to get forms"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a240"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Global Properties"/>
+            <column name="description" value="Able to get global properties on the administration screen"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a226"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get HL7 Inbound Archive"/>
+            <column name="description" value="Able to get an HL7 archive item"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a217"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get HL7 Inbound Exception"/>
+            <column name="description" value="Able to get an HL7 error item"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a216"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get HL7 Inbound Queue"/>
+            <column name="description" value="Able to get an HL7 Queue item"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a218"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get HL7 Source"/>
+            <column name="description" value="Able to get an HL7 Source"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a219"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Identifier Types"/>
+            <column name="description" value="Able to get patient identifier types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a239"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Location Attribute Types"/>
+            <column name="description" value="Able to get location attribute types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a212"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Locations"/>
+            <column name="description" value="Able to get locations"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a246"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Notes"/>
+            <column name="description" value="Able to get patient notes"/>
+            <column name="uuid" value="dcd11774-e77c-48d5-8f34-685741dec359"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Observations"/>
+            <column name="description" value="Able to get patient observations"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a245"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Order Frequencies"/>
+            <column name="description" value="Able to get Order Frequencies"/>
+            <column name="uuid" value="c78007dd-c641-400b-9aac-04420aecc5b6"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Order Sets"/>
+            <column name="description" value="Able to get order sets"/>
+            <column name="uuid" value="e52af909-2baf-4ab6-9862-8a6848448ec0"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Order Types"/>
+            <column name="description" value="Able to get order types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a233"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Orders"/>
+            <column name="description" value="Able to get orders"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a241"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Patient Cohorts"/>
+            <column name="description" value="Able to get patient cohorts"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a242"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Patient Identifiers"/>
+            <column name="description" value="Able to get patient identifiers"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a243"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Patient Programs"/>
+            <column name="description" value="Able to get which programs that patients are in"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a227"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Patients"/>
+            <column name="description" value="Able to get patients"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a244"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get People"/>
+            <column name="description" value="Able to get person objects"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a224"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Person Attribute Types"/>
+            <column name="description" value="Able to get person attribute types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a225"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Privileges"/>
+            <column name="description" value="Able to get user privileges"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a236"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Problems"/>
+            <column name="description" value="Able to get problems"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a221"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Programs"/>
+            <column name="description" value="Able to get patient programs"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a228"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Providers"/>
+            <column name="description" value="Able to get Providers"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a211"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Relationship Types"/>
+            <column name="description" value="Able to get relationship types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a232"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Relationships"/>
+            <column name="description" value="Able to get relationships"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a223"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Roles"/>
+            <column name="description" value="Able to get user roles"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a235"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Users"/>
+            <column name="description" value="Able to get users in OpenMRS"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a249"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Visit Attribute Types"/>
+            <column name="description" value="Able to get visit attribute types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a213"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Visit Types"/>
+            <column name="description" value="Able to get visit types"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a215"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Get Visits"/>
+            <column name="description" value="Able to get visits"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a214"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Address Templates"/>
+            <column name="description" value="Able to add/edit/delete address templates"/>
+            <column name="uuid" value="fb21b9ee-fd8a-47b6-8656-bd3a68a44925"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Alerts"/>
+            <column name="description" value="Able to add/edit/delete user alerts"/>
+            <column name="uuid" value="5f8a3282-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Attribute Types"/>
+            <column name="description" value="Able to add/edit/retire concept attribute types"/>
+            <column name="uuid" value="7550fbcb-cb61-4a9f-94d5-eb376afc727f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Classes"/>
+            <column name="description" value="Able to add/edit/retire concept classes"/>
+            <column name="uuid" value="5f8a32aa-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Datatypes"/>
+            <column name="description" value="Able to add/edit/retire concept datatypes"/>
+            <column name="uuid" value="5f8a32dc-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Map Types"/>
+            <column name="description" value="Able to add/edit/retire concept map types"/>
+            <column name="uuid" value="385096c5-6492-41f3-8304-c0144e8fb2e6"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Name tags"/>
+            <column name="description" value="Able to add/edit/delete concept name tags"/>
+            <column name="uuid" value="401cc09a-84c6-4d9e-bf93-4659837edbde"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Reference Terms"/>
+            <column name="description" value="Able to add/edit/retire reference terms"/>
+            <column name="uuid" value="80e45896-d4cd-48a1-b35e-30709bab36b6"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Sources"/>
+            <column name="description" value="Able to add/edit/delete concept sources"/>
+            <column name="uuid" value="5f8a3304-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concept Stop Words"/>
+            <column name="description" value="Able to view/add/remove the concept stop words"/>
+            <column name="uuid" value="47b5b16e-0ff5-4a4a-ae26-947af73c88ca"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Concepts"/>
+            <column name="description" value="Able to add/edit/delete concept entries"/>
+            <column name="uuid" value="5f8a3336-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Encounter Roles"/>
+            <column name="description" value="Able to add/edit/retire encounter roles"/>
+            <column name="uuid" value="0fbaddea-b053-4841-a1f1-2ca93fd71d9a"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Encounter Types"/>
+            <column name="description" value="Able to add/edit/delete encounter types"/>
+            <column name="uuid" value="5f8a3368-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Field Types"/>
+            <column name="description" value="Able to add/edit/retire field types"/>
+            <column name="uuid" value="5f8a3390-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage FormEntry XSN"/>
+            <column name="description" value="Allows user to upload and edit the xsns stored on the server"/>
+            <column name="uuid" value="5f8a33b8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Forms"/>
+            <column name="description" value="Able to add/edit/delete forms"/>
+            <column name="uuid" value="5f8a33ea-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Global Properties"/>
+            <column name="description" value="Able to add/edit global properties"/>
+            <column name="uuid" value="5f8a341c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage HL7 Messages"/>
+            <column name="description" value="Able to add/edit/delete HL7 messages"/>
+            <column name="uuid" value="e43b8830-7c95-42e6-8259-538fec951c66"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Identifier Types"/>
+            <column name="description" value="Able to add/edit/delete patient identifier types"/>
+            <column name="uuid" value="5f8a3444-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Implementation Id"/>
+            <column name="description" value="Able to view/add/edit the implementation id for the system"/>
+            <column name="uuid" value="20e102e1-74b4-4198-905e-9b598c8474f1"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Location Attribute Types"/>
+            <column name="description" value="Able to add/edit/retire location attribute types"/>
+            <column name="uuid" value="5c266720-20c2-4fa2-89d3-56886176d63a"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Location Tags"/>
+            <column name="description" value="Able to add/edit/delete location tags"/>
+            <column name="uuid" value="d6d83d7f-9241-42e6-9689-393920a4f733"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Locations"/>
+            <column name="description" value="Able to add/edit/delete locations"/>
+            <column name="uuid" value="5f8a3476-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Modules"/>
+            <column name="description" value="Able to add/remove modules to the system"/>
+            <column name="uuid" value="5f8a349e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Order Frequencies"/>
+            <column name="description" value="Able to add/edit/retire Order Frequencies"/>
+            <column name="uuid" value="e3a5205d-ab12-40ca-9160-9ba02198e389"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Order Sets"/>
+            <column name="description" value="Able to manage order sets"/>
+            <column name="uuid" value="059955e6-014f-4e50-b198-24e179784025"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Order Types"/>
+            <column name="description" value="Able to add/edit/retire order types"/>
+            <column name="uuid" value="5f8a34c6-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Person Attribute Types"/>
+            <column name="description" value="Able to add/edit/delete person attribute types"/>
+            <column name="uuid" value="5f8a34f8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Privileges"/>
+            <column name="description" value="Able to add/edit/delete privileges"/>
+            <column name="uuid" value="5f8a3520-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Programs"/>
+            <column name="description" value="Able to add/view/delete patient programs"/>
+            <column name="uuid" value="5f8a3552-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Providers"/>
+            <column name="description" value="Able to edit Provider"/>
+            <column name="uuid" value="b0b6fe18-9940-42b4-80fc-b05e6ee546f5"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Relationship Types"/>
+            <column name="description" value="Able to add/edit/retire relationship types"/>
+            <column name="uuid" value="5f8a357a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Relationships"/>
+            <column name="description" value="Able to add/edit/delete relationships"/>
+            <column name="uuid" value="5f8a35ac-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Roles"/>
+            <column name="description" value="Able to add/edit/delete user roles"/>
+            <column name="uuid" value="5f8a35d4-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Scheduler"/>
+            <column name="description" value="Able to add/edit/remove scheduled tasks"/>
+            <column name="uuid" value="5f8a3606-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Search Index"/>
+            <column name="description" value="Able to manage the search index"/>
+            <column name="uuid" value="657bfbbb-a008-43f3-85ac-3163d201b389"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Visit Attribute Types"/>
+            <column name="description" value="Able to add/edit/retire visit attribute types"/>
+            <column name="uuid" value="d0e19ed6-a299-4435-ab8f-2ea76e22fcc4"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Manage Visit Types"/>
+            <column name="description" value="Able to add/edit/delete visit types"/>
+            <column name="uuid" value="f9196849-164f-4522-80d8-488d36faeec2"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Demographics Section"/>
+            <column name="description" value="Able to view the 'Demographics' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a362e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Encounters Section"/>
+            <column name="description" value="Able to view the 'Encounters' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a3660-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Forms Section"/>
+            <column name="description" value="Allows user to view the Forms tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a3692-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Graphs Section"/>
+            <column name="description" value="Able to view the 'Graphs' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a36ce-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Overview Section"/>
+            <column name="description" value="Able to view the 'Overview' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a3700-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Patient Summary"/>
+            <column name="description" value="Able to view the 'Summary' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a3732-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Dashboard - View Regimen Section"/>
+            <column name="description" value="Able to view the 'Regimen' tab on the patient dashboard"/>
+            <column name="uuid" value="5f8a375a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Overview - View Allergies"/>
+            <column name="description" value="Able to view the Allergies portlet on the patient overview tab"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a261"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Overview - View Patient Actions"/>
+            <column name="description" value="Able to view the Patient Actions portlet on the patient overview tab"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a264"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Overview - View Problem List"/>
+            <column name="description" value="Able to view the Problem List portlet on the patient overview tab"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a260"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Overview - View Programs"/>
+            <column name="description" value="Able to view the Programs portlet on the patient overview tab"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a263"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Patient Overview - View Relationships"/>
+            <column name="description" value="Able to view the Relationships portlet on the patient overview tab"/>
+            <column name="uuid" value="d05118c6-2490-4d78-a41a-390e3596a262"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Purge Field Types"/>
+            <column name="description" value="Able to purge field types"/>
+            <column name="uuid" value="5f8a3796-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Remove Allergies"/>
+            <column name="description" value="Remove allergies"/>
+            <column name="uuid" value="dbdea8f5-9fca-4527-9ef6-5fa03eebf2bd"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Remove Problems"/>
+            <column name="description" value="Remove problems"/>
+            <column name="uuid" value="28ea7e84-e21a-4031-9f9f-2d3eda9d1200"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Task: Modify Allergies"/>
+            <column name="description" value="Able to add, edit, delete allergies"/>
+            <column name="uuid" value="eeb9108e-6905-4712-a13c-b9435db4abcb"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Update HL7 Inbound Archive"/>
+            <column name="description" value="Able to update an HL7 archive item"/>
+            <column name="uuid" value="5dd8306f-eeb4-430e-b5da-a6e02bcafb79"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Update HL7 Inbound Exception"/>
+            <column name="description" value="Able to update an HL7 archive item"/>
+            <column name="uuid" value="e2614f6d-a730-4292-9c10-baf6d912500f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Update HL7 Inbound Queue"/>
+            <column name="description" value="Able to update an HL7 Queue item"/>
+            <column name="uuid" value="f82b7723-110e-47d3-a35b-4552ea1bff9e"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Update HL7 Source"/>
+            <column name="description" value="Able to update an HL7 Source"/>
+            <column name="uuid" value="6e0abfb7-e95c-4efd-82a0-00a02b0e8335"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="Upload XSN"/>
+            <column name="description" value="Allows user to upload/overwrite the XSNs defined for forms"/>
+            <column name="uuid" value="5f8a37c8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Administration Functions"/>
+            <column name="description" value="Able to view the 'Administration' link in the navigation bar"/>
+            <column name="uuid" value="5f8a37fa-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Allergies"/>
+            <column name="description" value="Able to view allergies in OpenMRS"/>
+            <column name="uuid" value="5f8a382c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Concept Classes"/>
+            <column name="description" value="Able to view concept classes"/>
+            <column name="uuid" value="5f8a3958-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Concept Datatypes"/>
+            <column name="description" value="Able to view concept datatypes"/>
+            <column name="uuid" value="5f8a398a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Concept Proposals"/>
+            <column name="description" value="Able to view concept proposals to the system"/>
+            <column name="uuid" value="5f8a39bc-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Concept Sources"/>
+            <column name="description" value="Able to view concept sources"/>
+            <column name="uuid" value="5f8a39ee-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Concepts"/>
+            <column name="description" value="Able to view concept entries"/>
+            <column name="uuid" value="5f8a3a16-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Data Entry Statistics"/>
+            <column name="description" value="Able to view data entry statistics from the admin screen"/>
+            <column name="uuid" value="5f8a3a48-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Encounter Types"/>
+            <column name="description" value="Able to view encounter types"/>
+            <column name="uuid" value="5f8a3a7a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Encounters"/>
+            <column name="description" value="Able to view patient encounters"/>
+            <column name="uuid" value="5f8a3aa2-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Field Types"/>
+            <column name="description" value="Able to view field types"/>
+            <column name="uuid" value="5f8a3ad4-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Forms"/>
+            <column name="description" value="Able to view forms"/>
+            <column name="uuid" value="5f8a3afc-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Global Properties"/>
+            <column name="description" value="Able to view global properties on the administration screen"/>
+            <column name="uuid" value="5f8a3b2e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Identifier Types"/>
+            <column name="description" value="Able to view patient identifier types"/>
+            <column name="uuid" value="5f8a3b60-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Locations"/>
+            <column name="description" value="Able to view locations"/>
+            <column name="uuid" value="5f8a3b88-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Navigation Menu"/>
+            <column name="description" value="Ability to see the navigation menu"/>
+            <column name="uuid" value="5f8a3bba-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Observations"/>
+            <column name="description" value="Able to view patient observations"/>
+            <column name="uuid" value="5f8a3be2-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Order Types"/>
+            <column name="description" value="Able to view order types"/>
+            <column name="uuid" value="5f8a3c14-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Orders"/>
+            <column name="description" value="Able to view orders"/>
+            <column name="uuid" value="5f8a3c46-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Patient Cohorts"/>
+            <column name="description" value="Able to view patient cohorts"/>
+            <column name="uuid" value="5f8a3c6e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Patient Identifiers"/>
+            <column name="description" value="Able to view patient identifiers"/>
+            <column name="uuid" value="5f8a3ca0-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Patient Programs"/>
+            <column name="description" value="Able to see which programs that patients are in"/>
+            <column name="uuid" value="5f8a3cd2-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Patients"/>
+            <column name="description" value="Able to view patients"/>
+            <column name="uuid" value="5f8a3cfa-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View People"/>
+            <column name="description" value="Able to view person objects"/>
+            <column name="uuid" value="5f8a3d2c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Person Attribute Types"/>
+            <column name="description" value="Able to view person attribute types"/>
+            <column name="uuid" value="5f8a3d5e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Privileges"/>
+            <column name="description" value="Able to view user privileges"/>
+            <column name="uuid" value="5f8a3d86-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Problems"/>
+            <column name="description" value="Able to view problems in OpenMRS"/>
+            <column name="uuid" value="5f8a3db8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Programs"/>
+            <column name="description" value="Able to view patient programs"/>
+            <column name="uuid" value="5f8a3de0-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Relationship Types"/>
+            <column name="description" value="Able to view relationship types"/>
+            <column name="uuid" value="5f8a3e12-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Relationships"/>
+            <column name="description" value="Able to view relationships"/>
+            <column name="uuid" value="5f8a3e44-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Report Objects"/>
+            <column name="description" value="Able to view report objects"/>
+            <column name="uuid" value="5f8a3e6c-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Reports"/>
+            <column name="description" value="Able to view reports"/>
+            <column name="uuid" value="5f8a3e9e-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Roles"/>
+            <column name="description" value="Able to view user roles"/>
+            <column name="uuid" value="5f8a3ec6-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Unpublished Forms"/>
+            <column name="description" value="Able to view and fill out unpublished forms"/>
+            <column name="uuid" value="5f8a3ef8-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+        <insert tableName="privilege">
+            <column name="privilege" value="View Users"/>
+            <column name="description" value="Able to view users in OpenMRS"/>
+            <column name="uuid" value="5f8a3f2a-6814-11e8-923f-e9a88dcb533f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-21">
+        <insert tableName="relationship_type">
+            <column name="relationship_type_id" valueNumeric="1"/>
+            <column name="a_is_to_b" value="Doctor"/>
+            <column name="b_is_to_a" value="Patient"/>
+            <column name="preferred" valueBoolean="false"/>
+            <column name="weight" valueNumeric="0"/>
+            <column name="description" value="Relationship from a primary care provider to the patient"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d919b58-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="relationship_type">
+            <column name="relationship_type_id" valueNumeric="2"/>
+            <column name="a_is_to_b" value="Sibling"/>
+            <column name="b_is_to_a" value="Sibling"/>
+            <column name="preferred" valueBoolean="false"/>
+            <column name="weight" valueNumeric="0"/>
+            <column name="description" value="Relationship between brother/sister, brother/brother, and sister/sister"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d91a01c-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="relationship_type">
+            <column name="relationship_type_id" valueNumeric="3"/>
+            <column name="a_is_to_b" value="Parent"/>
+            <column name="b_is_to_a" value="Child"/>
+            <column name="preferred" valueBoolean="false"/>
+            <column name="weight" valueNumeric="0"/>
+            <column name="description" value="Relationship from a mother/father to the child"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d91a210-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+        <insert tableName="relationship_type">
+            <column name="relationship_type_id" valueNumeric="4"/>
+            <column name="a_is_to_b" value="Aunt/Uncle"/>
+            <column name="b_is_to_a" value="Niece/Nephew"/>
+            <column name="preferred" valueBoolean="false"/>
+            <column name="weight" valueNumeric="0"/>
+            <column name="description" value="Relationship from a parent's sibling to a child of that parent"/>
+            <column name="creator" valueNumeric="1"/>
+            <column name="date_created" valueDate="2007-05-04T00:00:00"/>
+            <column name="retired" valueBoolean="false"/>
+            <column name="retired_by"/>
+            <column name="date_retired"/>
+            <column name="retire_reason"/>
+            <column name="uuid" value="8d91a3dc-c2cc-11de-8d13-0010c6dffd0f"/>
+            <column name="date_changed"/>
+            <column name="changed_by"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-22">
+        <insert tableName="role">
+            <column name="role" value="Anonymous"/>
+            <column name="description" value="Privileges for non-authenticated users."/>
+            <column name="uuid" value="774b2af3-6437-4e5a-a310-547554c7c65c"/>
+        </insert>
+        <insert tableName="role">
+            <column name="role" value="Authenticated"/>
+            <column name="description" value="Privileges gained once authentication has been established."/>
+            <column name="uuid" value="f7fd42ef-880e-40c5-972d-e4ae7c990de2"/>
+        </insert>
+        <insert tableName="role">
+            <column name="role" value="Provider"/>
+            <column name="description" value="All users with the 'Provider' role will appear as options in the default Infopath "/>
+            <column name="uuid" value="8d94f280-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+        <insert tableName="role">
+            <column name="role" value="System Developer"/>
+            <column name="description" value="Developers of the OpenMRS .. have additional access to change fundamental structure of the database model."/>
+            <column name="uuid" value="8d94f852-c2cc-11de-8d13-0010c6dffd0f"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-23">
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Concept Classes"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Concept Datatypes"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Encounter Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Field Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Global Properties"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Identifier Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Locations"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Order Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Person Attribute Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Privileges"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Relationship Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Relationships"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Get Roles"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="Patient Overview - View Relationships"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Concept Classes"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Concept Datatypes"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Encounter Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Field Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Global Properties"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Identifier Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Locations"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Order Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Person Attribute Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Privileges"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Relationship Types"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Relationships"/>
+        </insert>
+        <insert tableName="role_privilege">
+            <column name="role" value="Authenticated"/>
+            <column name="privilege" value="View Roles"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-24">
+        <insert tableName="scheduler_task_config">
+            <column name="task_config_id" valueNumeric="2"/>
+            <column name="name" value="Auto Close Visits Task"/>
+            <column name="description" value="Stops all active visits that match the visit type(s) specified by the value of the global property 'visits.autoCloseVisitType'"/>
+            <column name="schedulable_class" value="org.openmrs.scheduler.tasks.AutoCloseVisitsTask"/>
+            <column name="start_time" valueDate="2011-11-28T23:59:59"/>
+            <column name="start_time_pattern" value="MM/dd/yyyy HH:mm:ss"/>
+            <column name="repeat_interval" valueNumeric="86400"/>
+            <column name="start_on_startup" valueBoolean="false"/>
+            <column name="started" valueBoolean="false"/>
+            <column name="created_by" valueNumeric="1"/>
+            <column name="date_created" valueDate="2018-06-04T18:30:16"/>
+            <column name="changed_by"/>
+            <column name="date_changed"/>
+            <column name="last_execution_time"/>
+            <column name="uuid" value="8c17b376-1a2b-11e1-a51a-00248140a5eb"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-25">
+        <insert tableName="user_property">
+            <column name="user_id" valueNumeric="1"/>
+            <column name="property" value="lockoutTimestamp"/>
+            <column name="property_value" value=""/>
+        </insert>
+        <insert tableName="user_property">
+            <column name="user_id" valueNumeric="1"/>
+            <column name="property" value="loginAttempts"/>
+            <column name="property_value" value="2"/>
+        </insert>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473679024-26">
+        <insert tableName="user_role">
+            <column name="user_id" valueNumeric="1"/>
+            <column name="role" value="Provider"/>
+        </insert>
+        <insert tableName="user_role">
+            <column name="user_id" valueNumeric="1"/>
+            <column name="role" value="System Developer"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.3.x.xml
@@ -1,0 +1,6060 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+	<changeSet author="wolf (generated)" id="1582473628795-1">
+        <createTable tableName="allergy">
+            <column autoIncrement="true" name="allergy_id" type="INT">
+                <constraints primaryKey="true" unique="true"/>
+            </column>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="severity_concept_id" type="INT"/>
+            <column name="coded_allergen" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="non_coded_allergen" type="VARCHAR(255)"/>
+            <column name="allergen_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="comments" type="VARCHAR(1024)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="true" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-2">
+        <createTable tableName="allergy_reaction">
+            <column autoIncrement="true" name="allergy_reaction_id" type="INT">
+                <constraints primaryKey="true" unique="true"/>
+            </column>
+            <column name="allergy_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reaction_concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="reaction_non_coded" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-3">
+        <createTable tableName="care_setting">
+            <column autoIncrement="true" name="care_setting_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="care_setting_type" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-4">
+        <createTable tableName="clob_datatype_storage">
+            <column autoIncrement="true" name="id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="value" type="CLOB">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-5">
+        <createTable tableName="cohort">
+            <column autoIncrement="true" name="cohort_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1000)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-6">
+        <createTable tableName="cohort_member">
+            <column name="cohort_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column autoIncrement="true" name="cohort_member_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="start_date" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_date" type="datetime"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-7">
+        <createTable tableName="concept">
+            <column autoIncrement="true" name="concept_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="short_name" type="VARCHAR(255)"/>
+            <column name="description" type="TEXT"/>
+            <column name="form_text" type="TEXT"/>
+            <column defaultValueNumeric="0" name="datatype_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="class_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="is_set" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(50)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-8">
+        <createTable tableName="concept_answer">
+            <column autoIncrement="true" name="concept_answer_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="answer_concept" type="INT"/>
+            <column name="answer_drug" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_weight" type="DOUBLE"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-9">
+        <createTable tableName="concept_attribute">
+            <column autoIncrement="true" name="concept_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-10">
+        <createTable tableName="concept_attribute_type">
+            <column autoIncrement="true" name="concept_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="min_occurs" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_occurs" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-11">
+        <createTable tableName="concept_class">
+            <column autoIncrement="true" name="concept_class_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-12">
+        <createTable tableName="concept_complex">
+            <column name="concept_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="handler" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-13">
+        <createTable tableName="concept_datatype">
+            <column autoIncrement="true" name="concept_datatype_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hl7_abbreviation" type="VARCHAR(3)"/>
+            <column name="description" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-14">
+        <createTable tableName="concept_description">
+            <column autoIncrement="true" name="concept_description_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="locale" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-15">
+        <createTable tableName="concept_map_type">
+            <column autoIncrement="true" name="concept_map_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="is_hidden" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-16">
+        <createTable tableName="concept_name">
+            <column autoIncrement="true" name="concept_name_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_id" type="INT"/>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="locale" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="locale_preferred" type="BOOLEAN"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="concept_name_type" type="VARCHAR(50)"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-17">
+        <createTable tableName="concept_name_tag">
+            <column autoIncrement="true" name="concept_name_tag_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="tag" type="VARCHAR(50)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-18">
+        <createTable tableName="concept_name_tag_map">
+            <column name="concept_name_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="concept_name_tag_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-19">
+        <createTable tableName="concept_numeric">
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="hi_absolute" type="DOUBLE"/>
+            <column name="hi_critical" type="DOUBLE"/>
+            <column name="hi_normal" type="DOUBLE"/>
+            <column name="low_absolute" type="DOUBLE"/>
+            <column name="low_critical" type="DOUBLE"/>
+            <column name="low_normal" type="DOUBLE"/>
+            <column name="units" type="VARCHAR(50)"/>
+            <column name="allow_decimal" type="BOOLEAN"/>
+            <column name="display_precision" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-20">
+        <createTable tableName="concept_proposal">
+            <column autoIncrement="true" name="concept_proposal_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_id" type="INT"/>
+            <column name="encounter_id" type="INT"/>
+            <column defaultValue="" name="original_text" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="final_text" type="VARCHAR(255)"/>
+            <column name="obs_id" type="INT"/>
+            <column name="obs_concept_id" type="INT"/>
+            <column defaultValue="UNMAPPED" name="state" type="VARCHAR(32)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="comments" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValue="" name="locale" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-21">
+        <createTable tableName="concept_proposal_tag_map">
+            <column name="concept_proposal_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="concept_name_tag_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-22">
+        <createTable tableName="concept_reference_map">
+            <column autoIncrement="true" name="concept_map_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_reference_term_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="1" name="concept_map_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-23">
+        <createTable tableName="concept_reference_source">
+            <column autoIncrement="true" name="concept_source_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="hl7_code" type="VARCHAR(50)">
+                <constraints unique="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="unique_id" type="VARCHAR(250)">
+                <constraints unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-24">
+        <createTable tableName="concept_reference_term">
+            <column autoIncrement="true" name="concept_reference_term_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_source_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="code" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="VARCHAR(255)"/>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-25">
+        <createTable tableName="concept_reference_term_map">
+            <column autoIncrement="true" name="concept_reference_term_map_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="term_a_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="term_b_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="a_is_to_b_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-26">
+        <createTable tableName="concept_set">
+            <column autoIncrement="true" name="concept_set_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_set" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_weight" type="DOUBLE"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-27">
+        <createTable tableName="concept_state_conversion">
+            <column autoIncrement="true" name="concept_state_conversion_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT"/>
+            <column defaultValueNumeric="0" name="program_workflow_id" type="INT"/>
+            <column defaultValueNumeric="0" name="program_workflow_state_id" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-28">
+        <createTable tableName="concept_stop_word">
+            <column autoIncrement="true" name="concept_stop_word_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="word" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="locale" type="VARCHAR(50)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-29">
+        <createTable tableName="conditions">
+            <column autoIncrement="true" name="condition_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="additional_detail" type="VARCHAR(255)"/>
+            <column name="previous_version" type="INT"/>
+            <column name="condition_coded" type="INT"/>
+            <column name="condition_non_coded" type="VARCHAR(255)"/>
+            <column name="condition_coded_name" type="INT"/>
+            <column name="clinical_status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="verification_status" type="VARCHAR(50)"/>
+            <column name="onset_date" type="datetime"/>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="VARCHAR(38)">
+                <constraints unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="changed_by" type="INT"/>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_date" type="datetime"/>
+            <column name="date_changed" type="datetime"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-30">
+        <createTable tableName="drug">
+            <column autoIncrement="true" name="drug_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)"/>
+            <column defaultValueBoolean="false" name="combination" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="dosage_form" type="INT"/>
+            <column name="maximum_daily_dose" type="DOUBLE"/>
+            <column name="minimum_daily_dose" type="DOUBLE"/>
+            <column name="route" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="strength" type="VARCHAR(255)"/>
+            <column name="dose_limit_units" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-31">
+        <createTable tableName="drug_ingredient">
+            <column name="drug_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="ingredient_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="strength" type="DOUBLE"/>
+            <column name="units" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-32">
+        <createTable tableName="drug_order">
+            <column defaultValueNumeric="0" name="order_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="drug_inventory_id" type="INT"/>
+            <column name="dose" type="DOUBLE"/>
+            <column name="as_needed" type="BOOLEAN"/>
+            <column name="dosing_type" type="VARCHAR(255)"/>
+            <column name="quantity" type="DOUBLE"/>
+            <column name="as_needed_condition" type="VARCHAR(255)"/>
+            <column name="num_refills" type="INT"/>
+            <column name="dosing_instructions" type="TEXT"/>
+            <column name="duration" type="INT"/>
+            <column name="duration_units" type="INT"/>
+            <column name="quantity_units" type="INT"/>
+            <column name="route" type="INT"/>
+            <column name="dose_units" type="INT"/>
+            <column name="frequency" type="INT"/>
+            <column name="brand_name" type="VARCHAR(255)"/>
+            <column defaultValueBoolean="false" name="dispense_as_written" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="drug_non_coded" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-33">
+        <createTable tableName="drug_reference_map">
+            <column autoIncrement="true" name="drug_reference_map_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="drug_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="term_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="concept_map_type" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-34">
+        <createTable tableName="encounter">
+            <column autoIncrement="true" name="encounter_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="encounter_type" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="location_id" type="INT"/>
+            <column name="form_id" type="INT"/>
+            <column name="encounter_datetime" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="visit_id" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-35">
+        <createTable tableName="encounter_diagnosis">
+            <column autoIncrement="true" name="diagnosis_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="diagnosis_coded" type="INT"/>
+            <column name="diagnosis_non_coded" type="VARCHAR(255)"/>
+            <column name="diagnosis_coded_name" type="INT"/>
+            <column name="encounter_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="condition_id" type="INT"/>
+            <column name="certainty" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rank" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-36">
+        <createTable tableName="encounter_provider">
+            <column autoIncrement="true" name="encounter_provider_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="encounter_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="provider_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="encounter_role_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_voided" type="datetime"/>
+            <column name="voided_by" type="INT"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-37">
+        <createTable tableName="encounter_role">
+            <column autoIncrement="true" name="encounter_role_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-38">
+        <createTable tableName="encounter_type">
+            <column autoIncrement="true" name="encounter_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(50)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="edit_privilege" type="VARCHAR(255)"/>
+            <column name="view_privilege" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-39">
+        <createTable tableName="field">
+            <column autoIncrement="true" name="field_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="field_type" type="INT"/>
+            <column name="concept_id" type="INT"/>
+            <column name="table_name" type="VARCHAR(50)"/>
+            <column name="attribute_name" type="VARCHAR(50)"/>
+            <column name="default_value" type="TEXT"/>
+            <column defaultValueBoolean="false" name="select_multiple" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-40">
+        <createTable tableName="field_answer">
+            <column defaultValueNumeric="0" name="field_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="answer_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-41">
+        <createTable tableName="field_type">
+            <column autoIncrement="true" name="field_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(50)"/>
+            <column name="description" type="TEXT"/>
+            <column defaultValueBoolean="false" name="is_set" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-42">
+        <createTable tableName="form">
+            <column autoIncrement="true" name="form_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="version" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="build" type="INT"/>
+            <column defaultValueBoolean="false" name="published" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="xslt" type="TEXT"/>
+            <column name="template" type="TEXT"/>
+            <column name="description" type="TEXT"/>
+            <column name="encounter_type" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retired_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-43">
+        <createTable tableName="form_field">
+            <column autoIncrement="true" name="form_field_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="form_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="field_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="field_number" type="INT"/>
+            <column name="field_part" type="VARCHAR(5)"/>
+            <column name="page_number" type="INT"/>
+            <column name="parent_form_field" type="INT"/>
+            <column name="min_occurs" type="INT"/>
+            <column name="max_occurs" type="INT"/>
+            <column defaultValueBoolean="false" name="required" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sort_weight" type="FLOAT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-44">
+        <createTable tableName="form_resource">
+            <column autoIncrement="true" name="form_resource_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="form_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-45">
+        <createTable tableName="global_property">
+            <column defaultValue="" name="property" type="VARCHAR(255)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="property_value" type="TEXT"/>
+            <column name="description" type="TEXT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-46">
+        <createTable tableName="hl7_in_archive">
+            <column autoIncrement="true" name="hl7_in_archive_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="hl7_source" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hl7_source_key" type="VARCHAR(255)"/>
+            <column name="hl7_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="2" name="message_state" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-47">
+        <createTable tableName="hl7_in_error">
+            <column autoIncrement="true" name="hl7_in_error_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="hl7_source" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hl7_source_key" type="TEXT"/>
+            <column name="hl7_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="error" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="error_details" type="MEDIUMTEXT"/>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-48">
+        <createTable tableName="hl7_in_queue">
+            <column autoIncrement="true" name="hl7_in_queue_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="hl7_source" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hl7_source_key" type="TEXT"/>
+            <column name="hl7_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="message_state" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_processed" type="datetime"/>
+            <column name="error_msg" type="TEXT"/>
+            <column name="date_created" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-49">
+        <createTable tableName="hl7_source">
+            <column autoIncrement="true" name="hl7_source_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-52">
+        <createTable tableName="location">
+            <column autoIncrement="true" name="location_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="address1" type="VARCHAR(255)"/>
+            <column name="address2" type="VARCHAR(255)"/>
+            <column name="city_village" type="VARCHAR(255)"/>
+            <column name="state_province" type="VARCHAR(255)"/>
+            <column name="postal_code" type="VARCHAR(50)"/>
+            <column name="country" type="VARCHAR(50)"/>
+            <column name="latitude" type="VARCHAR(50)"/>
+            <column name="longitude" type="VARCHAR(50)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="county_district" type="VARCHAR(255)"/>
+            <column name="address3" type="VARCHAR(255)"/>
+            <column name="address4" type="VARCHAR(255)"/>
+            <column name="address5" type="VARCHAR(255)"/>
+            <column name="address6" type="VARCHAR(255)"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="parent_location" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="address7" type="VARCHAR(255)"/>
+            <column name="address8" type="VARCHAR(255)"/>
+            <column name="address9" type="VARCHAR(255)"/>
+            <column name="address10" type="VARCHAR(255)"/>
+            <column name="address11" type="VARCHAR(255)"/>
+            <column name="address12" type="VARCHAR(255)"/>
+            <column name="address13" type="VARCHAR(255)"/>
+            <column name="address14" type="VARCHAR(255)"/>
+            <column name="address15" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-53">
+        <createTable tableName="location_attribute">
+            <column autoIncrement="true" name="location_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="location_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-54">
+        <createTable tableName="location_attribute_type">
+            <column autoIncrement="true" name="location_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="min_occurs" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_occurs" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-55">
+        <createTable tableName="location_tag">
+            <column autoIncrement="true" name="location_tag_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-56">
+        <createTable tableName="location_tag_map">
+            <column name="location_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="location_tag_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-57">
+        <createTable tableName="note">
+            <column defaultValueNumeric="0" name="note_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="note_type" type="VARCHAR(50)"/>
+            <column name="patient_id" type="INT"/>
+            <column name="obs_id" type="INT"/>
+            <column name="encounter_id" type="INT"/>
+            <column name="text" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="priority" type="INT"/>
+            <column name="parent" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-58">
+        <createTable tableName="notification_alert">
+            <column autoIncrement="true" name="alert_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="text" type="VARCHAR(512)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="satisfied_by_any" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="alert_read" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_to_expire" type="datetime"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-59">
+        <createTable tableName="notification_alert_recipient">
+            <column name="alert_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="user_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueBoolean="false" name="alert_read" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueComputed="CURRENT_TIMESTAMP" name="date_changed" type="timestamp">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-60">
+        <createTable tableName="notification_template">
+            <column autoIncrement="true" name="template_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(50)"/>
+            <column name="template" type="TEXT"/>
+            <column name="subject" type="VARCHAR(100)"/>
+            <column name="sender" type="VARCHAR(255)"/>
+            <column name="recipients" type="VARCHAR(512)"/>
+            <column defaultValueNumeric="0" name="ordinal" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-61">
+        <createTable tableName="obs">
+            <column autoIncrement="true" name="obs_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="encounter_id" type="INT"/>
+            <column name="order_id" type="INT"/>
+            <column name="obs_datetime" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="location_id" type="INT"/>
+            <column name="obs_group_id" type="INT"/>
+            <column name="accession_number" type="VARCHAR(255)"/>
+            <column name="value_group_id" type="INT"/>
+            <column name="value_coded" type="INT"/>
+            <column name="value_coded_name_id" type="INT"/>
+            <column name="value_drug" type="INT"/>
+            <column name="value_datetime" type="datetime"/>
+            <column name="value_numeric" type="DOUBLE"/>
+            <column name="value_modifier" type="VARCHAR(2)"/>
+            <column name="value_text" type="TEXT"/>
+            <column name="value_complex" type="VARCHAR(1000)"/>
+            <column name="comments" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="previous_version" type="INT"/>
+            <column name="form_namespace_and_path" type="VARCHAR(255)"/>
+            <column defaultValue="FINAL" name="status" type="VARCHAR(16)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="interpretation" type="VARCHAR(32)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-62">
+        <createTable tableName="order_frequency">
+            <column autoIncrement="true" name="order_frequency_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_id" type="INT">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="frequency_per_day" type="DOUBLE"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-63">
+        <createTable tableName="order_group">
+            <column autoIncrement="true" name="order_group_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="order_set_id" type="INT"/>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="encounter_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-64">
+        <createTable tableName="order_set">
+            <column autoIncrement="true" name="order_set_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="operator" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1000)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="category" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-65">
+        <createTable tableName="order_set_member">
+            <column autoIncrement="true" name="order_set_member_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="order_type" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="order_template" type="TEXT"/>
+            <column name="order_template_type" type="VARCHAR(1024)"/>
+            <column name="order_set_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="sequence_number" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-66">
+        <createTable tableName="order_type">
+            <column autoIncrement="true" name="order_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+			<column name="description" type="TEXT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="java_class_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="parent" type="INT"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-67">
+        <createTable tableName="order_type_class_map">
+            <column name="order_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="concept_class_id" type="INT">
+                <constraints primaryKey="true" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-68">
+        <createTable tableName="orders">
+            <column autoIncrement="true" name="order_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="order_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="orderer" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="encounter_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="instructions" type="TEXT"/>
+            <column name="date_activated" type="datetime"/>
+            <column name="auto_expire_date" type="datetime"/>
+            <column name="date_stopped" type="datetime"/>
+            <column name="order_reason" type="INT"/>
+            <column name="order_reason_non_coded" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="accession_number" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column defaultValue="ROUTINE" name="urgency" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="order_number" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="previous_order_id" type="INT"/>
+            <column name="order_action" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="comment_to_fulfiller" type="VARCHAR(1024)"/>
+            <column name="care_setting" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="scheduled_date" type="datetime"/>
+            <column name="order_group_id" type="INT"/>
+            <column name="sort_weight" type="DOUBLE"/>
+            <column name="fulfiller_comment" type="VARCHAR(1024)"/>
+            <column name="fulfiller_status" type="VARCHAR(50)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-69">
+        <createTable tableName="patient">
+            <column name="patient_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column defaultValue="Unknown" name="allergy_status" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-70">
+        <createTable tableName="patient_identifier">
+            <column autoIncrement="true" name="patient_identifier_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="identifier" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="identifier_type" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="preferred" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="location_id" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-71">
+        <createTable tableName="patient_identifier_type">
+            <column autoIncrement="true" name="patient_identifier_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="format" type="VARCHAR(255)"/>
+            <column defaultValueBoolean="false" name="check_digit" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="required" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="format_description" type="VARCHAR(255)"/>
+            <column name="validator" type="VARCHAR(200)"/>
+            <column name="location_behavior" type="VARCHAR(50)"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="uniqueness_behavior" type="VARCHAR(50)"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-72">
+        <createTable tableName="patient_program">
+            <column autoIncrement="true" name="patient_program_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="program_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_enrolled" type="datetime"/>
+            <column name="date_completed" type="datetime"/>
+            <column name="location_id" type="INT"/>
+            <column name="outcome_concept_id" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-73">
+        <createTable tableName="patient_program_attribute">
+            <column autoIncrement="true" name="patient_program_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="patient_program_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-74">
+        <createTable tableName="patient_state">
+            <column autoIncrement="true" name="patient_state_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="patient_program_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="state" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="start_date" type="date"/>
+            <column name="end_date" type="date"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-75">
+        <createTable tableName="person">
+            <column autoIncrement="true" name="person_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="gender" type="VARCHAR(50)"/>
+            <column name="birthdate" type="date"/>
+            <column defaultValueBoolean="false" name="birthdate_estimated" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="dead" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="death_date" type="datetime"/>
+            <column name="cause_of_death" type="INT"/>
+            <column name="creator" type="INT"/>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column defaultValueBoolean="false" name="deathdate_estimated" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="birthtime" type="time"/>
+            <column name="cause_of_death_non_coded" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-76">
+        <createTable tableName="person_address">
+            <column autoIncrement="true" name="person_address_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="person_id" type="INT"/>
+            <column defaultValueBoolean="false" name="preferred" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="address1" type="VARCHAR(255)"/>
+            <column name="address2" type="VARCHAR(255)"/>
+            <column name="city_village" type="VARCHAR(255)"/>
+            <column name="state_province" type="VARCHAR(255)"/>
+            <column name="postal_code" type="VARCHAR(50)"/>
+            <column name="country" type="VARCHAR(50)"/>
+            <column name="latitude" type="VARCHAR(50)"/>
+            <column name="longitude" type="VARCHAR(50)"/>
+            <column name="start_date" type="datetime"/>
+            <column name="end_date" type="datetime"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="county_district" type="VARCHAR(255)"/>
+            <column name="address3" type="VARCHAR(255)"/>
+            <column name="address4" type="VARCHAR(255)"/>
+            <column name="address5" type="VARCHAR(255)"/>
+            <column name="address6" type="VARCHAR(255)"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="address7" type="VARCHAR(255)"/>
+            <column name="address8" type="VARCHAR(255)"/>
+            <column name="address9" type="VARCHAR(255)"/>
+            <column name="address10" type="VARCHAR(255)"/>
+            <column name="address11" type="VARCHAR(255)"/>
+            <column name="address12" type="VARCHAR(255)"/>
+            <column name="address13" type="VARCHAR(255)"/>
+            <column name="address14" type="VARCHAR(255)"/>
+            <column name="address15" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-77">
+        <createTable tableName="person_attribute">
+            <column autoIncrement="true" name="person_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValue="" name="value" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="person_attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-78">
+        <createTable tableName="person_attribute_type">
+            <column autoIncrement="true" name="person_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="format" type="VARCHAR(50)"/>
+            <column name="foreign_key" type="INT"/>
+            <column defaultValueBoolean="false" name="searchable" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="edit_privilege" type="VARCHAR(255)"/>
+            <column name="sort_weight" type="DOUBLE"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-79">
+        <createTable tableName="person_merge_log">
+            <column autoIncrement="true" name="person_merge_log_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="winner_person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="loser_person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="merged_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-80">
+        <createTable tableName="person_name">
+            <column autoIncrement="true" name="person_name_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueBoolean="false" name="preferred" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="prefix" type="VARCHAR(50)"/>
+            <column name="given_name" type="VARCHAR(50)"/>
+            <column name="middle_name" type="VARCHAR(50)"/>
+            <column name="family_name_prefix" type="VARCHAR(50)"/>
+            <column name="family_name" type="VARCHAR(50)"/>
+            <column name="family_name2" type="VARCHAR(50)"/>
+            <column name="family_name_suffix" type="VARCHAR(50)"/>
+            <column name="degree" type="VARCHAR(50)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-81">
+        <createTable tableName="privilege">
+            <column name="privilege" type="VARCHAR(255)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-82">
+        <createTable tableName="program">
+            <column autoIncrement="true" name="program_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="outcomes_concept_id" type="INT"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-83">
+        <createTable tableName="program_attribute_type">
+            <column autoIncrement="true" name="program_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="min_occurs" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_occurs" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-84">
+        <createTable tableName="program_workflow">
+            <column autoIncrement="true" name="program_workflow_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="program_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-85">
+        <createTable tableName="program_workflow_state">
+            <column autoIncrement="true" name="program_workflow_state_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValueNumeric="0" name="program_workflow_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="concept_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="initial" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="terminal" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-86">
+        <createTable tableName="provider">
+            <column autoIncrement="true" name="provider_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="person_id" type="INT"/>
+            <column name="name" type="VARCHAR(255)"/>
+            <column name="identifier" type="VARCHAR(255)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="role_id" type="INT"/>
+            <column name="speciality_id" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-87">
+        <createTable tableName="provider_attribute">
+            <column autoIncrement="true" name="provider_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="provider_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-88">
+        <createTable tableName="provider_attribute_type">
+            <column autoIncrement="true" name="provider_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="min_occurs" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_occurs" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-89">
+        <createTable tableName="relationship">
+            <column autoIncrement="true" name="relationship_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="person_a" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="relationship" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="person_b" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="start_date" type="datetime"/>
+            <column name="end_date" type="datetime"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-90">
+        <createTable tableName="relationship_type">
+            <column autoIncrement="true" name="relationship_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="a_is_to_b" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="b_is_to_a" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="preferred" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="weight" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-91">
+        <createTable tableName="report_object">
+            <column autoIncrement="true" name="report_object_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1000)"/>
+            <column name="report_object_type" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="report_object_sub_type" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="xml_data" type="TEXT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-92">
+        <createTable tableName="report_schema_xml">
+            <column autoIncrement="true" name="report_schema_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="xml_data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-93">
+        <createTable tableName="role">
+            <column defaultValue="" name="role" type="VARCHAR(50)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="description" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-94">
+        <createTable tableName="role_privilege">
+            <column defaultValue="" name="role" type="VARCHAR(50)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="privilege" type="VARCHAR(255)">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-95">
+        <createTable tableName="role_role">
+            <column defaultValue="" name="parent_role" type="VARCHAR(50)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="child_role" type="VARCHAR(50)">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-96">
+        <createTable tableName="scheduler_task_config">
+            <column autoIncrement="true" name="task_config_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="schedulable_class" type="TEXT"/>
+            <column name="start_time" type="datetime"/>
+            <column name="start_time_pattern" type="VARCHAR(50)"/>
+            <column defaultValueNumeric="0" name="repeat_interval" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="start_on_startup" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="started" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueNumeric="0" name="created_by" type="INT"/>
+            <column name="date_created" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="last_execution_time" type="datetime"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-97">
+        <createTable tableName="scheduler_task_config_property">
+            <column autoIncrement="true" name="task_config_property_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="TEXT"/>
+            <column name="task_config_id" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-98">
+        <createTable tableName="serialized_object">
+            <column autoIncrement="true" name="serialized_object_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(5000)"/>
+            <column name="type" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="subtype" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="serialization_class" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="serialized_data" type="MEDIUMTEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_changed" type="datetime"/>
+            <column name="changed_by" type="INT"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_retired" type="datetime"/>
+            <column name="retired_by" type="INT"/>
+            <column name="retire_reason" type="VARCHAR(1000)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-99">
+        <createTable tableName="test_order">
+            <column defaultValueNumeric="0" name="order_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="specimen_source" type="INT"/>
+            <column name="laterality" type="VARCHAR(20)"/>
+            <column name="clinical_history" type="TEXT"/>
+            <column name="frequency" type="INT"/>
+            <column name="number_of_repeats" type="INT"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-100">
+        <createTable tableName="user_property">
+            <column defaultValueNumeric="0" name="user_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="property" type="VARCHAR(100)">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="property_value" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-101">
+        <createTable tableName="user_role">
+            <column defaultValueNumeric="0" name="user_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="role" type="VARCHAR(50)">
+                <constraints primaryKey="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-102">
+        <createTable tableName="users">
+            <column autoIncrement="true" name="user_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column defaultValue="" name="system_id" type="VARCHAR(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="username" type="VARCHAR(50)"/>
+            <column name="password" type="VARCHAR(128)"/>
+            <column name="salt" type="VARCHAR(128)"/>
+            <column name="secret_question" type="VARCHAR(255)"/>
+            <column name="secret_answer" type="VARCHAR(255)"/>
+            <column defaultValueNumeric="0" name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column name="person_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="activation_key" type="VARCHAR(255)"/>
+            <column name="email" type="VARCHAR(255)">
+                <constraints unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-103">
+        <createTable tableName="visit">
+            <column autoIncrement="true" name="visit_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="patient_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="visit_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_started" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_stopped" type="datetime"/>
+            <column name="indication_concept_id" type="INT"/>
+            <column name="location_id" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-104">
+        <createTable tableName="visit_attribute">
+            <column autoIncrement="true" name="visit_attribute_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="visit_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="attribute_type_id" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value_reference" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="voided" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="voided_by" type="INT"/>
+            <column name="date_voided" type="datetime"/>
+            <column name="void_reason" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-105">
+        <createTable tableName="visit_attribute_type">
+            <column autoIncrement="true" name="visit_attribute_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="datatype" type="VARCHAR(255)"/>
+            <column name="datatype_config" type="TEXT"/>
+            <column name="preferred_handler" type="VARCHAR(255)"/>
+            <column name="handler_config" type="TEXT"/>
+            <column name="min_occurs" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="max_occurs" type="INT"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-106">
+        <createTable tableName="visit_type">
+            <column autoIncrement="true" name="visit_type_id" type="INT">
+                <constraints primaryKey="true"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(1024)"/>
+            <column name="creator" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="date_created" type="datetime">
+                <constraints nullable="false"/>
+            </column>
+            <column name="changed_by" type="INT"/>
+            <column name="date_changed" type="datetime"/>
+            <column defaultValueBoolean="false" name="retired" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="retired_by" type="INT"/>
+            <column name="date_retired" type="datetime"/>
+            <column name="retire_reason" type="VARCHAR(255)"/>
+            <column name="uuid" type="CHAR(38)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-107">
+        <addUniqueConstraint columnNames="word, locale" constraintName="Unique_StopWord_Key" tableName="concept_stop_word"/>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-108">
+        <addUniqueConstraint columnNames="form_id, name" constraintName="unique_form_and_name" tableName="form_resource"/>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-109">
+        <addUniqueConstraint columnNames="program_workflow_id, concept_id" constraintName="unique_workflow_concept_in_conversion" tableName="concept_state_conversion"/>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-110">
+        <createIndex indexName="address_for_person" tableName="person_address">
+            <column name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-111">
+        <createIndex indexName="alert_creator" tableName="notification_alert">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-112">
+        <createIndex indexName="alert_date_to_expire_idx" tableName="notification_alert">
+            <column name="date_to_expire"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-113">
+        <createIndex indexName="alert_read_by_user" tableName="notification_alert_recipient">
+            <column name="user_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-114">
+        <createIndex indexName="allergy_changed_by_fk" tableName="allergy">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-115">
+        <createIndex indexName="allergy_coded_allergen_fk" tableName="allergy">
+            <column name="coded_allergen"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-116">
+        <createIndex indexName="allergy_creator_fk" tableName="allergy">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-117">
+        <createIndex indexName="allergy_patient_id_fk" tableName="allergy">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-118">
+        <createIndex indexName="allergy_reaction_allergy_id_fk" tableName="allergy_reaction">
+            <column name="allergy_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-119">
+        <createIndex indexName="allergy_reaction_reaction_concept_id_fk" tableName="allergy_reaction">
+            <column name="reaction_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-120">
+        <createIndex indexName="allergy_severity_concept_id_fk" tableName="allergy">
+            <column name="severity_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-121">
+        <createIndex indexName="allergy_voided_by_fk" tableName="allergy">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-122">
+        <createIndex indexName="answer" tableName="concept_answer">
+            <column name="answer_concept"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-123">
+        <createIndex indexName="answer_answer_drug_fk" tableName="concept_answer">
+            <column name="answer_drug"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-124">
+        <createIndex indexName="answer_concept" tableName="obs">
+            <column name="value_coded"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-125">
+        <createIndex indexName="answer_concept_drug" tableName="obs">
+            <column name="value_drug"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-126">
+        <createIndex indexName="answer_creator" tableName="concept_answer">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-127">
+        <createIndex indexName="answers_for_concept" tableName="concept_answer">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-128">
+        <createIndex indexName="attribute_changer" tableName="person_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-129">
+        <createIndex indexName="attribute_creator" tableName="person_attribute">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-130">
+        <createIndex indexName="attribute_is_searchable" tableName="person_attribute_type">
+            <column defaultValueBoolean="false" name="searchable"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-131">
+        <createIndex indexName="attribute_type_changer" tableName="person_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-132">
+        <createIndex indexName="attribute_type_creator" tableName="person_attribute_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-133">
+        <createIndex indexName="attribute_voider" tableName="person_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-134">
+        <createIndex indexName="care_setting_changed_by" tableName="care_setting">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-135">
+        <createIndex indexName="care_setting_creator" tableName="care_setting">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-136">
+        <createIndex indexName="care_setting_retired_by" tableName="care_setting">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-137">
+        <createIndex indexName="category_order_set_fk" tableName="order_set">
+            <column name="category"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-138">
+        <createIndex indexName="cohort_creator" tableName="cohort">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-139">
+        <createIndex indexName="cohort_member_creator" tableName="cohort_member">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-140">
+        <createIndex indexName="concept_attribute_attribute_type_id_fk" tableName="concept_attribute">
+            <column name="attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-141">
+        <createIndex indexName="concept_attribute_changed_by_fk" tableName="concept_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-142">
+        <createIndex indexName="concept_attribute_concept_fk" tableName="concept_attribute">
+            <column name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-143">
+        <createIndex indexName="concept_attribute_creator_fk" tableName="concept_attribute">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-144">
+        <createIndex indexName="concept_attribute_type_changed_by_fk" tableName="concept_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-145">
+        <createIndex indexName="concept_attribute_type_creator_fk" tableName="concept_attribute_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-146">
+        <createIndex indexName="concept_attribute_type_retired_by_fk" tableName="concept_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-147">
+        <createIndex indexName="concept_attribute_voided_by_fk" tableName="concept_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-148">
+        <createIndex indexName="concept_class_changed_by" tableName="concept_class">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-149">
+        <createIndex indexName="concept_class_creator" tableName="concept_class">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-150">
+        <createIndex indexName="concept_class_name_index" tableName="concept_class">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-151">
+        <createIndex indexName="concept_class_retired_status" tableName="concept_class">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-152">
+        <createIndex indexName="concept_classes" tableName="concept">
+            <column defaultValueNumeric="0" name="class_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-153">
+        <createIndex indexName="concept_creator" tableName="concept">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-154">
+        <createIndex indexName="concept_datatype_creator" tableName="concept_datatype">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-155">
+        <createIndex indexName="concept_datatype_name_index" tableName="concept_datatype">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-156">
+        <createIndex indexName="concept_datatype_retired_status" tableName="concept_datatype">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-157">
+        <createIndex indexName="concept_datatypes" tableName="concept">
+            <column defaultValueNumeric="0" name="datatype_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-158">
+        <createIndex indexName="concept_for_field" tableName="field">
+            <column name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-159">
+        <createIndex indexName="concept_for_proposal" tableName="concept_proposal">
+            <column name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-160">
+        <createIndex indexName="concept_map_type_for_drug_reference_map" tableName="drug_reference_map">
+            <column name="concept_map_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-161">
+        <createIndex indexName="concept_name_changed_by" tableName="concept_name">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-162">
+        <createIndex indexName="concept_name_tag_changed_by" tableName="concept_name_tag">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-163">
+        <createIndex indexName="concept_reference_source_changed_by" tableName="concept_reference_source">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-164">
+        <createIndex indexName="concept_reference_term_for_drug_reference_map" tableName="drug_reference_map">
+            <column name="term_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-165">
+        <createIndex indexName="concept_source_creator" tableName="concept_reference_source">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-166">
+        <createIndex indexName="concept_triggers_conversion" tableName="concept_state_conversion">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-167">
+        <createIndex indexName="condition_changed_by_fk" tableName="conditions">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-168">
+        <createIndex indexName="condition_condition_coded_fk" tableName="conditions">
+            <column name="condition_coded"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-169">
+        <createIndex indexName="condition_condition_coded_name_fk" tableName="conditions">
+            <column name="condition_coded_name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-170">
+        <createIndex indexName="condition_creator_fk" tableName="conditions">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-171">
+        <createIndex indexName="condition_patient_fk" tableName="conditions">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-172">
+        <createIndex indexName="condition_previous_version_fk" tableName="conditions">
+            <column name="previous_version"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-173">
+        <createIndex indexName="condition_voided_by_fk" tableName="conditions">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-174">
+        <createIndex indexName="conversion_to_state" tableName="concept_state_conversion">
+            <column defaultValueNumeric="0" name="program_workflow_state_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-175">
+        <createIndex indexName="defines_attribute_type" tableName="person_attribute">
+            <column defaultValueNumeric="0" name="person_attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-176">
+        <createIndex indexName="defines_identifier_type" tableName="patient_identifier">
+            <column defaultValueNumeric="0" name="identifier_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-177">
+        <createIndex indexName="description_for_concept" tableName="concept_description">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-178">
+        <createIndex indexName="discontinued_because" tableName="orders">
+            <column name="order_reason"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-179">
+        <createIndex indexName="dosage_form_concept" tableName="drug">
+            <column name="dosage_form"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-180">
+        <createIndex indexName="drug_changed_by" tableName="drug">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-181">
+        <createIndex indexName="drug_creator" tableName="drug">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-182">
+        <createIndex indexName="drug_dose_limit_units_fk" tableName="drug">
+            <column name="dose_limit_units"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-183">
+        <createIndex indexName="drug_for_drug_reference_map" tableName="drug_reference_map">
+            <column name="drug_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-184">
+        <createIndex indexName="drug_ingredient_ingredient_id_fk" tableName="drug_ingredient">
+            <column name="ingredient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-185">
+        <createIndex indexName="drug_ingredient_units_fk" tableName="drug_ingredient">
+            <column name="units"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-186">
+        <createIndex indexName="drug_order_dose_units" tableName="drug_order">
+            <column name="dose_units"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-187">
+        <createIndex indexName="drug_order_duration_units_fk" tableName="drug_order">
+            <column name="duration_units"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-188">
+        <createIndex indexName="drug_order_frequency_fk" tableName="drug_order">
+            <column name="frequency"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-189">
+        <createIndex indexName="drug_order_quantity_units" tableName="drug_order">
+            <column name="quantity_units"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-190">
+        <createIndex indexName="drug_order_route_fk" tableName="drug_order">
+            <column name="route"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-191">
+        <createIndex indexName="drug_reference_map_creator" tableName="drug_reference_map">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-192">
+        <createIndex indexName="drug_retired_by" tableName="drug">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-193">
+        <createIndex indexName="encounter_changed_by" tableName="encounter">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-194">
+        <createIndex indexName="encounter_datetime_idx" tableName="encounter">
+            <column name="encounter_datetime"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-195">
+        <createIndex indexName="encounter_diagnosis_changed_by_fk" tableName="encounter_diagnosis">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-196">
+        <createIndex indexName="encounter_diagnosis_coded_fk" tableName="encounter_diagnosis">
+            <column name="diagnosis_coded"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-197">
+        <createIndex indexName="encounter_diagnosis_coded_name_fk" tableName="encounter_diagnosis">
+            <column name="diagnosis_coded_name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-198">
+        <createIndex indexName="encounter_diagnosis_condition_id_fk" tableName="encounter_diagnosis">
+            <column name="condition_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-199">
+        <createIndex indexName="encounter_diagnosis_creator_fk" tableName="encounter_diagnosis">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-200">
+        <createIndex indexName="encounter_diagnosis_encounter_id_fk" tableName="encounter_diagnosis">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-201">
+        <createIndex indexName="encounter_diagnosis_patient_fk" tableName="encounter_diagnosis">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-202">
+        <createIndex indexName="encounter_diagnosis_voided_by_fk" tableName="encounter_diagnosis">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-203">
+        <createIndex indexName="encounter_for_proposal" tableName="concept_proposal">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-204">
+        <createIndex indexName="encounter_form" tableName="encounter">
+            <column name="form_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-205">
+        <createIndex indexName="encounter_ibfk_1" tableName="encounter">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-206">
+        <createIndex indexName="encounter_id_fk" tableName="encounter_provider">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-207">
+        <createIndex indexName="encounter_location" tableName="encounter">
+            <column name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-208">
+        <createIndex indexName="encounter_note" tableName="note">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-209">
+        <createIndex indexName="encounter_observations" tableName="obs">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-210">
+        <createIndex indexName="encounter_patient" tableName="encounter">
+            <column defaultValueNumeric="0" name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-211">
+        <createIndex indexName="encounter_provider_changed_by" tableName="encounter_provider">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-212">
+        <createIndex indexName="encounter_provider_creator" tableName="encounter_provider">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-213">
+        <createIndex indexName="encounter_provider_voided_by" tableName="encounter_provider">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-214">
+        <createIndex indexName="encounter_role_changed_by_fk" tableName="encounter_role">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-215">
+        <createIndex indexName="encounter_role_creator_fk" tableName="encounter_role">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-216">
+        <createIndex indexName="encounter_role_id_fk" tableName="encounter_provider">
+            <column name="encounter_role_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-217">
+        <createIndex indexName="encounter_role_retired_by_fk" tableName="encounter_role">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-218">
+        <createIndex indexName="encounter_type_changed_by" tableName="encounter_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-219">
+        <createIndex indexName="encounter_type_id" tableName="encounter">
+            <column name="encounter_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-220">
+        <createIndex indexName="encounter_type_retired_status" tableName="encounter_type">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-221">
+        <createIndex indexName="encounter_visit_id_fk" tableName="encounter">
+            <column name="visit_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-222">
+        <createIndex indexName="family_name2" tableName="person_name">
+            <column name="family_name2"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-223">
+        <createIndex indexName="field_answer_concept" tableName="field_answer">
+            <column defaultValueNumeric="0" name="answer_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-224">
+        <createIndex indexName="field_retired_status" tableName="field">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-225">
+        <createIndex indexName="field_within_form" tableName="form_field">
+            <column defaultValueNumeric="0" name="field_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-226">
+        <createIndex indexName="first_name" tableName="person_name">
+            <column name="given_name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-227">
+        <createIndex indexName="fk_orderer_provider" tableName="orders">
+            <column name="orderer"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-228">
+        <createIndex indexName="form_containing_field" tableName="form_field">
+            <column defaultValueNumeric="0" name="form_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-229">
+        <createIndex indexName="form_encounter_type" tableName="form">
+            <column name="encounter_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-230">
+        <createIndex indexName="form_field_hierarchy" tableName="form_field">
+            <column name="parent_form_field"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-231">
+        <createIndex indexName="form_published_and_retired_index" tableName="form">
+            <column defaultValueBoolean="false" name="published"/>
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-232">
+        <createIndex indexName="form_published_index" tableName="form">
+            <column defaultValueBoolean="false" name="published"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-233">
+        <createIndex indexName="form_resource_changed_by" tableName="form_resource">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-234">
+        <createIndex indexName="form_retired_index" tableName="form">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-235">
+        <createIndex indexName="global_property_changed_by" tableName="global_property">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-236">
+        <createIndex indexName="has_a" tableName="concept_set">
+            <column defaultValueNumeric="0" name="concept_set"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-237">
+        <createIndex indexName="hl7_in_archive_message_state_idx" tableName="hl7_in_archive">
+            <column defaultValueNumeric="2" name="message_state"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-238">
+        <createIndex indexName="hl7_source_with_queue" tableName="hl7_in_queue">
+            <column defaultValueNumeric="0" name="hl7_source"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-239">
+        <createIndex indexName="identifier_creator" tableName="patient_identifier">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-240">
+        <createIndex indexName="identifier_name" tableName="patient_identifier">
+            <column name="identifier"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-241">
+        <createIndex indexName="identifier_voider" tableName="patient_identifier">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-242">
+        <createIndex indexName="identifies_person" tableName="person_attribute">
+            <column defaultValueNumeric="0" name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-243">
+        <createIndex indexName="idx_code_concept_reference_term" tableName="concept_reference_term">
+            <column name="code"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-244">
+        <createIndex indexName="idx_concept_set_concept" tableName="concept_set">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-245">
+        <createIndex indexName="idx_patient_identifier_patient" tableName="patient_identifier">
+            <column defaultValueNumeric="0" name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-246">
+        <createIndex indexName="inherited_role" tableName="role_role">
+            <column name="child_role"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-247">
+        <createIndex indexName="inventory_item" tableName="drug_order">
+            <column name="drug_inventory_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-248">
+        <createIndex indexName="last_name" tableName="person_name">
+            <column name="family_name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-249">
+        <createIndex indexName="location_attribute_attribute_type_id_fk" tableName="location_attribute">
+            <column name="attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-250">
+        <createIndex indexName="location_attribute_changed_by_fk" tableName="location_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-251">
+        <createIndex indexName="location_attribute_creator_fk" tableName="location_attribute">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-252">
+        <createIndex indexName="location_attribute_location_fk" tableName="location_attribute">
+            <column name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-253">
+        <createIndex indexName="location_attribute_type_changed_by_fk" tableName="location_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-254">
+        <createIndex indexName="location_attribute_type_creator_fk" tableName="location_attribute_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-255">
+        <createIndex indexName="location_attribute_type_retired_by_fk" tableName="location_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-256">
+        <createIndex indexName="location_attribute_voided_by_fk" tableName="location_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-257">
+        <createIndex indexName="location_changed_by" tableName="location">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-258">
+        <createIndex indexName="location_retired_status" tableName="location">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-259">
+        <createIndex indexName="location_tag_changed_by" tableName="location_tag">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-260">
+        <createIndex indexName="location_tag_creator" tableName="location_tag">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-261">
+        <createIndex indexName="location_tag_map_tag" tableName="location_tag_map">
+            <column name="location_tag_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-262">
+        <createIndex indexName="location_tag_retired_by" tableName="location_tag">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-263">
+        <createIndex indexName="map_creator" tableName="concept_reference_map">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-264">
+        <createIndex indexName="map_for_concept" tableName="concept_reference_map">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-265">
+        <createIndex indexName="mapped_concept_map_type" tableName="concept_reference_map">
+            <column defaultValueNumeric="1" name="concept_map_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-266">
+        <createIndex indexName="mapped_concept_map_type_ref_term_map" tableName="concept_reference_term_map">
+            <column name="a_is_to_b_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-267">
+        <createIndex indexName="mapped_concept_name" tableName="concept_name_tag_map">
+            <column name="concept_name_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-268">
+        <createIndex indexName="mapped_concept_name_tag" tableName="concept_name_tag_map">
+            <column name="concept_name_tag_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-269">
+        <createIndex indexName="mapped_concept_proposal" tableName="concept_proposal_tag_map">
+            <column name="concept_proposal_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-270">
+        <createIndex indexName="mapped_concept_proposal_tag" tableName="concept_proposal_tag_map">
+            <column name="concept_name_tag_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-271">
+        <createIndex indexName="mapped_concept_reference_term" tableName="concept_reference_map">
+            <column name="concept_reference_term_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-272">
+        <createIndex indexName="mapped_concept_source" tableName="concept_reference_term">
+            <column name="concept_source_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-273">
+        <createIndex indexName="mapped_term_a" tableName="concept_reference_term_map">
+            <column name="term_a_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-274">
+        <createIndex indexName="mapped_term_b" tableName="concept_reference_term_map">
+            <column name="term_b_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-275">
+        <createIndex indexName="mapped_user_changed" tableName="concept_reference_term">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-276">
+        <createIndex indexName="mapped_user_changed_concept_map_type" tableName="concept_map_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-277">
+        <createIndex indexName="mapped_user_changed_ref_term" tableName="concept_reference_map">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-278">
+        <createIndex indexName="mapped_user_changed_ref_term_map" tableName="concept_reference_term_map">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-279">
+        <createIndex indexName="mapped_user_creator" tableName="concept_reference_term">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-280">
+        <createIndex indexName="mapped_user_creator_concept_map_type" tableName="concept_map_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-281">
+        <createIndex indexName="mapped_user_creator_ref_term_map" tableName="concept_reference_term_map">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-282">
+        <createIndex indexName="mapped_user_retired" tableName="concept_reference_term">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-283">
+        <createIndex indexName="mapped_user_retired_concept_map_type" tableName="concept_map_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-284">
+        <createIndex indexName="member_patient" tableName="cohort_member">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-285">
+        <createIndex indexName="middle_name" tableName="person_name">
+            <column name="middle_name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-286">
+        <createIndex indexName="name_for_concept" tableName="concept_name">
+            <column name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-287">
+        <createIndex indexName="name_for_person" tableName="person_name">
+            <column name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-288">
+        <createIndex indexName="name_of_attribute" tableName="person_attribute_type">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-289">
+        <createIndex indexName="name_of_concept" tableName="concept_name">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-290">
+        <createIndex indexName="name_of_location" tableName="location">
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-291">
+        <createIndex indexName="note_hierarchy" tableName="note">
+            <column name="parent"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-292">
+        <createIndex indexName="obs_concept" tableName="obs">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-293">
+        <createIndex indexName="obs_datetime_idx" tableName="obs">
+            <column name="obs_datetime"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-294">
+        <createIndex indexName="obs_enterer" tableName="obs">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-295">
+        <createIndex indexName="obs_grouping_id" tableName="obs">
+            <column name="obs_group_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-296">
+        <createIndex indexName="obs_location" tableName="obs">
+            <column name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-297">
+        <createIndex indexName="obs_name_of_coded_value" tableName="obs">
+            <column name="value_coded_name_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-298">
+        <createIndex indexName="obs_note" tableName="note">
+            <column name="obs_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-299">
+        <createIndex indexName="obs_order" tableName="obs">
+            <column name="order_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-300">
+        <createIndex indexName="order_creator" tableName="orders">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-301">
+        <createIndex indexName="order_for_patient" tableName="orders">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-302">
+        <createIndex indexName="order_frequency_changed_by_fk" tableName="order_frequency">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-303">
+        <createIndex indexName="order_frequency_creator_fk" tableName="order_frequency">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-304">
+        <createIndex indexName="order_frequency_retired_by_fk" tableName="order_frequency">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-305">
+        <createIndex indexName="order_group_changed_by_fk" tableName="order_group">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-306">
+        <createIndex indexName="order_group_creator_fk" tableName="order_group">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-307">
+        <createIndex indexName="order_group_encounter_id_fk" tableName="order_group">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-308">
+        <createIndex indexName="order_group_patient_id_fk" tableName="order_group">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-309">
+        <createIndex indexName="order_group_set_id_fk" tableName="order_group">
+            <column name="order_set_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-310">
+        <createIndex indexName="order_group_voided_by_fk" tableName="order_group">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-311">
+        <createIndex indexName="order_set_changed_by_fk" tableName="order_set">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-312">
+        <createIndex indexName="order_set_creator_fk" tableName="order_set">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-313">
+        <createIndex indexName="order_set_member_changed_by_fk" tableName="order_set_member">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-314">
+        <createIndex indexName="order_set_member_concept_id_fk" tableName="order_set_member">
+            <column name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-315">
+        <createIndex indexName="order_set_member_creator_fk" tableName="order_set_member">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-316">
+        <createIndex indexName="order_set_member_order_set_id_fk" tableName="order_set_member">
+            <column name="order_set_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-317">
+        <createIndex indexName="order_set_member_order_type_fk" tableName="order_set_member">
+            <column name="order_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-318">
+        <createIndex indexName="order_set_member_retired_by_fk" tableName="order_set_member">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-319">
+        <createIndex indexName="order_set_retired_by_fk" tableName="order_set">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-320">
+        <createIndex indexName="order_type_changed_by" tableName="order_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-321">
+        <createIndex indexName="order_type_parent_order_type" tableName="order_type">
+            <column name="parent"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-322">
+        <createIndex indexName="order_type_retired_status" tableName="order_type">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-323">
+        <createIndex indexName="orders_care_setting" tableName="orders">
+            <column name="care_setting"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-324">
+        <createIndex indexName="orders_in_encounter" tableName="orders">
+            <column name="encounter_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-325">
+        <createIndex indexName="orders_order_group_id_fk" tableName="orders">
+            <column name="order_group_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-326">
+        <createIndex indexName="parent_cohort" tableName="cohort_member">
+            <column name="cohort_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-327">
+        <createIndex indexName="parent_location" tableName="location">
+            <column name="parent_location"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-328">
+        <createIndex indexName="patient_address_creator" tableName="person_address">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-329">
+        <createIndex indexName="patient_address_void" tableName="person_address">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-330">
+        <createIndex indexName="patient_identifier_changed_by" tableName="patient_identifier">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-331">
+        <createIndex indexName="patient_identifier_ibfk_2" tableName="patient_identifier">
+            <column defaultValueNumeric="0" name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-332">
+        <createIndex indexName="patient_identifier_type_changed_by" tableName="patient_identifier_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-333">
+        <createIndex indexName="patient_identifier_type_retired_status" tableName="patient_identifier_type">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-334">
+        <createIndex indexName="patient_in_program" tableName="patient_program">
+            <column defaultValueNumeric="0" name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-335">
+        <createIndex indexName="patient_note" tableName="note">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-336">
+        <createIndex indexName="patient_program_attribute_attributetype_fk" tableName="patient_program_attribute">
+            <column name="attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-337">
+        <createIndex indexName="patient_program_attribute_changed_by_fk" tableName="patient_program_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-338">
+        <createIndex indexName="patient_program_attribute_creator_fk" tableName="patient_program_attribute">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-339">
+        <createIndex indexName="patient_program_attribute_programid_fk" tableName="patient_program_attribute">
+            <column name="patient_program_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-340">
+        <createIndex indexName="patient_program_attribute_voided_by_fk" tableName="patient_program_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-341">
+        <createIndex indexName="patient_program_creator" tableName="patient_program">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-342">
+        <createIndex indexName="patient_program_for_state" tableName="patient_state">
+            <column defaultValueNumeric="0" name="patient_program_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-343">
+        <createIndex indexName="patient_program_location_id" tableName="patient_program">
+            <column name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-344">
+        <createIndex indexName="patient_program_outcome_concept_id_fk" tableName="patient_program">
+            <column name="outcome_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-345">
+        <createIndex indexName="patient_state_changer" tableName="patient_state">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-346">
+        <createIndex indexName="patient_state_creator" tableName="patient_state">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-347">
+        <createIndex indexName="patient_state_voider" tableName="patient_state">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-348">
+        <createIndex indexName="person_a_is_person" tableName="relationship">
+            <column name="person_a"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-349">
+        <createIndex indexName="person_address_changed_by" tableName="person_address">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-350">
+        <createIndex indexName="person_attribute_type_retired_status" tableName="person_attribute_type">
+            <column defaultValueBoolean="false" name="retired"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-351">
+        <createIndex indexName="person_b_is_person" tableName="relationship">
+            <column name="person_b"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-352">
+        <createIndex indexName="person_birthdate" tableName="person">
+            <column name="birthdate"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-353">
+        <createIndex indexName="person_death_date" tableName="person">
+            <column name="death_date"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-354">
+        <createIndex indexName="person_died_because" tableName="person">
+            <column name="cause_of_death"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-355">
+        <createIndex indexName="person_id_for_user" tableName="users">
+            <column name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-356">
+        <createIndex indexName="person_merge_log_changed_by_fk" tableName="person_merge_log">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-357">
+        <createIndex indexName="person_merge_log_creator" tableName="person_merge_log">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-358">
+        <createIndex indexName="person_merge_log_loser" tableName="person_merge_log">
+            <column name="loser_person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-359">
+        <createIndex indexName="person_merge_log_voided_by_fk" tableName="person_merge_log">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-360">
+        <createIndex indexName="person_merge_log_winner" tableName="person_merge_log">
+            <column name="winner_person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-361">
+        <createIndex indexName="person_obs" tableName="obs">
+            <column name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-362">
+        <createIndex indexName="previous_order_id_order_id" tableName="orders">
+            <column name="previous_order_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-363">
+        <createIndex indexName="previous_version" tableName="obs">
+            <column name="previous_version"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-364">
+        <createIndex indexName="primary_drug_concept" tableName="drug">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-365">
+        <createIndex indexName="privilege_definitions" tableName="role_privilege">
+            <column name="privilege"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-366">
+        <createIndex indexName="privilege_which_can_edit" tableName="person_attribute_type">
+            <column name="edit_privilege"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-367">
+        <createIndex indexName="privilege_which_can_edit_encounter_type" tableName="encounter_type">
+            <column name="edit_privilege"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-368">
+        <createIndex indexName="privilege_which_can_view_encounter_type" tableName="encounter_type">
+            <column name="view_privilege"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-369">
+        <createIndex indexName="program_attribute_type_changed_by_fk" tableName="program_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-370">
+        <createIndex indexName="program_attribute_type_creator_fk" tableName="program_attribute_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-371">
+        <createIndex indexName="program_attribute_type_retired_by_fk" tableName="program_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-372">
+        <createIndex indexName="program_concept" tableName="program">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-373">
+        <createIndex indexName="program_creator" tableName="program">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-374">
+        <createIndex indexName="program_for_patient" tableName="patient_program">
+            <column defaultValueNumeric="0" name="program_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-375">
+        <createIndex indexName="program_for_workflow" tableName="program_workflow">
+            <column defaultValueNumeric="0" name="program_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-376">
+        <createIndex indexName="program_outcomes_concept_id_fk" tableName="program">
+            <column name="outcomes_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-377">
+        <createIndex indexName="proposal_obs_concept_id" tableName="concept_proposal">
+            <column name="obs_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-378">
+        <createIndex indexName="proposal_obs_id" tableName="concept_proposal">
+            <column name="obs_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-379">
+        <createIndex indexName="provider_attribute_attribute_type_id_fk" tableName="provider_attribute">
+            <column name="attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-380">
+        <createIndex indexName="provider_attribute_changed_by_fk" tableName="provider_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-381">
+        <createIndex indexName="provider_attribute_creator_fk" tableName="provider_attribute">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-382">
+        <createIndex indexName="provider_attribute_provider_fk" tableName="provider_attribute">
+            <column name="provider_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-383">
+        <createIndex indexName="provider_attribute_type_changed_by_fk" tableName="provider_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-384">
+        <createIndex indexName="provider_attribute_type_creator_fk" tableName="provider_attribute_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-385">
+        <createIndex indexName="provider_attribute_type_retired_by_fk" tableName="provider_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-386">
+        <createIndex indexName="provider_attribute_voided_by_fk" tableName="provider_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-387">
+        <createIndex indexName="provider_changed_by_fk" tableName="provider">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-388">
+        <createIndex indexName="provider_creator_fk" tableName="provider">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-389">
+        <createIndex indexName="provider_id_fk" tableName="encounter_provider">
+            <column name="provider_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-390">
+        <createIndex indexName="provider_person_id_fk" tableName="provider">
+            <column name="person_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-391">
+        <createIndex indexName="provider_retired_by_fk" tableName="provider">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-392">
+        <createIndex indexName="provider_role_id_fk" tableName="provider">
+            <column name="role_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-393">
+        <createIndex indexName="provider_speciality_id_fk" tableName="provider">
+            <column name="speciality_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-394">
+        <createIndex indexName="relation_creator" tableName="relationship">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-395">
+        <createIndex indexName="relation_voider" tableName="relationship">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-396">
+        <createIndex indexName="relationship_changed_by" tableName="relationship">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-397">
+        <createIndex indexName="relationship_type_changed_by" tableName="relationship_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-398">
+        <createIndex indexName="relationship_type_id" tableName="relationship">
+            <column defaultValueNumeric="0" name="relationship"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-399">
+        <createIndex indexName="report_object_creator" tableName="report_object">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-400">
+        <createIndex indexName="role_definitions" tableName="user_role">
+            <column name="role"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-401">
+        <createIndex indexName="role_privilege_to_role" tableName="role_privilege">
+            <column name="role"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-402">
+        <createIndex indexName="route_concept" tableName="drug">
+            <column name="route"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-403">
+        <createIndex indexName="scheduler_changer" tableName="scheduler_task_config">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-404">
+        <createIndex indexName="scheduler_creator" tableName="scheduler_task_config">
+            <column defaultValueNumeric="0" name="created_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-405">
+        <createIndex indexName="serialized_object_changed_by" tableName="serialized_object">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-406">
+        <createIndex indexName="serialized_object_creator" tableName="serialized_object">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-407">
+        <createIndex indexName="serialized_object_retired_by" tableName="serialized_object">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-408">
+        <createIndex indexName="state_changed_by" tableName="program_workflow_state">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-409">
+        <createIndex indexName="state_concept" tableName="program_workflow_state">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-410">
+        <createIndex indexName="state_creator" tableName="program_workflow_state">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-411">
+        <createIndex indexName="state_for_patient" tableName="patient_state">
+            <column defaultValueNumeric="0" name="state"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-412">
+        <createIndex indexName="task_config_for_property" tableName="scheduler_task_config_property">
+            <column name="task_config_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-413">
+        <createIndex indexName="test_order_frequency_fk" tableName="test_order">
+            <column name="frequency"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-414">
+        <createIndex indexName="test_order_specimen_source_fk" tableName="test_order">
+            <column name="specimen_source"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-415">
+        <createIndex indexName="type_created_by" tableName="order_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-416">
+        <createIndex indexName="type_creator" tableName="patient_identifier_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-417">
+        <createIndex indexName="type_of_field" tableName="field">
+            <column name="field_type"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-418">
+        <createIndex indexName="type_of_order" tableName="orders">
+            <column defaultValueNumeric="0" name="order_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-419">
+        <createIndex indexName="user_creator" tableName="users">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-420">
+        <createIndex indexName="user_role_to_users" tableName="user_role">
+            <column defaultValueNumeric="0" name="user_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-421">
+        <createIndex indexName="user_who_changed" tableName="patient_program">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-422">
+        <createIndex indexName="user_who_changed_alert" tableName="notification_alert">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-423">
+        <createIndex indexName="user_who_changed_cohort" tableName="cohort">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-424">
+        <createIndex indexName="user_who_changed_concept" tableName="concept">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-425">
+        <createIndex indexName="user_who_changed_description" tableName="concept_description">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-426">
+        <createIndex indexName="user_who_changed_drug_reference_map" tableName="drug_reference_map">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-427">
+        <createIndex indexName="user_who_changed_field" tableName="field">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-428">
+        <createIndex indexName="user_who_changed_note" tableName="note">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-429">
+        <createIndex indexName="user_who_changed_pat" tableName="patient">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-430">
+        <createIndex indexName="user_who_changed_person" tableName="person">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-431">
+        <createIndex indexName="user_who_changed_program" tableName="program">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-432">
+        <createIndex indexName="user_who_changed_proposal" tableName="concept_proposal">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-433">
+        <createIndex indexName="user_who_changed_report_object" tableName="report_object">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-434">
+        <createIndex indexName="user_who_changed_user" tableName="users">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-435">
+        <createIndex indexName="user_who_created" tableName="concept_set">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-436">
+        <createIndex indexName="user_who_created_description" tableName="concept_description">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-437">
+        <createIndex indexName="user_who_created_field" tableName="field">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-438">
+        <createIndex indexName="user_who_created_field_answer" tableName="field_answer">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-439">
+        <createIndex indexName="user_who_created_field_type" tableName="field_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-440">
+        <createIndex indexName="user_who_created_form" tableName="form">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-441">
+        <createIndex indexName="user_who_created_form_field" tableName="form_field">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-442">
+        <createIndex indexName="user_who_created_hl7_source" tableName="hl7_source">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-443">
+        <createIndex indexName="user_who_created_location" tableName="location">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-444">
+        <createIndex indexName="user_who_created_name" tableName="concept_name">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-445">
+        <createIndex indexName="user_who_created_name_tag" tableName="concept_name_tag">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-446">
+        <createIndex indexName="user_who_created_note" tableName="note">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-447">
+        <createIndex indexName="user_who_created_patient" tableName="patient">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-448">
+        <createIndex indexName="user_who_created_person" tableName="person">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-449">
+        <createIndex indexName="user_who_created_proposal" tableName="concept_proposal">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-450">
+        <createIndex indexName="user_who_created_rel" tableName="relationship_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-451">
+        <createIndex indexName="user_who_created_type" tableName="encounter_type">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-452">
+        <createIndex indexName="user_who_last_changed_form" tableName="form">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-453">
+        <createIndex indexName="user_who_last_changed_form_field" tableName="form_field">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-454">
+        <createIndex indexName="user_who_made_name" tableName="person_name">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-455">
+        <createIndex indexName="user_who_retired_concept" tableName="concept">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-456">
+        <createIndex indexName="user_who_retired_concept_class" tableName="concept_class">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-457">
+        <createIndex indexName="user_who_retired_concept_datatype" tableName="concept_datatype">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-458">
+        <createIndex indexName="user_who_retired_concept_source" tableName="concept_reference_source">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-459">
+        <createIndex indexName="user_who_retired_drug_reference_map" tableName="drug_reference_map">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-460">
+        <createIndex indexName="user_who_retired_encounter_type" tableName="encounter_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-461">
+        <createIndex indexName="user_who_retired_field" tableName="field">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-462">
+        <createIndex indexName="user_who_retired_form" tableName="form">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-463">
+        <createIndex indexName="user_who_retired_location" tableName="location">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-464">
+        <createIndex indexName="user_who_retired_order_type" tableName="order_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-465">
+        <createIndex indexName="user_who_retired_patient_identifier_type" tableName="patient_identifier_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-466">
+        <createIndex indexName="user_who_retired_person_attribute_type" tableName="person_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-467">
+        <createIndex indexName="user_who_retired_relationship_type" tableName="relationship_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-468">
+        <createIndex indexName="user_who_retired_this_user" tableName="users">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-469">
+        <createIndex indexName="user_who_voided_cohort" tableName="cohort">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-470">
+        <createIndex indexName="user_who_voided_encounter" tableName="encounter">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-471">
+        <createIndex indexName="user_who_voided_name" tableName="person_name">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-472">
+        <createIndex indexName="user_who_voided_name_tag" tableName="concept_name_tag">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-473">
+        <createIndex indexName="user_who_voided_obs" tableName="obs">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-474">
+        <createIndex indexName="user_who_voided_order" tableName="orders">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-475">
+        <createIndex indexName="user_who_voided_patient" tableName="patient">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-476">
+        <createIndex indexName="user_who_voided_patient_program" tableName="patient_program">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-477">
+        <createIndex indexName="user_who_voided_person" tableName="person">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-478">
+        <createIndex indexName="user_who_voided_report_object" tableName="report_object">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-479">
+        <createIndex indexName="user_who_voided_this_name" tableName="concept_name">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-480">
+        <createIndex indexName="visit_attribute_attribute_type_id_fk" tableName="visit_attribute">
+            <column name="attribute_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-481">
+        <createIndex indexName="visit_attribute_changed_by_fk" tableName="visit_attribute">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-482">
+        <createIndex indexName="visit_attribute_creator_fk" tableName="visit_attribute">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-483">
+        <createIndex indexName="visit_attribute_type_changed_by_fk" tableName="visit_attribute_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-484">
+        <createIndex indexName="visit_attribute_type_creator_fk" tableName="visit_attribute_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-485">
+        <createIndex indexName="visit_attribute_type_retired_by_fk" tableName="visit_attribute_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-486">
+        <createIndex indexName="visit_attribute_visit_fk" tableName="visit_attribute">
+            <column name="visit_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-487">
+        <createIndex indexName="visit_attribute_voided_by_fk" tableName="visit_attribute">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-488">
+        <createIndex indexName="visit_changed_by_fk" tableName="visit">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-489">
+        <createIndex indexName="visit_creator_fk" tableName="visit">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-490">
+        <createIndex indexName="visit_indication_concept_fk" tableName="visit">
+            <column name="indication_concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-491">
+        <createIndex indexName="visit_location_fk" tableName="visit">
+            <column name="location_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-492">
+        <createIndex indexName="visit_patient_index" tableName="visit">
+            <column name="patient_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-493">
+        <createIndex indexName="visit_type_changed_by" tableName="visit_type">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-494">
+        <createIndex indexName="visit_type_creator" tableName="visit_type">
+            <column name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-495">
+        <createIndex indexName="visit_type_fk" tableName="visit">
+            <column name="visit_type_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-496">
+        <createIndex indexName="visit_type_retired_by" tableName="visit_type">
+            <column name="retired_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-497">
+        <createIndex indexName="visit_voided_by_fk" tableName="visit">
+            <column name="voided_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-498">
+        <createIndex indexName="workflow_changed_by" tableName="program_workflow">
+            <column name="changed_by"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-499">
+        <createIndex indexName="workflow_concept" tableName="program_workflow">
+            <column defaultValueNumeric="0" name="concept_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-500">
+        <createIndex indexName="workflow_creator" tableName="program_workflow">
+            <column defaultValueNumeric="0" name="creator"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-501">
+        <createIndex indexName="workflow_for_state" tableName="program_workflow_state">
+            <column defaultValueNumeric="0" name="program_workflow_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-502">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="person_address" constraintName="address_for_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person"/>
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-503">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="notification_alert" constraintName="alert_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-504">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="notification_alert_recipient" constraintName="alert_read_by_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-505">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="allergy" constraintName="allergy_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-506">
+        <addForeignKeyConstraint baseColumnNames="coded_allergen" baseTableName="allergy" constraintName="allergy_coded_allergen_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-507">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="allergy" constraintName="allergy_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-508">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="allergy" constraintName="allergy_patient_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-509">
+        <addForeignKeyConstraint baseColumnNames="allergy_id" baseTableName="allergy_reaction" constraintName="allergy_reaction_allergy_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="allergy_id" referencedTableName="allergy" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-510">
+        <addForeignKeyConstraint baseColumnNames="reaction_concept_id" baseTableName="allergy_reaction" constraintName="allergy_reaction_reaction_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-511">
+        <addForeignKeyConstraint baseColumnNames="severity_concept_id" baseTableName="allergy" constraintName="allergy_severity_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-512">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="allergy" constraintName="allergy_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-513">
+        <addForeignKeyConstraint baseColumnNames="answer_concept" baseTableName="concept_answer" constraintName="answer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-514">
+        <addForeignKeyConstraint baseColumnNames="answer_drug" baseTableName="concept_answer" constraintName="answer_answer_drug_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="drug_id" referencedTableName="drug" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-515">
+        <addForeignKeyConstraint baseColumnNames="value_coded" baseTableName="obs" constraintName="answer_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-516">
+        <addForeignKeyConstraint baseColumnNames="value_drug" baseTableName="obs" constraintName="answer_concept_drug" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="drug_id" referencedTableName="drug" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-517">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_answer" constraintName="answer_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-518">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_answer" constraintName="answers_for_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-519">
+        <addForeignKeyConstraint baseColumnNames="field_id" baseTableName="field_answer" constraintName="answers_for_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="field_id" referencedTableName="field" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-520">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="person_attribute" constraintName="attribute_changer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-521">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person_attribute" constraintName="attribute_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-522">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="person_attribute_type" constraintName="attribute_type_changer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-523">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person_attribute_type" constraintName="attribute_type_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-524">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="person_attribute" constraintName="attribute_voider" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-525">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="care_setting" constraintName="care_setting_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-526">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="care_setting" constraintName="care_setting_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-527">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="care_setting" constraintName="care_setting_retired_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-528">
+        <addForeignKeyConstraint baseColumnNames="category" baseTableName="order_set" constraintName="category_order_set_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-529">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="cohort" constraintName="cohort_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-530">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="cohort_member" constraintName="cohort_member_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-531">
+        <addForeignKeyConstraint baseColumnNames="attribute_type_id" baseTableName="concept_attribute" constraintName="concept_attribute_attribute_type_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_attribute_type_id" referencedTableName="concept_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-532">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_attribute" constraintName="concept_attribute_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-533">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_attribute" constraintName="concept_attribute_concept_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-534">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_attribute" constraintName="concept_attribute_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-535">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_attribute_type" constraintName="concept_attribute_type_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-536">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_attribute_type" constraintName="concept_attribute_type_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-537">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_attribute_type" constraintName="concept_attribute_type_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-538">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="concept_attribute" constraintName="concept_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-539">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_complex" constraintName="concept_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-540">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_class" constraintName="concept_class_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-541">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_class" constraintName="concept_class_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-542">
+        <addForeignKeyConstraint baseColumnNames="class_id" baseTableName="concept" constraintName="concept_classes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_class_id" referencedTableName="concept_class" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-543">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept" constraintName="concept_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-544">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_datatype" constraintName="concept_datatype_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-545">
+        <addForeignKeyConstraint baseColumnNames="datatype_id" baseTableName="concept" constraintName="concept_datatypes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_datatype_id" referencedTableName="concept_datatype" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-546">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="field" constraintName="concept_for_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-547">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_proposal" constraintName="concept_for_proposal" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-548">
+        <addForeignKeyConstraint baseColumnNames="concept_map_type" baseTableName="drug_reference_map" constraintName="concept_map_type_for_drug_reference_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_map_type_id" referencedTableName="concept_map_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-549">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_name" constraintName="concept_name_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-550">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_name_tag" constraintName="concept_name_tag_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-551">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_reference_source" constraintName="concept_reference_source_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-552">
+        <addForeignKeyConstraint baseColumnNames="term_id" baseTableName="drug_reference_map" constraintName="concept_reference_term_for_drug_reference_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_reference_term_id" referencedTableName="concept_reference_term" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-553">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_reference_source" constraintName="concept_source_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-554">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_state_conversion" constraintName="concept_triggers_conversion" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-555">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="conditions" constraintName="condition_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-556">
+        <addForeignKeyConstraint baseColumnNames="condition_coded" baseTableName="conditions" constraintName="condition_condition_coded_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-557">
+        <addForeignKeyConstraint baseColumnNames="condition_coded_name" baseTableName="conditions" constraintName="condition_condition_coded_name_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_id" referencedTableName="concept_name" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-558">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="conditions" constraintName="condition_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-559">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="conditions" constraintName="condition_patient_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-560">
+        <addForeignKeyConstraint baseColumnNames="previous_version" baseTableName="conditions" constraintName="condition_previous_version_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="condition_id" referencedTableName="conditions" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-561">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="conditions" constraintName="condition_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-562">
+        <addForeignKeyConstraint baseColumnNames="program_workflow_id" baseTableName="concept_state_conversion" constraintName="conversion_involves_workflow" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_workflow_id" referencedTableName="program_workflow" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-563">
+        <addForeignKeyConstraint baseColumnNames="program_workflow_state_id" baseTableName="concept_state_conversion" constraintName="conversion_to_state" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_workflow_state_id" referencedTableName="program_workflow_state" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-564">
+        <addForeignKeyConstraint baseColumnNames="person_attribute_type_id" baseTableName="person_attribute" constraintName="defines_attribute_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_attribute_type_id" referencedTableName="person_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-565">
+        <addForeignKeyConstraint baseColumnNames="identifier_type" baseTableName="patient_identifier" constraintName="defines_identifier_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_identifier_type_id" referencedTableName="patient_identifier_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-566">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_description" constraintName="description_for_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-567">
+        <addForeignKeyConstraint baseColumnNames="order_reason" baseTableName="orders" constraintName="discontinued_because" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-568">
+        <addForeignKeyConstraint baseColumnNames="dosage_form" baseTableName="drug" constraintName="dosage_form_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-569">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="drug" constraintName="drug_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-570">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="drug" constraintName="drug_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-571">
+        <addForeignKeyConstraint baseColumnNames="dose_limit_units" baseTableName="drug" constraintName="drug_dose_limit_units_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-572">
+        <addForeignKeyConstraint baseColumnNames="drug_id" baseTableName="drug_reference_map" constraintName="drug_for_drug_reference_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="drug_id" referencedTableName="drug" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-573">
+        <addForeignKeyConstraint baseColumnNames="drug_id" baseTableName="drug_ingredient" constraintName="drug_ingredient_drug_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="drug_id" referencedTableName="drug" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-574">
+        <addForeignKeyConstraint baseColumnNames="ingredient_id" baseTableName="drug_ingredient" constraintName="drug_ingredient_ingredient_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-575">
+        <addForeignKeyConstraint baseColumnNames="units" baseTableName="drug_ingredient" constraintName="drug_ingredient_units_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-576">
+        <addForeignKeyConstraint baseColumnNames="dose_units" baseTableName="drug_order" constraintName="drug_order_dose_units" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-577">
+        <addForeignKeyConstraint baseColumnNames="duration_units" baseTableName="drug_order" constraintName="drug_order_duration_units_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-578">
+        <addForeignKeyConstraint baseColumnNames="frequency" baseTableName="drug_order" constraintName="drug_order_frequency_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_frequency_id" referencedTableName="order_frequency" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-579">
+        <addForeignKeyConstraint baseColumnNames="quantity_units" baseTableName="drug_order" constraintName="drug_order_quantity_units" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-580">
+        <addForeignKeyConstraint baseColumnNames="route" baseTableName="drug_order" constraintName="drug_order_route_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-581">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="drug_reference_map" constraintName="drug_reference_map_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-582">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="drug" constraintName="drug_retired_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-583">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="encounter" constraintName="encounter_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-584">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-585">
+        <addForeignKeyConstraint baseColumnNames="diagnosis_coded" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_coded_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-586">
+        <addForeignKeyConstraint baseColumnNames="diagnosis_coded_name" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_coded_name_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_id" referencedTableName="concept_name" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-587">
+        <addForeignKeyConstraint baseColumnNames="condition_id" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_condition_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="condition_id" referencedTableName="conditions" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-588">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-589">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_encounter_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-590">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_patient_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-591">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="encounter_diagnosis" constraintName="encounter_diagnosis_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-592">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="concept_proposal" constraintName="encounter_for_proposal" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-593">
+        <addForeignKeyConstraint baseColumnNames="form_id" baseTableName="encounter" constraintName="encounter_form" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="form_id" referencedTableName="form" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-594">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="encounter" constraintName="encounter_ibfk_1" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-595">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="encounter_provider" constraintName="encounter_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-596">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="encounter" constraintName="encounter_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-597">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="note" constraintName="encounter_note" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-598">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="obs" constraintName="encounter_observations" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-599">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="encounter" constraintName="encounter_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-600">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="encounter_provider" constraintName="encounter_provider_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-601">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="encounter_provider" constraintName="encounter_provider_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-602">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="encounter_provider" constraintName="encounter_provider_voided_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-603">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="encounter_role" constraintName="encounter_role_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-604">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="encounter_role" constraintName="encounter_role_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-605">
+        <addForeignKeyConstraint baseColumnNames="encounter_role_id" baseTableName="encounter_provider" constraintName="encounter_role_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_role_id" referencedTableName="encounter_role" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-606">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="encounter_role" constraintName="encounter_role_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-607">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="encounter_type" constraintName="encounter_type_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-608">
+        <addForeignKeyConstraint baseColumnNames="encounter_type" baseTableName="encounter" constraintName="encounter_type_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_type_id" referencedTableName="encounter_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-609">
+        <addForeignKeyConstraint baseColumnNames="visit_id" baseTableName="encounter" constraintName="encounter_visit_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="visit_id" referencedTableName="visit" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-610">
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="drug_order" constraintName="extends_order" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-611">
+        <addForeignKeyConstraint baseColumnNames="answer_id" baseTableName="field_answer" constraintName="field_answer_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-612">
+        <addForeignKeyConstraint baseColumnNames="field_id" baseTableName="form_field" constraintName="field_within_form" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="field_id" referencedTableName="field" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-613">
+        <addForeignKeyConstraint baseColumnNames="concept_class_id" baseTableName="order_type_class_map" constraintName="fk_order_type_class_map_concept_class_concept_class_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_class_id" referencedTableName="concept_class" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-614">
+        <addForeignKeyConstraint baseColumnNames="order_type_id" baseTableName="order_type_class_map" constraintName="fk_order_type_order_type_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_type_id" referencedTableName="order_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-615">
+        <addForeignKeyConstraint baseColumnNames="orderer" baseTableName="orders" constraintName="fk_orderer_provider" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="provider_id" referencedTableName="provider" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-616">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient_identifier" constraintName="fk_patient_id_patient_identifier" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-617">
+        <addForeignKeyConstraint baseColumnNames="form_id" baseTableName="form_field" constraintName="form_containing_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="form_id" referencedTableName="form" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-618">
+        <addForeignKeyConstraint baseColumnNames="encounter_type" baseTableName="form" constraintName="form_encounter_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_type_id" referencedTableName="encounter_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-619">
+        <addForeignKeyConstraint baseColumnNames="parent_form_field" baseTableName="form_field" constraintName="form_field_hierarchy" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="form_field_id" referencedTableName="form_field" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-620">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="form_resource" constraintName="form_resource_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-621">
+        <addForeignKeyConstraint baseColumnNames="form_id" baseTableName="form_resource" constraintName="form_resource_form_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="form_id" referencedTableName="form" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-622">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="global_property" constraintName="global_property_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-623">
+        <addForeignKeyConstraint baseColumnNames="concept_set" baseTableName="concept_set" constraintName="has_a" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-624">
+        <addForeignKeyConstraint baseColumnNames="hl7_source" baseTableName="hl7_in_queue" constraintName="hl7_source_with_queue" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="hl7_source_id" referencedTableName="hl7_source" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-625">
+        <addForeignKeyConstraint baseColumnNames="alert_id" baseTableName="notification_alert_recipient" constraintName="id_of_alert" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="alert_id" referencedTableName="notification_alert" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-626">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient_identifier" constraintName="identifier_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-627">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="patient_identifier" constraintName="identifier_voider" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-628">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="person_attribute" constraintName="identifies_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-629">
+        <addForeignKeyConstraint baseColumnNames="child_role" baseTableName="role_role" constraintName="inherited_role" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="role" referencedTableName="role" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-630">
+        <addForeignKeyConstraint baseColumnNames="drug_inventory_id" baseTableName="drug_order" constraintName="inventory_item" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="drug_id" referencedTableName="drug" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-631">
+        <addForeignKeyConstraint baseColumnNames="attribute_type_id" baseTableName="location_attribute" constraintName="location_attribute_attribute_type_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_attribute_type_id" referencedTableName="location_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-632">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="location_attribute" constraintName="location_attribute_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-633">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="location_attribute" constraintName="location_attribute_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-634">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="location_attribute" constraintName="location_attribute_location_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-635">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="location_attribute_type" constraintName="location_attribute_type_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-636">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="location_attribute_type" constraintName="location_attribute_type_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-637">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="location_attribute_type" constraintName="location_attribute_type_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-638">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="location_attribute" constraintName="location_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-639">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="location" constraintName="location_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-640">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="location_tag" constraintName="location_tag_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-641">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="location_tag" constraintName="location_tag_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-642">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="location_tag_map" constraintName="location_tag_map_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-643">
+        <addForeignKeyConstraint baseColumnNames="location_tag_id" baseTableName="location_tag_map" constraintName="location_tag_map_tag" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_tag_id" referencedTableName="location_tag" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-644">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="location_tag" constraintName="location_tag_retired_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-645">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_reference_map" constraintName="map_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-646">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_reference_map" constraintName="map_for_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-647">
+        <addForeignKeyConstraint baseColumnNames="concept_map_type_id" baseTableName="concept_reference_map" constraintName="mapped_concept_map_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_map_type_id" referencedTableName="concept_map_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-648">
+        <addForeignKeyConstraint baseColumnNames="a_is_to_b_id" baseTableName="concept_reference_term_map" constraintName="mapped_concept_map_type_ref_term_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_map_type_id" referencedTableName="concept_map_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-649">
+        <addForeignKeyConstraint baseColumnNames="concept_name_id" baseTableName="concept_name_tag_map" constraintName="mapped_concept_name" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_id" referencedTableName="concept_name" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-650">
+        <addForeignKeyConstraint baseColumnNames="concept_name_tag_id" baseTableName="concept_name_tag_map" constraintName="mapped_concept_name_tag" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_tag_id" referencedTableName="concept_name_tag" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-651">
+        <addForeignKeyConstraint baseColumnNames="concept_proposal_id" baseTableName="concept_proposal_tag_map" constraintName="mapped_concept_proposal" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_proposal_id" referencedTableName="concept_proposal" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-652">
+        <addForeignKeyConstraint baseColumnNames="concept_name_tag_id" baseTableName="concept_proposal_tag_map" constraintName="mapped_concept_proposal_tag" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_tag_id" referencedTableName="concept_name_tag" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-653">
+        <addForeignKeyConstraint baseColumnNames="concept_reference_term_id" baseTableName="concept_reference_map" constraintName="mapped_concept_reference_term" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_reference_term_id" referencedTableName="concept_reference_term" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-654">
+        <addForeignKeyConstraint baseColumnNames="concept_source_id" baseTableName="concept_reference_term" constraintName="mapped_concept_source" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_source_id" referencedTableName="concept_reference_source" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-655">
+        <addForeignKeyConstraint baseColumnNames="term_a_id" baseTableName="concept_reference_term_map" constraintName="mapped_term_a" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_reference_term_id" referencedTableName="concept_reference_term" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-656">
+        <addForeignKeyConstraint baseColumnNames="term_b_id" baseTableName="concept_reference_term_map" constraintName="mapped_term_b" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_reference_term_id" referencedTableName="concept_reference_term" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-657">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_reference_term" constraintName="mapped_user_changed" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-658">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_map_type" constraintName="mapped_user_changed_concept_map_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-659">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_reference_map" constraintName="mapped_user_changed_ref_term" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-660">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_reference_term_map" constraintName="mapped_user_changed_ref_term_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-661">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_reference_term" constraintName="mapped_user_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-662">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_map_type" constraintName="mapped_user_creator_concept_map_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-663">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_reference_term_map" constraintName="mapped_user_creator_ref_term_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-664">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_reference_term" constraintName="mapped_user_retired" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-665">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_map_type" constraintName="mapped_user_retired_concept_map_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-666">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="cohort_member" constraintName="member_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-667">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_name" constraintName="name_for_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-668">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="person_name" constraintName="name_for_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-669">
+        <addForeignKeyConstraint baseColumnNames="parent" baseTableName="note" constraintName="note_hierarchy" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="note_id" referencedTableName="note" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-670">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_numeric" constraintName="numeric_attributes" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-671">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="obs" constraintName="obs_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-672">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="obs" constraintName="obs_enterer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-673">
+        <addForeignKeyConstraint baseColumnNames="obs_group_id" baseTableName="obs" constraintName="obs_grouping_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="obs_id" referencedTableName="obs" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-674">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="obs" constraintName="obs_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-675">
+        <addForeignKeyConstraint baseColumnNames="value_coded_name_id" baseTableName="obs" constraintName="obs_name_of_coded_value" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_name_id" referencedTableName="concept_name" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-676">
+        <addForeignKeyConstraint baseColumnNames="obs_id" baseTableName="note" constraintName="obs_note" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="obs_id" referencedTableName="obs" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-677">
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="obs" constraintName="obs_order" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-678">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="orders" constraintName="order_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-679">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="orders" constraintName="order_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-680">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="order_frequency" constraintName="order_frequency_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-681">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="order_frequency" constraintName="order_frequency_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-682">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="order_frequency" constraintName="order_frequency_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-683">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="order_frequency" constraintName="order_frequency_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-684">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="order_group" constraintName="order_group_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-685">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="order_group" constraintName="order_group_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-686">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="order_group" constraintName="order_group_encounter_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-687">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="order_group" constraintName="order_group_patient_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-688">
+        <addForeignKeyConstraint baseColumnNames="order_set_id" baseTableName="order_group" constraintName="order_group_set_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_set_id" referencedTableName="order_set" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-689">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="order_group" constraintName="order_group_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-690">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="order_set" constraintName="order_set_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-691">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="order_set" constraintName="order_set_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-692">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="order_set_member" constraintName="order_set_member_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-693">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="order_set_member" constraintName="order_set_member_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-694">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="order_set_member" constraintName="order_set_member_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-695">
+        <addForeignKeyConstraint baseColumnNames="order_set_id" baseTableName="order_set_member" constraintName="order_set_member_order_set_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_set_id" referencedTableName="order_set" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-696">
+        <addForeignKeyConstraint baseColumnNames="order_type" baseTableName="order_set_member" constraintName="order_set_member_order_type_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_type_id" referencedTableName="order_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-697">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="order_set_member" constraintName="order_set_member_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-698">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="order_set" constraintName="order_set_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-699">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="order_type" constraintName="order_type_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-700">
+        <addForeignKeyConstraint baseColumnNames="parent" baseTableName="order_type" constraintName="order_type_parent_order_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_type_id" referencedTableName="order_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-701">
+        <addForeignKeyConstraint baseColumnNames="care_setting" baseTableName="orders" constraintName="orders_care_setting" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="care_setting_id" referencedTableName="care_setting" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-702">
+        <addForeignKeyConstraint baseColumnNames="encounter_id" baseTableName="orders" constraintName="orders_in_encounter" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="encounter_id" referencedTableName="encounter" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-703">
+        <addForeignKeyConstraint baseColumnNames="order_group_id" baseTableName="orders" constraintName="orders_order_group_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_group_id" referencedTableName="order_group" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-704">
+        <addForeignKeyConstraint baseColumnNames="cohort_id" baseTableName="cohort_member" constraintName="parent_cohort" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="cohort_id" referencedTableName="cohort" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-705">
+        <addForeignKeyConstraint baseColumnNames="parent_location" baseTableName="location" constraintName="parent_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-706">
+        <addForeignKeyConstraint baseColumnNames="parent_role" baseTableName="role_role" constraintName="parent_role" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="role" referencedTableName="role" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-707">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person_address" constraintName="patient_address_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-708">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="person_address" constraintName="patient_address_void" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-709">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient_identifier" constraintName="patient_identifier_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-710">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="patient_identifier" constraintName="patient_identifier_ibfk_2" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-711">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient_identifier_type" constraintName="patient_identifier_type_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-712">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient_program" constraintName="patient_in_program" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-713">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="note" constraintName="patient_note" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-714">
+        <addForeignKeyConstraint baseColumnNames="attribute_type_id" baseTableName="patient_program_attribute" constraintName="patient_program_attribute_attributetype_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_attribute_type_id" referencedTableName="program_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-715">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient_program_attribute" constraintName="patient_program_attribute_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-716">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient_program_attribute" constraintName="patient_program_attribute_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-717">
+        <addForeignKeyConstraint baseColumnNames="patient_program_id" baseTableName="patient_program_attribute" constraintName="patient_program_attribute_programid_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_program_id" referencedTableName="patient_program" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-718">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="patient_program_attribute" constraintName="patient_program_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-719">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient_program" constraintName="patient_program_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-720">
+        <addForeignKeyConstraint baseColumnNames="patient_program_id" baseTableName="patient_state" constraintName="patient_program_for_state" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_program_id" referencedTableName="patient_program" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-721">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="patient_program" constraintName="patient_program_location_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-722">
+        <addForeignKeyConstraint baseColumnNames="outcome_concept_id" baseTableName="patient_program" constraintName="patient_program_outcome_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-723">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient_state" constraintName="patient_state_changer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-724">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient_state" constraintName="patient_state_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-725">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="patient_state" constraintName="patient_state_voider" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-726">
+        <addForeignKeyConstraint baseColumnNames="person_a" baseTableName="relationship" constraintName="person_a_is_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-727">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="person_address" constraintName="person_address_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-728">
+        <addForeignKeyConstraint baseColumnNames="person_b" baseTableName="relationship" constraintName="person_b_is_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-729">
+        <addForeignKeyConstraint baseColumnNames="cause_of_death" baseTableName="person" constraintName="person_died_because" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-730">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="patient" constraintName="person_id_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-731">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="users" constraintName="person_id_for_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-732">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="person_merge_log" constraintName="person_merge_log_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-733">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person_merge_log" constraintName="person_merge_log_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-734">
+        <addForeignKeyConstraint baseColumnNames="loser_person_id" baseTableName="person_merge_log" constraintName="person_merge_log_loser" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-735">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="person_merge_log" constraintName="person_merge_log_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-736">
+        <addForeignKeyConstraint baseColumnNames="winner_person_id" baseTableName="person_merge_log" constraintName="person_merge_log_winner" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-737">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="obs" constraintName="person_obs" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="CASCADE" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-738">
+        <addForeignKeyConstraint baseColumnNames="previous_order_id" baseTableName="orders" constraintName="previous_order_id_order_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-739">
+        <addForeignKeyConstraint baseColumnNames="previous_version" baseTableName="obs" constraintName="previous_version" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="obs_id" referencedTableName="obs" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-740">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="drug" constraintName="primary_drug_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-741">
+        <addForeignKeyConstraint baseColumnNames="privilege" baseTableName="role_privilege" constraintName="privilege_definitions" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="privilege" referencedTableName="privilege" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-742">
+        <addForeignKeyConstraint baseColumnNames="edit_privilege" baseTableName="person_attribute_type" constraintName="privilege_which_can_edit" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="privilege" referencedTableName="privilege" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-743">
+        <addForeignKeyConstraint baseColumnNames="edit_privilege" baseTableName="encounter_type" constraintName="privilege_which_can_edit_encounter_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="privilege" referencedTableName="privilege" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-744">
+        <addForeignKeyConstraint baseColumnNames="view_privilege" baseTableName="encounter_type" constraintName="privilege_which_can_view_encounter_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="privilege" referencedTableName="privilege" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-745">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="program_attribute_type" constraintName="program_attribute_type_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-746">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="program_attribute_type" constraintName="program_attribute_type_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-747">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="program_attribute_type" constraintName="program_attribute_type_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-748">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="program" constraintName="program_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-749">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="program" constraintName="program_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-750">
+        <addForeignKeyConstraint baseColumnNames="program_id" baseTableName="patient_program" constraintName="program_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_id" referencedTableName="program" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-751">
+        <addForeignKeyConstraint baseColumnNames="program_id" baseTableName="program_workflow" constraintName="program_for_workflow" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_id" referencedTableName="program" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-752">
+        <addForeignKeyConstraint baseColumnNames="outcomes_concept_id" baseTableName="program" constraintName="program_outcomes_concept_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-753">
+        <addForeignKeyConstraint baseColumnNames="obs_concept_id" baseTableName="concept_proposal" constraintName="proposal_obs_concept_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-754">
+        <addForeignKeyConstraint baseColumnNames="obs_id" baseTableName="concept_proposal" constraintName="proposal_obs_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="obs_id" referencedTableName="obs" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-755">
+        <addForeignKeyConstraint baseColumnNames="attribute_type_id" baseTableName="provider_attribute" constraintName="provider_attribute_attribute_type_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="provider_attribute_type_id" referencedTableName="provider_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-756">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="provider_attribute" constraintName="provider_attribute_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-757">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="provider_attribute" constraintName="provider_attribute_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-758">
+        <addForeignKeyConstraint baseColumnNames="provider_id" baseTableName="provider_attribute" constraintName="provider_attribute_provider_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="provider_id" referencedTableName="provider" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-759">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="provider_attribute_type" constraintName="provider_attribute_type_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-760">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="provider_attribute_type" constraintName="provider_attribute_type_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-761">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="provider_attribute_type" constraintName="provider_attribute_type_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-762">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="provider_attribute" constraintName="provider_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-763">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="provider" constraintName="provider_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-764">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="provider" constraintName="provider_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-765">
+        <addForeignKeyConstraint baseColumnNames="provider_id" baseTableName="encounter_provider" constraintName="provider_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="provider_id" referencedTableName="provider" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-766">
+        <addForeignKeyConstraint baseColumnNames="person_id" baseTableName="provider" constraintName="provider_person_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="person_id" referencedTableName="person" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-767">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="provider" constraintName="provider_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-768">
+        <addForeignKeyConstraint baseColumnNames="role_id" baseTableName="provider" constraintName="provider_role_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-769">
+        <addForeignKeyConstraint baseColumnNames="speciality_id" baseTableName="provider" constraintName="provider_speciality_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-770">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="relationship" constraintName="relation_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-771">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="relationship" constraintName="relation_voider" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-772">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="relationship" constraintName="relationship_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-773">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="relationship_type" constraintName="relationship_type_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-774">
+        <addForeignKeyConstraint baseColumnNames="relationship" baseTableName="relationship" constraintName="relationship_type_id" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="relationship_type_id" referencedTableName="relationship_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-775">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="report_object" constraintName="report_object_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-776">
+        <addForeignKeyConstraint baseColumnNames="role" baseTableName="user_role" constraintName="role_definitions" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="role" referencedTableName="role" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-777">
+        <addForeignKeyConstraint baseColumnNames="role" baseTableName="role_privilege" constraintName="role_privilege_to_role" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="role" referencedTableName="role" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-778">
+        <addForeignKeyConstraint baseColumnNames="route" baseTableName="drug" constraintName="route_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-779">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="scheduler_task_config" constraintName="scheduler_changer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-780">
+        <addForeignKeyConstraint baseColumnNames="created_by" baseTableName="scheduler_task_config" constraintName="scheduler_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-781">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="serialized_object" constraintName="serialized_object_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-782">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="serialized_object" constraintName="serialized_object_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-783">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="serialized_object" constraintName="serialized_object_retired_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-784">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="program_workflow_state" constraintName="state_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-785">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="program_workflow_state" constraintName="state_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-786">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="program_workflow_state" constraintName="state_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-787">
+        <addForeignKeyConstraint baseColumnNames="state" baseTableName="patient_state" constraintName="state_for_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_workflow_state_id" referencedTableName="program_workflow_state" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-788">
+        <addForeignKeyConstraint baseColumnNames="task_config_id" baseTableName="scheduler_task_config_property" constraintName="task_config_for_property" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="task_config_id" referencedTableName="scheduler_task_config" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-789">
+        <addForeignKeyConstraint baseColumnNames="frequency" baseTableName="test_order" constraintName="test_order_frequency_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_frequency_id" referencedTableName="order_frequency" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-790">
+        <addForeignKeyConstraint baseColumnNames="order_id" baseTableName="test_order" constraintName="test_order_order_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_id" referencedTableName="orders" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-791">
+        <addForeignKeyConstraint baseColumnNames="specimen_source" baseTableName="test_order" constraintName="test_order_specimen_source_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-792">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="order_type" constraintName="type_created_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-793">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient_identifier_type" constraintName="type_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-794">
+        <addForeignKeyConstraint baseColumnNames="field_type" baseTableName="field" constraintName="type_of_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="field_type_id" referencedTableName="field_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-795">
+        <addForeignKeyConstraint baseColumnNames="order_type_id" baseTableName="orders" constraintName="type_of_order" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="order_type_id" referencedTableName="order_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-796">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="users" constraintName="user_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-797">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="user_property" constraintName="user_property_to_users" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-798">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="user_role" constraintName="user_role_to_users" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-799">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient_program" constraintName="user_who_changed" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-800">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="notification_alert" constraintName="user_who_changed_alert" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-801">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="cohort" constraintName="user_who_changed_cohort" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-802">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept" constraintName="user_who_changed_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-803">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_description" constraintName="user_who_changed_description" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-804">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="drug_reference_map" constraintName="user_who_changed_drug_reference_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-805">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="field" constraintName="user_who_changed_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-806">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="note" constraintName="user_who_changed_note" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-807">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="patient" constraintName="user_who_changed_pat" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-808">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="person" constraintName="user_who_changed_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-809">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="program" constraintName="user_who_changed_program" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-810">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="concept_proposal" constraintName="user_who_changed_proposal" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-811">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="report_object" constraintName="user_who_changed_report_object" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-812">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="users" constraintName="user_who_changed_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-813">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_set" constraintName="user_who_created" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-814">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_description" constraintName="user_who_created_description" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-815">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="field" constraintName="user_who_created_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-816">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="field_answer" constraintName="user_who_created_field_answer" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-817">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="field_type" constraintName="user_who_created_field_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-818">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="form" constraintName="user_who_created_form" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-819">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="form_field" constraintName="user_who_created_form_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-820">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="hl7_source" constraintName="user_who_created_hl7_source" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-821">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="location" constraintName="user_who_created_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-822">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_name" constraintName="user_who_created_name" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-823">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="note" constraintName="user_who_created_note" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-824">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="patient" constraintName="user_who_created_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-825">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person" constraintName="user_who_created_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-826">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="concept_proposal" constraintName="user_who_created_proposal" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-827">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="relationship_type" constraintName="user_who_created_rel" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-828">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="encounter_type" constraintName="user_who_created_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-829">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="form" constraintName="user_who_last_changed_form" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-830">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="form_field" constraintName="user_who_last_changed_form_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-831">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="person_name" constraintName="user_who_made_name" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-832">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept" constraintName="user_who_retired_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-833">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_class" constraintName="user_who_retired_concept_class" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-834">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_datatype" constraintName="user_who_retired_concept_datatype" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-835">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="concept_reference_source" constraintName="user_who_retired_concept_source" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-836">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="drug_reference_map" constraintName="user_who_retired_drug_reference_map" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-837">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="encounter_type" constraintName="user_who_retired_encounter_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-838">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="field" constraintName="user_who_retired_field" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-839">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="form" constraintName="user_who_retired_form" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-840">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="location" constraintName="user_who_retired_location" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-841">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="order_type" constraintName="user_who_retired_order_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-842">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="patient_identifier_type" constraintName="user_who_retired_patient_identifier_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-843">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="person_attribute_type" constraintName="user_who_retired_person_attribute_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-844">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="relationship_type" constraintName="user_who_retired_relationship_type" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-845">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="users" constraintName="user_who_retired_this_user" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-846">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="cohort" constraintName="user_who_voided_cohort" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-847">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="encounter" constraintName="user_who_voided_encounter" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-848">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="person_name" constraintName="user_who_voided_name" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-849">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="obs" constraintName="user_who_voided_obs" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-850">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="orders" constraintName="user_who_voided_order" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-851">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="patient" constraintName="user_who_voided_patient" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-852">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="patient_program" constraintName="user_who_voided_patient_program" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-853">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="person" constraintName="user_who_voided_person" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-854">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="report_object" constraintName="user_who_voided_report_object" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-855">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="concept_name" constraintName="user_who_voided_this_name" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-856">
+        <addForeignKeyConstraint baseColumnNames="attribute_type_id" baseTableName="visit_attribute" constraintName="visit_attribute_attribute_type_id_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="visit_attribute_type_id" referencedTableName="visit_attribute_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-857">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="visit_attribute" constraintName="visit_attribute_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-858">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="visit_attribute" constraintName="visit_attribute_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-859">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="visit_attribute_type" constraintName="visit_attribute_type_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-860">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="visit_attribute_type" constraintName="visit_attribute_type_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-861">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="visit_attribute_type" constraintName="visit_attribute_type_retired_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-862">
+        <addForeignKeyConstraint baseColumnNames="visit_id" baseTableName="visit_attribute" constraintName="visit_attribute_visit_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="visit_id" referencedTableName="visit" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-863">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="visit_attribute" constraintName="visit_attribute_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-864">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="visit" constraintName="visit_changed_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-865">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="visit" constraintName="visit_creator_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-866">
+        <addForeignKeyConstraint baseColumnNames="indication_concept_id" baseTableName="visit" constraintName="visit_indication_concept_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-867">
+        <addForeignKeyConstraint baseColumnNames="location_id" baseTableName="visit" constraintName="visit_location_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="location_id" referencedTableName="location" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-868">
+        <addForeignKeyConstraint baseColumnNames="patient_id" baseTableName="visit" constraintName="visit_patient_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="patient_id" referencedTableName="patient" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-869">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="visit_type" constraintName="visit_type_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-870">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="visit_type" constraintName="visit_type_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-871">
+        <addForeignKeyConstraint baseColumnNames="visit_type_id" baseTableName="visit" constraintName="visit_type_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="visit_type_id" referencedTableName="visit_type" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-872">
+        <addForeignKeyConstraint baseColumnNames="retired_by" baseTableName="visit_type" constraintName="visit_type_retired_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-873">
+        <addForeignKeyConstraint baseColumnNames="voided_by" baseTableName="visit" constraintName="visit_voided_by_fk" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-874">
+        <addForeignKeyConstraint baseColumnNames="changed_by" baseTableName="program_workflow" constraintName="workflow_changed_by" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-875">
+        <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="program_workflow" constraintName="workflow_concept" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="concept_id" referencedTableName="concept" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-876">
+        <addForeignKeyConstraint baseColumnNames="creator" baseTableName="program_workflow" constraintName="workflow_creator" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="user_id" referencedTableName="users" />
+    </changeSet>
+    <changeSet author="wolf (generated)" id="1582473628795-877">
+        <addForeignKeyConstraint baseColumnNames="program_workflow_id" baseTableName="program_workflow_state" constraintName="workflow_for_state" deferrable="false" initiallyDeferred="false" onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="program_workflow_id" referencedTableName="program_workflow" />
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Backporting `liquibase-schema-only-2.3.x.xml` and `liquibase-core-data-2.3.x.xml` so they are available for use elsewhere, i.e. with Initializer Validator.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-4830

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.