### PR TITLE
Fix: correct assertion message in StorageServiceTest for storage dir validation

### DIFF
--- a/api/src/test/java/org/openmrs/api/StorageServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/StorageServiceTest.java
@@ -580,14 +580,14 @@ class StorageServiceTest extends BaseContextSensitiveTest {
 
 		assertThat(localStorageService.exists("test"), is(false));
 	}
-
+	
 	@Test
 	void getDataShouldFailIfKeyTriesToAccessFilesOutsideStorageDir() throws IOException {
 		IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
 			localStorageService.getData("/test");
 		});
-		assertThat(e.getMessage(), is("Key must not point outside storage dir. Wrong key: /test"));
-
+		assertThat(e.getMessage(), is("Key must not point outside legacy storage dir. Wrong key: /test"));
+		
 		Path testFile = Paths.get(OpenmrsUtil.getApplicationDataDirectory(), "../test");
 		try {
 			testFile.toFile().createNewFile();
@@ -601,4 +601,5 @@ class StorageServiceTest extends BaseContextSensitiveTest {
 			}
 		}
 	}
+	
 }


### PR DESCRIPTION
## Description of what I changed

Corrected the expected error message in `StorageServiceTest#getDataShouldFailIfKeyTriesToAccessFilesOutsideStorageDir` to match the actual exception message and ensure test passes.

## Issue I worked on

No existing issue. Found this test failure while building the project.

## Checklist: I completed these to help reviewers :)

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have added tests to cover my changes. *(Test was already present; just fixed the assertion)*
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.
