### PR TITLE
TRUNK-6293 - Patient IdentifierType description should be length 65535 in the Hibernate annotation

### DIFF
--- a/api/src/main/java/org/openmrs/PatientIdentifierType.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifierType.java
@@ -32,7 +32,8 @@ import javax.persistence.Table;
 @Table(name = "patient_identifier_type")
 @Audited
 @AttributeOverrides({
-	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, length = 50))
+	@AttributeOverride(name = "name", column = @Column(name = "name", nullable = false, length = 50)),
+	@AttributeOverride(name = "description", column = @Column(name = "description", length = 65535))
 })
 public class PatientIdentifierType extends BaseChangeableOpenmrsMetadata {
 	


### PR DESCRIPTION
see https://openmrs.atlassian.net/browse/TRUNK-6293
