### PR TITLE
docs: add FHIR2 quickstart pointer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,9 @@ Talk to us on [OpenMRS Talk](https://talk.openmrs.org/)
 
 [MPL 2.0 w/ HD](http://openmrs.org/license/) © [OpenMRS Inc.](http://www.openmrs.org/)
 
+### FHIR Quickstart
+
+OpenMRS FHIR support is in the **FHIR2 module**. To use FHIR resources:
+1. Install and run OpenMRS Platform.
+2. Add the `openmrs-module-fhir2` and access endpoints at `/ws/fhir2`.
+Docs: https://github.com/openmrs/openmrs-module-fhir2


### PR DESCRIPTION
Adds a short FHIR quickstart pointer in the README.

Clarifies that FHIR support is via the FHIR2 module, with endpoints at `/ws/fhir2`, and includes a link to the FHIR2 module docs.

Docs-only change. No code modifications.
