### PR TITLE
TRUNK-6373: updatedReadme

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ cd openmrs-core/webapp
 mvn jetty:run
 ```
 
+To run Jetty on a custom port, use the `jetty.http.port` property:
+
+```bash
+mvn -Djetty.http.port=8081 jetty:run
+```
+
+To run on Cargo, use the `cargo:run` command:
+
+```bash
+mvn cargo:run
+```
+
+To run Cargo on a custom port, use the `cargo.servlet.port` property:
+
+```bash
+mvn -Dcargo.servlet.port=8081 cargo:run
+```
+
 If all goes well (check the console output) you can access the OpenMRS application at `localhost:8080/openmrs`.
 
 Refer to [Getting Started as a Developer - Maven](https://wiki.openmrs.org/display/docs/Maven) for some more information


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
TRUNK-6373: Add instructions for running Jetty and Cargo on custom ports

## Description of what I changed
Updated the `README.md` to include clear instructions for:
- Running Jetty on a custom port using `-Djetty.http.port`
- Running Cargo on the default port using `mvn cargo:run`
- Running Cargo on a custom port using `-Dcargo.servlet.port`

These changes help developers understand how to run the OpenMRS application on ports other than the default ones.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6373

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.
