### PR TITLE
TRUNK-6108  COPY: Useless Method: "globalPropertyDeleted(String propertyName)", So remove that method

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -675,15 +675,6 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	}
 	
 	/**
-	 * @see org.openmrs.api.GlobalPropertyListener#globalPropertyDeleted(java.lang.String)
-	 */
-	@Override
-	public void globalPropertyDeleted(String propertyName) {
-		// TODO Auto-generated method stub
-		
-	}
-	
-	/**
 	 * @see org.openmrs.api.GlobalPropertyListener#supportsPropertyName(java.lang.String)
 	 */
 	@Override


### PR DESCRIPTION
https://openmrs.atlassian.net/issues/TRUNK-6128?filter=10636

Useless Method: "globalPropertyDeleted(String propertyName)", So remove that method

## Description of what I changed
Unused and Unimplemented Method:
Observation: The globalPropertyDeleted method has been auto-generated but is not implemented; it contains a TODO comment.

Issue: The method doesn't serve any functional purpose in its current state, as the parameter propertyName is declared but not used, and the method body is empty.

Solution: Deleting the unused and unimplemented method helps to eliminate unnecessary code and improves code cleanliness.



## Issue I worked on

[see https://issues.openmrs.org/browse/TRUNK-](https://openmrs.atlassian.net/issues/TRUNK-6128?filter=10636)

## Checklist: I completed these to help reviewers :)

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [X] All new and existing **tests passed**.

- [X] My pull request is **based on the latest changes** of the master branch.
