### PR TITLE
TRUNK-6167: Condition should not lose the associated encounter or form…

### DIFF
--- a/api/src/main/java/org/openmrs/Condition.java
+++ b/api/src/main/java/org/openmrs/Condition.java
@@ -121,12 +121,15 @@ public class Condition extends BaseFormRecordableOpenmrsData {
 	public static Condition copy(Condition fromCondition, Condition toCondition) {
 		toCondition.setPreviousVersion(fromCondition.getPreviousVersion());
 		toCondition.setPatient(fromCondition.getPatient());
+		toCondition.setEncounter(fromCondition.getEncounter());
+		toCondition.setFormNamespaceAndPath(fromCondition.getFormNamespaceAndPath());
 		toCondition.setClinicalStatus(fromCondition.getClinicalStatus());
 		toCondition.setVerificationStatus(fromCondition.getVerificationStatus());
 		toCondition.setCondition(fromCondition.getCondition());
 		toCondition.setOnsetDate(fromCondition.getOnsetDate());
 		toCondition.setAdditionalDetail(fromCondition.getAdditionalDetail());
 		toCondition.setEndDate(fromCondition.getEndDate());
+		toCondition.setEndReason(fromCondition.getEndReason());
 		toCondition.setVoided(fromCondition.getVoided());
 		toCondition.setVoidedBy(fromCondition.getVoidedBy());
 		toCondition.setVoidReason(fromCondition.getVoidReason());


### PR DESCRIPTION
…NamespaceAndPath on edit.

## Description of what I changed
Ensures encounter and formNamespaceAndPath are copied into the new Condition on edit

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6167
