### PR TITLE
TRUNK-6041: Proper Restriction of XML External Entity Reference to prevent XXE attacks

### DIFF
--- a/liquibase/src/main/java/org/openmrs/liquibase/Main.java
+++ b/liquibase/src/main/java/org/openmrs/liquibase/Main.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 import org.dom4j.DocumentException;
+import org.xml.sax.SAXException;
 
 public class Main {
 	
@@ -37,7 +38,7 @@ public class Main {
 		schemaOnlyTuner = new SchemaOnlyTuner();
 	}
 	
-	public static void main(String[] args) throws DocumentException, IOException {
+	public static void main(String[] args) throws DocumentException, IOException, SAXException {
 		coreDataTuner.addLicenseHeaderToFileIfNeeded(LIQUIBASE_CORE_DATA_SOURCE_PATH);
 		coreDataTuner.createUpdatedChangeLogFile(LIQUIBASE_CORE_DATA_SOURCE_PATH, LIQUIBASE_CORE_DATA_TARGET_PATH);
 		schemaOnlyTuner.addLicenseHeaderToFileIfNeeded(LIQUIBASE_SCHEMA_ONLY_SOURCE_PATH);

--- a/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
@@ -34,6 +34,7 @@ import org.dom4j.XPath;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.xml.sax.SAXException;
 
 public class CoreDataTunerTest {
 	
@@ -66,7 +67,7 @@ public class CoreDataTunerTest {
 	}
 	
 	@Test
-	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException {
+	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException, SAXException {
 		// given
 		String sourcePath = PATH_TO_TEST_RESOURCES + File.separator + LIQUIBASE_CORE_DATA_SNAPSHOT_XML;
 		String targetPath = tempDir.resolve("liquibase-core-data-UPDATED-SNAPSHOT.xml").toString();

--- a/liquibase/src/test/java/org/openmrs/liquibase/MainTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/MainTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import org.dom4j.DocumentException;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.xml.sax.SAXException;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.times;
 public class MainTest {
 	
 	@Test
-	public void shouldCreateUpdatedSnapshotFiles() throws DocumentException, IOException {
+	public void shouldCreateUpdatedSnapshotFiles() throws DocumentException, IOException, SAXException {
 		CoreDataTuner coreDataTuner = Mockito.mock(CoreDataTuner.class);
 		SchemaOnlyTuner schemaOnlyTuner = Mockito.mock(SchemaOnlyTuner.class);
 		

--- a/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
+import org.xml.sax.SAXException;
 
 public class SchemaOnlyTunerTest {
 	
@@ -60,7 +61,7 @@ public class SchemaOnlyTunerTest {
 	}
 	
 	@Test
-	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException {
+	public void shouldCreateUpdatedChangeLogFile(@TempDir Path tempDir) throws DocumentException, IOException, SAXException {
 		// given
 		String sourcePath = PATH_TO_TEST_RESOURCES + File.separator + LIQUIBASE_SCHEMA_ONLY_SNAPSHOT_XML;
 		String targetPath = tempDir.resolve("liquibase-schema-only-UPDATED-SNAPSHOT.xml").toString();


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

The following SAXReader features have been configured in order to properly restrict xml external entity references in order to prevent xxe attacks and other security concerns:

1. `http://apache.org/xml/features/disallow-doctype-decl`: This disables the processing of Document Type Definitions (DTDs) which can be exploited for **XXE** attacks.

2. `http://xml.org/sax/features/external-general-entities`: This disables the loading of external general entities, another way to launch **XXE** attacks.

3. `http://xml.org/sax/features/external-parameter-entities`: This disables the processing of external parameter entities which is another way to perform **XXE** attacks.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6041

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

