### PR TITLE
TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null.

### DIFF
--- a/api/mytxtfile.txt
+++ b/api/mytxtfile.txt
@@ -1,0 +1,1 @@
+test content

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -296,6 +296,12 @@
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mysql</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-web</artifactId>
+			<version>5.3.13</version>
+		</dependency>
+
 	</dependencies>
 	<build>
 		<resources>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -75,6 +75,12 @@
 			<artifactId>reflectutils</artifactId>
 		</dependency>
 		<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>spring-web</artifactId>
+		<version>5.3.9</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity</artifactId>
 		</dependency>
@@ -296,12 +302,19 @@
 			<groupId>org.testcontainers</groupId>
 			<artifactId>mysql</artifactId>
 		</dependency>
+<<<<<<< HEAD
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 			<version>5.3.13</version>
 		</dependency>
 
+=======
+<<<<<<< HEAD
+=======
+
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
 	</dependencies>
 	<build>
 		<resources>

--- a/api/src/main/java/org/openmrs/obs/ComplexData.java
+++ b/api/src/main/java/org/openmrs/obs/ComplexData.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.obs;
 
+import java.io.File;
 import java.io.InputStream;
 
 /**
@@ -36,11 +37,11 @@ public class ComplexData implements java.io.Serializable {
 	/**
 	 * Default constructor requires title and data.
 	 * 
-	 * @param title Name or brief description of ComplexData.
+	 * @param fILENAME Name or brief description of ComplexData.
 	 * @param data The complex data for an Obs
 	 */
-	public ComplexData(String title, Object data) {
-		setTitle(title);
+	public ComplexData(String fILENAME, Object data) {
+		setTitle(fILENAME);
 		setData(data);
 	}
 	
@@ -119,6 +120,10 @@ public class ComplexData implements java.io.Serializable {
 	 */
 	public Long getLength() {
 		return this.length;
+	}
+	
+	public File[] getFiles() {
+		return null;
 	}
 	
 }

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -107,7 +107,7 @@ public class AbstractHandler {
 	/**
 	 * @see org.openmrs.obs.ComplexObsHandler#getObs(Obs, String)
 	 */
-	public Obs getObs(Obs obs, String view) {
+	public Obs getObs(Obs obs, String fILENAME) {
 		File file = BinaryDataHandler.getComplexDataFile(obs);
 		// null check to ensure that the file variable is not null before attempting to read its contents
 		if (file == null) {

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -105,6 +105,10 @@ public class AbstractHandler {
 	 */
 	public Obs getObs(Obs obs, String view) {
 		File file = BinaryDataHandler.getComplexDataFile(obs);
+		// null check to ensure that the file variable is not null before attempting to read its contents
+		if (file == null) {
+			return obs;
+		}
 		log.debug("value complex: " + obs.getValueComplex());
 		log.debug("file path: " + file.getAbsolutePath());
 		ComplexData complexData = null;

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -107,12 +107,29 @@ public class AbstractHandler {
 	/**
 	 * @see org.openmrs.obs.ComplexObsHandler#getObs(Obs, String)
 	 */
+<<<<<<< HEAD
 	public Obs getObs(Obs obs, String fILENAME) {
 		File file = BinaryDataHandler.getComplexDataFile(obs);
 		// null check to ensure that the file variable is not null before attempting to read its contents
 		if (file == null) {
 			return obs;
 		}
+=======
+	public Obs getObs(Obs obs, String view) {
+<<<<<<< HEAD
+		File file = BinaryDataHandler.getComplexDataFile(obs);
+=======
+		if (obs == null) {
+			return null;
+		}
+		File file = getComplexDataFile(obs);
+		// will return the original obs object if the valueComplex field is null or empty
+		if (file == null) {
+			return obs;
+		}
+		
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
 		log.debug("value complex: " + obs.getValueComplex());
 		log.debug("file path: " + file.getAbsolutePath());
 		ComplexData complexData = null;

--- a/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/AbstractHandler.java
@@ -55,6 +55,10 @@ public class AbstractHandler {
 	 * @return File that the complex data should be written to
 	 */
 	public File getOutputFileToWrite(Obs obs) throws IOException {
+		//null check for obs
+		if (obs == null || obs.getComplexData() == null) {
+			throw new IllegalArgumentException("Obs  cannot be null");
+		}
 		String title = obs.getComplexData().getTitle();
 		String titleWithoutExtension = FilenameUtils.removeExtension(title);
 		String extension = "." + StringUtils.defaultIfEmpty(FilenameUtils.getExtension(title), "dat");
@@ -129,6 +133,10 @@ public class AbstractHandler {
 	 * @see org.openmrs.obs.ComplexObsHandler#purgeComplexData(org.openmrs.Obs)
 	 */
 	public boolean purgeComplexData(Obs obs) {
+		//null check for the obs object before using it to get the file for the complex data
+		if (obs == null) {
+			throw new IllegalArgumentException("Obs cannot be null");
+		}
 		File file = getComplexDataFile(obs);
 		if (!file.exists()) {
 			return true;
@@ -149,7 +157,8 @@ public class AbstractHandler {
 	 * @return File object
 	 */
 	public static File getComplexDataFile(Obs obs) {
-		String[] names = obs.getValueComplex().split("\\|");
+		//check for null value before splitting
+		String[] names = (obs.getValueComplex()!=null)? obs.getValueComplex().split("\\|"): new String[0];
 		String filename = names.length < 2 ? names[0] : names[names.length - 1];
 		File dir = OpenmrsUtil.getDirectoryInApplicationDataDirectory(
 		    Context.getAdministrationService().getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_COMPLEX_OBS_DIR));

--- a/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
@@ -52,6 +52,10 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 	@Override
 	public Obs getObs(Obs obs, String view) {
 		File file = getComplexDataFile(obs);
+		//will return the original obs object if the valueComplex field is null or empty
+		if (file == null) {
+			return obs;
+		}
 		log.debug("value complex: " + obs.getValueComplex());
 		log.debug("file path: " + file.getAbsolutePath());
 		ComplexData complexData = null;

--- a/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
@@ -64,12 +64,22 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 		if (ComplexObsHandler.RAW_VIEW.equals(view)) {
 			// to handle problem with downloading/saving files with blank spaces or commas in their names
 			// also need to remove the "file" text appended to the end of the file name
+<<<<<<< HEAD
 			// null check
 			String[] names = (obs.getValueComplex()!=null)? obs.getValueComplex().split("\\|"):new String[0];
 			String originalFilename =  (names.length > 0) ? names[0] : "";
+=======
+<<<<<<< HEAD
+			String[] names = obs.getValueComplex().split("\\|");
+			String originalFilename = names[0];
+=======
+			// null check
+			String[] names = (obs.getValueComplex()!=null)? obs.getValueComplex().split("\\|"):new String[0];
+			String originalFilename =  names.length > 0 ? names[0] : "";
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
 			originalFilename = originalFilename.replaceAll(",", "").replaceAll(" ", "").replaceAll("file$", "");
-			
-			try {
+		try {
 				complexData = new ComplexData(originalFilename, OpenmrsUtil.getFileAsBytes(file));
 			}
 			catch (IOException e) {

--- a/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
+++ b/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java
@@ -64,8 +64,9 @@ public class BinaryDataHandler extends AbstractHandler implements ComplexObsHand
 		if (ComplexObsHandler.RAW_VIEW.equals(view)) {
 			// to handle problem with downloading/saving files with blank spaces or commas in their names
 			// also need to remove the "file" text appended to the end of the file name
-			String[] names = obs.getValueComplex().split("\\|");
-			String originalFilename = names[0];
+			// null check
+			String[] names = (obs.getValueComplex()!=null)? obs.getValueComplex().split("\\|"):new String[0];
+			String originalFilename =  (names.length > 0) ? names[0] : "";
 			originalFilename = originalFilename.replaceAll(",", "").replaceAll(" ", "").replaceAll("file$", "");
 			
 			try {

--- a/api/src/test/java/org/openmrs/obs/AbstractHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/AbstractHandlerTest.java
@@ -9,9 +9,10 @@
  */
 package org.openmrs.obs;
 
-import static org.junit.Assert.fail;
+// import static org.junit.Assert.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import org.apache.commons.io.FilenameUtils;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -26,8 +27,8 @@ import java.nio.file.Path;
 import java.text.ParseException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.junit.jupiter.api.BeforeEach;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openmrs.GlobalProperty;
@@ -53,7 +54,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 	@TempDir
 	public Path complexObsTestFolder;
 	
-	@BeforeEach
+	@Before(value = "")
 	public void initializeContext() throws APIException, IOException {
 		handler = new  AbstractHandler();
 		adminService.saveGlobalProperty(new GlobalProperty(
@@ -163,7 +164,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
     public void getOutputFileToWrite_shouldThrowIllegalArgumentExceptionIfObsIsNull() throws IOException {
 		try {
 			handler.getOutputFileToWrite(null);
-			fail("Expected IllegalArgumentException was not thrown");
+			Assertions.fail("Expected IllegalArgumentException was not thrown");
 		} catch (IllegalArgumentException e) {
 			// Test passed
 		}
@@ -171,10 +172,11 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 
 	@Test
     public void getOutputFileToWrite_shouldThrowIllegalArgumentExceptionIfComplexDataIsNull() throws IOException {
+		Obs obs = new Obs();
 		try {
 			obs.setComplexData(null);
 			handler.getOutputFileToWrite(obs);
-			fail("Expected IllegalArgumentException was not thrown");
+			Assertions.fail("Expected IllegalArgumentException was not thrown");
 		} catch (IllegalArgumentException e) {
 			// Test passed
 		}
@@ -184,7 +186,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
     public void purgeComplexData_shouldThrowIllegalArgumentExceptionIfObsIsNull() {
 		try {
 			handler.purgeComplexData(null);
-			fail("Expected an IllegalArgumentException to be thrown");
+			Assertions.fail("Expected an IllegalArgumentException to be thrown");
 		} catch (IllegalArgumentException e) {
 			// expected exception thrown
 		}
@@ -192,6 +194,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 
 	@Test
     public void getObs_shouldReturnOriginalObsIfFileIsNull() {
+		Obs obs = new Obs();
         Obs result = handler.getObs(obs, null);
         assertEquals(obs, result);
     }
@@ -201,6 +204,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 	public void getObs_shouldReturnOriginalObsIfFileIsValid() throws Exception {
 	String testContent = "test content";
 	File file = new File(FILENAME);
+	Obs obs = new Obs();
     FileUtils.writeByteArrayToFile(file, testContent.getBytes(StandardCharsets.UTF_8));
 
 	obs.setComplexData(new ComplexData("text/plain", new File(FILENAME).toURI().toURL()));
@@ -210,27 +214,30 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 	}
 	@Test
     public void getComplexDataFile_shouldReturnEmptyArrayIfValueComplexIsNull() {
+		Obs obs = new Obs();
         obs.setValueComplex(null);
+		
         File result = AbstractHandler.getComplexDataFile(obs);
         assertEquals(0, result.length());
     }
 
 	@Test
-    public void testGetOutputFileToWriteWithNullComplexData() {
+    public void shouldGetOutputFileToWriteWithNullComplexData() {
     Obs obs = new Obs();
     obs.setComplexData(null);
 		try {
 			handler.getOutputFileToWrite(obs);
-			fail("Expected an IllegalArgumentException to be thrown");
+			Assertions.fail("Expected an IllegalArgumentException to be thrown");
 		} catch (IllegalArgumentException e) {
 			// expected exception
 		} catch (Exception e) {
-			fail("Expected an IllegalArgumentException to be thrown, but got " + e);
+			Assertions.fail("Expected an IllegalArgumentException to be thrown, but got " + e);
 		}
     }
 
 	@Test
-    public void getObs_shouldReturnEmptyArrayIfObsValueComplexIsNull() throws Exception {
+    public void shouldReturnEmptyArrayIfObsValueComplexIsNull() throws Exception {
+		Obs obs = new Obs();
         obs.setValueComplex(null);
 
         String result = handler.getObs(obs, FILENAME).getValueComplex();
@@ -241,6 +248,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 
 	@Test
     public void getObs_shouldReturnOriginalObsIfObsValueComplexIsNull() throws Exception {
+		Obs obs = new Obs();
         obs.setValueComplex(null);
         Obs result = handler.getObs(obs, FILENAME);
         assertEquals(obs, result);
@@ -248,7 +256,7 @@ public class AbstractHandlerTest extends BaseContextSensitiveTest {
 
 
 	@Test
-    public void getComplexDataFile_shouldReturnEmptyArrayIfObsIsNull() {
+    public void shouldReturnEmptyArrayIfObsIsNull_getComplexDataFile() {
         File result = AbstractHandler.getComplexDataFile(null);
         assertEquals(0, result.length());
     }

--- a/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
+++ b/api/src/test/java/org/openmrs/obs/BinaryDataHandlerTest.java
@@ -18,6 +18,7 @@ import static org.openmrs.test.jupiter.BaseContextSensitiveTest.log;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+<<<<<<< HEAD
 import java.util.logging.Logger;
 import org.apache.commons.logging.Log;
 
@@ -27,6 +28,16 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.apache.commons.io.FileUtils;
+=======
+<<<<<<< HEAD
+
+=======
+import org.slf4j.LoggerFactory;
+
+
+import org.apache.commons.io.FileUtils;
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,6 +48,11 @@ import org.openmrs.obs.handler.BinaryDataHandler;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.OpenmrsConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
 
 public class BinaryDataHandlerTest extends BaseContextSensitiveTest {
 	
@@ -48,8 +64,16 @@ public class BinaryDataHandlerTest extends BaseContextSensitiveTest {
 
 	BinaryDataHandler handler;
 
+<<<<<<< HEAD
 	private Obs obs;
 
+=======
+<<<<<<< HEAD
+=======
+	private Obs obs;
+	
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
 	@BeforeEach
     public void setUp() {
     handler = new BinaryDataHandler();
@@ -121,9 +145,20 @@ public class BinaryDataHandlerTest extends BaseContextSensitiveTest {
     Obs result = handler.getObs(obs, ComplexObsHandler.RAW_VIEW);
     assertEquals(obs, result);
 }
+<<<<<<< HEAD
 
 @Test
 public ResponseEntity<byte[]> getObs_shouldReturnOriginalObsIfFileIsValid() throws Exception {
+=======
+<<<<<<< HEAD
+=======
+
+@Test
+public ResponseEntity<byte[]> getObs_shouldReturnOriginalObsIfFileIsValid() throws Exception {
+	org.slf4j.Logger log = LoggerFactory.getLogger(getClass());
+
+
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
     try {
         Obs resultObs = handler.getObs(obs, ComplexObsHandler.RAW_VIEW);
 
@@ -148,7 +183,11 @@ public ResponseEntity<byte[]> getObs_shouldReturnOriginalObsIfFileIsValid() thro
 
         // Set the response headers
         HttpHeaders headers = new HttpHeaders();
+<<<<<<< HEAD
         headers.setContentType(MediaType.parseMediaType(complexData.getMimeType()));
+=======
+        headers.setContentType(org.springframework.http.MediaType.parseMediaType(complexData.getMimeType()));
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
         headers.setContentLength(fileContent.length);
         headers.setContentDisposition(ContentDisposition.builder("attachment").filename(complexData.getTitle()).build());
 
@@ -156,6 +195,10 @@ public ResponseEntity<byte[]> getObs_shouldReturnOriginalObsIfFileIsValid() thro
         ResponseEntity<byte[]> response = new ResponseEntity<>(fileContent, headers, HttpStatus.OK);
         assertEquals(HttpStatus.OK, response.getStatusCode());
     } catch (Exception e) {
+<<<<<<< HEAD
+=======
+		
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
         log.error("Error getting complex obs", e);
         ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
     }
@@ -200,4 +243,9 @@ public ResponseEntity<byte[]> getObs(Obs obs) throws Exception {
 }
 
 
+<<<<<<< HEAD
         
+=======
+        
+>>>>>>> e09e68135 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)
+>>>>>>> 58a93d278 (TRUNK-7521: Complex obs handlers to return obs as is when underlying file is null)

--- a/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/jupiter/BaseContextSensitiveTest.java
@@ -119,7 +119,7 @@ import org.xml.sax.InputSource;
 @ExtendWith(MockitoExtension.class)
 public abstract class BaseContextSensitiveTest {
 	
-	private static final Logger log = LoggerFactory.getLogger(BaseContextSensitiveTest.class);
+	public static final Logger log = LoggerFactory.getLogger(BaseContextSensitiveTest.class);
 	
 	/**
 	 * Only the classpath/package path and filename of the initial dataset


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
Added a null check to ensure that the file variable is not null before attempting to read its contents:
This will return the original obs object if the file is null, rather than attempting to construct a ComplexData object from a null file and throwing a NullPointerException.
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5721

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  

