### PR TITLE
TRUNK-6301:Upgrade Hibernate Search to version 6.2.4.

### DIFF
--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -84,6 +84,8 @@
 		<mapping resource="org/openmrs/api/db/hibernate/Cohort.hbm.xml" />
 		<mapping resource="org/openmrs/api/db/hibernate/CohortMembership.hbm.xml"/>
 		<mapping resource="org/openmrs/api/db/hibernate/OrderFrequency.hbm.xml" />
+		<property name="hibernate.search.default.directory_provider">filesystem</property>
+		<property name="hibernate.search.default.indexbase">/path/to/index</property>
 
 		<!-- HL7 -->
 		<mapping resource="org/openmrs/hl7/db/hibernate/HL7Source.hbm.xml" />

--- a/pom.xml
+++ b/pom.xml
@@ -1240,6 +1240,17 @@
 		<junitVersion>5.11.4</junitVersion>
 		<mockitoVersion>3.12.4</mockitoVersion>
 		<hamcrestVersion>3.0</hamcrestVersion>
+		<dependency>
+			<groupId>org.hibernate.search</groupId>
+			<artifactId>hibernate-search-mapper-orm</artifactId>
+			<version>6.2.4.Final</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-core</artifactId>
+			<version>5.4.x.Final</version> <!-- Ensure compatibility with Hibernate Search -->
+		</dependency>
 
 		<slf4jVersion>1.7.36</slf4jVersion>
 		<log4jVersion>2.22.1</log4jVersion>


### PR DESCRIPTION
Overview: This pull request addresses the upgrade of Hibernate Search from its current version to 6.2.4. This upgrade is essential for improving performance and integrating new features for our search functionalities.

Related Issue:

This upgrade is necessary for the completion of TRUNK-6301: Add ElasticSearch backend for full text search.
Changes Made:

Updated Hibernate Search library version in the project dependencies.
Adjusted configuration files to align with the new version requirements.
Conducted initial testing to ensure compatibility.
Further Steps:

Additional testing is needed to verify full functionality and performance post-upgrade.
Review and feedback from the team is appreciated before finalizing the integration.
Status:

Currently marked as IN PROGRESS

