### PR TITLE
TRUNK-6252: Conditional resource path should be interpreted as a globs

### DIFF
--- a/api/src/main/java/org/openmrs/module/Module.java
+++ b/api/src/main/java/org/openmrs/module/Module.java
@@ -83,6 +83,8 @@ public final class Module {
 	
 	private Set<String> packagesWithMappedClasses = new HashSet<>();
 	
+	private String configVersion;
+	
 	private Document config = null;
 	
 	private Document sqldiff = null;
@@ -116,13 +118,15 @@ public final class Module {
 	 * @param description
 	 * @param version
 	 */
-	public Module(String name, String moduleId, String packageName, String author, String description, String version) {
+	public Module(String name, String moduleId, String packageName, String author, String description, String version,
+				  String configVersion) {
 		this.name = name;
 		this.moduleId = moduleId;
 		this.packageName = packageName;
 		this.author = author;
 		this.description = description;
 		this.version = version;
+		this.configVersion = configVersion;
 		log.debug("Creating module " + name);
 	}
 	
@@ -644,7 +648,21 @@ public final class Module {
 	public void setConfig(Document config) {
 		this.config = config;
 	}
-	
+
+	/**
+	 * @since 2.8.0
+	 */
+	public String getConfigVersion() {
+		return configVersion;
+	}
+
+	/**
+	 * @since 2.8.0
+	 */
+	public void setConfigVersion(String configVersion) {
+		this.configVersion = configVersion;
+	}
+
 	public Document getSqldiff() {
 		return sqldiff;
 	}

--- a/api/src/main/java/org/openmrs/module/ModuleFileParser.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFileParser.java
@@ -85,6 +85,7 @@ public class ModuleFileParser {
 		validConfigVersions.add("1.5");
 		validConfigVersions.add("1.6");
 		validConfigVersions.add("1.7");
+		validConfigVersions.add("2.0");
 	}
 	
 	// TODO - remove this field once ModuleFileParser(File), ModuleFileParser(InputStream) are removed.
@@ -318,7 +319,7 @@ public class ModuleFileParser {
 		String desc = getElementTrimmed(configRoot, "description");
 		String version = getElementTrimmed(configRoot, "version");
 
-		Module module = new Module(name, moduleId, packageName, author, desc, version);
+		Module module = new Module(name, moduleId, packageName, author, desc, version, configVersion);
 
 		module.setActivatorName(getElementTrimmed(configRoot, "activator"));
 		module.setRequireDatabaseVersion(getElementTrimmed(configRoot, "require_database_version"));

--- a/api/src/main/resources/org/openmrs/module/dtd/config-2.0.dtd
+++ b/api/src/main/resources/org/openmrs/module/dtd/config-2.0.dtd
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+	<!--
+		Top level configuration element.
+		-->
+	<!ELEMENT module (
+		(id),
+		(name),
+		(version),
+		(package),
+		(author),
+		(description),
+		(activator),
+		(updateURL?),
+		(require_version?),
+		(require_database_version?),
+		(require_modules?),
+		(aware_of_modules?),
+		(start_before_modules?),
+		(mandatory?),
+		(library*),
+		(extension*),
+		(advice*),
+		(privilege*),
+		(globalProperty*),
+		(dwr?),
+		(servlet*),
+		(filter*),
+		(filter-mapping*),
+		(messages*),
+		(mappingFiles?),
+		(packagesWithMappedClasses?),
+		(conditionalResources?)
+		)>
+	<!ATTLIST module configVersion CDATA #FIXED "2.0">
+
+	<!ELEMENT id (#PCDATA)>
+	<!ELEMENT name (#PCDATA)>
+	<!ELEMENT version (#PCDATA)>
+	<!ELEMENT package (#PCDATA)>
+	<!ELEMENT author (#PCDATA)>
+	<!ELEMENT description (#PCDATA)>
+	<!ELEMENT activator (#PCDATA)>
+	<!ELEMENT updateURL (#PCDATA)>
+	<!ELEMENT require_version (#PCDATA)>
+	<!ELEMENT require_database_version (#PCDATA)>
+
+	<!ELEMENT require_modules (require_module+)>
+	<!ELEMENT require_module (#PCDATA)>
+	<!ATTLIST require_module version CDATA #IMPLIED>
+
+	<!ELEMENT aware_of_modules (aware_of_module+)>
+	<!ELEMENT aware_of_module (#PCDATA)>
+	<!ATTLIST aware_of_module version CDATA #IMPLIED>
+
+	<!ELEMENT start_before_modules (module+)>
+	<!ELEMENT start_before_module (#PCDATA)>
+	<!ATTLIST start_before_module version CDATA #IMPLIED>
+
+	<!ELEMENT mandatory (#PCDATA)>
+
+	<!ELEMENT library EMPTY>
+	<!ATTLIST library
+		id CDATA #REQUIRED
+		path CDATA #REQUIRED
+		type (resources|library) #REQUIRED
+		>
+
+	<!ELEMENT extension (point, class)>
+	<!ELEMENT advice (point, class)>
+	<!ELEMENT point (#PCDATA)>
+	<!ELEMENT class (#PCDATA)>
+
+	<!ELEMENT privilege (name, description)>
+
+	<!ELEMENT globalProperty (property, defaultValue?, description)>
+	<!ELEMENT property (#PCDATA)>
+	<!ELEMENT defaultValue (#PCDATA)>
+
+	<!ELEMENT dwr (allow, signatures?)>
+	<!ELEMENT allow (create*, convert*)>
+
+	<!ELEMENT create (param, include*)>
+	<!ATTLIST create creator CDATA #REQUIRED javascript CDATA #REQUIRED>
+
+	<!ELEMENT param EMPTY>
+	<!ATTLIST param name CDATA #REQUIRED value CDATA #REQUIRED>
+
+	<!ELEMENT include EMPTY>
+	<!ATTLIST include method CDATA #REQUIRED>
+
+	<!ELEMENT convert (param?)>
+	<!ATTLIST convert converter CDATA #REQUIRED match CDATA #REQUIRED>
+
+	<!ELEMENT signatures (#PCDATA)>
+
+	<!ELEMENT servlet (servlet-name, servlet-class, init-param*)>
+	<!ELEMENT servlet-name (#PCDATA)>
+	<!ELEMENT servlet-class (#PCDATA)>
+
+	<!ELEMENT filter (filter-name, filter-class, init-param*)>
+	<!ELEMENT filter-name (#PCDATA)>
+	<!ELEMENT filter-class (#PCDATA)>
+	<!ELEMENT init-param (param-name, param-value)>
+	<!ELEMENT param-name (#PCDATA)>
+	<!ELEMENT param-value (#PCDATA)>
+
+	<!ELEMENT filter-mapping (filter-name, (url-pattern | servlet-name))>
+	<!ELEMENT url-pattern (#PCDATA)>
+
+	<!ELEMENT messages (lang, file)>
+	<!ELEMENT lang (#PCDATA)>
+	<!ELEMENT file (#PCDATA)>
+
+	<!ELEMENT mappingFiles (#PCDATA)>
+	<!ELEMENT packagesWithMappedClasses (#PCDATA)>
+
+	<!ELEMENT conditionalResources (conditionalResource+)>
+	<!-- Beginning with configVersion="2.0", the "path" in <conditionalResource> uses glob syntax instead of regex. -->
+	<!ELEMENT conditionalResource (path, (openmrsVersion | modules))>
+	<!ELEMENT path (#PCDATA)>
+	<!ELEMENT openmrsVersion (#PCDATA)>
+	<!ELEMENT modules (module+)>
+	<!ELEMENT module (moduleId, version)>
+	<!ELEMENT moduleId (#PCDATA)>

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -11,26 +11,33 @@ package org.openmrs.module;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
 public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	
-	Module mockModule;
+	Module mockModuleV1_0;
+	Module mockModuleV2_0;
 	
 	Map<String, String> mockModules;
 	
 	@BeforeEach
 	public void before() {
-		mockModule = new Module("mockmodule", "mockmodule", "org.openmrs.module.mockmodule", "author", "description", "1.0");
+		mockModuleV1_0 = new Module("mockmodule", "mockmodule", "org.openmrs.module.mockmodule", "author", "description", "1.0", "1.0");
+		mockModuleV2_0 = new Module("mockmodule", "mockmodule", "org.openmrs.module.mockmodule", "author", "description", "2.0", "2.0");
 		mockModules = new HashMap<>();
 	}
 	
@@ -45,9 +52,9 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		resource.setPath("lib/mockmodule-api-1.10.jar");
 		resource.setOpenmrsPlatformVersion("1.7-1.8,1.10-1.11");
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
@@ -64,9 +71,9 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		resource.setPath("lib/mockmodule-api-1.10.jar");
 		resource.setOpenmrsPlatformVersion("1.7-1.8, 1.10-1.11");
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.12.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(false));
@@ -83,9 +90,9 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		resource.setPath("lib/mockmodule-api.jar");
 		resource.setOpenmrsPlatformVersion("1.10-1.11");
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.9.8-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
@@ -106,11 +113,11 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("3.0-4.0,1.0-2.0");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
 		mockModules.put("module", "1.1");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
@@ -131,9 +138,9 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("!");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
@@ -154,12 +161,12 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("!");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
-		ModuleFactory.getStartedModulesMap().put("module", new Module("", "module", "", "", "", "3.0"));
+		ModuleFactory.getStartedModulesMap().put("module", new Module("", "module", "", "", "", "3.0", "1.0"));
 		mockModules.put("module", "3.0");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(false));
@@ -182,11 +189,11 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("1.0-2.0");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
 		mockModules.put("module", "3.0");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(false));
@@ -208,11 +215,11 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("1.0-2.0,4.0");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
 		mockModules.put("module", "3.0");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(false));
@@ -232,11 +239,11 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("1.0-2.0");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
 		mockModules.put("differentModule", "1.0");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(false));
@@ -257,13 +264,232 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		module.setVersion("1.0-2.0");
 		resource.getModules().add(module);
 		
-		mockModule.getConditionalResources().add(resource);
+		mockModuleV1_0.getConditionalResources().add(resource);
 		
 		mockModules.put("module", "3.0");
 		
-		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModule, URI.create(
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV1_0, URI.create(
 		    "file://module/mockmodule/lib/mockmodule-api-1.10.jar").toURL(), "1.10.0-SNAPSHOT", mockModules);
 		
 		assertThat(result, is(true));
+	}
+
+	/**
+	 * @throws MalformedURLException
+	 * @see ModuleClassLoader#shouldResourceBeIncluded(Module, java.net.URL, String, java.util.Map)
+	 */
+	@Test
+	public void shouldResourceBeIncluded_ShouldNotIncludeWhenVersionWildcardMatchUsingGlobs() throws MalformedURLException {
+
+		final String conditionalResourceModuleId = "module123";
+		final String conditionalResourceVersion = "!";
+		final String conditionalResourcePath = "/lib/jackson-mapper-asl*";
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+		final String relatedModuleVersion = "1.2.3";
+		
+		Map<String, String> startedRelatedModules = new HashMap<>();
+		startedRelatedModules.put(conditionalResourceModuleId, relatedModuleVersion);
+
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceVersion);
+
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath(conditionalResourcePath);
+		resource.setOpenmrsPlatformVersion("1.7-1.8,1.10-1.11");
+		resource.setModules(Collections.singletonList(moduleIdAndVersion));
+		mockModuleV2_0.getConditionalResources().add(resource);
+
+		ModuleFactory.getStartedModulesMap().put(conditionalResourceModuleId, new Module("", conditionalResourceModuleId, "", "", "", "3.0", "1.0"));
+
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV2_0, fileUrl, "1.10.0-SNAPSHOT", startedRelatedModules);
+
+		assertThat(result, is(false));
+		
+		ModuleFactory.getStartedModulesMap().clear();
+	}
+
+	@Test
+	public void shouldResourceBeIncluded_ShouldIncludeMatchingPlatformVersionsUsingGlobs()
+		throws MalformedURLException {
+
+		final String conditionalResourceModuleId = "module123";
+		final String commonModuleVersion = "1.2.3";
+		final String commonPlatformVersion = "1.6.0";
+		final String conditionalResourcePath = "/lib/jackson-mapper-asl*";
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+
+		Map<String, String> startedRelatedModules = new HashMap<>();
+		startedRelatedModules.put(conditionalResourceModuleId, commonModuleVersion);
+
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(commonModuleVersion);
+
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath(conditionalResourcePath);
+		resource.setOpenmrsPlatformVersion(commonPlatformVersion);
+		resource.setModules(Collections.singletonList(moduleIdAndVersion));
+		mockModuleV2_0.getConditionalResources().add(resource);
+
+		ModuleFactory.getStartedModulesMap().put(conditionalResourceModuleId, new Module("", conditionalResourceModuleId, "", "", "", commonModuleVersion, "1.0"));
+
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV2_0, fileUrl, commonPlatformVersion, startedRelatedModules);
+
+		assertThat(result, is(true));
+
+		ModuleFactory.getStartedModulesMap().clear();
+	}
+
+	@Test
+	public void shouldResourceBeIncluded_ShouldNotIncludeModuleWhenVersionsMatchUsingGlobs()
+		throws MalformedURLException {
+
+		final String conditionalResourceModuleId = "module123";
+		final String commonPlatformVersion = "1.2.3";
+		final String conditionalResourceModuleVersion = "1.2.*";
+		final String otherModuleVersion = "2.2.2";
+		final String conditionalResourcePath = "/lib/jackson-mapper-asl*";
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+
+		Map<String, String> startedRelatedModules = new HashMap<>();
+		startedRelatedModules.put(conditionalResourceModuleId, otherModuleVersion);
+
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceModuleVersion);
+
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath(conditionalResourcePath);
+		resource.setOpenmrsPlatformVersion(commonPlatformVersion);
+		resource.setModules(Collections.singletonList(moduleIdAndVersion));
+		mockModuleV2_0.getConditionalResources().add(resource);
+
+		ModuleFactory.getStartedModulesMap().put(conditionalResourceModuleId, new Module("", conditionalResourceModuleId, "", "", "", otherModuleVersion, "1.0"));
+
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV2_0, fileUrl, commonPlatformVersion, startedRelatedModules);
+
+		assertThat(result, is(false));
+
+		ModuleFactory.getStartedModulesMap().clear();
+	}
+	
+	@Test
+	public void shouldResourceBeIncluded_ShouldNotIncludeWhenPlatformVersionsMisnmatchUsingGlobs()
+		throws MalformedURLException {
+
+		final String conditionalResourceModuleId = "module123";
+		final String conditionalResourceVersion = "1.0.0";
+		final String conditionalResourcePath = "/lib/jackson-mapper-asl*";
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+
+		final String conditionalResourcePlatformVersion = "1.0.*";
+		final String openmrsPlatformVersion = "2.0.0";
+
+		Map<String, String> startedRelatedModules = new HashMap<>();
+		startedRelatedModules.put(conditionalResourceModuleId, conditionalResourceVersion);
+
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceVersion);
+
+		ModuleConditionalResource resource = new ModuleConditionalResource();
+		resource.setPath(conditionalResourcePath);
+		resource.setOpenmrsPlatformVersion(conditionalResourcePlatformVersion);
+		resource.setModules(Collections.singletonList(moduleIdAndVersion));
+		mockModuleV2_0.getConditionalResources().add(resource);
+
+		ModuleFactory.getStartedModulesMap().put(conditionalResourceModuleId, new Module("", conditionalResourceModuleId, "", "", "", "3.0", "1.0"));
+
+		boolean result = ModuleClassLoader.shouldResourceBeIncluded(mockModuleV2_0, fileUrl, openmrsPlatformVersion, startedRelatedModules);
+
+		assertThat(result, is(false));
+
+		ModuleFactory.getStartedModulesMap().clear();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"lib/jackson-mapper-asl-1.9.13.jar",
+		"/lib/jackson-mapper-asl-1.9.13.jar",
+		"\\lib/jackson-mapper-asl-1.9.13.jar",
+		"atomfeed/lib/jackson-mapper-asl-1.9.13.jar",
+		"/atomfeed/lib/jackson-mapper-asl-1.9.13.jar",
+		"\\atomfeed/lib/jackson-mapper-asl-1.9.13.jar",
+		"/lib/jackson-mapper-asl-**.jar",
+		"/lib/jackson-mapper-asl-**",
+		"/lib/jackson-**-1.9.13.jar",
+		"atomfeed/*/jackson-mapper-asl-1.9.13.jar",
+		"C:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar",
+		"D:\\atomfeed\\lib\\jackson-mapper-asl-1.9.13.jar"
+	})
+	void testGlobPatternMatches(String filePath) throws MalformedURLException {
+		final String conditionalResourceModuleId = "module123";
+		final String conditionalResourceVersion = "1.0.0";
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceVersion);
+
+		ModuleConditionalResource conditionalResource = new ModuleConditionalResource();
+		conditionalResource.setPath(filePath);
+
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+		assertTrue(ModuleClassLoader.isMatchingConditionalResource(mockModuleV2_0, fileUrl, conditionalResource),
+			"Path should match glob pattern: " + filePath);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"/libs/jackson-mapper-asl.jar",
+		"/library/jackson-mapper-asl-1.9.13.jar",
+		"/otherpath/lib/jackson-mapping-asl-1.9.13.jar",
+		"/lib/jackson-mapper-xyz.jar",
+		"/lib/jackson-mapper-asl.txt",
+		"/lib/jackson-mapper-asl-1.9.13.json",
+		"/lib/otherfolder/jackson-mapper-asl.jar",
+		"/lib/jackson-mapper-asl/subdir/jackson-mapper-asl-1.9.13.jar",
+		"C:/atomfeeds/lib/jackson-mapper-asl.jar",
+		"D:\\lib\\jackson-mapper-asl-1.9.13.doc",
+		"/a/b/c/atomfeed/lib/jackson-mapper-asl-1.9.13.jar",
+		"/a/b/c/atomfeed/lib/jackson-mapper-asl-**.jar",
+	})
+	void testGlobPatternDoesNotMatch(String filePath) throws MalformedURLException {
+		final String conditionalResourceModuleId = "module123";
+		final String conditionalResourceVersion = "1.0.0";
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceVersion);
+
+		ModuleConditionalResource conditionalResource = new ModuleConditionalResource();
+		conditionalResource.setPath(filePath);
+
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+
+		assertFalse(ModuleClassLoader.isMatchingConditionalResource(mockModuleV2_0, fileUrl, conditionalResource),
+			"Path should not match glob pattern: " + filePath);
+	}
+
+	@Test
+	void testIsMatchingConditionalResourceWithNullConfigVersionDoesNotThrow() throws MalformedURLException {
+		final String conditionalResourceModuleId = "module123";
+		final String conditionalResourceVersion = "1.0.0";
+		ModuleConditionalResource.ModuleAndVersion moduleIdAndVersion = new ModuleConditionalResource.ModuleAndVersion();
+		moduleIdAndVersion.setModuleId(conditionalResourceModuleId);
+		moduleIdAndVersion.setVersion(conditionalResourceVersion);
+
+		ModuleConditionalResource conditionalResource = new ModuleConditionalResource();
+		conditionalResource.setPath("/libs/jackson-mapper-asl.jar");
+
+		final Module moduleWithNullConfigVersions = new Module("mockmodule", "mockmodule", "org.openmrs.module.mockmodule", "author", "description", "2.0", null);
+
+		final URL fileUrl = URI.create(
+			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
+		assertFalse(ModuleClassLoader.isMatchingConditionalResource(moduleWithNullConfigVersions, fileUrl, conditionalResource));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/ModuleExtensionsTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleExtensionsTest.java
@@ -47,7 +47,7 @@ public class ModuleExtensionsTest extends BaseContextMockTest {
 
 	@BeforeEach
 	public void before() {
-		module = new Module("Extension Test", "extensiontest", "org.openmrs.module.extensiontest", "", "", "0.0.1");
+		module = new Module("Extension Test", "extensiontest", "org.openmrs.module.extensiontest", "", "", "0.0.1", "1.0");
 	}
 	
 	@AfterEach

--- a/api/src/test/java/org/openmrs/module/ModuleFileParserTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleFileParserTest.java
@@ -119,7 +119,7 @@ public class ModuleFileParserTest extends BaseContextSensitiveTest {
 		String invalidConfigVersion = "0.0.1";
 		String expectedMessage = messageSourceService
 			.getMessage("Module.error.invalidConfigVersion",
-				new Object[] { invalidConfigVersion, "1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7" }, Context.getLocale());
+				new Object[] { invalidConfigVersion, "1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 2.0" }, Context.getLocale());
 
 		Document configXml = documentBuilder.newDocument();
 		Element root = configXml.createElement("module");
@@ -142,6 +142,7 @@ public class ModuleFileParserTest extends BaseContextSensitiveTest {
 		assertThat(module.getActivatorName(), is("org.openmrs.logic.LogicModuleActivator"));
 		assertThat(module.getMappingFiles().size(), is(1));
 		assertThat(module.getMappingFiles(), hasItems("LogicRuleToken.hbm.xml"));
+		assertThat(module.getConfigVersion(), is("1.3"));
 	}
 
 	private void expectModuleExceptionWithTranslatedMessage(Executable executable, String s) {

--- a/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
@@ -36,6 +36,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
@@ -747,6 +749,45 @@ public class ModuleUtilTest extends BaseContextSensitiveTest {
 			assertFalse(string.contains("META-INF"));
 			assertFalse(string.contains("web/module"));
 		}
+	}
+
+	/**
+	 * @see ModuleUtil#matchRequiredVersions(String, String) 
+	 */
+	@ParameterizedTest(name = "configVersion={0}, versionRange={1} => expected={2}")
+	@CsvSource({
+		// Exact version matches
+		"2.0, 2.0, true",
+		"2.1, 2.0, true",
+		"1.9, 2.0, false",
+
+		// Wildcard major version matches
+		"1.5, 1.*, true",
+		"1.0, 1.*, true",
+		"2.0, 1.*, false",
+
+		// Wildcard minor version matches
+		"2.0.1, 2.0.*, true",
+		"2.0.0, 2.0.*, true",
+		"2.1.0, 2.0.*, false",
+
+		// Version range matches
+		"1.5, 1.0 - 2.0, true",
+		"2.0, 1.0 - 2.0, true",
+		"2.1, 1.0 - 2.0, false",
+		"0.9, 1.0 - 2.0, false",
+
+		// No version range (null or empty)
+		"2.0, , true",
+		"1.5, , true",
+
+		// Edge cases
+		"1.0.0, 1.0, true",
+		"1.0.1, 1.0, true",
+		"0.9.9, 1.0, false"
+	})
+	void testMatchConfigVersions(String configVersion, String versionRange, boolean expected) {
+		assertEquals(expected, ModuleUtil.matchRequiredVersions(configVersion, versionRange));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_0.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_0.java
@@ -33,7 +33,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_0 {
 	
-	private static final String[] compatibleVersions = new String[] { "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] { "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_1.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_1.java
@@ -33,7 +33,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_1 {
 	
-	private static final String[] compatibleVersions = new String[] { "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] { "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_2.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_2.java
@@ -31,7 +31,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_2 {
 	
-	private static final String[] compatibleVersions = new String[] {"1.2", "1.3", "1.4", "1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] {"1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_3.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_3.java
@@ -29,7 +29,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_3 {
 	
-	private static final String[] compatibleVersions = new String[] {"1.3", "1.4", "1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] {"1.3", "1.4", "1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_4.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_4.java
@@ -39,7 +39,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_4 {
 	
-	private static final String[] compatibleVersions = new String[] {"1.4", "1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] {"1.4", "1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_5.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_5.java
@@ -39,7 +39,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_5 {
 	
-	private static final String[] compatibleVersions = new String[] {"1.5", "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] {"1.5", "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_6.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V1_6.java
@@ -36,7 +36,7 @@ import static org.openmrs.module.dtd.DtdTestValidator.isValidConfigXml;
 
 public class ModuleConfigDTDTest_V1_6 {
 	
-	private static final String[] compatibleVersions = new String[] { "1.6", "1.7" };
+	private static final String[] compatibleVersions = new String[] { "1.6", "1.7", "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")

--- a/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V2_0.java
+++ b/api/src/test/java/org/openmrs/module/dtd/ModuleConfigDTDTest_V2_0.java
@@ -18,10 +18,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -32,33 +28,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 
-public class ModuleConfigDTDTest_V1_7 {
+public class ModuleConfigDTDTest_V2_0 {
 	
-	private static final String[] compatibleVersions = new String[] { "1.7", "2.0" };
+	private static final String[] compatibleVersions = new String[] { "2.0" };
 	
 	@ParameterizedTest
 	@MethodSource("getCompatibleVersions")
-	public void configXmlServletWithInitParams(String version) throws ParserConfigurationException, TransformerException, IOException, URISyntaxException {
-		Map<String, String> initParams = new HashMap<>();
-		initParams.put("param1", "value1");
-		initParams.put("param2", "value2");
-
+	public void configXmlServletWithMinimalTags(String version) throws ParserConfigurationException, TransformerException, IOException, URISyntaxException {
 		Document configXml = withMinimalTags(version)
-			.withServlet(Optional.of("ServletName"), Optional.of("ServletClass"), initParams)
 			.build();
 
-		try (InputStream inputStream = writeToInputStream(configXml)) {
-			assertTrue(isValidConfigXml(inputStream));
-		}
-	}
-
-	@ParameterizedTest
-	@MethodSource("getCompatibleVersions")
-	public void configXmlServletMissingInitParamsIsValid(String version) throws ParserConfigurationException, TransformerException, IOException, URISyntaxException {
-		Document configXml = withMinimalTags(version)
-			.withServlet(Optional.of("ServletName"), Optional.of("ServletClass"), Collections.emptyMap())
-			.build();
-		
 		try (InputStream inputStream = writeToInputStream(configXml)) {
 			assertTrue(isValidConfigXml(inputStream));
 		}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This PR updates the logic to use globs instead of regex when matching conditional resources. This logic is only applied to config versions 2.0 and onwards, earlier config.xml versions will still use regex. 

The default pattern is `glob:**/%s` to make it agnostic to absolute paths, allowing users to focus on matching relative paths instead.

This change also includes adding the config.xml version to the `Module` class as `configVersion` to allow us to check if we should use glob or regex logic. This PR also uses the `ModuleUtil.matchRequiredVersions` function as this seems to work well for configVersions that only have two parts like 2.0. 

I tried to add parameterized tests to cover different glob input patterns and config versions, please let me know if  you notice any other patterns that should be included.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6252

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

