### PR TITLE
Trunk 6210 Concept Searching should be "diacritic-insensitive"

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptName.java
+++ b/api/src/main/java/org/openmrs/ConceptName.java
@@ -16,6 +16,7 @@ import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilterFactory;
 import org.apache.lucene.analysis.standard.StandardFilterFactory;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.codehaus.jackson.annotate.JsonIgnore;
@@ -37,8 +38,12 @@ import org.openmrs.api.db.hibernate.search.bridge.LocaleFieldBridge;
  * locale.
  */
 @Indexed
-@AnalyzerDef(name = "ConceptNameAnalyzer", tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class), filters = {
-        @TokenFilterDef(factory = StandardFilterFactory.class), @TokenFilterDef(factory = LowerCaseFilterFactory.class) })
+@AnalyzerDef(
+	name = "ConceptNameAnalyzer", tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class), filters = {
+        @TokenFilterDef(factory = StandardFilterFactory.class), 
+		@TokenFilterDef(factory = LowerCaseFilterFactory.class), 
+		@TokenFilterDef(factory = ASCIIFoldingFilterFactory.class)
+	})
 @Analyzer(definition = "ConceptNameAnalyzer")
 public class ConceptName extends BaseOpenmrsObject implements Auditable, Voidable, java.io.Serializable {
 	

--- a/api/src/test/java/org/openmrs/api/db/ConceptDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/ConceptDAOTest.java
@@ -226,5 +226,28 @@ public class ConceptDAOTest extends BaseContextSensitiveTest {
 		assertEquals(c1, searchResults1.get(0).getConcept());
 		assertEquals(cn1b, searchResults1.get(0).getConceptName());
 	}
-	
+
+	/**
+	 * @see {@link ConceptDAO#getConcepts(String, List, boolean, List, List, List, List, Concept, Integer, Integer)} 
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void getConcepts_shouldBeDiacriticInsensitive() {
+		executeDataSet("org/openmrs/api/include/ConceptServiceTest-accents.xml");
+		Context.getConceptService().updateConceptIndexes();
+		List<ConceptSearchResult> searchResults = dao.getConcepts(
+			"Hysterectom", 
+			Collections.singletonList(Locale.ENGLISH), 
+			false, 
+			Collections.EMPTY_LIST,
+			Collections.EMPTY_LIST, 
+			Collections.EMPTY_LIST, 
+			Collections.EMPTY_LIST, 
+			null, 
+			null, 
+			null
+		);
+		assertEquals(4, searchResults.size());
+		assertEquals("Hystérectomie", searchResults.get(0).getConcept().getName().getName());
+	}
 }

--- a/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-accents.xml
+++ b/api/src/test/resources/org/openmrs/api/include/ConceptServiceTest-accents.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <concept concept_id="240" retired="0" datatype_id="4" class_id="3" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e1"/>
+  <concept concept_id="357" retired="0" datatype_id="4" class_id="3" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e2"/>
+  <concept concept_id="798" retired="0" datatype_id="4" class_id="8" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e3"/>
+  <concept concept_id="328" retired="0" datatype_id="4" class_id="5" is_set="false" creator="1" date_created="2008-08-15 15:27:51.0" uuid="568b58c8-e878-11e0-950d-00248140a5e4"/>
+
+  <concept_name concept_id="240" name="Hysterectomie subtotal" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="240" voided="false" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" uuid="67ce91b2-e879-11e0-950d-00248140a5e1"/>
+  <concept_name concept_id="357" name="Hysterectomie hemostatique post-partum" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="357" voided="false" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" uuid="67ce91b2-e879-11e0-950d-00248140a5e2"/>
+  <concept_name concept_id="798" name="Hystérectomie" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="798" voided="false" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" uuid="67ce91b2-e879-11e0-950d-00248140a5e3"/>
+  <concept_name concept_id="328" name="Caesarean hysterectomy" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_id="328" voided="false" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" uuid="67ce91b2-e879-11e0-950d-00248140a5e7"/>
+
+</dataset>


### PR DESCRIPTION
This updates the Lucene analyzer configuration for ConceptName to include the ASCIIFoldingFilterFactory which enables diacritic-insensitive searching

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6210
