### PR TITLE
O3-4957: Add global properties for encounter editing time restriction

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -998,7 +998,7 @@ public final class OpenmrsConstants {
 		                "An integer which, if specified, would determine the maximum number of encounters to display on the encounter tab of the patient dashboard."));
 		
 		props.add(new GlobalProperty(GP_ENCOUNTER_EDITABLE_DURATION, "",
-		        "The length of time in minutes after encounter creation during which the encounter is allowed to be edited. By default, there is no limit."));
+		        "The length of time in minutes after encounter creation during which the encounter is allowed to be edited. By default, there is no limit. Examples: '1440' for 24 hours, '43200' for 30 days."));
 		
 		props.add(new GlobalProperty(GP_ENCOUNTER_EDITABLE_DURATION_OVERRIDE_PRIVILEGES, "",
 		        "A comma-separated list of privileges that allow users to edit encounters regardless of the editable duration."));

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -640,6 +640,16 @@ public final class OpenmrsConstants {
 	 * Global property that stores the number of days for users to be deactivated.
 	 */
 	public static final String GP_NUMBER_OF_DAYS_TO_AUTO_RETIRE_USERS = "users.numberOfDaysToRetire";
+
+	/**
+	 * Sets the length of time after encounter creation during which the encounter is allowed to be edited.
+	 */
+	public static final String GP_ENCOUNTER_EDITABLE_DURATION = "encounter.editableDuration";
+
+	/**
+	 * Allow users with certain privileges to edit encounters regardless of the editable duration.
+	 */
+	public static final String GP_ENCOUNTER_EDITABLE_DURATION_OVERRIDE_PRIVILEGES = "encounter.editableDurationOverridePrivileges";
 	
 	/**
 	 * At OpenMRS startup these global properties/default values/descriptions are inserted into the
@@ -987,6 +997,12 @@ public final class OpenmrsConstants {
 		                "3",
 		                "An integer which, if specified, would determine the maximum number of encounters to display on the encounter tab of the patient dashboard."));
 		
+		props.add(new GlobalProperty(GP_ENCOUNTER_EDITABLE_DURATION, "",
+		        "The length of time in minutes after encounter creation during which the encounter is allowed to be edited. By default, there is no limit."));
+		
+		props.add(new GlobalProperty(GP_ENCOUNTER_EDITABLE_DURATION_OVERRIDE_PRIVILEGES, "",
+		        "A comma-separated list of privileges that allow users to edit encounters regardless of the editable duration."));
+
 		props.add(new GlobalProperty(GP_VISIT_TYPES_TO_AUTO_CLOSE, "",
 		        "comma-separated list of the visit type(s) to automatically close"));
 		


### PR DESCRIPTION
## Description of what I changed

Added two global properties. One allows creating a limit to how long after encounter creation the encounter can be edited. By default there remains no limit. The other allows specifying privileges of users that are allowed to override the time limit.

These are going to be used in the O3 frontend. Eventually they should be respected by the APIs as well.

## Issue I worked on

https://openmrs.atlassian.net/browse/O3-4957

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

Is this project not set up with an .editorconfig file or post-commit hook?

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

It's a GP

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

Haha wait this is what does the formatting; what's the first checkbox for???

- [ ] All new and existing **tests passed**.

N/A

- [x] My pull request is **based on the latest changes** of the master branch.
