### PR TITLE
TRUNK-6404: Update README links to point directly to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,8 @@ If you haven't found what you were looking for refer to the [Module - wiki](http
 
 If you want to contribute please refer to these resources
 
-* [Getting Started as a Developer](https://wiki.openmrs.org/display/docs/Get+Started+as+a+Developer)
-* [How To Configure Your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE)
+* [Getting Started as a Developer](https://openmrs.atlassian.net/wiki/spaces/docs/pages/25477022/Getting+Started+as+a+Developer)
+* [How To Configure Your IDE](https://openmrs.atlassian.net/wiki/spaces/Archives/pages/25506949/How-To+Setup+And+Use+Your+IDE)
 * [How To Make a Pull Request](https://wiki.openmrs.org/display/docs/Pull+Request+Tips)
 
 ### Wiki


### PR DESCRIPTION
## Description of what I changed
I updated the **README.md** file to replace the indirect links for:
- *Getting Started as a Developer*
- *How To Configure Your IDE*

Previously, these links redirected to intermediate pages that only contained the final resource URL. This change makes the links point directly to the intended resources, removing the unnecessary intermediate step.

## Issue I worked on
see https://openmrs.atlassian.net/browse/TRUNK-6404

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.
