### PR TITLE
TRUNK-5979: Clarify log message when servlet/filter initialization fails during first startup

### DIFF
--- a/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
+++ b/web/src/main/java/org/openmrs/module/web/WebModuleUtil.java
@@ -510,7 +510,13 @@ public class WebModuleUtil {
 				httpServlet.init(servletConfig);
 			}
 			catch (Exception e) {
-				log.warn("Unable to initialize servlet {}", name, e);
+				log.warn(
+    "Unable to initialize servlet '{}' because the servlet context is already initialized. "
+  + "This is expected during first startup due to servlet lifecycle limitations.",
+    name,
+    e
+);
+
 				throw new ModuleException("Unable to initialize servlet " + name, mod.getModuleId(), e);
 			}
 			
@@ -638,7 +644,12 @@ public class WebModuleUtil {
 				filter.init(config);
 			}
 			catch (Exception e) {
-				log.warn("Unable to initialize servlet {}", name, e);
+				log.warn(
+    "Unable to initialize filter '{}' because the servlet context is already initialized. "
+  + "This is expected during first startup due to servlet lifecycle limitations.",
+    name,
+    e
+);
 				throw new ModuleException("Unable to initialize servlet " + name, module.getModuleId(), e);
 			}
 			


### PR DESCRIPTION
### Problem overview

While looking into TRUNK-5979, I spent some time reading through the prior discussion
around the IllegalStateException that appears when modules attempt to register
filters or servlets after the servlet context has already been initialized.


Based on earlier comments, this behavior is expected due to servlet lifecycle constraints in Tomcat and does not indicate a functional problem in OpenMRS.
However, the current log message can be misleading and make it appear as though
something has gone wrong during startup.

### What this change does

This change updates the log message to better explain the context in which this
occurs (typically during the first startup), while keeping the existing behavior
unchanged. The goal is simply to reduce confusion when reading startup logs, not
to alter module loading or servlet/filter registration logic.

### Related Jira issue
https://issues.openmrs.org/browse/TRUNK-5979

