### PR TITLE
TRUNK-5951: Register SerializedObject in Hibernate metadata for tests

### DIFF
--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -18,7 +18,7 @@ import org.hibernate.cfg.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
+import org.openmrs.api.db.SerializedObject;
 import org.openmrs.Allergy;
 import org.openmrs.AllergyReaction;
 import org.openmrs.CareSetting;


### PR DESCRIPTION
### What this PR does

Includes `SerializedObject` in the annotation-based Hibernate metadata used by `OrderServiceTest`, so that the annotated mapping is picked up when building the test SessionFactory.

### Jira Issue

https://issues.openmrs.org/browse/TRUNK-5951
