### PR TITLE
Trunk 6514 performance markers

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleUtil.java
+++ b/api/src/main/java/org/openmrs/module/ModuleUtil.java
@@ -875,7 +875,8 @@ public class ModuleUtil {
 		for (Module module : startedModules) {
 			try {
 				if (module.getModuleActivator() != null) {
-					log.debug("Run module willRefreshContext: {}", module.getModuleId());
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Run module willRefreshContext: {}",
+					    module.getModuleId());
 					Thread.currentThread().setContextClassLoader(ModuleFactory.getModuleClassLoader(module));
 					module.getModuleActivator().willRefreshContext();
 				}
@@ -898,7 +899,7 @@ public class ModuleUtil {
 		ctx.setClassLoader(OpenmrsClassLoader.getInstance());
 		Thread.currentThread().setContextClassLoader(OpenmrsClassLoader.getInstance());
 
-		log.debug("Refreshing context");
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing context");
 		ServiceContext.getInstance().startRefreshingContext();
 		try {
 			ctx.refresh();
@@ -908,7 +909,7 @@ public class ModuleUtil {
 		} finally {
 			ServiceContext.getInstance().doneRefreshingContext();
 		}
-		log.debug("Done refreshing context");
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing context");
 
 		ctx.setClassLoader(OpenmrsClassLoader.getInstance());
 		Thread.currentThread().setContextClassLoader(OpenmrsClassLoader.getInstance());
@@ -916,7 +917,8 @@ public class ModuleUtil {
 		OpenmrsClassLoader.setThreadsToNewClassLoader();
 
 		// reload the advice points that were lost when refreshing Spring
-		log.debug("Reloading advice for all started modules: {}", startedModules.size());
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Reloading advice for all started modules: {}",
+		    startedModules.size());
 
 		try {
 			//The call backs in this block may need lazy loading of objects
@@ -934,20 +936,24 @@ public class ModuleUtil {
 					ModuleFactory.passDaemonToken(module);
 
 					if (module.getModuleActivator() != null) {
-						log.debug("Run module contextRefreshed: {}", module.getModuleId());
+						log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Run module contextRefreshed: {}",
+						    module.getModuleId());
 						module.getModuleActivator().contextRefreshed();
 						try {
 							//if it is system start up, call the started method for all started modules
 							if (isOpenmrsStartup) {
-								log.debug("Run module started: {}", module.getModuleId());
+								log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Run module started: {}",
+								    module.getModuleId());
 								module.getModuleActivator().started();
 							}
 							//if refreshing the context after a user started or uploaded a new module
 							else if (!isOpenmrsStartup && module.equals(startedModule)) {
-								log.debug("Run module started: {}", module.getModuleId());
+								log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Run module started: {}",
+								    module.getModuleId());
 								module.getModuleActivator().started();
 							}
-							log.debug("Done running module started: {}", module.getModuleId());
+							log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done running module started: {}",
+							    module.getModuleId());
 						} catch (Error e) {
 							log.warn("Unable to invoke started() method on the module's activator", e);
 							ModuleFactory.stopModule(module, true, true);

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -31,6 +31,8 @@ import org.openmrs.module.ModuleFactory;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 
 import liquibase.GlobalConfiguration;
 
@@ -45,6 +47,13 @@ import static java.util.Arrays.asList;
 public final class OpenmrsConstants {
 
 	private static final Logger log = LoggerFactory.getLogger(OpenmrsConstants.class);
+
+	/**
+	 * Marker used for performance-related log entries. To filter log files: grep "performance"
+	 * openmrs.log To find usages in source: Get-ChildItem -Recurse -Filter *.java | Select-String
+	 * "PERFORMANCE_MARKER"
+	 */
+	public static final Marker PERFORMANCE_MARKER = MarkerFactory.getMarker("performance");
 
 	public static String KEY_OPENMRS_APPLICATION_DATA_DIRECTORY = "OPENMRS_APPLICATION_DATA_DIRECTORY";
 

--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -59,6 +59,7 @@ import org.openmrs.module.web.filter.ModuleFilterMapping;
 import org.openmrs.scheduler.SchedulerException;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.TaskDefinition;
+import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.DispatcherServlet;
@@ -118,7 +119,7 @@ public class WebModuleUtil {
 	 */
 	public static boolean startModule(Module mod, ServletContext servletContext, boolean delayContextRefresh) {
 
-		log.debug("Trying to start module {}", mod);
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Trying to start module {}", mod);
 
 		// only try and start this module if the api started it without a
 		// problem.
@@ -301,11 +302,12 @@ public class WebModuleUtil {
 			// refresh the spring web context to get the just-created xml
 			// files into it (if we copied an xml file)
 			if (moduleNeedsContextRefresh && !delayContextRefresh) {
-				log.debug("Refreshing context for module {}", mod.getModuleId());
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing context for module {}", mod.getModuleId());
 
 				try {
 					refreshWAC(servletContext, false, mod);
-					log.debug("Done refreshing context for module {}", mod.getModuleId());
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing context for module {}",
+					    mod.getModuleId());
 				} catch (Exception e) {
 					String msg = "Unable to refresh the WebApplicationContext";
 					mod.setStartupErrorMessage(msg, e);
@@ -325,9 +327,11 @@ public class WebModuleUtil {
 					}
 
 					// try starting the application context again
-					log.debug("Refreshing context for module {} (re-trying)", mod.getModuleId());
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing context for module {} (re-trying)",
+					    mod.getModuleId());
 					refreshWAC(servletContext, false, mod);
-					log.debug("Done refreshing context for module {} (re-trying)", mod.getModuleId());
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing context for module {} (re-trying)",
+					    mod.getModuleId());
 
 					notifySuperUsersAboutModuleFailure(mod);
 				}
@@ -342,7 +346,7 @@ public class WebModuleUtil {
 
 				// find and cache the module's servlets
 				//(only if the module started successfully previously)
-				log.debug("Loading servlets and filters for module {}", mod);
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Loading servlets and filters for module {}", mod);
 				servletContext.setAttribute(OpenmrsJspServlet.OPENMRS_TLD_SCAN_NEEDED, true);
 				loadServlets(mod, servletContext);
 				loadFilters(mod, servletContext);
@@ -902,8 +906,8 @@ public class WebModuleUtil {
 	        Module startedModule) {
 		XmlWebApplicationContext wac = (XmlWebApplicationContext) WebApplicationContextUtils
 		        .getWebApplicationContext(servletContext);
-		log.debug("Refreshing Web Application Context of class: {}", wac.getClass().getName());
-
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing Web Application Context of class: {}",
+		    wac.getClass().getName());
 		if (dispatcherServlet != null) {
 			dispatcherServlet.stopAndCloseApplicationContext();
 		}

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -244,11 +244,11 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				 * This logic is from ContextLoader.initWebApplicationContext. Copied here instead of calling that
 				 * so that the context is not cached and hence not garbage collected
 				 */
-				log.debug("Refreshing WAC");
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing WAC");
 				XmlWebApplicationContext context = (XmlWebApplicationContext) createWebApplicationContext(servletContext);
 				configureAndRefreshWebApplicationContext(context, servletContext);
 				servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
-				log.debug("Done refreshing WAC");
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing WAC");
 
 				WebDaemon.startOpenmrs(event.getServletContext());
 			} else {
@@ -335,7 +335,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		// start openmrs
 		try {
 			// load bundled modules that are packaged into the webapp
-			log.debug("Loading bundled modules");
+			log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Loading bundled modules");
 			Listener.loadBundledModules(servletContext);
 
 			Context.startup(getRuntimeProperties());
@@ -348,7 +348,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		// TODO catch openmrs errors here and drop the user back out to the setup screen
 
 		try {
-			log.debug("Performing start of modules");
+			log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Performing start of modules");
 			// web load modules
 			Listener.performWebStartOfModules(servletContext);
 
@@ -677,7 +677,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 
 		boolean someModuleNeedsARefresh = false;
 		for (Module mod : startedModules) {
-			log.debug("Staring module: {}", mod.getModuleId());
+			log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Staring module: {}", mod.getModuleId());
 			try {
 				boolean thisModuleCausesRefresh = WebModuleUtil.startModule(mod, servletContext,
 				    /* delayContextRefresh */true);
@@ -689,9 +689,9 @@ public final class Listener extends ContextLoader implements ServletContextListe
 
 		if (someModuleNeedsARefresh) {
 			try {
-				log.debug("Refreshing WAC as required by some module");
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Refreshing WAC as required by some module");
 				WebModuleUtil.refreshWAC(servletContext, true, null);
-				log.debug("Done refreshing WAC as required by some module");
+				log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing WAC as required by some module");
 			} catch (ModuleMustStartException | BeanCreationException ex) {
 				// pass this up to the calling method so that openmrs loading stops
 				throw ex;
@@ -702,7 +702,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 					    "Unable to refresh the spring application context.  Root Cause was:", rootCause);
 				} else {
 					log.error(MarkerFactory.getMarker("FATAL"),
-					    "nable to refresh the spring application context. Unloading all modules,  Error was:", e);
+					    "Unable to refresh the spring application context. Unloading all modules,  Error was:", e);
 				}
 
 				try {
@@ -718,9 +718,9 @@ public final class Listener extends ContextLoader implements ServletContextListe
 							}
 						}
 					}
-					log.debug("Retrying refreshing WebApplicationContext");
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Retrying refreshing WebApplicationContext");
 					WebModuleUtil.refreshWAC(servletContext, true, null);
-					log.debug("Done refreshing WebApplicationContext");
+					log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done refreshing WebApplicationContext");
 				} catch (MandatoryModuleException ex) {
 					// pass this up to the calling method so that openmrs loading stops
 					throw new MandatoryModuleException(ex.getModuleId(), "Got an error while starting a mandatory module: "
@@ -737,7 +737,7 @@ public final class Listener extends ContextLoader implements ServletContextListe
 		// because we delayed the refresh, we need to load+start all servlets and filters now
 		// (this is to protect servlets/filters that depend on their module's spring xml config being available)
 		for (Module mod : ModuleFactory.getStartedModulesInOrder()) {
-			log.debug("Loading servlets and filters for module: {}", mod.getModuleId());
+			log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Loading servlets and filters for module: {}", mod.getModuleId());
 			WebModuleUtil.loadServlets(mod, servletContext);
 			WebModuleUtil.loadFilters(mod, servletContext);
 		}

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -218,7 +218,7 @@ public class InitializationFilter extends StartupFilter {
 	 */
 	@Override
 	protected void doGet(HttpServletRequest httpRequest, HttpServletResponse httpResponse) throws IOException {
-		log.debug("Entered initialization filter");
+		log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Entered initialization filter");
 
 		SessionModelUtils.loadFromSession(httpRequest.getSession(), wizardModel);
 		initializeWizardFromResolvedPropertiesIfPresent();
@@ -1357,7 +1357,7 @@ public class InitializationFilter extends StartupFilter {
 		}
 
 		public synchronized void setMessage(String message) {
-			log.debug(message);
+			log.debug(OpenmrsConstants.PERFORMANCE_MARKER, message);
 			this.message = message;
 			setStepsComplete(getStepsComplete() + 1);
 		}
@@ -1606,7 +1606,7 @@ public class InitializationFilter extends StartupFilter {
 						}
 
 						if (wizardModel.createTables) {
-							log.debug("Creating tables");
+							log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Creating tables");
 							// use liquibase to create core data + tables
 							try {
 								String liquibaseSchemaFileName = changeLogVersionFinder.getLatestSchemaSnapshotFilename()
@@ -1731,10 +1731,10 @@ public class InitializationFilter extends StartupFilter {
 						// start spring
 						// after this point, all errors need to also call: contextLoader.closeWebApplicationContext(event.getServletContext())
 						// logic copied from org.springframework.web.context.ContextLoaderListener
-						log.debug("Initializing WAC");
+						log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Initializing WAC");
 						ContextLoader contextLoader = new ContextLoader();
 						contextLoader.initWebApplicationContext(filterConfig.getServletContext());
-						log.debug("Done initializing WAC");
+						log.debug(OpenmrsConstants.PERFORMANCE_MARKER, "Done initializing WAC");
 
 						// output properties to the openmrs runtime properties file so that this wizard is not run again
 						FileOutputStream fos = null;


### PR DESCRIPTION
## Description of what I changed
In this pull request, I have introduced SLF4J `performance` markers to the `log.debug` statements that were originally added in TRUNK-6436 to monitor OpenMRS startup performance. This change allows developers and system administrators to easily filter or redirect performance-related logs by targeting the "performance" marker.

The following changes were implemented:
* Created a reusable `PERFORMANCE_MARKER` using `MarkerFactory.getMarker("performance")` in multiple core and web classes.
* Updated logging calls to include the marker in `ModuleUtil.java`, `WebModuleUtil.java`, `Listener.java` and `InitializationFilter.java`.
* Verified that all strings are parameterized to follow OpenMRS logging best practices.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6514

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (N/A: This is a logging enhancement; verified by existing startup performance tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.