### PR TITLE
Add getters and setters for closedLow and closedHigh in DoubleRange

### DIFF
--- a/api/src/main/java/org/openmrs/util/DoubleRange.java
+++ b/api/src/main/java/org/openmrs/util/DoubleRange.java
@@ -23,7 +23,7 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	
 	private Double high;
 	
-	private boolean closedLow = true; //TODO: add setters and getters for these
+	private boolean closedLow = true;
 	
 	private boolean closedHigh = false;
 	
@@ -75,6 +75,34 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	 */
 	public void setLow(Double low) {
 		this.low = low == null ? new Double(Double.NEGATIVE_INFINITY) : low;
+	}
+	
+	/**
+	 * @return Returns whether the low bound is closed (inclusive).
+	 */
+	public boolean isClosedLow() {
+		return closedLow;
+	}
+	
+	/**
+	 * @param closedLow Whether the low bound should be closed (inclusive).
+	 */
+	public void setClosedLow(boolean closedLow) {
+		this.closedLow = closedLow;
+	}
+	
+	/**
+	 * @return Returns whether the high bound is closed (inclusive).
+	 */
+	public boolean isClosedHigh() {
+		return closedHigh;
+	}
+	
+	/**
+	 * @param closedHigh Whether the high bound should be closed (inclusive).
+	 */
+	public void setClosedHigh(boolean closedHigh) {
+		this.closedHigh = closedHigh;
 	}
 	
 	/**


### PR DESCRIPTION
## Summary
Added the missing getters and setters for `closedLow` and `closedHigh` fields in `DoubleRange.java` as requested by the TODO comment.

## Changes
- Added `isClosedLow()` and `setClosedLow(boolean)` methods
- Added `isClosedHigh()` and `setClosedHigh(boolean)` methods
- Removed TODO comment

## Why
The `DoubleRange` class had a TODO requesting these accessors. Currently the `closedLow` and `closedHigh` fields could only be set via direct access or defaults, making it impossible to configure interval boundary behavior from external code.

## Testing
The existing tests continue to pass. The new methods follow the same pattern as existing `getLow/setLow` and `getHigh/setHigh` accessors.