### PR TITLE
TRUNK-6266: Order drug search results from simple to complex formulat...

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.Comparator;
 
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -415,8 +416,17 @@ public class HibernateConceptDAO implements ConceptDAO {
 			return Collections.emptyList();
 		}
 		
-		return drugQuery.fetchAllHits();
-	}
+	List<Drug> results = drugQuery.fetchAllHits();
+
+    results.sort(Comparator.comparingInt(drug -> {
+        if (drug.getIngredients() != null) {
+            return drug.getIngredients().size();
+        }
+        return 1;
+    }));
+
+    return results;
+}
 	
 	/**
 	 * @see org.openmrs.api.db.ConceptDAO#getConceptClass(java.lang.Integer)


### PR DESCRIPTION
…ions

## Description
This change updates the ordering of drug search results returned by the
existing search mechanism. As discussed in TRUNK-6266, the goal is not to
introduce a new search, but to improve how results are scored and ordered.

Currently, combination drugs can appear before simpler formulations.
This update adjusts the ordering so that simpler (single-ingredient)
formulations are prioritized ahead of more complex combination drugs,
which better matches expected clinical usage.

Alphabetical ordering alone is not sufficient in these cases (e.g.
Paracetamol should appear before Ibuprofen + Paracetamol), so this change
focuses on formulation complexity rather than name sorting.

## Changes
- Adjusted result ordering in `getDrugs(String phrase)`
- Simple (single-ingredient) drugs are listed before combination drugs

## Related ticket
https://issues.openmrs.org/browse/TRUNK-6266


