### PR TITLE
TRUNK-6212: Add sortWeight to order frequencies

### DIFF
--- a/api/src/main/java/org/openmrs/OrderFrequency.java
+++ b/api/src/main/java/org/openmrs/OrderFrequency.java
@@ -30,7 +30,7 @@ public class OrderFrequency extends BaseChangeableOpenmrsMetadata {
 	private String uuid;
 	
 	private Concept concept;
-	
+	private Integer sortWeight;
 	/**
 	 * Get the orderFrequencyId
 	 */
@@ -102,6 +102,22 @@ public class OrderFrequency extends BaseChangeableOpenmrsMetadata {
 	}
 	
 	/**
+	 * Gets the sort weight used to order this frequency in dropdowns.
+	 */
+	public Integer getSortWeight() {
+		return sortWeight;
+	}
+
+	/**
+	 * Sets the sort weight used to order this frequency in dropdowns.
+	 *
+	 * @param sortWeight the sort order value
+	 */
+	public void setSortWeight(Integer sortWeight) {
+		this.sortWeight = sortWeight;
+	}
+	
+	/**
 	 * @see BaseOpenmrsMetadata#getDescription()
 	 */
 	@Override
@@ -127,4 +143,6 @@ public class OrderFrequency extends BaseChangeableOpenmrsMetadata {
 	public String toString() {
 		return getName();
 	}
+	
+	
 }

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -61,7 +61,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-
+import java.util.Comparator;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -805,7 +805,14 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 	 */
 	@Override
 	public List<OrderFrequency> getOrderFrequencies(boolean includeRetired) {
-		return dao.getOrderFrequencies(includeRetired);
+		List<OrderFrequency> frequencies = dao.getOrderFrequencies(includeRetired);
+		
+		if (frequencies != null) {
+			frequencies.sort(Comparator.comparing(
+				f -> f.getSortWeight() == null ? 0 : f.getSortWeight()
+			));
+		}
+		return frequencies;
 	}
 	
 	/**
@@ -817,7 +824,16 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		if (searchPhrase == null) {
 			throw new IllegalArgumentException("searchPhrase is required");
 		}
-		return dao.getOrderFrequencies(searchPhrase, locale, exactLocale, includeRetired);
+
+		List<OrderFrequency> frequencies = dao.getOrderFrequencies(searchPhrase, locale, exactLocale, includeRetired);
+
+		if (frequencies != null) {
+			frequencies.sort(Comparator.comparing(
+				f -> f.getSortWeight() == null ? 0 : f.getSortWeight()
+			));
+		}
+		
+		return frequencies;
 	}
 	
 	/**

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderFrequency.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderFrequency.hbm.xml
@@ -28,6 +28,7 @@
 			not-null="true" column="concept_id" unique="true" />
 		<property name="frequencyPerDay" type="double" column="frequency_per_day"
 			length="22" />
+		<property name="sortWeight" column="sort_weight" type="integer" />
 		<many-to-one name="creator" class="org.openmrs.User"
 			not-null="true" />
 		<property name="dateCreated" type="java.util.Date" column="date_created"

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/OrderFrequency.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/OrderFrequency.hbm.xml
@@ -21,9 +21,7 @@
 				<param name="sequence">order_frequency_order_frequency_id_seq</param>
 			</generator>
 		</id>
-
 		
-
 		<many-to-one name="concept" class="org.openmrs.Concept"
 			not-null="true" column="concept_id" unique="true" />
 		<property name="frequencyPerDay" type="double" column="frequency_per_day"
@@ -43,10 +41,7 @@
 			length="255" />
 		<property name="uuid" type="java.lang.String" column="uuid"
 			length="38" unique="true" />
-
         <many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
-
         <property name="dateChanged" type="java.util.Date" column="date_changed" length="19" />
-
 	</class>
 </hibernate-mapping>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
@@ -83,4 +83,10 @@
 		<modifyDataType tableName="concept_reference_range" columnName="criteria" newDataType="TEXT" />
 	</changeSet>
 
+	<changeSet id="TRUNK-6212-2025-12-09" author="raufbyrmv8">
+		<addColumn tableName="order_frequency">
+			<column name="sort_weight" type="INT" defaultValueNumeric="0"/>
+		</addColumn>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Description

This PR addresses TRUNK-6212 by introducing a `sort_weight` field for order frequencies and ensuring they are sorted when displayed (e.g. in the "Choose Frequency" dropdown).

## Changes

* Added `sort_weight` column to the `order_frequency` table via Liquibase.
* Added `sortWeight` property to `OrderFrequency` and Hibernate mapping.
* Updated `OrderServiceImpl#getOrderFrequencies(...)` to sort frequencies by `sortWeight`.

## Issue

https://issues.openmrs.org/browse/TRUNK-6212
