### PR TITLE
TRUNK-6427: Move bean declarations from xml to Java config

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/OpenmrsApplicationContextConfig.java
+++ b/api/src/main/java/org/openmrs/api/context/OpenmrsApplicationContextConfig.java
@@ -1,0 +1,208 @@
+package org.openmrs.api.context;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.annotation.Handler;
+import org.openmrs.annotation.OpenmrsProfileExcludeFilter;
+import org.openmrs.annotation.OpenmrsProfileIncludeFilter;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.CohortService;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.ConditionService;
+import org.openmrs.api.DatatypeService;
+import org.openmrs.api.DiagnosisService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.EventListeners;
+import org.openmrs.api.FormService;
+import org.openmrs.api.GlobalPropertyListener;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.MedicationDispenseService;
+import org.openmrs.api.ObsService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.OrderSetService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.PersonService;
+import org.openmrs.api.ProgramWorkflowService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.SerializationService;
+import org.openmrs.api.UserService;
+import org.openmrs.api.VisitService;
+import org.openmrs.api.db.ContextDAO;
+import org.openmrs.api.db.hibernate.AuditableInterceptor;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+import org.openmrs.api.db.hibernate.HibernateSessionFactoryBean;
+import org.openmrs.api.impl.AdministrationServiceImpl;
+import org.openmrs.api.impl.GlobalLocaleList;
+import org.openmrs.api.impl.OrderServiceImpl;
+import org.openmrs.api.impl.PersonNameGlobalPropertyListener;
+import org.openmrs.hl7.HL7Service;
+import org.openmrs.logging.LoggingConfigurationGlobalPropertyListener;
+import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.notification.AlertService;
+import org.openmrs.notification.MessageService;
+import org.openmrs.scheduler.SchedulerService;
+import org.openmrs.util.ConfigUtil;
+import org.openmrs.util.HttpClient;
+import org.openmrs.util.LocaleUtility;
+import org.openmrs.util.LocationUtility;
+import org.openmrs.util.TestTypeFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+@Configuration
+@ComponentScan(
+    basePackages = "org.openmrs",
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Handler.class),
+        @ComponentScan.Filter(type = FilterType.CUSTOM, classes = OpenmrsProfileIncludeFilter.class)
+    },
+    excludeFilters = {
+        @ComponentScan.Filter(type = FilterType.CUSTOM, classes = TestTypeFilter.class),
+        @ComponentScan.Filter(type = FilterType.CUSTOM, classes = OpenmrsProfileExcludeFilter.class)
+    }
+)
+public class OpenmrsApplicationContextConfig {
+
+    @Bean
+    public EventListeners clearOpenmrsEventListeners() {
+        EventListeners eventListeners = new EventListeners();
+        eventListeners.setGlobalPropertyListenersToEmpty(false);
+        return eventListeners;
+    }
+
+    @Bean
+    public LocaleUtility localeUtility() {
+        return new LocaleUtility();
+    }
+
+    @Bean
+    public LocationUtility locationUtility() {
+        return new LocationUtility();
+    }
+
+    @Bean
+    public ConfigUtil configUtilGlobalPropertyListener() {
+        return new ConfigUtil();
+    }
+
+    @Bean
+    public PersonNameGlobalPropertyListener personNameGlobalPropertyListener() {
+        return new PersonNameGlobalPropertyListener();
+    }
+
+    @Bean
+    public LoggingConfigurationGlobalPropertyListener loggingConfigurationGlobalPropertyListener() {
+        return new LoggingConfigurationGlobalPropertyListener();
+    }
+
+    @Bean
+    @DependsOn("clearOpenmrsEventListeners")
+    public EventListeners openmrsEventListeners(LocaleUtility localeUtility, LocationUtility locationUtility,
+            ConfigUtil configUtilGlobalPropertyListener,
+            PersonNameGlobalPropertyListener personNameGlobalPropertyListener,
+            LoggingConfigurationGlobalPropertyListener loggingConfigurationGlobalPropertyListener,
+            GlobalLocaleList globalLocaleList, AdministrationServiceImpl adminService,
+            OrderServiceImpl orderService) {
+        EventListeners eventListeners = new EventListeners();
+        List<GlobalPropertyListener> globalPropertyListeners = List.of(localeUtility, locationUtility,
+                configUtilGlobalPropertyListener, personNameGlobalPropertyListener,
+                loggingConfigurationGlobalPropertyListener, globalLocaleList, adminService, orderService);
+        eventListeners.setGlobalPropertyListeners(globalPropertyListeners);
+        return eventListeners;
+    }
+
+    @Bean(destroyMethod = "destroyInstance")
+    public ServiceContext serviceContext(PatientService patientService, PersonService personService,
+            ConceptService conceptService, UserService userService, ObsService obsService,
+            EncounterService encounterService, LocationService locationService, OrderService orderService,
+            ConditionService conditionService, DiagnosisService diagnosisService,
+            MedicationDispenseService medicationDispenseService, OrderSetService orderSetService,
+            FormService formService, AdministrationService adminService, DatatypeService datatypeService,
+            ProgramWorkflowService programWorkflowService, CohortService cohortService, MessageService messageService,
+            SerializationService serializationService, SchedulerService schedulerService, AlertService alertService,
+            HL7Service hL7Service, MessageSourceService messageSourceService, VisitService visitService,
+            ProviderService providerService) {
+        ServiceContext serviceContext = ServiceContext.getInstance();
+        serviceContext.setPatientService(patientService);
+        serviceContext.setPersonService(personService);
+        serviceContext.setConceptService(conceptService);
+        serviceContext.setUserService(userService);
+        serviceContext.setObsService(obsService);
+        serviceContext.setEncounterService(encounterService);
+        serviceContext.setLocationService(locationService);
+        serviceContext.setOrderService(orderService);
+        serviceContext.setConditionService(conditionService);
+        serviceContext.setDiagnosisService(diagnosisService);
+        serviceContext.setMedicationDispenseService(medicationDispenseService);
+        serviceContext.setOrderSetService(orderSetService);
+        serviceContext.setFormService(formService);
+        serviceContext.setAdministrationService(adminService);
+        serviceContext.setDatatypeService(datatypeService);
+        serviceContext.setProgramWorkflowService(programWorkflowService);
+        serviceContext.setCohortService(cohortService);
+        serviceContext.setMessageService(messageService);
+        serviceContext.setSerializationService(serializationService);
+        serviceContext.setSchedulerService(schedulerService);
+        serviceContext.setAlertService(alertService);
+        serviceContext.setHl7Service(hL7Service);
+        serviceContext.setMessageSourceService(messageSourceService);
+        serviceContext.setVisitService(visitService);
+        serviceContext.setProviderService(providerService);
+        return serviceContext;
+    }
+
+    @Bean
+    public Context context(ContextDAO contextDAO, ServiceContext serviceContext) {
+        Context context = new Context();
+        context.setServiceContext(serviceContext);
+        context.setContextDAO(contextDAO);
+        return context;
+    }
+
+    @Bean
+    public List<Object> moduleTestingMappingJarLocations() {
+        return new ArrayList<>();
+    }
+
+    @Bean
+    public List<Object> mappingJarResources() {
+        List<Object> mergedList = new ArrayList<>(moduleTestingMappingJarLocations());
+        return mergedList;
+    }
+
+    @Bean
+    public AuditableInterceptor auditableInterceptor() {
+        return new AuditableInterceptor();
+    }
+
+    @Bean
+    public HibernateSessionFactoryBean sessionFactory(Resource mappingJarResources) {
+        HibernateSessionFactoryBean sessionFactory = new HibernateSessionFactoryBean();
+        sessionFactory.setConfigLocations(new Resource[] {
+                new ClassPathResource("hibernate.cfg.xml")
+        });
+        sessionFactory.setMappingJarLocations(mappingJarResources);
+        sessionFactory.setPackagesToScan("org.openmrs");
+        return sessionFactory;
+    }
+
+    @Bean
+    public DbSessionFactory dbSessionFactory(SessionFactory sessionFactory) {
+        return new DbSessionFactory(sessionFactory);
+    }
+
+    @Bean
+    public HttpClient implementationIdHttpClient() throws MalformedURLException {
+        HttpClient httpClient = new HttpClient("https://implementation.openmrs.org");
+        return httpClient;
+    }
+
+}

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -84,24 +84,25 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	
 	private static final Logger log = LoggerFactory.getLogger(AdministrationServiceImpl.class);
 
-	@Autowired
 	protected AdministrationDAO dao;
 	
-	@Autowired
-	@Qualifier("openmrsEventListeners")
 	private EventListeners eventListeners;
 	
 	/**
 	 * An always up-to-date collection of the allowed locales.
 	 */
-	@Autowired
-	@Qualifier("globalLocaleList")
 	private GlobalLocaleList globalLocaleList;
 	
-	@Autowired
-	@Qualifier("implementationIdHttpClient")
 	private HttpClient implementationIdHttpClient;
 	
+	@Autowired
+	public AdministrationServiceImpl(GlobalLocaleList globalLocaleList, @Qualifier("openmrsEventListeners") EventListeners eventListeners, @Qualifier("implementationIdHttpClient") HttpClient implementationIdHttpClient, AdministrationDAO dao) {
+		this.globalLocaleList = globalLocaleList;
+		this.eventListeners = eventListeners;
+		this.implementationIdHttpClient = implementationIdHttpClient;
+		this.dao = dao;
+	}
+
 	/**
 	 * Default empty constructor
 	 */

--- a/api/src/main/java/org/openmrs/api/impl/GlobalLocaleList.java
+++ b/api/src/main/java/org/openmrs/api/impl/GlobalLocaleList.java
@@ -17,11 +17,14 @@ import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
+import org.springframework.stereotype.Component;
 
 /**
  * A utility class which caches the current list of allowed locales, rebuilding the list whenever
  * the global properties are updated.
  */
+
+@Component
 public class GlobalLocaleList implements GlobalPropertyListener {
 	
 	private Set<Locale> allowedLocales = null;

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -22,75 +22,6 @@
 			http://www.springframework.org/schema/context/spring-context-3.0.xsd
             http://www.springframework.org/schema/util
             http://www.springframework.org/schema/util/spring-util-3.0.xsd">
-	
-	<bean class="org.openmrs.api.impl.GlobalLocaleList" id="globalLocaleList"/>
-
-	<!--  **************************  EVENT LISTENERS ***************************** -->
-
-	<!--  Clear out the global property listeners list first -->
-	<bean id="clearOpenmrsEventListeners" class="org.openmrs.api.EventListeners">
-		<property name="globalPropertyListenersToEmpty" value="false"/>
-	</bean>
-
-	<bean id="localeUtility" class="org.openmrs.util.LocaleUtility"/>
-	<bean id="locationUtility" class="org.openmrs.util.LocationUtility"/>
-	<bean id="configUtilGlobalPropertyListener" class="org.openmrs.util.ConfigUtil"/>
-	<bean id="personNameGlobalPropertyListener" class="org.openmrs.api.impl.PersonNameGlobalPropertyListener"/>
-	<bean id="loggingConfigurationGlobalPropertyListener"
-		  class="org.openmrs.logging.LoggingConfigurationGlobalPropertyListener"/>
-
-	<bean id="openmrsEventListeners" class="org.openmrs.api.EventListeners" depends-on="clearOpenmrsEventListeners">
-		<property name="globalPropertyListeners">
-			<list value-type="org.openmrs.api.GlobalPropertyListener">
-				<ref bean="localeUtility"/>
-				<ref bean="locationUtility"/>
-				<ref bean="configUtilGlobalPropertyListener"/>
-				<ref bean="personNameGlobalPropertyListener"/>
-				<ref bean="loggingConfigurationGlobalPropertyListener"/>
-				<ref bean="globalLocaleList"/>
-				<ref bean="adminService"/>
-				<ref bean="orderService"/>
-			</list>
-		</property>
-	</bean>
-
-
-	<!--  **************************  SERVICE CONTEXT CONFIGURATION  *************************  -->
-
-	<!-- Single application context (our own context, not Spring's ApplicationContext -->
-	<bean id="serviceContext" class="org.openmrs.api.context.ServiceContext" factory-method="getInstance"
-		  destroy-method="destroyInstance">
-		<property name="patientService" ref="patientService"/>
-		<property name="personService" ref="personService"/>
-		<property name="conceptService" ref="conceptService"/>
-		<property name="userService" ref="userService"/>
-		<property name="obsService" ref="obsService"/>
-		<property name="encounterService" ref="encounterService"/>
-		<property name="locationService" ref="locationService"/>
-		<property name="orderService" ref="orderService"/>
-		<property name="conditionService" ref="conditionService"/>
-		<property name="diagnosisService" ref="diagnosisService"/>
-		<property name="medicationDispenseService" ref="medicationDispenseService"/>
-		<property name="orderSetService" ref="orderSetService"/>
-		<property name="formService" ref="formService"/>
-		<property name="administrationService" ref="adminService"/>
-		<property name="datatypeService" ref="datatypeService"/>
-		<property name="programWorkflowService" ref="programWorkflowService"/>
-		<property name="cohortService" ref="cohortService"/>
-		<property name="messageService" ref="messageService"/>
-		<property name="serializationService" ref="serializationService"/>
-		<property name="schedulerService" ref="schedulerService"/>
-		<property name="alertService" ref="alertService"/>
-		<property name="hl7Service" ref="hL7Service"/>
-		<property name="messageSourceService" ref="messageSourceService"/>
-		<property name="visitService" ref="visitService"/>
-		<property name="providerService" ref="providerService"/>
-	</bean>
-
-	<bean id="context" class="org.openmrs.api.context.Context" init-method="setAuthenticationScheme">
-		<property name="serviceContext" ref="serviceContext"/>
-		<property name="contextDAO" ref="contextDAO"/>
-	</bean>
 
 	<!--  **************************  DATA ACCESS OBJECTS  *************************  -->
 
@@ -179,44 +110,6 @@
 		<property name="sessionFactory" ref="sessionFactory"/>
 	</bean>
 
-	<!--  **************************  SESSION FACTORY  *************************  -->
-
-	<util:list id="moduleTestingMappingJarLocations">
-
-	</util:list>
-
-	<bean id="mappingJarResources" class="org.springframework.beans.factory.config.ListFactoryBean"
-		  parent="moduleTestingMappingJarLocations">
-		<property name="sourceList">
-			<list merge="true">
-
-			</list>
-		</property>
-	</bean>
-
-	<!-- will be autowired to the HibernateSessionFactoryBean by type -->
-	<!-- interceptors are used in order of name, this needs to be one of the first and should be since auditable happens to start with 'a' -->
-	<bean id="auditableInterceptor" class="org.openmrs.api.db.hibernate.AuditableInterceptor"/>
-
-	<bean id="sessionFactory" class="org.openmrs.api.db.hibernate.HibernateSessionFactoryBean">
-		<property name="configLocations">
-			<list>
-				<value>classpath:hibernate.cfg.xml</value>
-			</list>
-		</property>
-		<property name="mappingJarLocations" ref="mappingJarResources"/>
-		<property name="packagesToScan">
-			<list>
-				<value>org.openmrs</value>
-			</list>
-		</property>
-		<!-- default properties must be set in the hibernate.default.properties -->
-	</bean>
-
-	<bean id="dbSessionFactory" class="org.openmrs.api.db.hibernate.DbSessionFactory">
-		<constructor-arg name="sessionFactory" ref="sessionFactory"/>
-	</bean>
-	
 	<!--  ******************************  MESSAGE SERVICES  ****************************** -->
 
 	<!-- Messaging Service -->
@@ -241,52 +134,6 @@
 		</property>
     </bean>   
 	-->
-
-	<!--  **************************  VALIDATOR CONFIGURATION  *************************  -->
-	<!--  Configuration for all openmrs validators                                        -->
-
-	<bean id="allergyValidator" class="org.openmrs.validator.AllergyValidator"/>
-	<bean id="personValidator" class="org.openmrs.validator.PersonValidator"/>
-	<bean id="patientValidator" class="org.openmrs.validator.PatientValidator"/>
-	<bean id="locationValidator" class="org.openmrs.validator.LocationValidator"/>
-	<bean id="personNameValidator" class="org.openmrs.validator.PersonNameValidator"/>
-	<bean id="patientIdentifierValidator" class="org.openmrs.validator.PatientIdentifierValidator"/>
-	<bean id="patientIdentifierTypeValidator" class="org.openmrs.validator.PatientIdentifierTypeValidator"/>
-	<bean id="personAttributeTypeValidator" class="org.openmrs.validator.PersonAttributeTypeValidator"/>
-	<bean id="userValidator" class="org.openmrs.validator.UserValidator"/>
-	<bean id="roleValidator" class="org.openmrs.validator.RoleValidator"/>
-	<bean id="privilegeValidator" class="org.openmrs.validator.PrivilegeValidator"/>
-	<bean id="encounterTypeValidator" class="org.openmrs.validator.EncounterTypeValidator"/>
-	<bean id="conceptClassValidator" class="org.openmrs.validator.ConceptClassValidator"/>
-	<bean id="conceptDatatypeValidator" class="org.openmrs.validator.ConceptDatatypeValidator"/>
-	<bean id="conceptSourceValidator" class="org.openmrs.validator.ConceptSourceValidator"/>
-	<bean id="formEditValidator" class="org.openmrs.validator.FormValidator"/>
-	<bean id="fieldTypeValidator" class="org.openmrs.validator.FieldTypeValidator"/>
-	<bean id="programValidator" class="org.openmrs.validator.ProgramValidator"/>
-	<bean id="stateConversionValidator" class="org.openmrs.validator.StateConversionValidator"/>
-	<bean id="taskValidator" class="org.openmrs.validator.SchedulerFormValidator"/>
-	<bean id="obsValidator" class="org.openmrs.validator.ObsValidator"/>
-	<bean id="orderValidator" class="org.openmrs.validator.OrderValidator"/>
-	<bean id="drugOrderValidator" class="org.openmrs.validator.DrugOrderValidator"/>
-	<bean id="requireNameValidator" class="org.openmrs.validator.RequireNameValidator"/>
-	<bean id="conceptDrugValidator" class="org.openmrs.validator.ConceptDrugValidator"/>
-	<bean id="hl7SourceValidator" class="org.openmrs.validator.HL7SourceValidator"/>
-	<bean id="personAddressValidator" class="org.openmrs.validator.PersonAddressValidator"/>
-	<bean id="visitTypeValidator" class="org.openmrs.validator.VisitTypeValidator"/>
-	<bean id="visitAttributeTypeValidator" class="org.openmrs.validator.VisitAttributeTypeValidator"/>
-	<bean id="providerAttributeTypeValidator" class="org.openmrs.validator.ProviderAttributeTypeValidator"/>
-	<bean id="encounterValidator" class="org.openmrs.validator.EncounterValidator"/>
-	<bean id="locationAttributeTypeValidator" class="org.openmrs.validator.LocationAttributeTypeValidator"/>
-	<bean id="providerValidator" class="org.openmrs.validator.ProviderValidator"/>
-	<bean id="patientProgramValidator" class="org.openmrs.validator.PatientProgramValidator"/>
-	<bean id="conceptValidator" class="org.openmrs.validator.ConceptValidator"/>
-	<bean id="personMergeLogValidator" class="org.openmrs.validator.PersonMergeLogValidator"/>
-	<bean id="conceptReferenceTermValidator" class="org.openmrs.validator.ConceptReferenceTermValidator"/>
-	<bean id="conceptMapTypeValidator" class="org.openmrs.validator.ConceptMapTypeValidator"/>
-	<bean id="conceptAttributeTypeValidator" class="org.openmrs.validator.ConceptAttributeTypeValidator"/>
-	<bean id="implementationIdHttpClient" class="org.openmrs.util.HttpClient">
-		<constructor-arg name="url" value="https://implementation.openmrs.org"/>
-	</bean>
 
 	<!--  ************************ END VALIDATOR CONFIGURATION  ************************  -->
 


### PR DESCRIPTION
- Replaced XML-defined beans in applicationContext-service.xml with @Configuration + @Bean methods in OpenmrsApplicationContextConfig
- Annotated classes with @Component where applicable
- Preserved component scanning for @Handler and OpenMRS profile filters
- Converted serviceContext, Context, event listeners, and Hibernate-related beans
- Preserved bean dependencies and initialization order using @DependsOn and constructor args
- Updated component scan to include/exclude filters previously defined in XML