### PR TITLE
TRUNK-6370: Improve Readiness Check for Elastic search

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -13,10 +13,32 @@ echo "Waiting for database to initialize..."
 
 /openmrs/wait-for-it.sh -t 3600 -h "${OMRS_DB_HOSTNAME}" -p "${OMRS_DB_PORT}"
 
+wait_for_es()
+{
+	IFS=',' read -a es_uris <<< "${OMRS_SEARCH_ES_URIS}"
+    
+    EXIT_STATUS=1  
+    while [ $EXIT_STATUS -ne 0 ]
+    do
+		for es_uri in "${es_uris[@]}"; do
+			echo "Waiting for elastic search ${es_uri} to initialize..."
+			ELASTIC_SEARCH_HOST_PORT=(${es_uri//// })
+			/openmrs/wait-for-it.sh -t 120 "${ELASTIC_SEARCH_HOST_PORT[1]}" 
+			EXIT_STATUS=$?
+			if [ $EXIT_STATUS -eq 0 ]; then
+            	break 
+            fi
+            
+		done
+    done
+    
+    return EXIT_STATUS
+}
+
 if [ "${OMRS_SEARCH}" = "elasticsearch" ]; then
-  echo "Waiting for elastic search to initialize..."
-  ELASTIC_SEARCH_HOST_PORT=(${OMRS_SEARCH_ES_URIS//// })
-  /openmrs/wait-for-it.sh -t 3600 "${ELASTIC_SEARCH_HOST_PORT[1]}" 
+	set +e
+	wait_for_es
+	set -e
 fi
 
 TOMCAT_DIR="/usr/local/tomcat"


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
Loop through all the elastic search nodes with lower timeout and pass as soon as one of them reports readiness

## Issue I worked on
https://openmrs.atlassian.net/browse/TRUNK-6370

## Testing
I tested on docker locally
OMRS_SEARCH_ES_URIS="http://test:1234,http://test2:4321,http://es:9200"

<img width="542" alt="image" src="https://github.com/user-attachments/assets/b3321572-1348-4796-a671-a207df7b8bc3" />


## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

