### PR TITLE
Trunk 6497 - Fix NPE for Integration Test Failures running on mysql or postgresql

### DIFF
--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -311,10 +311,7 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 	 * @return Properties runtime
 	 */
 	public Properties getRuntimeProperties() {
-
-		System.err.println("DEBUG: getRuntimeProperties() ENTER; runtimeProperties=" + runtimeProperties);
-
-		
+	
 		// cache the properties for subsequent calls
 		if (runtimeProperties == null)
 			runtimeProperties = TestUtil.getRuntimeProperties(getWebappName());

--- a/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/test/BaseContextSensitiveTest.java
@@ -311,10 +311,19 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 	 * @return Properties runtime
 	 */
 	public Properties getRuntimeProperties() {
+
+		System.err.println("DEBUG: getRuntimeProperties() ENTER; runtimeProperties=" + runtimeProperties);
+
 		
 		// cache the properties for subsequent calls
 		if (runtimeProperties == null)
 			runtimeProperties = TestUtil.getRuntimeProperties(getWebappName());
+
+		// ensure runtimeProperties is not null
+		if (runtimeProperties == null) {
+			// Fallback to an empty properties object to avoid NullPointerExceptions
+			runtimeProperties = new Properties();
+		}
 		
 		// if we're using the in-memory hypersonic database, add those
 		// connection properties here to override what is in the runtime
@@ -335,17 +344,34 @@ public abstract class BaseContextSensitiveTest extends AbstractJUnit4SpringConte
 			
 			// automatically create the tables defined in the hbm files
 			runtimeProperties.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
-		}
-		else {
+
+		}else {
 			String url = System.getProperty("databaseUrl");
 			String username = System.getProperty("databaseUsername");
 			String password = System.getProperty("databasePassword");
+			String driver = System.getProperty("databaseDriver");
+			String dialect = System.getProperty("databaseDialect");
+
+			// Validate that all required system properties are present
+			if (url == null || username == null || password == null || driver == null || dialect == null) {
+				String msg = "Required database system properties are missing. When using -DuseInMemoryDatabase=false, "
+						+ "the following system properties must be set: databaseUrl, databaseUsername, databasePassword, "
+						+ "databaseDriver, and databaseDialect. "
+						+ "These should be set by Containers.ensureDatabaseRunning() or manually. "
+						+ "Example:\n"
+						+ "mvn -DuseInMemoryDatabase=false -Ddatabase=postgres -DdatabaseUrl=<jdbc> -DdatabaseUsername=<user> "
+						+ "-DdatabasePassword=<pass> -DdatabaseDriver=org.postgresql.Driver -DdatabaseDialect=org.hibernate.dialect.PostgreSQL95Dialect test";
+				log.error(msg);
+				throw new IllegalStateException(msg);
+			}
+			
 			
 			runtimeProperties.setProperty(Environment.URL, url);
-			runtimeProperties.setProperty(Environment.DRIVER, System.getProperty("databaseDriver"));
+			runtimeProperties.setProperty(Environment.DRIVER, driver);
 			runtimeProperties.setProperty(Environment.USER, username);
 			runtimeProperties.setProperty(Environment.PASS, password);
-			runtimeProperties.setProperty(Environment.DIALECT, System.getProperty("databaseDialect"));
+			runtimeProperties.setProperty(Environment.DIALECT, dialect);
+	
 			
 			// these properties need to be set in case the user has this exact
 			// phrasing in their runtime file.


### PR DESCRIPTION
Problem - When running tests with -DuseInMemoryDatabase=false, many tests fail with NullPointerException at line 341 in getRuntimeProperties().

Error Pattern:
[ERROR] DrugOrderValidatorTest.<init>:53->BaseContextSensitiveTest.<init>:208 >BaseContextSensitiveTest.getRuntimeProperties:341 » NullPointer

Root Cause
In both BaseContextSensitiveTest classes (JUnit 4 and JUnit 5), but this error comes from Junit 5 when useInMemoryDatabase=false: The code reads system properties (databaseUrl, databaseUsername, databasePassword, databaseDriver, databaseDialect) that may be null. These null values are passed directly to  runtimeProperties.setProperty(). Later access to these properties causes NullPointerException.

The issue occurs because:
Containers.ensureDatabaseRunning() may not have set the system properties yet, or The properties weren't set manually, or There was a failure in the container initialization.

Solution
1. Added validation in both test base classes: Null check for runtimeProperties: ensure it's not null after loading from TestUtil.getRuntimeProperties().
2. Validation of system properties: check all required database properties before use.
3. Clear error handling: throw IllegalStateException with a helpful message instead of NPE.

Suggested Entire Fix 

1. The NPE is resolved by validation, but the root cause remains: missing system properties (databaseUrl, databaseUsername, databasePassword, databaseDriver, databaseDialect) when useInMemoryDatabase=false.

2. To fully fix the error, we must ensure those properties are set before tests start—either by letting Containers.ensureDatabaseRunning() set them, or by passing them explicitly on the Maven command line.

3. If using MySQL, swap the driver/dialect and URL accordingly.

4. If Containers.ensureDatabaseRunning() is supposed to set these automatically, we should verify why it isn’t running or isn’t able to set them in the current environment (e.g., missing -Ddatabase flag, Testcontainers disabled, or network/permission issues).
