### PR TITLE
TRUNK-6368: Log OpenMRS access URL after Jetty server starts

### DIFF
--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -250,6 +250,22 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
 				
 				WebDaemon.startOpenmrs(event.getServletContext());
+				new Thread(() -> {
+					try {
+						Thread.sleep(3000);
+						String[] portProps = { "jetty.http.port", "cargo.servlet.port" };
+						for (String key : portProps) {
+							String val = System.getProperty(key);
+							if (val != null && !val.isEmpty()) {
+								log.warn("✅ OpenMRS is running at: {}:{}{}", "http://localhost", val, servletContext.getContextPath());
+								return;
+							}
+						}
+						log.warn("✅ OpenMRS is running at: {}{}", "http://localhost:8080", servletContext.getContextPath());
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				}).start();
 			} else {
 				setupNeeded = true;
 			}


### PR DESCRIPTION
## Description of what I changed

Updated `Listener.contextInitialized()` to log the actual URL OpenMRS is running on when using:

- `mvn jetty:run`
- `mvn -Djetty.http.port=9999 jetty:run`

A new thread waits 3 seconds and prints the full access URL using the detected port and context path.

## Issue I worked on

see [TRUNK-6368](https://issues.openmrs.org/browse/TRUNK-6368)

## Checklist: I completed these to help reviewers 🙂

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I ran `mvn clean package` and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

---

### Notes

- `log.info()` was not being printed, so I used `log.warn()` to ensure the message appears in logs.
- For `mvn -Dcargo.servlet.port=8046 cargo:run`, the custom port is used, but due to limitations in how the Cargo plugin exposes port info, we can't access it reliably to print the full URL. The server still works normally on the specified port.




[TRUNK-6368]: https://openmrs.atlassian.net/browse/TRUNK-6368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ