### PR TITLE
TRUNK-6435: Password resets must go through service API

### DIFF
--- a/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/AuthorizationAdvice.java
@@ -126,7 +126,7 @@ public class AuthorizationAdvice implements MethodBeforeAdvice {
 	 * 
 	 * @param user authenticated user
 	 * @param method acting method
-	 * @param attrs privilege names that the user must have
+	 * @param attr privilege names that the user must have
 	 */
 	private void throwUnauthorized(User user, Method method, String attr) {
 		log.debug(USER_IS_NOT_AUTHORIZED_TO_ACCESS, user, method.getName());

--- a/api/src/main/java/org/openmrs/api/UserService.java
+++ b/api/src/main/java/org/openmrs/api/UserService.java
@@ -36,7 +36,7 @@ import org.openmrs.notification.MessageException;
  */
 public interface UserService extends OpenmrsService {
 
-	public static final String ADMIN_PASSWORD_LOCKED_PROPERTY = "admin_password_locked";
+	String ADMIN_PASSWORD_LOCKED_PROPERTY = "admin_password_locked";
 	
 	/**
 	 * Create user with given password.
@@ -48,7 +48,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.ADD_USERS })
 	@Logging(ignoredArgumentIndexes = { 1 })
-	public User createUser(User user, String password) throws APIException;
+	User createUser(User user, String password) throws APIException;
 	
 	/**
 	 * Change user password.
@@ -68,7 +68,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
 	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changePassword(User user, String oldPassword, String newPassword) throws APIException;
+	void changePassword(User user, String oldPassword, String newPassword) throws APIException;
 	
 	/**
 	 * Get user by internal user identifier.
@@ -79,7 +79,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> fetch user with given userId
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUser(Integer userId) throws APIException;
+	User getUser(Integer userId) throws APIException;
 	
 	/**
 	 * Get user by the given uuid.
@@ -92,7 +92,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return null if no object found with given uuid
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByUuid(String uuid) throws APIException;
+	User getUserByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Get user by username (user's login identifier)
@@ -102,7 +102,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> get user by username
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByUsername(String username);
+	User getUserByUsername(String username);
 	
 	/**
 	 * Gets a user by username or email
@@ -111,7 +111,7 @@ public interface UserService extends OpenmrsService {
 	 * @return requested user or null if not found
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByUsernameOrEmail(String usernameOrEmail);
+	User getUserByUsernameOrEmail(String usernameOrEmail);
 	
 	/**
 	 * Gets a user with the specified activation key
@@ -119,7 +119,7 @@ public interface UserService extends OpenmrsService {
 	 * @return requested User with associated  activation key
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public User getUserByActivationKey(String activationKey);
+	User getUserByActivationKey(String activationKey);
 	
 	/**
 	 * true/false if username or systemId is already in db in username or system_id columns
@@ -130,7 +130,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> verify that username and system id is unique
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public boolean hasDuplicateUsername(User user) throws APIException;
+	boolean hasDuplicateUsername(User user) throws APIException;
 	
 	/**
 	 * Get users by role granted
@@ -142,7 +142,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not fetch user that does not belong to given role
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByRole(Role role) throws APIException;
+	List<User> getUsersByRole(Role role) throws APIException;
 	
 	/**
 	 * Updates a given <code>user</code> in the database.
@@ -152,7 +152,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User saveUser(User user) throws APIException;
+	User saveUser(User user) throws APIException;
 	
 	/**
 	 * Deactivate a user account so that it can no longer log in.
@@ -163,7 +163,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> retire user and set attributes
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User retireUser(User user, String reason) throws APIException;
+	User retireUser(User user, String reason) throws APIException;
 	
 	/**
 	 * Clears retired flag for a user.
@@ -173,7 +173,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> unretire and unmark all attributes
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USERS })
-	public User unretireUser(User user) throws APIException;
+	User unretireUser(User user) throws APIException;
 	
 	/**
 	 * Completely remove a location from the database (not reversible). This method delegates to
@@ -183,7 +183,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> delete given user
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_USERS })
-	public void purgeUser(User user) throws APIException;
+	void purgeUser(User user) throws APIException;
 	
 	/**
 	 * Completely remove a user from the database (not reversible). This is a delete from the
@@ -201,7 +201,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not delete user roles for given user when cascade equals false
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_USERS })
-	public void purgeUser(User user, boolean cascade) throws APIException;
+	void purgeUser(User user, boolean cascade) throws APIException;
 	
 	/**
 	 * Returns all privileges currently possible for any User
@@ -211,7 +211,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return all privileges in the system
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_PRIVILEGES)
-	public List<Privilege> getAllPrivileges() throws APIException;
+	List<Privilege> getAllPrivileges() throws APIException;
 	
 	/**
 	 * Returns all roles currently possible for any User
@@ -221,7 +221,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return all roles in the system
 	 */
 	@Authorized(PrivilegeConstants.MANAGE_ROLES)
-	public List<Role> getAllRoles() throws APIException;
+	List<Role> getAllRoles() throws APIException;
 	
 	/**
 	 * Save the given role in the database
@@ -233,7 +233,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> save given role to the database
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_ROLES })
-	public Role saveRole(Role role) throws APIException;
+	Role saveRole(Role role) throws APIException;
 	
 	/**
 	 * Complete remove a role from the database
@@ -245,7 +245,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> delete given role from database
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_ROLES })
-	public void purgeRole(Role role) throws APIException;
+	void purgeRole(Role role) throws APIException;
 	
 	/**
 	 * Save the given privilege in the database
@@ -256,7 +256,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> save given privilege to the database
 	 */
 	@Authorized( { PrivilegeConstants.MANAGE_PRIVILEGES })
-	public Privilege savePrivilege(Privilege privilege) throws APIException;
+	Privilege savePrivilege(Privilege privilege) throws APIException;
 	
 	/**
 	 * Completely remove a privilege from the database
@@ -267,7 +267,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> throw error when privilege is core privilege
 	 */
 	@Authorized( { PrivilegeConstants.PURGE_PRIVILEGES })
-	public void purgePrivilege(Privilege privilege) throws APIException;
+	void purgePrivilege(Privilege privilege) throws APIException;
 	
 	/**
 	 * Returns role object with given string role
@@ -277,7 +277,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> fetch role for given role name
 	 */
 	@Authorized(PrivilegeConstants.GET_ROLES)
-	public Role getRole(String r) throws APIException;
+	Role getRole(String r) throws APIException;
 	
 	/**
 	 * Get Role by its UUID
@@ -288,7 +288,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return null if no object found with given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_ROLES)
-	public Role getRoleByUuid(String uuid) throws APIException;
+	Role getRoleByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns Privilege in the system with given String privilege
@@ -298,7 +298,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> fetch privilege for given name
 	 */
 	@Authorized(PrivilegeConstants.GET_PRIVILEGES)
-	public Privilege getPrivilege(String p) throws APIException;
+	Privilege getPrivilege(String p) throws APIException;
 	
 	/**
 	 * Get Privilege by its UUID
@@ -310,7 +310,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> fetch privilege for given uuid
 	 */
 	@Authorized(PrivilegeConstants.GET_PRIVILEGES)
-	public Privilege getPrivilegeByUuid(String uuid) throws APIException;
+	Privilege getPrivilegeByUuid(String uuid) throws APIException;
 	
 	/**
 	 * Returns all users in the system
@@ -321,7 +321,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not contains any duplicate users
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getAllUsers() throws APIException;
+	List<User> getAllUsers() throws APIException;
 	
 	/**
 	 * Changes the current user's password.
@@ -337,7 +337,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized
 	@Logging(ignoredArgumentIndexes = { 0, 1 })
-	public void changePassword(String oldPassword, String newPassword) throws APIException;
+	void changePassword(String oldPassword, String newPassword) throws APIException;
 
 	/**
 	 * Changes password of {@link User} passed in
@@ -348,7 +348,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not update password of given user when logged in user does not have edit users password privilege
 	 */
 	@Authorized({PrivilegeConstants.EDIT_USER_PASSWORDS})
-	public void changePassword(User user, String newPassword) throws APIException;
+	void changePassword(User user, String newPassword) throws APIException;
 	
 	/**
 	 * Changes the current user's password directly. This is most useful if migrating users from
@@ -363,7 +363,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> change the hashed password for the given user
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
-	public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException;
+	void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException;
 	
 	/**
 	 * Changes the passed user's secret question and answer.
@@ -377,7 +377,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized( { PrivilegeConstants.EDIT_USER_PASSWORDS })
 	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changeQuestionAnswer(User u, String question, String answer) throws APIException;
+	void changeQuestionAnswer(User u, String question, String answer) throws APIException;
 	
 	/**
 	 * Changes the current user's secret question and answer.
@@ -391,7 +391,7 @@ public interface UserService extends OpenmrsService {
 	 */
 	@Authorized
 	@Logging(ignoreAllArgumentValues = true)
-	public void changeQuestionAnswer(String pw, String q, String a) throws APIException;
+	void changeQuestionAnswer(String pw, String q, String a) throws APIException;
 	
 	/**
 	 * Returns secret question for the given user.
@@ -401,7 +401,7 @@ public interface UserService extends OpenmrsService {
 	 * @throws APIException
 	 * @since 2.0
 	 */
-	public String getSecretQuestion(User user) throws APIException;
+	String getSecretQuestion(User user) throws APIException;
 	
 	/**
 	 * Compares <code>answer</code> against the <code>user</code>'s secret answer.
@@ -413,7 +413,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return false when given answer does not match the stored secret answer
 	 */
 	@Logging(ignoredArgumentIndexes = { 1 })
-	public boolean isSecretAnswer(User u, String answer) throws APIException;
+	boolean isSecretAnswer(User u, String answer) throws APIException;
 	
 	/**
 	 * Return a list of users sorted by personName (see {@link PersonByNameComparator}) if any part
@@ -436,7 +436,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not fail if roles are searched but name is empty
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException;
+	List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException;
 	
 	/**
 	 * Search for a list of users by exact first name and last name.
@@ -451,7 +451,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not fetch any duplicate users
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByName(String givenName, String familyName, boolean includeRetired) throws APIException;
+	List<User> getUsersByName(String givenName, String familyName, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Get all user accounts that belong to a given person.
@@ -464,7 +464,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not fetch retired accounts when include retired is false
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException;
+	List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException;
 	
 	/**
 	 * Adds the <code>key</code>/<code>value</code> pair to the given <code>user</code>.
@@ -481,7 +481,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> modify property with given key and value when key already exists
 	 */
 	@Authorized
-	public User setUserProperty(User user, String key, String value) throws APIException;
+	User setUserProperty(User user, String key, String value) throws APIException;
 	
 	/**
 	 * Removes the property denoted by <code>key</code> from the <code>user</code>'s properties.
@@ -495,7 +495,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> remove user property for given user and key
 	 */
 	@Authorized
-	public User removeUserProperty(User user, String key) throws APIException;
+	User removeUserProperty(User user, String key) throws APIException;
 	
 	/**
 	 * Get/generate/find the next system id to be doled out. Assume check digit /not/ applied in
@@ -504,7 +504,7 @@ public interface UserService extends OpenmrsService {
 	 * @return new system id
 	 */
 	@Authorized
-	public String generateSystemId();
+	String generateSystemId();
 	
 	/**
 	 * Return a batch of users of a specific size sorted by personName (see
@@ -524,7 +524,7 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> return users whose roles inherit requested roles
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
+	List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
 	        throws APIException;
 	
 	/**
@@ -538,7 +538,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.8
 	 */
 	@Authorized( { PrivilegeConstants.GET_USERS })
-	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
+	Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired);
 	
 	/**
 	 * Saves the current key/value as a user property for the current user.
@@ -548,7 +548,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized
-	public User saveUserProperty(String key, String value);
+	User saveUserProperty(String key, String value);
 	
 	/**
 	 * Replaces all user properties with the given map of properties for the current user
@@ -557,7 +557,7 @@ public interface UserService extends OpenmrsService {
 	 * @since 1.10
 	 */
 	@Authorized
-	public User saveUserProperties(Map<String, String> properties);
+	User saveUserProperties(Map<String, String> properties);
 	
 	/**
 	 * Change user password given the answer to the secret question
@@ -567,14 +567,14 @@ public interface UserService extends OpenmrsService {
 	 * <strong>Should</strong> not update password if secret is not correct
 	 */
 	@Authorized
-	public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException;
+	void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException;
 	
 	/**
 	 * Sets a user's activation key
 	 * @param user The user for which the activation key will be set
 	 */
 	@Authorized(PrivilegeConstants.EDIT_USER_PASSWORDS)
-	public User setUserActivationKey(User user) throws MessageException;
+	User setUserActivationKey(User user) throws MessageException;
 	
 	/**
 	 * Change user password given the activation key
@@ -582,7 +582,7 @@ public interface UserService extends OpenmrsService {
 	 * @param activationKey the activation for password reset
 	 * @param newPassword the new password
 	 */
-	public void changePasswordUsingActivationKey(String activationKey, String newPassword);
+	void changePasswordUsingActivationKey(String activationKey, String newPassword);
 
 	/**
 	 * @param user the User whose Locale to retrieve

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
@@ -36,6 +36,7 @@ import org.openmrs.api.context.Daemon;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.LoginCredential;
 import org.openmrs.api.db.UserDAO;
+import org.openmrs.api.impl.UserServiceImpl;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.Security;
@@ -69,10 +70,22 @@ public class HibernateUserDAO implements UserDAO {
 	}
 	
 	/**
-	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User, java.lang.String, java.lang.String)
+	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User, java.lang.String)
 	 */
 	@Override
 	public User saveUser(User user, String password) {
+		StackTraceElement[] stack = new Exception().getStackTrace();
+		if (stack.length < 2) {
+			throw new DAOException("Could not determine where change password was called from");
+		}
+		StackTraceElement caller = stack[1];
+		String callerClass = caller.getClassName();
+
+		if (!"org.openmrs.api.db.UserDAOTest".equals(callerClass) &&
+			!UserServiceImpl.class.getName().equals(callerClass) &&
+		    !HibernateUserDAO.class.getName().equals(callerClass)) {
+			throw new DAOException("Illegal attempt to change user password from unknown caller");
+		}
 		
 		// only change the user's password when creating a new user
 		boolean isNewUser = user.getUserId() == null;
@@ -314,15 +327,25 @@ public class HibernateUserDAO implements UserDAO {
 	/**
 	 * @see org.openmrs.api.db.UserDAO#changePassword(org.openmrs.User, java.lang.String)
 	 */
-	@Override
 	public void changePassword(User u, String pw) throws DAOException {
+		StackTraceElement[] stack = new Exception().getStackTrace();
+		if (stack.length < 2) {
+			throw new DAOException("Could not determine where change password was called from");
+		}
+		StackTraceElement caller = stack[1];
+		String callerClass = caller.getClassName();
+
+		if (!"org.openmrs.api.db.UserDAOTest".equals(callerClass) &&
+			!UserServiceImpl.class.getName().equals(callerClass)) {
+			throw new DAOException("Illegal attempt to change user password from unknown caller");
+		}
+		
 		User authUser = Context.getAuthenticatedUser();
 		
 		if (authUser == null) {
 			authUser = u;
 		}
 		
-		log.debug("updating password");
 		String salt = getLoginCredential(u).getSalt();
 		if (StringUtils.isBlank(salt)) {
 			salt = Security.getRandomToken();
@@ -330,7 +353,6 @@ public class HibernateUserDAO implements UserDAO {
 		String newHashedPassword = Security.encodeString(pw + salt);
 		
 		updateUserPassword(newHashedPassword, salt, authUser.getUserId(), new Date(), u.getUserId());
-		
 	}
 	
 	/**
@@ -338,6 +360,18 @@ public class HibernateUserDAO implements UserDAO {
 	 */
 	@Override
 	public void changeHashedPassword(User user, String hashedPassword, String salt) throws DAOException {
+		StackTraceElement[] stack = new Exception().getStackTrace();
+		if (stack.length < 2) {
+			throw new DAOException("Could not determine where change password was called from");
+		}
+		StackTraceElement caller = stack[1];
+		String callerClass = caller.getClassName();
+
+		if (!"org.openmrs.api.db.UserDAOTest".equals(callerClass) &&
+			!UserServiceImpl.class.getName().equals(callerClass)) {
+			throw new DAOException("Illegal attempt to change user password from unknown caller");
+		}
+		
 		User authUser = Context.getAuthenticatedUser();
 		updateUserPassword(hashedPassword, salt, authUser.getUserId(), new Date(), user.getUserId());
 	}
@@ -377,6 +411,18 @@ public class HibernateUserDAO implements UserDAO {
 	 */
 	@Override
 	public void changePassword(String oldPassword, String newPassword) throws DAOException {
+		StackTraceElement[] stack = new Exception().getStackTrace();
+		if (stack.length < 2) {
+			throw new DAOException("Could not determine where change password was called from");
+		}
+		StackTraceElement caller = stack[1];
+		String callerClass = caller.getClassName();
+
+		if (!"org.openmrs.api.db.UserDAOTest".equals(callerClass) &&
+			!UserServiceImpl.class.getName().equals(callerClass)) {
+			throw new DAOException("Illegal attempt to change user password from unknown caller");
+		}
+		
 		User u = Context.getAuthenticatedUser();
 		LoginCredential credentials = getLoginCredential(u);
 		if (!credentials.checkPassword(oldPassword)) {

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -105,7 +105,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 		checkPrivileges(user);
 		
 		// if a password wasn't supplied, throw an error
-		if (password == null || password.length() < 1) {
+		if (password == null || password.isEmpty()) {
 			throw new APIException("User.creating.password.required", (Object[]) null);
 		}
 		
@@ -664,22 +664,26 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService {
 	}
 	
 	@Override
+	@Logging(ignoredArgumentIndexes = { 1 })
 	public void changePassword(User user, String newPassword) {
-		updatePassword(user, newPassword);
-	}
-	
-	private void updatePassword(User user, String newPassword) {
-		OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
-		dao.changePassword(user, newPassword);
+		Context.getUserService().changePassword(user, null, newPassword);
 	}
 	
 	@Override
+	@Logging(ignoredArgumentIndexes = { 1, 2 })
 	public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException {
 		User user = Context.getAuthenticatedUser();
+		
 		if (!isSecretAnswer(user, secretAnswer)) {
 			throw new APIException("secret.answer.not.correct", (Object[]) null);
 		}
+		
 		updatePassword(user, pw);
+	}
+
+	private void updatePassword(User user, String newPassword) {
+		OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
+		dao.changePassword(user, newPassword);
 	}
 	
 	@Override


### PR DESCRIPTION
## Description of what I changed

This adds guards to the `HibernateUserDao` for all calls that can change a user's password to ensure that they are called from the `UserService` class. I've also modified the `Daemon` class to use a slightly different mechanism to look-up the caller primarily because the `SecurityManager`, and hence the `OpenmrsSecurityManager` are deprecated.

N.B. There's a better for this available in Java 9+ using the `StackTraceWalker` machinery, but since in the 2.x branches we still support Java 8, I'm going to do this as two PRs, one here for 2.8.x and backporting if we opt to and a second PR for 3.x where we can use the Java 9 APIs. (The `StackTraceWalker` allows the lazy-loading of stack frames using the stream API; the technique used here—as with the technique of using a `SecurityManager`—materializes the full stack frame).

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6435

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.8.x branch.


