### PR TITLE
TRUNK-6030 : The allergy field in the Allergy UI should validate the input string

### DIFF
--- a/api/src/main/java/org/openmrs/validator/AllergyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AllergyValidator.java
@@ -63,6 +63,11 @@ public class AllergyValidator implements Validator {
 		ValidationUtils.rejectIfEmpty(errors, "patient", "allergyapi.patient.required");
 		
 		Allergy allergy = (Allergy) target;
+
+		    // Additional validation: Ensure allergen does not contain numeric values
+			if (allergy.getAllergen() != null && StringUtils.isNumeric(allergy.getAllergen().getNonCodedAllergen())) {
+				errors.rejectValue("allergen", "error.allergyapi.allergy.Allergen.cannotContainNumeric");
+			}
 		
 		if (allergy.getReactionNonCoded() != null) {
 			if (NumberUtils.isParsable(allergy.getReactionNonCoded())) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -94,6 +94,7 @@ error.email.alreadyInUse=Email address is already assigned to another user accou
 error.activationkey.invalid =Invalid user activation Key
 error.usernameOrEmail.notNullOrBlank =Username Or email cannot be null or blank
 error.allergyapi.allergy.ReactionNonCoded.cannotBeNumeric=Reaction Non-coded must not be only a number
+error.allergyapi.allergen.nonCodedAllergen.cannotBeNumeric=Non-coded Allergen must not be only a number
 
 general.at=at
 general.with=with

--- a/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/AllergyValidatorTest.java
@@ -191,4 +191,12 @@ public class AllergyValidatorTest extends BaseContextMockTest {
 		validator.validate(allergy, errors);
 		assertTrue(errors.hasErrors());
 	}
+	@Test
+	public void validate_shouldRejectNumericAllergenValue() {
+		Allergen allergen = new Allergen(AllergenType.DRUG, null , "45" );
+		allergy.setAllergen(allergen);
+		Errors errors = new BindException(allergy,"allergy");
+		validator.validate(allergy, errors);
+		assertTrue(errors.hasErrors());
+	}
 }


### PR DESCRIPTION
The allergy field in the Allergy UI allows the user to enter a numeric value, considering allergies cannot have numeric name, we must validate the input string before allowing the user to procced further

## Description of what I changed
This pull request enhances the AllergyValidator in the Allergy UI to provide improved validation for the allergen field. Previously, the allergen field allowed users to enter numeric values, which is not a valid scenario for allergy names.
### Changes Made:
* Updated the AllergyValidator class to include validation for numeric values in the allergen field.
* If the allergen field contains numeric values, a custom error is triggered to inform the user about the restriction on using 
  numeric values for allergy names.
  
  ### How to Test:
  * Enter a valid non-numeric allergen name. The validation should pass.
  * Attempt to enter an allergen name containing numeric values. The validation should reject the input and display an appropriate error message.

## Issue I worked on
https://openmrs.atlassian.net/issues/TRUNK-6030?filter=10636

## Checklist: I completed these to help reviewers :)

- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

