### PR TITLE
TRUNK-5025: Obs.setValueAsString should support time zones and more date formats

### DIFF
--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -77,7 +77,15 @@ public class Obs extends BaseFormRecordableOpenmrsData {
 		PRELIMINARY, FINAL, AMENDED
 	}
 	
-	private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm";
+	private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm:ss";
+
+	private static final String DATE_TIME_PATTERN2 = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+
+	private static final String DATE_TIME_PATTERN3 = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+	private static final String DATE_TIME_PATTERN4 = "yyyy-MM-dd'T'HH:mm:ssXXX";
+
+	private static final String DATE_TIME_PATTERN5 = "yyyy-MM-dd'T'HH:mm:ssZ";
 	
 	private static final String TIME_PATTERN = "HH:mm";
 	
@@ -1080,8 +1088,29 @@ public class Obs extends BaseFormRecordableOpenmrsData {
 				DateFormat timeFormat = new SimpleDateFormat(TIME_PATTERN);
 				setValueDatetime(timeFormat.parse(s));
 			} else if ("TS".equals(abbrev)) {
-				DateFormat datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
-				setValueDatetime(datetimeFormat.parse(s));
+				DateFormat datetimeFormat;
+				try {
+					datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN5);
+					setValueDatetime(datetimeFormat.parse(s));
+				} catch (ParseException p) {
+					try {
+						datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN4);
+						setValueDatetime(datetimeFormat.parse(s));
+					} catch (ParseException pe) {
+						try {
+							datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN3);
+							setValueDatetime(datetimeFormat.parse(s));
+						} catch (ParseException pe2) {
+							try {
+								datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN2);
+								setValueDatetime(datetimeFormat.parse(s));
+							} catch (ParseException pe3) {
+								datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
+								setValueDatetime(datetimeFormat.parse(s));
+							}
+						}
+					}
+				}
 			} else if ("ST".equals(abbrev)) {
 				setValueText(s);
 			} else {

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -54,9 +54,10 @@ public class ObsTest {
 	
 	//ignore these fields, groupMembers and formNamespaceAndPath field are taken care of by other tests
 	private static final List<String> IGNORED_FIELDS = Arrays.asList("dirty", "log", "serialVersionUID",
-	    "DATE_TIME_PATTERN", "TIME_PATTERN", "DATE_PATTERN", "FORM_NAMESPACE_PATH_SEPARATOR",
-	    "FORM_NAMESPACE_PATH_MAX_LENGTH", "obsId", "groupMembers", "uuid", "changedBy", "dateChanged", "voided", "voidedBy",
-	    "voidReason", "dateVoided", "formNamespaceAndPath", "$jacocoData");
+	    "DATE_TIME_PATTERN", "DATE_TIME_PATTERN2", "DATE_TIME_PATTERN3", "DATE_TIME_PATTERN4", "DATE_TIME_PATTERN5", 
+		"TIME_PATTERN", "DATE_PATTERN", "FORM_NAMESPACE_PATH_SEPARATOR", "FORM_NAMESPACE_PATH_MAX_LENGTH", "obsId", 
+		"groupMembers", "uuid", "changedBy", "dateChanged", "voided", "voidedBy", "voidReason", "dateVoided", 
+		"formNamespaceAndPath", "$jacocoData");
 	
 	private void resetObs(Obs obs) throws Exception {
 		Field field = Obs.class.getDeclaredField("dirty");

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -323,6 +323,25 @@ public class ObsTest {
 		Obs obs = new Obs();
 		assertThrows(RuntimeException.class, () -> obs.setValueAsString(null));
 	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldPassForAllTheDates() throws Exception {
+		Obs obs = new Obs();
+		ConceptDatatype cd = new ConceptDatatype();
+		cd.setName("Datetime");
+		cd.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cd);
+		obs.setConcept(c);
+
+		String[] dateFormats = {"2011-05-01 00:00:00", "2011-05-01T00:00:00.000", "2011-05-01T00:00:00.000",
+			"2016-01-12T06:00:00+05:30", "2016-01-12T06:00:00+0530", "2014-02-20T11:00:00.000-05:00", "2014-02-20T11:00:00.000-05" };
+		for (String dateFormat : dateFormats)
+			obs.setValueAsString(dateFormat);
+	}
 	
 	/**
 	 * @see Obs#getValueAsBoolean()


### PR DESCRIPTION

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-5025

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

