### PR TITLE
TRUNK-6171: Address inconsistency issues with ConditionService

### DIFF
--- a/api/src/main/java/org/openmrs/CodedOrFreeText.java
+++ b/api/src/main/java/org/openmrs/CodedOrFreeText.java
@@ -9,9 +9,6 @@
  */
 package org.openmrs;
 
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-
 import javax.persistence.Embeddable;
 import javax.persistence.ManyToOne;
 
@@ -51,24 +48,6 @@ public class CodedOrFreeText {
 		this.coded = coded;
 		this.specificName = specificName;
 		this.nonCoded = nonCoded;
-	}
-
-	@Override
-	public int hashCode() {
-		return new HashCodeBuilder().append(coded).append(specificName).append(nonCoded).toHashCode();
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		if (object == null || !(object instanceof CodedOrFreeText)) {
-			return false;
-		}
-		CodedOrFreeText that = (CodedOrFreeText) object; 
-		EqualsBuilder b = new EqualsBuilder();
-		b.append(this.coded, that.coded);
-		b.append(this.specificName, that.specificName);
-		b.append(this.nonCoded, that.nonCoded);
-		return b.isEquals();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/CodedOrFreeText.java
+++ b/api/src/main/java/org/openmrs/CodedOrFreeText.java
@@ -9,6 +9,9 @@
  */
 package org.openmrs;
 
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
 import javax.persistence.Embeddable;
 import javax.persistence.ManyToOne;
 
@@ -49,7 +52,25 @@ public class CodedOrFreeText {
 		this.specificName = specificName;
 		this.nonCoded = nonCoded;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		return new HashCodeBuilder().append(coded).append(specificName).append(nonCoded).toHashCode();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (object == null || !(object instanceof CodedOrFreeText)) {
+			return false;
+		}
+		CodedOrFreeText that = (CodedOrFreeText) object; 
+		EqualsBuilder b = new EqualsBuilder();
+		b.append(this.coded, that.coded);
+		b.append(this.specificName, that.specificName);
+		b.append(this.nonCoded, that.nonCoded);
+		return b.isEquals();
+	}
+
 	/**
 	 * Gets the coded concept
 	 *

--- a/api/src/main/java/org/openmrs/CodedOrFreeText.java
+++ b/api/src/main/java/org/openmrs/CodedOrFreeText.java
@@ -49,7 +49,7 @@ public class CodedOrFreeText {
 		this.specificName = specificName;
 		this.nonCoded = nonCoded;
 	}
-
+	
 	/**
 	 * Gets the coded concept
 	 *

--- a/api/src/main/java/org/openmrs/Condition.java
+++ b/api/src/main/java/org/openmrs/Condition.java
@@ -165,13 +165,18 @@ public class Condition extends BaseFormRecordableOpenmrsData {
 		if (c == null) {
 			return false;
 		}
+		CodedOrFreeText coft1 = getCondition() == null ? new CodedOrFreeText() : getCondition();
+		CodedOrFreeText coft2 = c.getCondition() == null ? new CodedOrFreeText() : c.getCondition();
+		
 		boolean ret = (OpenmrsUtil.nullSafeEquals(getPreviousVersion(), c.getPreviousVersion()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getPatient(), c.getPatient()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getEncounter(), c.getEncounter()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getFormNamespaceAndPath(), c.getFormNamespaceAndPath()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getClinicalStatus(), c.getClinicalStatus()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getVerificationStatus(), c.getVerificationStatus()));
-		ret = ret && (OpenmrsUtil.nullSafeEquals(getCondition(), c.getCondition()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(coft1.getCoded(), coft2.getCoded()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(coft1.getSpecificName(), coft2.getSpecificName()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(coft1.getNonCoded(), coft2.getNonCoded()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getOnsetDate(), c.getOnsetDate()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getAdditionalDetail(), c.getAdditionalDetail()));
 		ret = ret && (OpenmrsUtil.nullSafeEquals(getEndDate(), c.getEndDate()));

--- a/api/src/main/java/org/openmrs/Condition.java
+++ b/api/src/main/java/org/openmrs/Condition.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs;
 
+import org.openmrs.util.OpenmrsUtil;
+
 import javax.persistence.AssociationOverride;
 import javax.persistence.AssociationOverrides;
 import javax.persistence.AttributeOverride;
@@ -25,7 +27,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-
 import java.util.Date;
 
 /**
@@ -113,11 +114,24 @@ public class Condition extends BaseFormRecordableOpenmrsData {
 		this.endDate = endDate != null ? new Date(endDate.getTime()) : null;
 		this.patient = patient;
 	}
-	
+
+	/**
+	 * Creates a new Condition instance from the passed condition such that the newly created Condition
+	 * matches the passed Condition @see Condition#matches, but does not equal the passed Condition (uuid, id differ)
+	 * @param condition the Condition to copy
+	 * @return a new Condition that is a copy of the passed condition
+	 */
 	public static Condition newInstance(Condition condition) {
 		return copy(condition, new Condition());
 	}
-	
+
+	/**
+	 * Copies property values from the fromCondition to the toCondition such that fromCondition
+	 * matches toCondition @see Condition#matches, but does not equal toCondition (uuid, id differ)
+	 * @param fromCondition the Condition to copy from
+	 * @param toCondition the Condition to copy into                      
+	 * @return a new Condition that is a copy of the passed condition
+	 */
 	public static Condition copy(Condition fromCondition, Condition toCondition) {
 		toCondition.setPreviousVersion(fromCondition.getPreviousVersion());
 		toCondition.setPatient(fromCondition.getPatient());
@@ -135,6 +149,38 @@ public class Condition extends BaseFormRecordableOpenmrsData {
 		toCondition.setVoidReason(fromCondition.getVoidReason());
 		toCondition.setDateVoided(fromCondition.getDateVoided());
 		return toCondition;
+	}
+
+	/**
+	 * Compares properties with those in the given Condition to determine if they have the same meaning
+	 * This method will return true immediately following the creation of a Condition from another Condition
+	 * @see Condition#newInstance(Condition)
+	 * This method will return false if any value is different, excepting identity data (id, uuid)
+	 * If the given instance is null, this will return false
+	 * @param c the Condition to compare against 	
+	 * @return true if the given Condition has the same meaningful properties as the passed Condition
+	 * @since 2.6.1
+	 */
+	public boolean matches(Condition c) {
+		if (c == null) {
+			return false;
+		}
+		boolean ret = (OpenmrsUtil.nullSafeEquals(getPreviousVersion(), c.getPreviousVersion()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getPatient(), c.getPatient()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getEncounter(), c.getEncounter()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getFormNamespaceAndPath(), c.getFormNamespaceAndPath()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getClinicalStatus(), c.getClinicalStatus()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getVerificationStatus(), c.getVerificationStatus()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getCondition(), c.getCondition()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getOnsetDate(), c.getOnsetDate()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getAdditionalDetail(), c.getAdditionalDetail()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getEndDate(), c.getEndDate()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getEndReason(), c.getEndReason()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getVoided(), c.getVoided()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getVoidedBy(), c.getVoidedBy()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getVoidReason(), c.getVoidReason()));
+		ret = ret && (OpenmrsUtil.nullSafeEquals(getDateVoided(), c.getDateVoided()));
+		return ret;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
@@ -106,8 +106,10 @@ public class HibernateConditionDAO implements ConditionDAO {
 	@Override
 	public List<Condition> getAllConditions(Patient patient) {
 		Query<Condition> query = sessionFactory.getCurrentSession().createQuery(
-				"from Condition con where con.patient.patientId = :patientId " +
-						"order by con.dateCreated desc", Condition.class);
+				"from Condition c " +
+					"where c.patient.patientId = :patientId " +
+					"and c.voided = false " +
+					"order by c.dateCreated desc", Condition.class);
 		query.setParameter("patientId", patient.getId());
 		return query.list();
 	}

--- a/api/src/main/java/org/openmrs/api/impl/ConditionServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConditionServiceImpl.java
@@ -118,20 +118,8 @@ public class ConditionServiceImpl extends BaseOpenmrsService implements Conditio
 		boolean conditionHasChanged = !newCondition.matches(condition);
 		boolean existingVoided = BooleanUtils.isTrue(condition.getVoided());
 		boolean newVoided = BooleanUtils.isTrue(newCondition.getVoided());
-		boolean unVoidOriginal = existingVoided && !newVoided;
 		boolean voidOriginal = !existingVoided && conditionHasChanged;
-		boolean saveNew = !newVoided && !unVoidOriginal && conditionHasChanged;
-
-		// If the intention is to un-void the original, then modify the original Condition and return it
-		if (unVoidOriginal) {
-			Condition.copy(newCondition, condition);
-			condition.setVoided(false);
-			condition.setVoidedBy(null);
-			condition.setDateVoided(null);
-			condition.setVoidReason(null);
-			condition = conditionDAO.saveCondition(condition);
-			return condition;
-		}
+		boolean saveNew = !newVoided && conditionHasChanged;
 		
 		// If the intention is to void or change the original Condition, then void the existing and save the new
 		if (voidOriginal) {

--- a/api/src/test/java/org/openmrs/ConditionTest.java
+++ b/api/src/test/java/org/openmrs/ConditionTest.java
@@ -1,0 +1,184 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests of methods within the Condition class
+ * @see Condition
+ */
+public class ConditionTest {
+	
+	Condition baseCondition = new Condition();
+	Concept concept1 = new Concept(1);
+	Concept concept2 = new Concept(2);
+	ConceptName conceptName1 = new ConceptName(1);
+	ConceptName conceptName2 = new ConceptName(2);
+	String text1 = "Text 1";
+	String text2 = "Text 2";
+	DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+	
+	@BeforeEach
+	public void before() throws Exception {
+		baseCondition.setConditionId(1234);
+		baseCondition.setUuid(UUID.randomUUID().toString());
+		baseCondition.setCondition(new CodedOrFreeText(concept1, conceptName1, text1));
+		baseCondition.setPreviousVersion(null);
+		baseCondition.setPatient(null);
+		baseCondition.setEncounter(null);
+		baseCondition.setAdditionalDetail(text1);
+		baseCondition.setFormNamespaceAndPath(text1);
+		baseCondition.setOnsetDate(df.parse("2022-03-22"));
+		baseCondition.setEndDate(df.parse("2023-01-19"));
+		baseCondition.setEndReason(text1);
+		baseCondition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		baseCondition.setVerificationStatus(ConditionVerificationStatus.PROVISIONAL);
+		baseCondition.setVoided(false);
+		baseCondition.setVoidReason(null);
+		baseCondition.setDateVoided(null);
+		baseCondition.setVoidedBy(null);
+	}
+	
+	@Test
+	public void matches_shouldReturnFalseIfNoFieldsHaveChanged() {
+		Condition condition = Condition.newInstance(baseCondition);
+		assertTrue(condition.matches(baseCondition));
+		assertTrue(baseCondition.matches(condition));
+	}
+
+	@Test
+	public void matches_shouldReturnFalseIfOnlyIdentityFieldsHaveChanged() {
+		Condition condition = Condition.newInstance(baseCondition);
+		condition.setId(5678);
+		assertTrue(condition.matches(baseCondition));
+		assertTrue(baseCondition.matches(condition));
+		condition.setUuid(UUID.randomUUID().toString());
+		assertTrue(condition.matches(baseCondition));
+		assertTrue(baseCondition.matches(condition));
+	}
+
+	@Test
+	public void matches_shouldReturnTrueIfNonIdentityFieldsHaveChanged() {
+		Condition condition = Condition.newInstance(baseCondition);
+		assertTrue(condition.matches(baseCondition));
+		
+		// Condition Coded
+		condition.setCondition(new CodedOrFreeText(concept2, conceptName1, text1));
+		assertFalse(condition.matches(baseCondition));
+		condition.setCondition(baseCondition.getCondition());
+		assertTrue(condition.matches(baseCondition));
+
+		// Condition Concept Name
+		condition.setCondition(new CodedOrFreeText(concept1, conceptName2, text1));
+		assertFalse(condition.matches(baseCondition));
+		condition.setCondition(baseCondition.getCondition());
+		assertTrue(condition.matches(baseCondition));
+
+		// Condition Non-Coded
+		condition.setCondition(new CodedOrFreeText(concept1, conceptName1, text2));
+		assertFalse(condition.matches(baseCondition));
+		condition.setCondition(baseCondition.getCondition());
+		assertTrue(condition.matches(baseCondition));
+
+		// Previous version
+		condition.setPreviousVersion(new Condition());
+		assertFalse(condition.matches(baseCondition));
+		condition.setPreviousVersion(baseCondition.getPreviousVersion());
+		assertTrue(condition.matches(baseCondition));
+
+		// Patient
+		condition.setPatient(new Patient());
+		assertFalse(condition.matches(baseCondition));
+		condition.setPatient(baseCondition.getPatient());
+		assertTrue(condition.matches(baseCondition));
+
+		// Encounter
+		condition.setEncounter(new Encounter());
+		assertFalse(condition.matches(baseCondition));
+		condition.setEncounter(baseCondition.getEncounter());
+		assertTrue(condition.matches(baseCondition));
+
+		// Additional details
+		condition.setAdditionalDetail(text2);
+		assertFalse(condition.matches(baseCondition));
+		condition.setAdditionalDetail(baseCondition.getAdditionalDetail());
+		assertTrue(condition.matches(baseCondition));
+
+		// Form namespace and path
+		condition.setFormNamespaceAndPath(text2);
+		assertFalse(condition.matches(baseCondition));
+		condition.setFormNamespaceAndPath(baseCondition.getFormNamespaceAndPath());
+		assertTrue(condition.matches(baseCondition));
+
+		// Onset date
+		condition.setOnsetDate(new Date());
+		assertFalse(condition.matches(baseCondition));
+		condition.setOnsetDate(baseCondition.getOnsetDate());
+		assertTrue(condition.matches(baseCondition));
+
+		// Onset date
+		condition.setEndDate(new Date());
+		assertFalse(condition.matches(baseCondition));
+		condition.setEndDate(baseCondition.getEndDate());
+		assertTrue(condition.matches(baseCondition));
+
+		// End reason
+		condition.setEndReason(text2);
+		assertFalse(condition.matches(baseCondition));
+		condition.setEndReason(baseCondition.getEndReason());
+		assertTrue(condition.matches(baseCondition));
+
+		// Clinical Status
+		condition.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
+		assertFalse(condition.matches(baseCondition));
+		condition.setClinicalStatus(baseCondition.getClinicalStatus());
+		assertTrue(condition.matches(baseCondition));
+
+		// Verification Status
+		condition.setVerificationStatus(ConditionVerificationStatus.CONFIRMED);
+		assertFalse(condition.matches(baseCondition));
+		condition.setVerificationStatus(baseCondition.getVerificationStatus());
+		assertTrue(condition.matches(baseCondition));
+
+		// Voided
+		condition.setVoided(true);
+		assertFalse(condition.matches(baseCondition));
+		condition.setVoided(baseCondition.getVoided());
+		assertTrue(condition.matches(baseCondition));
+
+		// Void reason
+		condition.setVoidReason(text2);
+		assertFalse(condition.matches(baseCondition));
+		condition.setVoidReason(baseCondition.getVoidReason());
+		assertTrue(condition.matches(baseCondition));
+
+		// Date voided
+		condition.setDateVoided(new Date());
+		assertFalse(condition.matches(baseCondition));
+		condition.setDateVoided(baseCondition.getDateVoided());
+		assertTrue(condition.matches(baseCondition));
+
+		// Voided by
+		condition.setVoidedBy(new User());
+		assertFalse(condition.matches(baseCondition));
+		condition.setVoidedBy(baseCondition.getVoidedBy());
+		assertTrue(condition.matches(baseCondition));
+	}
+}

--- a/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
@@ -252,9 +252,9 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		assertNull(unvoidedCondition.getVoidReason());
 
 		Condition oldCondition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
-		assertEquals(unvoidedCondition.getId(), oldCondition.getId());
-		assertFalse(oldCondition.getVoided());
-		assertNull(oldCondition.getVoidReason());
+		assertNotEquals(unvoidedCondition.getId(), oldCondition.getId());
+		assertTrue(oldCondition.getVoided());
+		assertEquals("Voided by a test", oldCondition.getVoidReason());
 		int endingNum = conditionService.getAllConditions(patient).size();
 		assertEquals(startingNum, endingNum-1);
 	}

--- a/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
@@ -100,26 +100,34 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void saveCondition_shouldReplaceExistingCondition() {
+
 		// setup
-		Condition condition = new Condition();
-		condition.setCondition(new CodedOrFreeText());
-		condition.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
-		condition.setVerificationStatus(ConditionVerificationStatus.CONFIRMED);
-		condition.setUuid(EXISTING_CONDITION_UUID);
-		condition.setPatient(new Patient(2));
+		Condition condition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		Integer oldConditionId = condition.getConditionId();
 		
 		// perform
-		Condition newCondition = conditionService.saveCondition(condition);
+		condition.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
+		condition = conditionService.saveCondition(condition);
+		Integer newConditionId = condition.getConditionId();
 		
 		// verify
-		Condition oldCondition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		assertNotEquals(oldConditionId, newConditionId);
+		
+		// existing condition should be unchanged, but voided
+		Condition oldCondition = conditionService.getCondition(oldConditionId);
+		assertEquals(EXISTING_CONDITION_UUID, oldCondition.getUuid());
+		assertEquals(ConditionClinicalStatus.ACTIVE, oldCondition.getClinicalStatus());
 		assertTrue(oldCondition.getVoided());
+		assertNotNull(oldCondition.getOnsetDate());
+		assertNull(oldCondition.getEndDate());
+		
+		// new condition should reflect changed existing condition and have it as a previous version
+		Condition newCondition = conditionService.getCondition(newConditionId);
+		assertNotEquals(EXISTING_CONDITION_UUID, newCondition.getUuid());
 		assertEquals(newCondition.getPreviousVersion(), oldCondition);
 		assertEquals(newCondition.getClinicalStatus(), ConditionClinicalStatus.INACTIVE);
-		
-		// asserting previous behaviour using onset and end date no longer has any effect
-		assertNull(newCondition.getOnsetDate());
-		assertNull(oldCondition.getEndDate());
+		assertEquals(oldCondition.getOnsetDate().getTime(), newCondition.getOnsetDate().getTime());
+		assertNull(newCondition.getEndDate());
 	}
 
 	@Test
@@ -142,14 +150,11 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		c.setFormNamespaceAndPath("form1/namespace2/path3");
 		c = conditionService.saveCondition(c);
 		Integer conditionId1 = c.getConditionId();
-		Context.clearSession();
 		
 		// edit
 		c.setAdditionalDetail("Edited info");
 		c = conditionService.saveCondition(c);
 		Integer conditionId2 = c.getConditionId();
-		Context.flushSession();
-		Context.clearSession();
 		
 		// verify
 		assertNotEquals(conditionId1, conditionId2);
@@ -179,8 +184,6 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		c.setCondition(codedOrFreeText);
 		c = conditionService.saveCondition(c);
 		Integer conditionId3 = c.getConditionId();
-		Context.flushSession();
-		Context.clearSession();
 
 		// verify again
 		Condition c3 = conditionService.getCondition(conditionId3);
@@ -189,16 +192,29 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		assertNull(c3.getCondition().getSpecificName());
 		assertEquals("Non-coded condition", c3.getCondition().getNonCoded());
 	}
+
+	@Test
+	public void saveCondition_shouldNotVoidAndRecreateIfUnchanged() throws Exception {
+		Condition condition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		Integer conditionId = condition.getConditionId();
+		int startingNum = conditionService.getAllConditions(condition.getPatient()).size();
+		condition = conditionService.saveCondition(condition);
+		int endingNum = conditionService.getAllConditions(condition.getPatient()).size();
+		assertEquals(startingNum, endingNum);
+		assertEquals(EXISTING_CONDITION_UUID, condition.getUuid());
+		assertEquals(conditionId, condition.getConditionId());
+	}
 	
 	@Test
-	public void saveCondition_shouldVoidExistingCondition() {
+	public void saveCondition_shouldVoidExistingConditionAndNotCreateNewCondition() {
 		// setup
-		Condition condition = new Condition();
-		condition.setUuid(EXISTING_CONDITION_UUID);
-		condition.setVoided(true);
-		condition.setVoidReason("Voided by a test");
+		Condition condition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		Patient patient = condition.getPatient();
+		int startingNum = conditionService.getAllConditions(patient).size();
 		
 		// perform
+		condition.setVoided(true);
+		condition.setVoidReason("Voided by a test");
 		Condition voidedCondition = conditionService.saveCondition(condition);
 		
 		// verify
@@ -209,85 +225,38 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		assertEquals(voidedCondition.getId(), oldCondition.getId());
 		assertTrue(oldCondition.getVoided());
 		assertEquals(voidedCondition.getVoidReason(), oldCondition.getVoidReason());
-	}
 
-	@Test
-	public void saveCondition_shouldNotChangeAnyOtherFieldsWhenVoidingCondition() {
-		// setup
-		Condition condition = new Condition();
-		condition.setUuid(EXISTING_CONDITION_UUID);
-		condition.setVoided(true);
-		condition.setVoidReason("Voided by a test");
-		condition.setPatient(new Patient(8));
-
-		// perform
-		Condition voidedCondition = conditionService.saveCondition(condition);
-
-		// verify
-		assertTrue(voidedCondition.getVoided());
-		assertEquals("Voided by a test", voidedCondition.getVoidReason());
-		assertEquals(voidedCondition.getPatient().getId(), 2);
+		int endingNum = conditionService.getAllConditions(patient).size();
+		assertEquals(startingNum, endingNum+1);
 	}
 
 	@Test
 	public void saveCondition_shouldUnvoidExistingVoidedCondition() {
 		// setup
-		Context.getConditionService().voidCondition(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID), "Voided for test");
-		assertTrue(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID).getVoided());
-		
-		Condition condition = new Condition();
-		condition.setVoided(false);
-		condition.setUuid(EXISTING_CONDITION_UUID);
+		Condition condition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		Patient patient = condition.getPatient();
+		condition.setVoided(true);
+		condition.setVoidReason("Voided by a test");
+		condition = conditionService.saveCondition(condition);
+		assertTrue(condition.getVoided());
+		int startingNum = conditionService.getAllConditions(patient).size();
 
 		// perform
+		condition.setVoided(false);
 		Condition unvoidedCondition = conditionService.saveCondition(condition);
 
 		// verify
 		assertFalse(unvoidedCondition.getVoided());
+		assertNull(unvoidedCondition.getDateVoided());
+		assertNull(unvoidedCondition.getVoidedBy());
 		assertNull(unvoidedCondition.getVoidReason());
 
 		Condition oldCondition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
 		assertEquals(unvoidedCondition.getId(), oldCondition.getId());
 		assertFalse(oldCondition.getVoided());
-		assertEquals(unvoidedCondition.getVoidReason(), oldCondition.getVoidReason());
-	}
-
-	@Test
-	public void saveCondition_shouldNotChangeAnyOtherFieldsWhenUnvoidingCondition() {
-		// setup
-		Context.getConditionService().voidCondition(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID), "Voided for test");
-		assertTrue(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID).getVoided());
-
-		Condition condition = new Condition();
-		condition.setVoided(false);
-		condition.setUuid(EXISTING_CONDITION_UUID);
-		condition.setPatient(new Patient(8));
-
-		// perform
-		Condition unvoidedCondition = conditionService.saveCondition(condition);
-
-		// verify
-		assertFalse(unvoidedCondition.getVoided());
-		assertEquals(unvoidedCondition.getPatient().getId(), 2);
-	}
-
-	@Test
-	public void saveCondition_shouldNotUpdateAVoidedCondition() {
-		// setup
-		Context.getConditionService().voidCondition(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID), "Voided for test");
-		assertTrue(conditionService.getConditionByUuid(EXISTING_CONDITION_UUID).getVoided());
-
-		Condition condition = new Condition();
-		condition.setVoided(true);
-		condition.setUuid(EXISTING_CONDITION_UUID);
-		condition.setPatient(new Patient(8));
-
-		// perform
-		Condition voidedCondition = conditionService.saveCondition(condition);
-
-		// verify
-		assertTrue(voidedCondition.getVoided());
-		assertEquals(voidedCondition.getPatient().getId(), 2);
+		assertNull(oldCondition.getVoidReason());
+		int endingNum = conditionService.getAllConditions(patient).size();
+		assertEquals(startingNum, endingNum-1);
 	}
 
 	/**
@@ -303,7 +272,7 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		condition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
 		
 		// replay
-		condition.setEncounter(new Encounter(2039));
+		condition.setEncounter(encounterService.getEncounter(2039));
 		conditionService.saveCondition(condition);
 		
 		// verify
@@ -384,9 +353,7 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 	@Test
 	public void getActiveConditions_shouldGetActiveConditions() {
 		List<Condition> activeConditions = conditionService.getActiveConditions(patientService.getPatient(2));
-		
 		assertThat(activeConditions, hasSize(1));
-		
 		assertEquals("2cc6880e-2c46-11e4-9138-a6c5e4d20fb7", activeConditions.get(0).getUuid());
 	}
 
@@ -394,14 +361,13 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 	 * @see ConditionService#getAllConditions(Patient)
 	 */
 	@Test
-	public void getAllConditions_shouldGetAllConditions() {
-		List<Condition> conditions = conditionService.getAllConditions(patientService.getPatient(2));
-		
-		assertThat(conditions, hasSize(3));
-		
-		assertThat(conditions.get(0).getUuid(), equalTo("2cb6880e-2cd6-11e4-9138-a6c5e4d20fb7"));
-		assertThat(conditions.get(1).getUuid(), equalTo("2cc6880e-2c46-15e4-9038-a6c5e4d22fb7"));
-		assertThat(conditions.get(2).getUuid(), equalTo("2cc6880e-2c46-11e4-9138-a6c5e4d20fb7"));
+	public void getAllConditions_shouldGetAllUnvoidedConditions() {
+		Patient patient = patientService.getPatient(2);
+		List<Condition> conditions = conditionService.getAllConditions(patient);
+		assertThat(conditions, hasSize(2));
+		// Condition with uuid 2cb6880e-2cd6-11e4-9138-a6c5e4d20fb7 is voided
+		assertThat(conditions.get(0).getUuid(), equalTo("2cc6880e-2c46-15e4-9038-a6c5e4d22fb7"));
+		assertThat(conditions.get(1).getUuid(), equalTo("2cc6880e-2c46-11e4-9138-a6c5e4d20fb7"));
 	}
 	
 	/**
@@ -451,7 +417,7 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		assertTrue(voidedCondition.getVoided());
 		assertNotNull(voidedCondition.getVoidReason());
 		assertNotNull(voidedCondition.getDateVoided());
-		assertEquals(new Integer(1), voidedCondition.getVoidedBy().getUserId());
+		assertEquals(1, voidedCondition.getVoidedBy().getUserId());
 		
 		Condition unVoidedCondition = conditionService.unvoidCondition(voidedCondition);
 		


### PR DESCRIPTION
## Description of what I changed
This makes the following changes to conditions:
* Fixes the ConditionService#saveCondition method to only void and recreate if a Condition has changed
* Fixes the ConditionService#saveCondition method to not exclude updates to properties when a Condition is voided
* Fixes the ConditionService#saveCondition method to not exclude updates to properties when a Condition is unvoided
* Fixes the ConditionService#getAllConditions(Patient) method to exclude voided Conditions
* Adds missing hashcode and equals methods to CodedOrFreeText
* Add new method to Condition to compare whether it matches another Condition

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6171
