### PR TITLE
Temporary fix for 2.5.x CI job

### DIFF
--- a/bamboo-specs/bamboo.yml
+++ b/bamboo-specs/bamboo.yml
@@ -11,232 +11,46 @@ stages:
           final: false
           jobs:
               - Build
-    - Test:
-          manual: false
-          final: false
-          jobs:
-              - Unit Test
               - Integration Test
     - Deploy:
           manual: false
           final: false
           jobs:
               - Deploy to maven
-              - Deploy to docker
-    - Release:
-          manual: true
-          final: false
-          jobs:
-              - Release
 Build:
-    key: BUIL
+    key: BUILD
     tasks:
         - checkout:
-              force-clean-build: 'false'
-              description: Checkout Default Repository
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                      #!/bin/bash -eux
-                      
-                      set +x
-                      
-                      export IMAGE=${bamboo.docker.image.name}:${bamboo.docker.image.tag}-dev
-                      
-                      docker login -u ${bamboo.dockerhub.username} -p ${bamboo.dockerhub.password}
-                      
-                      docker buildx build --pull --push --platform ${bamboo.docker.image.platforms} \
-                          --cache-to=type=registry,mode=max,ref=${IMAGE}-cache --cache-from ${IMAGE}-cache --target dev \
-                          --build-arg MVN_ARGS="clean install -DskipTests" -t ${IMAGE} .
-                      
-                      sleep 10
-                      
-                      docker pull ${IMAGE}
-                      
-                      echo "Inspecting image for id"
-                      docker image inspect --format='{{index .RepoDigests 0}}' ${IMAGE} > docker-image.txt
-              description: Build and push dev image
-        - any-task:
-              plugin-key: com.atlassian.bamboo.plugins.variable.updater.variable-updater-generic:variable-file-reader
-              configuration:
-                  filename: docker-image.txt
-                  variable: docker.image.id
-                  variableScope: RESULT
-              description: Store docker image id
-    artifact-subscriptions: []
-Unit Test:
-    key: UT
-    tasks:
-        # Checkout Task for default repository will be added implicitly during Specs import
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                      #!/bin/bash -eu
-                      
-                      set -x
-                      
-                      export IMAGE=${bamboo.docker.image.id}
-                      
-                      docker pull ${IMAGE}
-                      
-                      docker run -v m2-repo:/root/.m2/repository --rm ${IMAGE} mvn test
-              description: Run unit tests
+            force-clean-build: 'false'
+            description: Checkout Default Repository
+        - maven:
+            executable: Maven 3
+            jdk: openjdk-8-jdk
+            goal: clean package
+            tests: 'true'
+            environment: JAVA_HOME=${bamboo.capability.system.jdk.openjdk-8-jdk} MAVEN_OPTS="-Xmx2g"
+            description: Build and execute Unit Tests
     artifact-subscriptions: []
 Integration Test:
     key: IT
     tasks:
-        # Checkout Task for default repository will be added implicitly during Specs import
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                      #!/bin/bash -eu
-                      
-                      set -x
-                      
-                      export IMAGE=${bamboo.docker.image.id}
-                      
-                      docker pull ${IMAGE}
-                      
-                      docker run -v m2-repo:/root/.m2/repository --rm ${IMAGE} mvn test -Pskip-default-test -Pintegration-test
-              description: Run integration tests
+        - maven:
+            executable: Maven 3
+            jdk: openjdk-8-jdk
+            goal: clean test -Pskip-default-test -Pintegration-test
+            tests: 'true'
+            description: Execute integration tests
     artifact-subscriptions: []
 Deploy to maven:
     key: DTM
     tasks:
-        # Checkout Task for default repository will be added implicitly during Specs import
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                      #!/bin/bash -eu
-                      
-                      set -x
-                      
-                      export IMAGE=${bamboo.docker.image.id}
-                      
-                      docker pull $IMAGE
-                      
-                      docker run -v m2-repo:/root/.m2/repository -v ~/.m2/settings.xml:/.m2/settings.xml:ro \
-                          --rm ${IMAGE} mvn deploy -DskipTests --settings /.m2/settings.xml
-              description: Deploy to maven repo
+      - maven:
+          executable: Maven 3
+          jdk: openjdk-8-jdk
+          goal: ${bamboo.mavenDeployGoals}
+          description: Deploy to maven repo
     artifact-subscriptions: []
-Deploy to docker:
-    key: DTD
-    tasks:
-        - checkout:
-              force-clean-build: 'false'
-              description: Checkout source
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                      #!/bin/bash -eux
-                      
-                      set +x
-                      
-                      export IMAGE=${bamboo.docker.image.id}
-                      export IMAGE_NIGHTLY=${bamboo.docker.image.name}:${bamboo.docker.image.tag}-nightly
-                      export IMAGE_DEV=${bamboo.docker.image.name}:${bamboo.docker.image.tag}-dev
-                      
-                      docker login -u ${bamboo.dockerhub.username} -p ${bamboo.dockerhub.password}
-                      
-                      docker pull $IMAGE
-                      
-                      docker buildx build --pull --push --platform ${bamboo.docker.image.platforms} \
-                          --cache-to=type=registry,mode=max,ref=${IMAGE_NIGHTLY}-cache \
-                          --cache-from=${IMAGE},${IMAGE_DEV}-cache,${IMAGE_NIGHTLY}-cache \
-                          --build-arg MVN_ARGS="install -DskipTests" -t ${IMAGE_NIGHTLY}  .
-              description: Deploy to docker
-    artifact-subscriptions: []
-Release:
-    key: RTD
-    tasks:
-        - checkout:
-              force-clean-build: 'false'
-              description: Checkout Default Repository
-        - script:
-              interpreter: SHELL
-              scripts:
-                  - |-
-                        #!/bin/bash -eux
-    
-                        set +x
-                        
-                        export OMRS_VERSION=${bamboo.maven.release.version}
-                        export IMAGE=${bamboo.docker.image.name}:${OMRS_VERSION}
-                        export DEV_IMAGE=${bamboo.docker.image.name}:${OMRS_VERSION}-dev
-                        export BUILD_IMAGE=${bamboo.docker.image.id}
-                      
-                        # Set to be able to push
-                        git remote set-url origin git@github.com:openmrs/openmrs-core.git
-                        
-                        docker login -u ${bamboo.dockerhub.username} -p ${bamboo.dockerhub.password}
-                        
-                        echo "Setting the release version"
-                        docker pull ${BUILD_IMAGE}
-                        docker run --rm -v m2-repo:/root/.m2/repository -v $(pwd):/openmrs_core \
-                        ${BUILD_IMAGE} mvn versions:set -DnewVersion=${OMRS_VERSION} -DgenerateBackupPoms=false
-                        git commit -am "[skip-ci] Releasing ${OMRS_VERSION}"
-                        
-                        echo "Building the dev image"
-                        docker buildx build --pull --push --platform ${bamboo.docker.image.platforms} \
-                        --cache-from ${BUILD_IMAGE} --target dev \
-                        --build-arg MVN_ARGS="clean install -DskipTests" -t ${DEV_IMAGE} .
-                        
-                        echo "Building the production image"
-                        docker buildx build --pull --push --platform ${bamboo.docker.image.platforms} \
-                        --cache-from ${BUILD_IMAGE}-cache \
-                        --build-arg MVN_ARGS="clean install -DskipTests" -t ${IMAGE} .
-                        
-                        echo "Inspecting the image for id"
-                        sleep 10
-                        docker pull ${IMAGE}
-                        docker image inspect --format='{{index .RepoDigests 0}}' ${IMAGE} > docker-image.txt
-                        
-                        echo "Releasing to maven"
-                        docker pull ${DEV_IMAGE}
-                        docker run -v m2-repo:/root/.m2/repository -v ~/.m2/settings.xml:/.m2/settings.xml:ro \
-                        --rm ${DEV_IMAGE} mvn deploy -DskipTests --settings /.m2/settings.xml
-                        
-                        echo "Tagging the release in git"
-                        git tag ${OMRS_VERSION}
-                        git push origin ${OMRS_VERSION}
-                        
-                        (
-                        echo "Updating the main branch to a new SNAPSHOT version"
-                        git push
-                        docker run --rm -v m2-repo:/root/.m2/repository -v $(pwd):/openmrs_core \
-                        ${DEV_IMAGE} mvn versions:set -DnextSnapshot=true -DgenerateBackupPoms=false
-                        
-                        git commit -am "Setting new SNAPSHOT version"
-                        git push
-                        ) || (
-                        echo "Unable to update the main branch to a new SNAPSHOT version. Please update it manually if needed."
-                        exit 0
-                        )
-              description: Build and push images
-        - any-task:
-              plugin-key: com.atlassian.bamboo.plugins.variable.updater.variable-updater-generic:variable-file-reader
-              configuration:
-                  filename: docker-image.txt
-                  variable: docker.image.id
-                  variableScope: RESULT
-              description: Store docker image id
-        - any-task:
-              plugin-key: com.atlassian.bamboo.plugins.variable.updater.variable-updater-generic:variable-extractor
-              configuration:
-                  variable: maven.release.version
-                  removeSnapshot: 'true'
-                  variableScope: PLAN
-              description: Save next release version
-    artifact-subscriptions: []
-variables:
-    docker.image.name: openmrs/openmrs-core
-    docker.image.tag: 2.5.x
-    maven.release.version: 2.5.10
+
 repositories:
     - openmrs-core-2.5.x:
           scope: global


### PR DESCRIPTION
This is the kind of thing I'm looking at doing in the absence of properly fixing the 2.5.x build in Bamboo, which is currently down.  See the #infra Channel in slack for commentary / description of the issues around this.  Hopefully we can get a proper fix in place and this is unnecessary, but if we can't get the build issues resolved, then this is something I may look to try.  Feedback and input please.