### PR TITLE
TRUNK-6373: Add alternative Maven run commands to README for better onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ mvn jetty:run
 
 If all goes well (check the console output) you can access the OpenMRS application at `localhost:8080/openmrs`.
 
+You can also specify a different port for jetty to run on:
+```bash
+mvn -Djetty.http.port=xxxx jetty:run
+```
+
+Alternatively, you can use cargo to run the application:
+```bash
+mvn -Dcargo.servlet.port=xxxx cargo:run
+```
+
 Refer to [Getting Started as a Developer - Maven](https://wiki.openmrs.org/display/docs/Maven) for some more information
 on useful Maven commands and build options.
 


### PR DESCRIPTION

## Description of what I changed

I updated the `README.md` file to include two additional Maven commands:

mvn -Djetty.http.port=xxxx jetty:run
mvn -Dcargo.servlet.port=xxxx cargo:run


These commands are helpful for contributors who want to run the application on custom ports or use Cargo instead of Jetty. Including them improves onboarding and developer flexibility.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6373

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. *(Not applicable for README updates)*

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
