### PR TITLE
TRUNK-6221: Use LocaleUtils.toLocale() for locales

### DIFF
--- a/api/src/main/java/org/openmrs/util/LocaleUtility.java
+++ b/api/src/main/java/org/openmrs/util/LocaleUtility.java
@@ -21,6 +21,7 @@ import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 /**
  * A utility class for working with Locales.
@@ -131,15 +132,20 @@ public class LocaleUtility implements GlobalPropertyListener {
 		
 		localeSpecification = localeSpecification.trim();
 		
-		String[] localeComponents = localeSpecification.split("_");
-		if (localeComponents.length == 1) {
-			createdLocale = new Locale(localeComponents[0]);
-		} else if (localeComponents.length == 2) {
-			createdLocale = new Locale(localeComponents[0], localeComponents[1]);
-		} else if (localeComponents.length > 2) {
-			String variant = localeSpecification.substring(localeSpecification.indexOf(localeComponents[2])); // gets everything after the
-			// second underscore
-			createdLocale = new Locale(localeComponents[0], localeComponents[1], variant);
+		try {
+			createdLocale = LocaleUtils.toLocale(localeSpecification);
+		}
+		catch (IllegalArgumentException e) {
+			String[] localeComponents = localeSpecification.split("[-_]");
+			if (localeComponents.length == 1) {
+				createdLocale = new Locale(localeComponents[0]);
+			} else if (localeComponents.length == 2) {
+				createdLocale = new Locale(localeComponents[0], localeComponents[1]);
+			} else if (localeComponents.length > 2) {
+				String variant = localeSpecification.substring(localeSpecification.indexOf(localeComponents[2])); // gets everything after the
+				// second underscore
+				createdLocale = new Locale(localeComponents[0], localeComponents[1], variant);
+			}
 		}
 		
 		return createdLocale;


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
Use LocaleUtils.toLocale() for locales
<!--- It can simply be your commit message, which you must have -->

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6221

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`


As per this ticket https://openmrs.atlassian.net/browse/TRUNK-6221, @ibacher suggests that we use 
LocaleUtils.toLocale() for the locale handling.
Whereas it can handle both hyphens and underscores, I have seen that it seems to have its own restrictions.


For example, when you pass the following localeSpecification string, `en_US_Traditional_WIN` it seems to 
raise an **IllegalArgumentException**, especially from the way it handles multi-part variants as seen from the `toLocale`
and `parseLocale` functions in this decompiled java class file: (https://github.com/trevor-james-nangosha/files/blob/main/LocaleUtils.class)

For starters, I have decided to use the `toLocale` function as a default and use our custom logic from before as a fallback.
@ibacher, what do you think about this approach?
