### PR TITLE
TRUNK-6082: Make failed login lockout timeout configurable

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Hibernate specific implementation of the {@link ContextDAO}. These methods should not be used
@@ -60,6 +61,8 @@ import java.util.concurrent.Future;
 public class HibernateContextDAO implements ContextDAO {
 	
 	private static final Logger log = LoggerFactory.getLogger(HibernateContextDAO.class);
+	
+	private static final Long DEFAULT_UNLOCK_ACCOUNT_WAITING_TIME = TimeUnit.MILLISECONDS.convert(5L, TimeUnit.MINUTES);
 	
 	/**
 	 * Hibernate session factory
@@ -123,11 +126,11 @@ public class HibernateContextDAO implements ContextDAO {
 			log.debug("Candidate user id: {}", candidateUser.getUserId());
 
 			String lockoutTimeString = candidateUser.getUserProperty(OpenmrsConstants.USER_PROPERTY_LOCKOUT_TIMESTAMP, null);
-			long lockoutTime = -1;
-			if (StringUtils.isNotBlank(lockoutTimeString) && !"0".equals(lockoutTimeString)) {
+			Long lockoutTime = null;
+			if (lockoutTimeString != null && !"0".equals(lockoutTimeString)) {
 				try {
 					// putting this in a try/catch in case the admin decided to put junk into the property
-					lockoutTime = Long.parseLong(lockoutTimeString);
+					lockoutTime = Long.valueOf(lockoutTimeString);
 				}
 				catch (NumberFormatException e) {
 					log.warn("bad value stored in {} user property: {}", OpenmrsConstants.USER_PROPERTY_LOCKOUT_TIMESTAMP,
@@ -136,10 +139,11 @@ public class HibernateContextDAO implements ContextDAO {
 			}
 
 			// if they've been locked out, don't continue with the authentication
-			if (lockoutTime > 0) {
-				// unlock them after 5 mins, otherwise reset the timestamp
-				// to now and make them wait another 5 mins
-				if (System.currentTimeMillis() - lockoutTime > 300000) {
+			if (lockoutTime != null) {
+				// unlock them after x mins, otherwise reset the timestamp
+				// to now and make them wait another x mins
+				final Long unlockTime = getUnlockTimeMs();
+				if (System.currentTimeMillis() - lockoutTime > unlockTime) {
 					candidateUser.setUserProperty(OpenmrsConstants.USER_PROPERTY_LOGIN_ATTEMPTS, "0");
 					candidateUser.removeUserProperty(OpenmrsConstants.USER_PROPERTY_LOCKOUT_TIMESTAMP);
 					saveUserProperties(candidateUser);
@@ -210,6 +214,28 @@ public class HibernateContextDAO implements ContextDAO {
 		// message regardless of username/pw combo entered
 		log.info("Failed login attempt (login={}) - {}", login, errorMsg);
 		throw new ContextAuthenticationException(errorMsg);
+	}
+	
+	private Long getUnlockTimeMs() {
+		String unlockTimeGPValue = Context.getAdministrationService().getGlobalProperty(
+				OpenmrsConstants.GP_UNLOCK_ACCOUNT_WAITING_TIME);
+		if (StringUtils.isNotBlank(unlockTimeGPValue)) {
+			return convertUnlockAccountWaitingTimeGP(unlockTimeGPValue);
+		}
+		else {
+			return DEFAULT_UNLOCK_ACCOUNT_WAITING_TIME;
+		}
+	}
+	
+	private Long convertUnlockAccountWaitingTimeGP(String waitingTime) {
+		try {
+			return TimeUnit.MILLISECONDS.convert(Long.valueOf(waitingTime), TimeUnit.MINUTES);
+		} catch (Exception ex) {
+			log.error("Unable to convert the global property "
+					+ OpenmrsConstants.GP_UNLOCK_ACCOUNT_WAITING_TIME
+					+ "to a valid Long. Using default value of 5");
+			return DEFAULT_UNLOCK_ACCOUNT_WAITING_TIME;
+		}
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -128,7 +128,7 @@ public final class OpenmrsConstants {
 		
 		return null;
 	}
-		
+	
 	public static String DATABASE_NAME = "openmrs";
 	
 	public static String DATABASE_BUSINESS_NAME = "openmrs";
@@ -179,7 +179,7 @@ public final class OpenmrsConstants {
 	
 	/**
 	 * These words are ignored in concept and patient searches
-	 * 
+	 *
 	 * @return Collection&lt;String&gt; of words that are ignored
 	 */
 	public static final Collection<String> STOP_WORDS() {
@@ -202,7 +202,7 @@ public final class OpenmrsConstants {
 	 * A gender character to gender name map<br>
 	 * TODO issues with localization. How should this be handled?
 	 * @deprecated As of 2.2, replaced by {@link #GENDERS}
-	 * 
+	 *
 	 * @return Map&lt;String, String&gt; of gender character to gender name
 	 */
 	@Deprecated
@@ -218,10 +218,10 @@ public final class OpenmrsConstants {
 	 * A list of 1-letter strings representing genders
 	 */
 	public static final List<String> GENDERS = Collections.unmodifiableList(asList("M", "F"));
-		
+	
 	/**
 	 * These roles are given to a user automatically and cannot be assigned
-	 * 
+	 *
 	 * @return <code>Collection&lt;String&gt;</code> of the auto-assigned roles
 	 */
 	public static final Collection<String> AUTO_ROLES() {
@@ -568,6 +568,8 @@ public final class OpenmrsConstants {
 	public static final String AUTO_CLOSE_VISITS_TASK_NAME = "Auto Close Visits Task";
 	
 	public static final String GP_ALLOWED_FAILED_LOGINS_BEFORE_LOCKOUT = "security.allowedFailedLoginsBeforeLockout";
+
+	public static final String GP_UNLOCK_ACCOUNT_WAITING_TIME  = "security.unlockAccountWaitingTime";
 	
 	/**
 	 * @since 1.9.9, 1.10.2, 1.11
@@ -604,7 +606,7 @@ public final class OpenmrsConstants {
 	
 	/**
 	 * Indicates the version of the search index. The index will be rebuilt, if the version changes.
-	 * 
+	 *
 	 * @since 1.11
 	 */
 	public static final Integer SEARCH_INDEX_VERSION = 7;
@@ -635,7 +637,7 @@ public final class OpenmrsConstants {
 	/**
 	 * At OpenMRS startup these global properties/default values/descriptions are inserted into the
 	 * database if they do not exist yet.
-	 * 
+	 *
 	 * @return List&lt;GlobalProperty&gt; of the core global properties
 	 */
 	public static final List<GlobalProperty> CORE_GLOBAL_PROPERTIES() {
@@ -983,7 +985,10 @@ public final class OpenmrsConstants {
 		
 		props.add(new GlobalProperty(GP_ALLOWED_FAILED_LOGINS_BEFORE_LOCKOUT, "7",
 		        "Maximum number of failed logins allowed after which username is locked out"));
-		
+
+		props.add(new GlobalProperty(GP_UNLOCK_ACCOUNT_WAITING_TIME, "5",
+			"Waiting time for account to get automatically unlocked after getting locked due to multiple invalid login tries"));
+
 		props.add(new GlobalProperty(GP_DEFAULT_CONCEPT_MAP_TYPE, "NARROWER-THAN",
 		        "Default concept map type which is used when no other is set"));
 		
@@ -1224,14 +1229,14 @@ public final class OpenmrsConstants {
 	
 	/**
 	 * It points to a directory where 'openmrs.log' is stored.
-	 * 
+	 *
 	 * @since 1.9.2
 	 */
 	public static final String GP_LOG_LOCATION = "log.location";
 	
 	/**
 	 * It specifies a log layout pattern used by the OpenMRS file appender.
-	 * 
+	 *
 	 * @since 1.9.2
 	 */
 	public static final String GP_LOG_LAYOUT = "log.layout";
@@ -1266,13 +1271,13 @@ public final class OpenmrsConstants {
 
 	/**
 	 * Default url responsible for authentication if a user is not logged in.
-	 * 
+	 *
 	 * @see  #GP_LOGIN_URL
 	 */
 	public static final String LOGIN_URL = "login.htm";
 	
 	/**
-	 * Global property name that defines the default url 
+	 * Global property name that defines the default url
 	 * responsible for authentication if user is not logged in.
 	 *
 	 *  @see #LOGIN_URL
@@ -1282,7 +1287,7 @@ public final class OpenmrsConstants {
 	/**
 	 * These enumerations should be used in ObsService and PersonService getters to help determine
 	 * which type of object to restrict on
-	 * 
+	 *
 	 * @see org.openmrs.api.ObsService
 	 * @see org.openmrs.api.PersonService
 	 */


### PR DESCRIPTION
## Description of what I changed
Added 'security.waitingTimeUnlockAccountAfterLockout' Globap property which configures for how long in minutes the account is blocked after a number of failed login attempts. 
The number of failed attempts is already configurable via: security.allowedFailedLoginsBeforeLockout

## Issue I worked on
https://issues.openmrs.org/browse/TRUNK-6082

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

