### PR TITLE
TRUNK-6368: Log OpenMRS access URL after Jetty server starts

### DIFF
--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -250,6 +250,32 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
 				
 				WebDaemon.startOpenmrs(event.getServletContext());
+
+                // ✅ Print the access URL
+				final String contextPath = servletContext.getContextPath();
+
+				String portTmp = System.getProperty("jetty.port");
+				if (portTmp == null || portTmp.isEmpty()) {
+					portTmp = System.getProperty("server.port");
+				}
+				if (portTmp == null || portTmp.isEmpty()) {
+					portTmp = "8080"; // fallback
+				}
+				final String port = portTmp;
+				
+				final String host = "http://localhost";
+				
+				new Thread(() -> {
+					try {
+						Thread.sleep(3000); // Let Jetty finish logging
+						System.out.println("✅ Server running at: " + host + ":" + port + contextPath);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}).start();
+				
+		
+
 			} else {
 				setupNeeded = true;
 			}


### PR DESCRIPTION
## Description of what I changed
Added a console print in `Listener.java` that logs the full access URL (`http://localhost:port/contextPath`) after the Jetty server has started successfully. This helps developers easily identify the URL to access the application during local development.

## Issue I worked on
see https://openmrs.atlassian.net/browse/TRUNK-6368

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

![bpr](https://github.com/user-attachments/assets/db33bced-bad6-4c87-bfea-9213e8492745)

