### PR TITLE
Refactor MessageService to Use Spring Dependency Injection

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -565,23 +565,22 @@ public class Context {
 	 *
 	 * @return message service
 	 */
-	public static MessageService getMessageService() {
-		MessageService ms = getServiceContext().getMessageService();
-		try {
-			// Message service dependencies
-			if (ms.getMessagePreparator() == null) {
-				ms.setMessagePreparator(getMessagePreparator());
-			}
-
-			if (ms.getMessageSender() == null) {
-				ms.setMessageSender(getMessageSender());
-			}
-
+	public static MessageService getMessageService() throws APIException {
+		return getServiceContext().getMessageService();
+	}
+	
+	/**
+	 * Convenience method to configure the MessageService via dependency injection.
+	 *
+	 * @param sender      the MessageSender to set
+	 * @param preparator  the MessagePreparator to set
+	 */
+	public static void configureMessageService(MessageSender sender, MessagePreparator preparator) {
+		MessageService messageService = getServiceContext().getMessageService();
+		if (messageService != null) {
+			messageService.setMessageSender(sender);
+			messageService.setMessagePreparator(preparator);
 		}
-		catch (Exception e) {
-			log.error("Unable to create message service due", e);
-		}
-		return ms;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/context/ContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ContextTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.List;
 import java.util.Locale;
@@ -34,6 +35,10 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.handler.EncounterVisitHandler;
 import org.openmrs.api.handler.ExistingOrNewVisitAssignmentHandler;
+import org.openmrs.notification.MessagePreparator;
+import org.openmrs.notification.MessageSender;
+import org.openmrs.notification.MessageService;
+import org.openmrs.notification.impl.MessageServiceImpl;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
@@ -353,4 +358,22 @@ public class ContextTest extends BaseContextSensitiveTest {
 		assertFalse(sf.getCache().containsEntity(PERSON_NAME_CLASS, PERSON_NAME_ID_8));
 		assertFalse(sf.getCache().containsEntity(Patient.class, PERSON_NAME_ID_2));
 	}
+	@Test
+	public void configureMessageService_shouldSetMessageSenderAndPreparator() {
+		// Given
+		MessageService messageService = new MessageServiceImpl();
+		MessageSender mockSender = mock(MessageSender.class);
+		MessagePreparator mockPreparator = mock(MessagePreparator.class);
+
+		// Inject test instance
+		Context.getServiceContext().setMessageService(messageService);
+
+		// When
+		Context.configureMessageService(mockSender, mockPreparator);
+
+		// Then
+		assertEquals(mockSender, messageService.getMessageSender());
+		assertEquals(mockPreparator, messageService.getMessagePreparator());
+	}
+
 }


### PR DESCRIPTION
TRUNK-4988: Refactor MessageService to Use Spring Dependency Injection

## Description of what I changed
Implemented the configureMessageService(MessageSender, MessagePreparator) method to configure MessageService using Spring’s Dependency Injection.

Updated getMessageService() to rely on Spring DI and removed the manual setting of dependencies.

Refactored MessageService initialization for cleaner, more maintainable code that follows DI principles.

Added a unit test to verify that the configureMessageService() method works as expected.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see [This](https://openmrs.atlassian.net/browse/TRUNK-4988)

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
![Screenshot from 2025-03-26 21-23-56](https://github.com/user-attachments/assets/a3000bd4-32d9-4633-883d-d2da18ff1b41)

