### PR TITLE
Revert "maven(deps): bump org.eclipse.jetty:jetty-maven-plugin from 9.4.35.v20201120 to 11.0.25"

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -100,7 +100,7 @@
          <plugin>
              <groupId>org.eclipse.jetty</groupId>
              <artifactId>jetty-maven-plugin</artifactId>
-             <version>11.0.25</version>
+             <version>9.4.35.v20201120</version>
              <configuration>
                <webApp>
                	  <descriptor>${project.build.directory}/jetty/WEB-INF/web.xml</descriptor>


### PR DESCRIPTION
Reverts openmrs/openmrs-core#4964