### PR TITLE
TRUNK-6248: Backend Docker should not fail starting if curl command is failing

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -50,7 +50,7 @@ echo "Starting up OpenMRS..."
 
 # Trigger first filter to start data import
 sleep 15
-curl -sL "http://localhost:8080/${OMRS_WEBAPP_NAME}/" > /dev/null
+curl -sL "http://localhost:8080/${OMRS_WEBAPP_NAME}/" > /dev/null || true
 sleep 15
 
 # Bring tomcat process to foreground again


### PR DESCRIPTION
See https://openmrs.atlassian.net/browse/TRUNK-6248

See https://openmrs.slack.com/archives/C02PYQD5D0A/p1721160589093129