### PR TITLE
TRUNK-6388: Upgrade Tomcat to 10.1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,7 @@ RUN if [ "$TARGETARCH" = "arm64" ] ; then TINI_URL="${TINI_URL}-arm64" TINI_SHA=
 # Setup Tomcat for development
 ARG TOMCAT_VERSION=9.0.107
 ARG TOMCAT_SHA="1815837fa10083258b653dab1f3947fadbad377fa66546fa74aecea1439c6fed2ef4e40c86fa55e176d8c5739ad448196a7415ddfca6ff8d17c6fe8cdba0fefb"
-ARG TOMCAT_URL="https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
+ARG TOMCAT_URL="https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-10/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz"
 RUN curl -fL -o /tmp/apache-tomcat.tar.gz "$TOMCAT_URL" \
     && echo "${TOMCAT_SHA}  /tmp/apache-tomcat.tar.gz" | sha512sum -c \
     && mkdir -p /usr/local/tomcat && gzip -d /tmp/apache-tomcat.tar.gz  \
@@ -105,7 +105,7 @@ ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/mvn-entrypoint.sh"]
 CMD ["/openmrs/startup-dev.sh"]
 
 ### Production Stage
-FROM tomcat:9-$RUNTIME_JDK
+FROM tomcat:10.1.16-jdk21
 
 RUN yum -y update && yum clean all && rm -rf /usr/local/tomcat/webapps/*
 


### PR DESCRIPTION
Upgraded Tomcat from 9.0.107 to 10.1.16 in the Dockerfile as part of TRUNK-6388.
