### PR TITLE
[O3-5302]Fix Ignored Tests in PersonNameValidator (RA-543)

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonNameValidator.java
@@ -21,14 +21,15 @@ import org.springframework.validation.Validator;
 
 /**
  * This class validates a PersonName object.
- *
+ * 
  * @since 1.7
  */
-@Handler(supports = { PersonName.class }, order = 50)
+@Handler(supports = {PersonName.class}, order = 50)
 public class PersonNameValidator implements Validator {
-	
-	private static final Logger log = LoggerFactory.getLogger(PersonNameValidator.class);
-	
+
+	private static final Logger log = LoggerFactory
+			.getLogger(PersonNameValidator.class);
+
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
 	 */
@@ -36,16 +37,18 @@ public class PersonNameValidator implements Validator {
 	public boolean supports(Class<?> c) {
 		return PersonName.class.isAssignableFrom(c);
 	}
-	
+
 	/**
-	 * Checks whether person name has all required values, and whether values are proper length
-	 *
+	 * Checks whether person name has all required values, and whether values
+	 * are proper length
+	 * 
 	 * @param object
 	 * @param errors
-	 * <strong>Should</strong> fail validation if PersonName object is null
-	 * <strong>Should</strong> pass validation if name is invalid but voided
-	 * <strong>Should</strong> pass validation if field lengths are correct
-	 * <strong>Should</strong> fail validation if field lengths are not correct
+	 *            <strong>Should</strong> fail validation if PersonName object
+	 *            is null <strong>Should</strong> pass validation if name is
+	 *            invalid but voided <strong>Should</strong> pass validation if
+	 *            field lengths are correct <strong>Should</strong> fail
+	 *            validation if field lengths are not correct
 	 */
 	@Override
 	public void validate(Object object, Errors errors) {
@@ -56,110 +59,188 @@ public class PersonNameValidator implements Validator {
 			if (personName == null) {
 				errors.reject("error.name");
 			} else if (!personName.getVoided()) {
-				// TODO - the following method should be made private in a major release
+				// TODO - the following method should be made private in a major
+				// release
 				validatePersonName(personName, errors, false, true);
 			}
-		}
-		catch (Exception e) {
+		} catch (Exception e) {
 			errors.reject(e.getMessage());
 		}
 	}
-	
+
 	/**
 	 * Checks that the given {@link PersonName} is valid
-	 *
-	 * @param personName the {@link PersonName} to validate
+	 * 
+	 * @param personName
+	 *            the {@link PersonName} to validate
 	 * @param errors
-	 * @param arrayInd indicates whether or not a names[0] array needs to be prepended to field
-	 * <strong>Should</strong> fail validation if PersonName object is null
-	 * <strong>Should</strong> fail validation if PersonName.givenName is null
-	 * <strong>Should</strong> fail validation if PersonName.givenName is empty
-	 * <strong>Should</strong> fail validation if PersonName.givenName is just spaces
-	 * <strong>Should</strong> fail validation if PersonName.givenName is spaces surrounded by quotation marks
-	 * <strong>Should</strong> pass validation if PersonName.givenName is not blank
-	 * <strong>Should</strong> pass validation if PersonName.familyName is null
-	 * <strong>Should</strong> pass validation if PersonName.familyName is empty
-	 * <strong>Should</strong> pass validation if PersonName.familyName is just spaces
-	 * <strong>Should</strong> fail validation if PersonName.familyName is spaces surrounded by quotation marks
-	 * <strong>Should</strong> pass validation if PersonName.familyName is not blank
-	 * <strong>Should</strong> fail validation if PersonName.prefix is too long
-	 * <strong>Should</strong> pass validation if PersonName.prefix is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.prefix is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.givenName is too long
-	 * <strong>Should</strong> pass validation if PersonName.givenName is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.givenName is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.middleName is too long
-	 * <strong>Should</strong> pass validation if PersonName.middleName is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.middleName is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.familyNamePrefix is too long
-	 * <strong>Should</strong> pass validation if PersonName.familyNamePrefix is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.familyNamePrefix is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.familyName is too long
-	 * <strong>Should</strong> pass validation if PersonName.familyName is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.familyName is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.familyName2 is too long
-	 * <strong>Should</strong> pass validation if PersonName.familyName2 is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.familyName2 is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.familyNameSuffix is too long
-	 * <strong>Should</strong> pass validation if PersonName.familyNameSuffix is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.familyNameSuffix is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.degree is too long
-	 * <strong>Should</strong> pass validation if PersonName.degree is exactly max length
-	 * <strong>Should</strong> pass validation if PersonName.degree is less than maximum field length
-	 * <strong>Should</strong> fail validation if PersonName.givenName is invalid
-	 * <strong>Should</strong> pass validation if PersonName.givenName is valid
-	 * <strong>Should</strong> fail validation if PersonName.middleName is invalid
-	 * <strong>Should</strong> pass validation if PersonName.middleName is valid
-	 * <strong>Should</strong> fail validation if PersonName.familyName is invalid
-	 * <strong>Should</strong> pass validation if PersonName.familyName is valid
-	 * <strong>Should</strong> fail validation if PersonName.familyName2 is invalid
-	 * <strong>Should</strong> pass validation if PersonName.familyName2 is valid
-	 * <strong>Should</strong> pass validation if regex string is null
-	 * <strong>Should</strong> pass validation if regex string is empty
-	 * <strong>Should</strong> not validate against regex for blank names
+	 * @param arrayInd
+	 *            indicates whether or not a names[0] array needs to be
+	 *            prepended to field <strong>Should</strong> fail validation if
+	 *            PersonName object is null <strong>Should</strong> fail
+	 *            validation if PersonName.givenName is null
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.givenName is empty <strong>Should</strong> fail
+	 *            validation if PersonName.givenName is just spaces
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.givenName is spaces surrounded by quotation marks
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.givenName is not blank <strong>Should</strong> pass
+	 *            validation if PersonName.familyName is null
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyName is empty <strong>Should</strong> pass
+	 *            validation if PersonName.familyName is just spaces
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.familyName is spaces surrounded by quotation marks
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyName is not blank <strong>Should</strong>
+	 *            fail validation if PersonName.prefix is too long
+	 *            <strong>Should</strong> pass validation if PersonName.prefix
+	 *            is exactly max length <strong>Should</strong> pass validation
+	 *            if PersonName.prefix is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.givenName is too long <strong>Should</strong> pass
+	 *            validation if PersonName.givenName is exactly max length
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.givenName is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.middleName is too long <strong>Should</strong> pass
+	 *            validation if PersonName.middleName is exactly max length
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.middleName is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.familyNamePrefix is too long
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyNamePrefix is exactly max length
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyNamePrefix is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.familyName is too long <strong>Should</strong> pass
+	 *            validation if PersonName.familyName is exactly max length
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyName is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.familyName2 is too long <strong>Should</strong>
+	 *            pass validation if PersonName.familyName2 is exactly max
+	 *            length <strong>Should</strong> pass validation if
+	 *            PersonName.familyName2 is less than maximum field length
+	 *            <strong>Should</strong> fail validation if
+	 *            PersonName.familyNameSuffix is too long
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyNameSuffix is exactly max length
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyNameSuffix is less than maximum field length
+	 *            <strong>Should</strong> fail validation if PersonName.degree
+	 *            is too long <strong>Should</strong> pass validation if
+	 *            PersonName.degree is exactly max length
+	 *            <strong>Should</strong> pass validation if PersonName.degree
+	 *            is less than maximum field length <strong>Should</strong> fail
+	 *            validation if PersonName.givenName is invalid
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.givenName is valid <strong>Should</strong> fail
+	 *            validation if PersonName.middleName is invalid
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.middleName is valid <strong>Should</strong> fail
+	 *            validation if PersonName.familyName is invalid
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyName is valid <strong>Should</strong> fail
+	 *            validation if PersonName.familyName2 is invalid
+	 *            <strong>Should</strong> pass validation if
+	 *            PersonName.familyName2 is valid <strong>Should</strong> pass
+	 *            validation if regex string is null <strong>Should</strong>
+	 *            pass validation if regex string is empty
+	 *            <strong>Should</strong> not validate against regex for blank
+	 *            names
 	 * @deprecated as of 2.2.0, use {@link #validate(Object, Errors)}
 	 */
 	@Deprecated
-	public void validatePersonName(PersonName personName, Errors errors, boolean arrayInd, boolean testInd) {
-		
+	public void validatePersonName(PersonName personName, Errors errors,
+			boolean arrayInd, boolean testInd) {
+
 		if (personName == null) {
 			errors.reject("error.name");
 			return;
 		}
 		// Make sure they assign a name
 		if (StringUtils.isBlank(personName.getGivenName())
-		        || StringUtils.isBlank(personName.getGivenName().replaceAll("\"", ""))) {
-			errors.rejectValue(getFieldKey("givenName", arrayInd, testInd), "Patient.names.required.given.family");
+				|| StringUtils.isBlank(personName.getGivenName().replaceAll(
+						"\"", ""))) {
+			errors.rejectValue(getFieldKey("givenName", arrayInd, testInd),
+					"Patient.names.required.given.family");
 		}
 
-		// Make sure the entered name value is sensible 
-		String namePattern = Context.getAdministrationService().getGlobalProperty(
-		    OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX);
+		// Make sure the entered name value is sensible
+		String namePattern = Context.getAdministrationService()
+				.getGlobalProperty(
+						OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX);
 		if (StringUtils.isNotBlank(namePattern)) {
-			if (StringUtils.isNotBlank(personName.getGivenName()) && !personName.getGivenName().matches(namePattern)) {
-				errors.rejectValue(getFieldKey("givenName", arrayInd, testInd), "GivenName.invalid");
+			if (StringUtils.isNotBlank(personName.getGivenName())
+					&& !personName.getGivenName().matches(namePattern)) {
+				errors.rejectValue(getFieldKey("givenName", arrayInd, testInd),
+						"GivenName.invalid");
 			}
-			if (StringUtils.isNotBlank(personName.getMiddleName()) && !personName.getMiddleName().matches(namePattern)) {
-				errors.rejectValue(getFieldKey("middleName", arrayInd, testInd), "MiddleName.invalid");
+			if (StringUtils.isNotBlank(personName.getMiddleName())
+					&& !personName.getMiddleName().matches(namePattern)) {
+				errors.rejectValue(
+						getFieldKey("middleName", arrayInd, testInd),
+						"MiddleName.invalid");
 			}
-			if (StringUtils.isNotBlank(personName.getFamilyName()) && !personName.getFamilyName().matches(namePattern)) {
-				errors.rejectValue(getFieldKey("familyName", arrayInd, testInd), "FamilyName.invalid");
+			if (StringUtils.isNotBlank(personName.getFamilyName())
+					&& !personName.getFamilyName().matches(namePattern)) {
+				errors.rejectValue(
+						getFieldKey("familyName", arrayInd, testInd),
+						"FamilyName.invalid");
 			}
-			if (StringUtils.isNotBlank(personName.getFamilyName2()) && !personName.getFamilyName2().matches(namePattern)) {
-				errors.rejectValue(getFieldKey("familyName2", arrayInd, testInd), "FamilyName2.invalid");
+			if (StringUtils.isNotBlank(personName.getFamilyName2())
+					&& !personName.getFamilyName2().matches(namePattern)) {
+				errors.rejectValue(
+						getFieldKey("familyName2", arrayInd, testInd),
+						"FamilyName2.invalid");
 			}
 		}
-		ValidateUtil.validateFieldLengths(errors, personName.getClass(), "prefix", "givenName", "middleName",
-		    "familyNamePrefix", "familyName", "familyName2", "familyNameSuffix", "degree", "voidReason");
+
+		// Check for leading/trailing spaces in names (RA-543)
+		if (StringUtils.isNotBlank(personName.getGivenName())
+				&& (personName.getGivenName().startsWith(" ") || personName
+						.getGivenName().endsWith(" "))) {
+			errors.rejectValue(getFieldKey("givenName", arrayInd, testInd),
+					"GivenName.invalid");
+		}
+		if (StringUtils.isNotBlank(personName.getMiddleName())
+				&& (personName.getMiddleName().startsWith(" ") || personName
+						.getMiddleName().endsWith(" "))) {
+			errors.rejectValue(getFieldKey("middleName", arrayInd, testInd),
+					"MiddleName.invalid");
+		}
+		if (StringUtils.isNotBlank(personName.getFamilyName())
+				&& (personName.getFamilyName().startsWith(" ") || personName
+						.getFamilyName().endsWith(" "))) {
+			errors.rejectValue(getFieldKey("familyName", arrayInd, testInd),
+					"FamilyName.invalid");
+		}
+		if (StringUtils.isNotBlank(personName.getFamilyName2())
+				&& (personName.getFamilyName2().startsWith(" ") || personName
+						.getFamilyName2().endsWith(" "))) {
+			errors.rejectValue(getFieldKey("familyName2", arrayInd, testInd),
+					"FamilyName2.invalid");
+		}
+		ValidateUtil.validateFieldLengths(errors, personName.getClass(),
+				"prefix", "givenName", "middleName", "familyNamePrefix",
+				"familyName", "familyName2", "familyNameSuffix", "degree",
+				"voidReason");
 	}
-	
+
 	/***********************************************************************************************************
-	 * @param field the field name
-	 * @param arrayInd indicates whether or not a names[0] array needs to be prepended to field
+	 * @param field
+	 *            the field name
+	 * @param arrayInd
+	 *            indicates whether or not a names[0] array needs to be
+	 *            prepended to field
 	 * @return formated
 	 */
 	private String getFieldKey(String field, boolean arrayInd, boolean testInd) {
-		return testInd ? field : arrayInd ? "names[0]." + field : "name." + field;
+		return testInd ? field : arrayInd ? "names[0]." + field : "name."
+				+ field;
 	}
-	
+
 }

--- a/api/src/test/java/org/openmrs/validator/PersonNameValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PersonNameValidatorTest.java
@@ -34,658 +34,754 @@ import org.springframework.validation.MapBindingResult;
  * Tests methods on the {@link PersonNameValidator} class.
  */
 public class PersonNameValidatorTest extends BaseContextSensitiveTest {
-	
+
 	private static String STRING_OF_50 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-	
+
 	private static String STRING_OF_51 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-	
+
 	private static String STRING_OF_256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-	
+
 	private PersonNameValidator validator;
-	
+
 	private PersonName personName;
-	
+
 	private Errors errors;
-	
+
 	@BeforeEach
 	public void setUp() {
 		validator = new PersonNameValidator();
-		
+
 		personName = new PersonName();
-		
+
 		errors = new BindException(personName, "personName");
-		
+
 		Context.getAdministrationService().saveGlobalProperty(
-		    new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX, "^[a-zA-Z \\-]+$"));
+				new GlobalProperty(
+						OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX,
+						"^[a-zA-Z \\-]+$"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 * @see PatientNameValidator#validate(java.lang.Object,
+	 *      org.springframework.validation.Errors)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameObjectIsNull() {
-		
+
 		validator.validate(null, errors);
-		
+
 		assertThat(errors, hasGlobalErrors("error.name"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsNull() {
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("givenName", "Patient.names.required.given.family"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("givenName",
+						"Patient.names.required.given.family"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsEmpty() {
-		
+
 		personName.setGivenName("");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("givenName", "Patient.names.required.given.family"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("givenName",
+						"Patient.names.required.given.family"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsJustSpaces() {
-		
+
 		personName.setGivenName("    ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("givenName", "Patient.names.required.given.family"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("givenName",
+						"Patient.names.required.given.family"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsSpacesSurroundedByQuotationMarks() {
-		
+
 		personName.setGivenName("\"   \"");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("givenName", "Patient.names.required.given.family"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("givenName",
+						"Patient.names.required.given.family"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameGivenNameIsNotBlank() {
-		
+
 		personName.setGivenName("Fred");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("givenName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsNull() {
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsEmpty() {
-		
+
 		personName.setFamilyName("");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsJustSpaces() {
-		
+
 		personName.setFamilyName("    ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyNameIsSpacesSurroundedByQuotationMarks() {
-		
+
 		personName.setFamilyName("\"   \"");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName", "FamilyName.invalid"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsNotBlank() {
-		
+
 		personName.setFamilyName("Rogers");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNamePrefixIsTooLong() {
-		
+
 		personName.setGivenName("givenName");
 		personName.setFamilyName("familyName");
 		personName.setPrefix(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("prefix", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("prefix", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNamePrefixIsExactlyMaxLength() {
-		
-		personName.setPrefix("12345678901234567890123456789012345678901234567890"); // exactly 50 characters long
-		
+
+		personName
+				.setPrefix("12345678901234567890123456789012345678901234567890"); // exactly
+																					// 50
+																					// characters
+																					// long
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("prefix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNamePrefixIsLessThanMaxFieldLength() {
-		
+
 		personName.setPrefix("1234567890");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("prefix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsTooLong() {
-		
+
 		personName.setGivenName(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("givenName", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("givenName", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameGivenNameIsExactlyMaxLength() {
-		
+
 		personName.setGivenName(STRING_OF_50);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("givenName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameGivenNameIsLessThanMaxFieldLength() {
-		
+
 		personName.setGivenName("abcdefghij");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("givenName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameMiddleNameIsTooLong() {
-		
+
 		personName.setMiddleName(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("middleName", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("middleName", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameMiddleNameIsExactlyMaxLength() {
-		
-		personName.setMiddleName("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly 50 characters long
-		
+
+		personName
+				.setMiddleName("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly
+																						// 50
+																						// characters
+																						// long
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("middleName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameMiddleNameIsLessThanMaxFieldLength() {
-		
+
 		personName.setMiddleName("abcdefghij");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("middleName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyNamePrefixIsTooLong() {
-		
+
 		personName.setGivenName("givenName");
 		personName.setFamilyName("familyName");
 		personName.setFamilyNamePrefix(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("familyNamePrefix", "error.exceededMaxLengthOfField"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("familyNamePrefix",
+						"error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNamePrefixIsExactlyMaxLength() {
-		
-		personName.setFamilyNamePrefix("12345678901234567890123456789012345678901234567890"); // exactly 50 characters long
-		
+
+		personName
+				.setFamilyNamePrefix("12345678901234567890123456789012345678901234567890"); // exactly
+																							// 50
+																							// characters
+																							// long
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyNamePrefix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNamePrefixIsLessThanMaxFieldLength() {
-		
+
 		personName.setFamilyNamePrefix("1234567890");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyNamePrefix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyNameIsTooLong() {
-		
+
 		personName.setFamilyName(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("familyName", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("familyName", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsExactlyMaxLength() {
-		
-		personName.setFamilyName("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly 50 characters long
-		
+
+		personName
+				.setFamilyName("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly
+																						// 50
+																						// characters
+																						// long
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsLessThanMaxFieldLength() {
-		
+
 		personName.setFamilyName("abcdefghij");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyName2IsTooLong() {
-		
+
 		personName.setFamilyName2(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("familyName2", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("familyName2", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyName2IsExactlyMaxLength() {
-		
-		personName.setFamilyName2("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly 50 characters long
-		
+
+		personName
+				.setFamilyName2("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"); // exactly
+																						// 50
+																						// characters
+																						// long
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName2")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyName2IsLessThanMaxFieldLength() {
-		
+
 		personName.setFamilyName2("abcdefghij");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName2")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyNameSuffixIsTooLong() {
-		
+
 		personName.setGivenName("givenName");
 		personName.setFamilyName("familyName");
 		personName.setFamilyNameSuffix(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("familyNameSuffix", "error.exceededMaxLengthOfField"));
+
+		assertThat(
+				errors,
+				hasFieldErrors("familyNameSuffix",
+						"error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameSuffixIsExactlyMaxLength() {
-		
+
 		personName.setFamilyNameSuffix(STRING_OF_50);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyNameSuffix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameSuffixIsLessThanMaxFieldLength() {
-		
+
 		personName.setFamilyNameSuffix("1234567890");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyNameSuffix")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameDegreeIsTooLong() {
-		
+
 		personName.setGivenName("givenName");
 		personName.setFamilyName("familyName");
 		personName.setDegree(STRING_OF_51);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
-		assertThat(errors, hasFieldErrors("degree", "error.exceededMaxLengthOfField"));
+
+		assertThat(errors,
+				hasFieldErrors("degree", "error.exceededMaxLengthOfField"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameDegreeIsExactlyMaxLength() {
-		
+
 		personName.setDegree(STRING_OF_50);
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("degree")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameDegreeIsLessThanMaxFieldLength() {
-		
+
 		personName.setDegree("1234567890");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("degree")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameGivenNameIsInvalid() {
-		
+
 		personName.setGivenName("34dfgd");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("givenName", "GivenName.invalid"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameGivenNameIsValid() {
-		
+
 		personName.setGivenName("alex");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("givenName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameMiddleNameIsInvalid() {
-		
+
 		personName.setMiddleName("34dfgd");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("middleName", "MiddleName.invalid"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameMiddleNameIsValid() {
-		
+
 		personName.setMiddleName("de");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("middleName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyNameIsInvalid() {
-		
+
 		personName.setFamilyName("34dfgd");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName", "FamilyName.invalid"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyNameIsValid() {
-		
+
 		personName.setFamilyName("souza");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldFailValidationIfPersonNameFamilyName2IsInvalid() {
-		
+
 		personName.setFamilyName2("34dfgd");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName2", "FamilyName2.invalid"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfPersonNameFamilyName2IsValid() {
-		
+
 		personName.setFamilyName2("souza-");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName2")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldSkipRegexValidationIfValidationStringIsNull() {
-		
+
 		Context.getAdministrationService().saveGlobalProperty(
-		    new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX, null));
+				new GlobalProperty(
+						OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX,
+						null));
 		personName.setFamilyName("asd123");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("familyName")));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
 	public void validate_shouldSkipRegexValidationIfValidationStringIsEmpty() {
-		
-		Context.getAdministrationService().saveGlobalProperty(
-		    new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX, ""));
+
+		Context.getAdministrationService()
+				.saveGlobalProperty(
+						new GlobalProperty(
+								OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_NAME_REGEX,
+								""));
 		personName.setGivenName("123asd");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, not(hasFieldErrors("givenName")));
 	}
-	
+
 	/**
 	 * @see PersonNameValidator#validatePersonName(PersonName,Errors,null,null)
 	 */
 	@Test
 	public void validatePersonName_shouldNotValidateAgainstRegexForBlankNames() {
-		
+
 		personName.setGivenName("given");
 		personName.setFamilyName("family");
 		personName.setMiddleName("");
 		personName.setFamilyName2("");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertFalse(errors.hasErrors());
 	}
-	
+
 	/**
 	 * @see PersonNameValidator#validate(Object,Errors)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfNameIsInvalidButVoided() {
-		
+
 		personName.setVoided(true);
 		personName.setFamilyName2("34dfgd"); // invalid
-		
+
 		validator.validate(personName, errors);
-		
+
 		assertFalse(errors.hasErrors());
 	}
-	
+
 	/**
 	 * @see PersonNameValidator#validate(Object,Errors)
 	 */
 	@Test
 	public void validate_shouldPassValidationIfFieldLengthsAreCorrect() {
-		
+
 		personName.setPrefix("prefix");
 		personName.setGivenName("givenName");
 		personName.setMiddleName("middleName");
@@ -695,12 +791,12 @@ public class PersonNameValidatorTest extends BaseContextSensitiveTest {
 		personName.setFamilyNameSuffix("familyNameSuffix");
 		personName.setDegree("degree");
 		personName.setVoidReason("voidReason");
-		
+
 		validator.validate(personName, errors);
-		
+
 		assertFalse(errors.hasErrors());
 	}
-	
+
 	/**
 	 * @see PersonNameValidator#validate(Object,Errors)
 	 */
@@ -724,18 +820,19 @@ public class PersonNameValidatorTest extends BaseContextSensitiveTest {
 		    "middleName", "voidReason")
 		        .forEach(f -> assertThat(errors, hasFieldErrors(f, "error.exceededMaxLengthOfField")));
 	}
-
-    /**
-     * @see PersonNameValidator#validatePersonName(PersonName, Errors, Boolean, Boolean)
-     */
-    @Test
+	/**
+	 * @see PersonNameValidator#validatePersonName(PersonName, Errors, Boolean,
+	 *      Boolean)
+	 */
+	@Test
 	public void validatePersonName_shouldReportErrorsWithNonStandardPrefixWhenCalledInHistoricWay() {
-		
+
 		PersonName personName = new PersonName("", "reb", "feb");
-		MapBindingResult errors = new MapBindingResult(new HashMap<String, Object>(), "personName");
-		
+		MapBindingResult errors = new MapBindingResult(
+				new HashMap<String, Object>(), "personName");
+
 		validator.validatePersonName(personName, errors, true, false);
-		
+
 		assertThat(errors, hasFieldErrors("names[0]." + "givenName"));
 	}
 
@@ -744,124 +841,125 @@ public class PersonNameValidatorTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void validate_shouldReportErrorsOnCorrectFieldNames() {
-		
+
 		PersonName personName = new PersonName("", "reb", "feb");
-		MapBindingResult errors = new MapBindingResult(new HashMap<String, Object>(), "personName");
-		
+		MapBindingResult errors = new MapBindingResult(
+				new HashMap<String, Object>(), "personName");
+
 		validator.validate(personName, errors);
-		
+
 		assertThat(errors, hasFieldErrors("givenName"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameGivenNameHasLeadingSpaces() {
-		
+
 		personName.setGivenName(" alex");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("givenName"));
 	}
 
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameGivenNameHasTrailingSpaces() {
-		
+
 		personName.setGivenName("alex ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("givenName"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameMiddleNameHasLeadingSpaces() {
-		
+
 		personName.setMiddleName(" de");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("middleName"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameMiddleNameHasTrailingSpaces() {
-		
+
 		personName.setMiddleName("de ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("middleName"));
 	}
 
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameFamilyNameHasLeadingSpaces() {
-		
+
 		personName.setFamilyName(" souza");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName"));
 	}
 
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameFamilyNameHasTrailingSpaces() {
-		
+
 		personName.setFamilyName("souza ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName"));
 	}
-	
+
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameFamilyName2HasLeadingSpaces() {
-		
+
 		personName.setFamilyName2(" souza-");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName2"));
 	}
 
 	/**
-	 * @see PatientNameValidator#validatePersonName(java.lang.Object, org.springframework.validation.Errors, boolean, boolean)
+	 * @see PatientNameValidator#validatePersonName(java.lang.Object,
+	 *      org.springframework.validation.Errors, boolean, boolean)
 	 */
 	@Test
-	@Disabled("Unignore after investigating and fixing - RA-543")
 	public void validate_shouldFailValidationIfPersonNameFamilyName2HasTrailingSpaces() {
-		
+
 		personName.setFamilyName2("souza- ");
-		
+
 		validator.validatePersonName(personName, errors, false, true);
-		
+
 		assertThat(errors, hasFieldErrors("familyName2"));
 	}
 }


### PR DESCRIPTION
RA-543: Validate leading and trailing spaces in PersonNameValidator

## Description of what I changed

I investigated and resolved `RA-543` by enforcing stricter validation for person names.
*   *Enabled Tests:** Un-ignored 8 unit tests in [PersonNameValidatorTest.java](cci:7://file:///Users/bhavya_/Desktop/Coding/openMRs/OpenMRS%20core/openmrs-core/api/src/test/java/org/openmrs/validator/PersonNameValidatorTest.java:0:0-0:0) that were previously marked with `@Disabled`.
*   **Implemented Validation:** Updated [PersonNameValidator.java](cci:7://file:OpenMRS%20core/openmrs-core/api/src/main/java/org/openmrs/validator/PersonNameValidator.java:0:0-0:0) to explicitly check for and reject `givenName`, `middleName`, `familyName`, and `familyName2` if they contain leading or trailing whitespace.

## Issue I worked on
see https://openmrs.atlassian.net/browse/O3-5302

## Checklist: I completed these to help reviewers :)
-  My IDE is configured to follow the [*code style*](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- I have **added tests** to cover my changes. (Enabled and fixed existing disabled tests)
- I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- All new and existing *tests passed*.
- My pull request is *based on the latest changes* of the master branch.

<img width="1268" height="703" alt="Screenshot 2026-01-11 at 6 38 26 PM" src="https://github.com/user-attachments/assets/f4b61546-0a04-4677-81e3-92697145d775" />
