### PR TITLE
Add unit test for getPatientByUuid in PatientService

### DIFF
--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -3313,5 +3313,14 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		PatientIdentifierException patientIdentifierException = assertThrows(PatientIdentifierException.class, () -> patientService.getIdentifierValidator("com.example.InvalidIdentifierValidator"));
 		assertEquals("Could not find patient identifier validator com.example.InvalidIdentifierValidator", patientIdentifierException.getMessage());
 	}
+	 @Test
+    public void getPatientByUuid_shouldReturnPatientWhenUuidExists() {
+        Patient patient = Context.getPatientService().getPatient(2);
 
+        Patient fetched = Context.getPatientService()
+                .getPatientByUuid(patient.getUuid());
+
+        assertNotNull(fetched);
+        assertEquals(patient.getUuid(), fetched.getUuid());
+}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
## Description
This pull request adds a unit test to verify that `getPatientByUuid` correctly returns a patient when a valid UUID exists.

The test ensures that:
- A patient can be fetched using an existing UUID
- The returned patient is not null
- The fetched patient's UUID matches the expected value

No functional or production code changes were made.

## Related Issue
N/A (test coverage improvement)

## Checklist
- [x] My IDE is configured to follow the project’s Java code style
- [x] I have added tests to cover my changes
- [x] All tests pass locally
