### PR TITLE
TRUNK-6170 - ConditionService getActiveConditions should consider all…

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.hibernate.query.Query;
@@ -19,6 +20,10 @@ import org.openmrs.Patient;
 import org.openmrs.api.APIException;
 import org.openmrs.api.db.ConditionDAO;
 import org.openmrs.api.db.DAOException;
+
+import static org.openmrs.ConditionClinicalStatus.ACTIVE;
+import static org.openmrs.ConditionClinicalStatus.RECURRENCE;
+import static org.openmrs.ConditionClinicalStatus.RELAPSE;
 
 /**
  * Hibernate implementation of the ConditionDAO
@@ -85,9 +90,13 @@ public class HibernateConditionDAO implements ConditionDAO {
 	@Override
 	public List<Condition> getActiveConditions(Patient patient) {
 		Query<Condition> query = sessionFactory.getCurrentSession().createQuery(
-				"from Condition c where c.patient.patientId = :patientId and c.clinicalStatus = 'ACTIVE' and c.voided = false order "
-						+ "by c.dateCreated desc", Condition.class);
+				 "from Condition c " +
+					 "where c.patient.patientId = :patientId " +
+					"and c.clinicalStatus in :activeStatuses " +
+					"and c.voided = false " +
+					"order by c.dateCreated desc", Condition.class);
 		query.setParameter("patientId", patient.getId());
+		query.setParameterList("activeStatuses", Arrays.asList(ACTIVE, RECURRENCE, RELAPSE));
 		return query.list();
 	}
 

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateConditionDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateConditionDAOTest.java
@@ -116,8 +116,10 @@ public class HibernateConditionDAOTest extends BaseContextSensitiveTest {
 	public void shouldGetAllConditions() {
 		Patient patient = new Patient(2);
 		List<Condition> conditions = dao.getAllConditions(patient);
-		
 		assertEquals(3, conditions.size());
+		patient = new Patient(8);
+		conditions = dao.getAllConditions(patient);
+		assertEquals(7, conditions.size());
 	}
 	
 	@Test
@@ -125,6 +127,9 @@ public class HibernateConditionDAOTest extends BaseContextSensitiveTest {
 		Patient patient = new Patient(2);
 		List<Condition> active = dao.getActiveConditions(patient);
 		assertEquals(1, active.size());
+		patient = new Patient(8);
+		active = dao.getActiveConditions(patient);
+		assertEquals(3, active.size());
 	}
 	
 	@Test

--- a/api/src/test/resources/org/openmrs/api/db/hibernate/include/HibernateConditionDAOTestDataSet.xml
+++ b/api/src/test/resources/org/openmrs/api/db/hibernate/include/HibernateConditionDAOTestDataSet.xml
@@ -19,4 +19,16 @@
     onset_date="2017-01-12 00:00:52" end_date="2017-06-12 00:10:52" verification_status="CONFIRMED" uuid="2cb6880e-2cd6-11e4-9138-a6c5e4d20fb7"/>
   <conditions condition_id="6" patient_id="8" clinical_status="ACTIVE" creator="1" date_created="2015-04-12 00:00:00" voided="false"
     onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="2cd6780e-2a46-11e4-9038-a6c5e4d26fc2"/>
+  <conditions condition_id="7" patient_id="8" clinical_status="INACTIVE" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="45c3b712-cca9-11ed-b5dc-0242ac120002"/>
+  <conditions condition_id="8" patient_id="8" clinical_status="HISTORY_OF" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="518f7352-cca9-11ed-b5dc-0242ac120002"/>
+  <conditions condition_id="9" patient_id="8" clinical_status="RECURRENCE" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="55bc5a3d-cca9-11ed-b5dc-0242ac120002"/>
+  <conditions condition_id="10" patient_id="8" clinical_status="RELAPSE" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="593cb96e-cca9-11ed-b5dc-0242ac120002"/>
+  <conditions condition_id="11" patient_id="8" clinical_status="REMISSION" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="5c6b5bda-cca9-11ed-b5dc-0242ac120002"/>
+  <conditions condition_id="12" patient_id="8" clinical_status="RESOLVED" creator="1" date_created="2015-04-12 00:00:00" voided="false"
+	onset_date="2017-02-12 00:40:00" verification_status="CONFIRMED" uuid="5fdf3744-cca9-11ed-b5dc-0242ac120002"/>
 </dataset>


### PR DESCRIPTION
… active statuses

## Description of what I changed
Updated HibernateConditionDAO to include conditions with status of RECURRANCE and RELAPSE when retrieving active conditions.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6170