### PR TITLE
Fix typo in logging messages

### DIFF
--- a/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterTypeNameChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/DuplicateEncounterTypeNameChangeSet.java
@@ -143,7 +143,7 @@ public class DuplicateEncounterTypeNameChangeSet implements CustomTaskChange {
 			}
 		}
 		catch (BatchUpdateException e) {
-			log.warn("Error generated while processsing batch insert", e);
+			log.warn("Error generated while processing batch insert", e);
 			
 			try {
 				log.debug("Rolling back batch", e);


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
fix the typo `processsing` -> `processing` in logging messages


