### PR TITLE
(chore) Revert ossf/scorecard-action version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.3.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The purpose of this PR is to fix: https://github.com/openmrs/openmrs-core/actions/runs/9995004178/job/27626138324