### PR TITLE
TRUNK-6380: Use Daemon to authenticate task instead of scheduler.username and scheduler.password

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/timer/TimerSchedulerTask.java
@@ -99,4 +99,24 @@ public class TimerSchedulerTask extends TimerTask {
 		} 
 		saveLastExecutionTime(task);
 	}
+
+	/**
+	 * Authenticate so that the task can call service layer.
+	 */
+	protected void authenticate() {
+
+		if (Daemon.isDaemonThread()) {
+			log.error("Authentication attempted while operating on a daemon thread," 
+				+ " authenticating is not necessary or allowed");
+			return;
+		}
+
+		try {
+			Daemon.authenticateTask();
+		} 
+		catch (Exception e) {
+			log.error("FATAL ERROR: [{}], Task authentication failed due to exception [{}]", e.getClass().getName(), e);
+			SchedulerUtil.sendSchedulerError(e);
+		}
+	}
 }


### PR DESCRIPTION
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6380

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

