### PR TITLE
TRUNK-6164 - Fix to enable adding new drug reference maps during drug creation

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/DrugReferenceMap.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/DrugReferenceMap.hbm.xml
@@ -17,7 +17,7 @@
 <hibernate-mapping package="org.openmrs">
 	<class name="DrugReferenceMap" table="drug_reference_map">
 
-		<id name="drugReferenceMapId" type="java.lang.Integer" column="drug_reference_map_id">
+		<id name="drugReferenceMapId" type="java.lang.Integer" column="drug_reference_map_id" unsaved-value="0">
 			<generator class="native">
 				<param name="sequence">drug_reference_map_drug_reference_map_id_seq</param>
 			</generator>
@@ -27,7 +27,7 @@
 
 		<many-to-one name="drug" class="Drug" column="drug_id" not-null="true"/>
 
-		<many-to-one name="conceptReferenceTerm" class="ConceptReferenceTerm" column="term_id" not-null="true"/>
+		<many-to-one name="conceptReferenceTerm" class="ConceptReferenceTerm" column="term_id" not-null="true" cascade="save-update"/>
 
 		<many-to-one name="conceptMapType" class="ConceptMapType" column="concept_map_type" not-null="true"/>
 

--- a/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
@@ -41,6 +41,7 @@ import org.openmrs.ConceptSearchResult;
 import org.openmrs.ConceptSet;
 import org.openmrs.ConceptSource;
 import org.openmrs.Drug;
+import org.openmrs.DrugReferenceMap;
 import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
@@ -343,6 +344,31 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		savedDrug.setCombination(true);
 		conceptService.saveDrug(savedDrug);
 		assertTrue(conceptService.getDrug(savedDrug.getDrugId()).getCombination());
+	}
+
+	/**
+	 * @see ConceptServiceImpl#saveDrug(Drug)
+	 */
+	@Test
+	public void saveDrug_shouldSaveNewDrugReferenceMap() {
+		Drug drug = new Drug();
+		Concept concept = new Concept();
+		concept.addName(new ConceptName("Concept", new Locale("en", "US")));
+		concept.addDescription(new ConceptDescription("Description", new Locale("en", "US")));
+		concept.setConceptClass(new ConceptClass(1));
+		concept.setDatatype(new ConceptDatatype(1));
+		Concept savedConcept = conceptService.saveConcept(concept);
+		drug.setConcept(savedConcept);
+		drug.setName("Example Drug");
+		ConceptMapType sameAs = conceptService.getConceptMapTypeByUuid(ConceptMapType.SAME_AS_MAP_TYPE_UUID);
+		ConceptSource snomedCt = conceptService.getConceptSourceByName("SNOMED CT");
+		DrugReferenceMap map = new DrugReferenceMap();
+		map.setDrug(drug);
+		map.setConceptMapType(sameAs);
+		map.setConceptReferenceTerm(new ConceptReferenceTerm(snomedCt, "example", ""));
+		drug.addDrugReferenceMap(map);
+		drug = conceptService.saveDrug(drug);
+		assertEquals(1, conceptService.getDrug(drug.getDrugId()).getDrugReferenceMaps().size());
 	}
 	
 	/**


### PR DESCRIPTION
Failing unit test and fix that allows the unit test to pass.