### PR TITLE
SCA Vulnerability Fixes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -280,10 +280,6 @@
 			<artifactId>jakarta.activation</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -410,6 +410,12 @@
 				<artifactId>commons-fileupload</artifactId>
 				<version>1.6.0</version>
 			</dependency>
+			<!-- CVE-2022-3509/CVE-2024-7254 fix: Upgrade protobuf-java to address textformat parsing issue -->
+			<dependency>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protobuf-java</artifactId>
+				<version>4.28.2</version>
+			</dependency>
 			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
@@ -581,11 +587,6 @@
 				<version>33.5.0-jre</version>
 			</dependency>
 			<dependency>
-			    <groupId>jakarta.xml.bind</groupId>
-			    <artifactId>jakarta.xml.bind-api</artifactId>
-			    <version>4.0.4</version>
-			</dependency>
-			<dependency>
 				<groupId>com.sun.mail</groupId>
 				<artifactId>javax.mail</artifactId>
 				<version>1.6.2</version>
@@ -636,6 +637,39 @@
 				<groupId>org.jboss.logging</groupId>
 				<artifactId>jboss-logging</artifactId>
 				<version>3.6.1.Final</version>
+			</dependency>
+			<!-- Override netty dependencies to fix CVE-2025-55163 -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http2</artifactId>
+				<version>4.2.4.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler</artifactId>
+				<version>4.2.4.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec</artifactId>
+				<version>4.2.4.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler-proxy</artifactId>
+				<version>4.2.4.Final</version>
+			</dependency>
+			<!-- Override netty dependency to fix CVE-2025-58056 -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http</artifactId>
+				<version>4.2.5.Final</version>
+			</dependency>
+			<!-- Override netty dependencies to fix CVE-2025-58057 -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-compression</artifactId>
+				<version>4.2.5.Final</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Fixed Trivy generated SCA Vulnerabilities.

Before : 
Total Vulnerabilities : 25
[trivy-report-initial.json](https://github.com/user-attachments/files/23223023/trivy-report-initial.json)
<img width="1076" height="425" alt="trivy-vulns-initial" src="https://github.com/user-attachments/assets/9b81481e-f741-45ac-ba13-bc97b02de0e2" />

After : 
Total Vulnerabilities : 9 (but without any fixed versions provided by Trivy)
[trivy-report-final.json](https://github.com/user-attachments/files/23223028/trivy-report-final.json)
<img width="1072" height="425" alt="trivy-vulns-final-screenshot" src="https://github.com/user-attachments/assets/406b779b-646b-4aac-abab-ed3c209dee66" />
<img width="1214" height="721" alt="trivy-final-full-report-1" src="https://github.com/user-attachments/assets/72abf0db-39e6-4956-a78e-dee27ff1d57f" />
<img width="1213" height="214" alt="trivy-final-full-report-2" src="https://github.com/user-attachments/assets/b4fdbb26-9b9e-4b90-bfab-915c0a9373f8" />

Please note the final 9 vulnerabilities being shown do not have any fixed versions, so they do not need to be fixed.