### PR TITLE
TRUNK-5208 ModuleUtil compareVersions should sort a SNAPSHOT version as "less than"

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -322,9 +322,9 @@ public class ModuleUtil {
 						upperBound = upperBound.replaceAll("\\*", Integer.toString(Integer.MAX_VALUE));
 					}
 					
-					int lowerReturn = compareVersionIgnoringSnapshotQualifier(version, lowerBound);
+					int lowerReturn = compareVersionIgnoringQualifier(version, lowerBound);
 					
-					int upperReturn = compareVersionIgnoringSnapshotQualifier(version, upperBound);
+					int upperReturn = compareVersionIgnoringQualifier(version, upperBound);
 					
 					if (lowerReturn < 0 || upperReturn > 0) {
 						log.debug("Version " + version + " is not between " + lowerBound + " and " + upperBound);
@@ -332,7 +332,7 @@ public class ModuleUtil {
 						return true;
 					}
 				} else {
-					if (compareVersionIgnoringSnapshotQualifier(version, range) < 0) {
+					if (compareVersionIgnoringQualifier(version, range) < 0) {
 						log.debug("Version " + version + " is below " + range);
 					} else {
 						return true;
@@ -413,11 +413,11 @@ public class ModuleUtil {
 	 * @return the value <code>0</code> if versions are equal; a value less than <code>0</code> if first version is
 	 * 		   before the second one; a value greater than <code>0</code> if first version is after the second one.
 	 */
-	public static int compareVersionIgnoringSnapshotQualifier(String versionA, String versionB) {
+	public static int compareVersionIgnoringQualifier(String versionA, String versionB) {
 		return compareVersion(versionA, versionB, true);
 	}
 
-	private static int compareVersion(String versionA, String versionB, boolean ignoreSnapshotQualifier) {
+	private static int compareVersion(String versionA, String versionB, boolean ignoreQualifier) {
 		try {
 			if (versionA == null || versionB == null) {
 				return 0;
@@ -463,7 +463,7 @@ public class ModuleUtil {
 			}
 			
 			// At this point the version numbers are equal.
-			if (!ignoreSnapshotQualifier) {
+			if (!ignoreQualifier) {
 				if (qualifierIndexA >= 0 && qualifierIndexB < 0) {
 					return -1;
 				} else if (qualifierIndexA < 0 && qualifierIndexB >= 0) {

--- a/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
@@ -357,6 +357,16 @@ public class ModuleUtilTest extends BaseContextSensitiveTest {
 		String requiredVersion = "1.4.0 - 1.4.10";
 		assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
 	}
+
+	/**
+	 * @see ModuleUtil#matchRequiredVersions(String,String)
+	 */
+	@Test
+	public void matchRequiredVersions_shouldMatchWhenVersionHasQualifierAndIsOnLowerBoundary() {
+		String openmrsVersion = "1.4.0-SNAPSHOT";
+		String requiredVersion = "1.4.0 - 1.4.10";
+		assertTrue(ModuleUtil.matchRequiredVersions(openmrsVersion, requiredVersion));
+	}
 	
 	/**
 	 * @see ModuleUtil#matchRequiredVersions(String,String)

--- a/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleUtilTest.java
@@ -501,14 +501,57 @@ public class ModuleUtilTest extends BaseContextSensitiveTest {
 	 * @see org.openmrs.module.ModuleUtil#compareVersion(String,String)
 	 */
 	@Test
-	public void compareVersion_shouldTreatSNAPSHOTAsEarliestVersion() {
-		String olderVersion = "1.8.3";
+	public void compareVersion_shouldCorrectlyCompareOlderSNAPSHOTAndNewerSNAPSHOTVersion() {
+		String olderVersion = "1.8.3-SNAPSHOT";
 		String newerVersion = "1.8.4-SNAPSHOT";
 		assertTrue(ModuleUtil.compareVersion(newerVersion, olderVersion) > 0);
-		//should still return the correct value if the arguments are switched
 		assertTrue(ModuleUtil.compareVersion(olderVersion, newerVersion) < 0);
 	}
 	
+	/**
+	 * @see org.openmrs.module.ModuleUtil#compareVersion(String,String)
+	 */
+	@Test
+	public void compareVersion_shouldCorrectlyCompareOlderPlainAndNewerSNAPSHOTVersion() {
+		String olderVersion = "1.8.3";
+		String newerVersion = "1.8.4-SNAPSHOT";
+		assertTrue(ModuleUtil.compareVersion(newerVersion, olderVersion) > 0);
+		assertTrue(ModuleUtil.compareVersion(olderVersion, newerVersion) < 0);
+	}
+	
+	/**
+	 * @see org.openmrs.module.ModuleUtil#compareVersion(String,String)
+	 */
+	@Test
+	public void compareVersion_shouldCorrectlyCompareNewerPlainAndOlderSNAPSHOTVersion() {
+		String olderVersion = "1.8.3-SNAPSHOT";
+		String newerVersion = "1.8.4";
+		assertTrue(ModuleUtil.compareVersion(newerVersion, olderVersion) > 0);
+		assertTrue(ModuleUtil.compareVersion(olderVersion, newerVersion) < 0);
+	}
+	
+	/**
+	 * @see org.openmrs.module.ModuleUtil#compareVersion(String,String)
+	 */
+	@Test
+	public void compareVersion_shouldCorrectlyCompareSamePlainAndSNAPSHOTVersions() {
+		String olderVersion = "1.8.4-SNAPSHOT";
+		String newerVersion = "1.8.4";
+		assertTrue(ModuleUtil.compareVersion(newerVersion, olderVersion) > 0);
+		assertTrue(ModuleUtil.compareVersion(olderVersion, newerVersion) < 0);
+	}
+	
+	/**
+	 * @see org.openmrs.module.ModuleUtil#compareVersion(String,String)
+	 */
+	@Test
+	public void compareVersion_shouldCorrectlyCompareSamePlainAndRandomQualifierVersions() {
+		String olderVersion = "1.8.4-RandomQualifier";
+		String newerVersion = "1.8.4";
+		assertTrue(ModuleUtil.compareVersion(newerVersion, olderVersion) > 0);
+		assertTrue(ModuleUtil.compareVersion(olderVersion, newerVersion) < 0);
+	}
+
 	/**
 	 * @see org.openmrs.module.ModuleUtil#checkRequiredVersion(String, String)
 	 */


### PR DESCRIPTION
## Description of what I changed

TRUNK-5208 compareVersion orders SNAPSHOT version before regular one

That means a version string like "1.2.3-SNAPSHOT" is ordered before version string "1.2.3".

Also update javadoc and give more descriptive names to variables.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-5208

## Checklist: I completed these to help reviewers :)

- [ x ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ x ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ x ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ x ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ x ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

