### PR TITLE
Refactor HibernateHL7DAO to use Hibernate 6 typed queries

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/db/HL7DAO.java
+++ b/api/src/main/java/org/openmrs/hl7/db/HL7DAO.java
@@ -19,72 +19,73 @@ import org.openmrs.hl7.HL7Service;
 import org.openmrs.hl7.HL7Source;
 
 /**
- * OpenMRS HL7 database related methods This class shouldn't be instantiated by itself. Use the
+ * OpenMRS HL7 database related methods This class shouldn't be instantiated by
+ * itself. Use the
  * {@link org.openmrs.api.context.Context}
  * 
  * @see org.openmrs.hl7.HL7Service
  */
 public interface HL7DAO {
-	
+
 	/* HL7Source */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7Source(org.openmrs.hl7.HL7Source)
 	 */
 	public HL7Source saveHL7Source(HL7Source hl7Source) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7Source(Integer)
 	 */
 	public HL7Source getHL7Source(Integer hl7SourceId) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7SourceByName(String)
 	 */
 	public HL7Source getHL7SourceByName(String name) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7Sources()
 	 */
 	public List<HL7Source> getAllHL7Sources() throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#purgeHL7Source(org.openmrs.hl7.HL7Source)
 	 */
 	public void deleteHL7Source(HL7Source hl7Source) throws DAOException;
-	
+
 	/* HL7InQueue */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
 	public HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InQueue(Integer)
 	 */
 	public HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws DAOException;
-	
+
 	/**
 	 * @see HL7Service#getHL7InQueueByUuid(String)
 	 */
 	public HL7InQueue getHL7InQueueByUuid(String uuid) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InQueues()
 	 */
 	public List<HL7InQueue> getAllHL7InQueues() throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getNextHL7InQueue()
 	 */
 	public HL7InQueue getNextHL7InQueue() throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#purgeHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
 	public void deleteHL7InQueue(HL7InQueue hl7InQueue) throws DAOException;
-	
+
 	/**
 	 * Returns hl7s based on batch settings and filtered by a query
 	 * 
@@ -95,9 +96,8 @@ public interface HL7DAO {
 	 * @param query
 	 * @return list of hl7s
 	 */
-	@SuppressWarnings("rawtypes")
-	public <T> List<T> getHL7Batch(Class clazz, int start, int length, Integer messageState, String query);
-	
+	public <T> List<T> getHL7Batch(Class<T> clazz, int start, int length, Integer messageState, String query);
+
 	/**
 	 * Returns the amount of HL7 items in the database
 	 * 
@@ -106,41 +106,40 @@ public interface HL7DAO {
 	 * @param query
 	 * @return count of HL7 items
 	 */
-	@SuppressWarnings("rawtypes")
-	public Long countHL7s(Class clazz, Integer messageState, String query);
-	
+	public <T> Long countHL7s(Class<T> clazz, Integer messageState, String query);
+
 	/* HL7InArchive */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
 	public HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchive(Integer)
 	 */
 	public HL7InArchive getHL7InArchive(Integer hl7InArchiveId) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchiveByUuid(String)
 	 */
 	public HL7InArchive getHL7InArchiveByUuid(String uuid) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InArchiveByState(Integer state)
 	 */
 	public List<HL7InArchive> getHL7InArchiveByState(Integer state) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InQueueByState(Integer stateId)
 	 */
 	public List<HL7InQueue> getHL7InQueueByState(Integer stateId) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InArchives()
 	 */
 	public List<HL7InArchive> getAllHL7InArchives() throws DAOException;
-	
+
 	/**
 	 * Returns hl7 in archives but with a limited resultset size to save memory
 	 * 
@@ -148,49 +147,49 @@ public interface HL7DAO {
 	 * @return list of hl7 archives
 	 */
 	public List<HL7InArchive> getAllHL7InArchives(Integer maxResults);
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#purgeHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
 	public void deleteHL7InArchive(HL7InArchive hl7InArchive) throws DAOException;
-	
+
 	/**
 	 * provides a list of archives to be migrated
 	 */
 	public List<HL7InArchive> getHL7InArchivesToMigrate();
-	
+
 	/* HL7InError */
 
 	/**
 	 * @see org.openmrs.hl7.HL7Service#saveHL7InError(org.openmrs.hl7.HL7InError)
 	 */
 	public HL7InError saveHL7InError(HL7InError hl7InError) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getHL7InError(Integer)
 	 */
 	public HL7InError getHL7InError(Integer hl7InErrorId) throws DAOException;
-	
+
 	/**
 	 * @see HL7Service#getHL7InErrorByUuid(String)
 	 */
 	public HL7InError getHL7InErrorByUuid(String uuid) throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#getAllHL7InErrors()
 	 */
 	public List<HL7InError> getAllHL7InErrors() throws DAOException;
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#purgeHL7InError(org.openmrs.hl7.HL7InError)
 	 */
 	public void deleteHL7InError(HL7InError hl7InError) throws DAOException;
-	
+
 	// miscellaneous
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#garbageCollect()
 	 */
 	public void garbageCollect();
-	
+
 }

--- a/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
+++ b/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.hl7.db.hibernate;
 
-import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
@@ -21,7 +20,6 @@ import java.util.List;
 
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
-import org.hibernate.type.StandardBasicTypes;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.hibernate.HibernateUtil;
@@ -38,7 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /**
- * OpenMRS HL7 API database default hibernate implementation This class shouldn't be instantiated by
+ * OpenMRS HL7 API database default hibernate implementation This class
+ * shouldn't be instantiated by
  * itself. Use the {@link org.openmrs.api.context.Context}
  *
  * @see org.openmrs.hl7.HL7Service
@@ -48,21 +47,20 @@ import org.springframework.stereotype.Repository;
 public class HibernateHL7DAO implements HL7DAO {
 
 	private final SessionFactory sessionFactory;
-	
+
 	@Autowired
 	public HibernateHL7DAO(SessionFactory sessionFactory) {
 		this.sessionFactory = sessionFactory;
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#saveHL7Source(org.openmrs.hl7.HL7Source)
 	 */
 	@Override
 	public HL7Source saveHL7Source(HL7Source hl7Source) throws DAOException {
-		sessionFactory.getCurrentSession().saveOrUpdate(hl7Source);
-		return hl7Source;
+		return sessionFactory.getCurrentSession().merge(hl7Source);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7Source(java.lang.Integer)
 	 */
@@ -70,7 +68,7 @@ public class HibernateHL7DAO implements HL7DAO {
 	public HL7Source getHL7Source(Integer hl7SourceId) throws DAOException {
 		return sessionFactory.getCurrentSession().get(HL7Source.class, hl7SourceId);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7SourceByName(java.lang.String)
 	 */
@@ -90,28 +88,28 @@ public class HibernateHL7DAO implements HL7DAO {
 	 * @see org.openmrs.hl7.db.HL7DAO#getAllHL7Sources()
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<HL7Source> getAllHL7Sources() throws DAOException {
-		return sessionFactory.getCurrentSession().createQuery("from HL7Source").list();
+		return sessionFactory.getCurrentSession()
+				.createQuery("from HL7Source", HL7Source.class)
+				.getResultList();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#deleteHL7Source(org.openmrs.hl7.HL7Source)
 	 */
 	@Override
 	public void deleteHL7Source(HL7Source hl7Source) throws DAOException {
-		sessionFactory.getCurrentSession().delete(hl7Source);
+		sessionFactory.getCurrentSession().remove(hl7Source);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#saveHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
 	@Override
 	public HL7InQueue saveHL7InQueue(HL7InQueue hl7InQueue) throws DAOException {
-		sessionFactory.getCurrentSession().saveOrUpdate(hl7InQueue);
-		return hl7InQueue;
+		return sessionFactory.getCurrentSession().merge(hl7InQueue);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InQueue(java.lang.Integer)
 	 */
@@ -119,32 +117,37 @@ public class HibernateHL7DAO implements HL7DAO {
 	public HL7InQueue getHL7InQueue(Integer hl7InQueueId) throws DAOException {
 		return sessionFactory.getCurrentSession().get(HL7InQueue.class, hl7InQueueId);
 	}
-	
+
 	@Override
 	public HL7InQueue getHL7InQueueByUuid(String uuid) throws DAOException {
 		return HibernateUtil.getUniqueEntityByUUID(sessionFactory, HL7InQueue.class, uuid);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getAllHL7InQueues()
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<HL7InQueue> getAllHL7InQueues() throws DAOException {
 		return sessionFactory.getCurrentSession()
-		        .createQuery("from HL7InQueue where messageState = ?1 order by HL7InQueueId").setParameter(1,
-		            HL7Constants.HL7_STATUS_PENDING, StandardBasicTypes.INTEGER).list();
+				.createQuery(
+						"from HL7InQueue where messageState = :state order by hl7InQueueId",
+						HL7InQueue.class)
+				.setParameter("state", HL7Constants.HL7_STATUS_PENDING)
+				.getResultList();
+
 	}
-	
+
 	/**
-	 * creates a Criteria object for use with counting and finding HL7InQueue objects
+	 * creates a Criteria object for use with counting and finding HL7InQueue
+	 * objects
 	 *
 	 * @param messageState status of HL7InQueue object
-	 * @param query string query to match against
+	 * @param query        string query to match against
 	 * @return a Criteria object
 	 */
-	@SuppressWarnings("rawtypes")
-	private List<Predicate> getHL7SearchCriteria(CriteriaBuilder cb, Root<?> root, Class<?> clazz, Integer messageState, String query) throws DAOException {
+	private <T> List<Predicate> getHL7SearchCriteria(CriteriaBuilder cb, Root<T> root, Class<T> clazz,
+			Integer messageState,
+			String query) throws DAOException {
 		if (clazz == null) {
 			throw new DAOException("no class defined for HL7 search");
 		}
@@ -176,18 +179,17 @@ public class HibernateHL7DAO implements HL7DAO {
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7Batch(Class, int, int, Integer, String)
 	 */
 	@Override
-	@SuppressWarnings( { "rawtypes", "unchecked" })
-	public <T> List<T> getHL7Batch(Class clazz, int start, int length, Integer messageState, String query)
-	        throws DAOException {
+	public <T> List<T> getHL7Batch(Class<T> clazz, int start, int length, Integer messageState, String query)
+			throws DAOException {
 		Session session = sessionFactory.getCurrentSession();
 		CriteriaBuilder cb = session.getCriteriaBuilder();
 		CriteriaQuery<T> cq = cb.createQuery(clazz);
 		Root<T> root = cq.from(clazz);
-		
+
 		List<Predicate> predicates = getHL7SearchCriteria(cb, root, clazz, messageState, query);
 
-		cq.where(predicates.toArray(new Predicate[]{}))
-			.orderBy(cb.asc(root.get("dateCreated")));
+		cq.where(predicates.toArray(new Predicate[] {}))
+				.orderBy(cb.asc(root.get("dateCreated")));
 
 		TypedQuery<T> typedQuery = session.createQuery(cq);
 		typedQuery.setFirstResult(start);
@@ -195,56 +197,59 @@ public class HibernateHL7DAO implements HL7DAO {
 
 		return typedQuery.getResultList();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#countHL7s(Class, Integer, String)
 	 */
 	@Override
-	@SuppressWarnings("rawtypes")
-	public Long countHL7s(Class clazz, Integer messageState, String query) {
+	public <T> Long countHL7s(Class<T> clazz, Integer messageState, String query) {
 		Session session = sessionFactory.getCurrentSession();
 		CriteriaBuilder cb = session.getCriteriaBuilder();
 		CriteriaQuery<Long> cq = cb.createQuery(Long.class);
-		Root<?> root = cq.from(clazz);
+		Root<T> root = cq.from(clazz);
 
 		List<Predicate> predicates = getHL7SearchCriteria(cb, root, clazz, messageState, query);
 		cq.select(cb.count(root))
-			.where(predicates.toArray(new Predicate[]{}));
+				.where(predicates.toArray(new Predicate[] {}));
 
 		return session.createQuery(cq).getSingleResult();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getNextHL7InQueue()
 	 */
 	@Override
 	public HL7InQueue getNextHL7InQueue() throws DAOException {
-		Query query = sessionFactory.getCurrentSession().createQuery(
-		    "from HL7InQueue as hiq where hiq.messageState = ?1 order by HL7InQueueId").setParameter(1,
-		    HL7Constants.HL7_STATUS_PENDING, StandardBasicTypes.INTEGER).setMaxResults(1);
+		TypedQuery<HL7InQueue> query = sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InQueue hiq where hiq.messageState = :state order by hiq.hl7InQueueId",
+						HL7InQueue.class)
+				.setParameter("state", HL7Constants.HL7_STATUS_PENDING)
+				.setMaxResults(1);
+
 		if (query == null) {
 			return null;
 		}
 		return JpaUtils.getSingleResultOrNull(query);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#deleteHL7InQueue(org.openmrs.hl7.HL7InQueue)
 	 */
 	@Override
 	public void deleteHL7InQueue(HL7InQueue hl7InQueue) throws DAOException {
-		sessionFactory.getCurrentSession().delete(hl7InQueue);
+		sessionFactory.getCurrentSession().remove(hl7InQueue);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#saveHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
 	@Override
 	public HL7InArchive saveHL7InArchive(HL7InArchive hl7InArchive) throws DAOException {
-		sessionFactory.getCurrentSession().save(hl7InArchive);
+		sessionFactory.getCurrentSession().persist(hl7InArchive);
 		return hl7InArchive;
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InArchive(java.lang.Integer)
 	 */
@@ -252,7 +257,7 @@ public class HibernateHL7DAO implements HL7DAO {
 	public HL7InArchive getHL7InArchive(Integer hl7InArchiveId) throws DAOException {
 		return sessionFactory.getCurrentSession().get(HL7InArchive.class, hl7InArchiveId);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InArchiveByState(Integer state)
 	 */
@@ -260,30 +265,37 @@ public class HibernateHL7DAO implements HL7DAO {
 	public List<HL7InArchive> getHL7InArchiveByState(Integer state) throws DAOException {
 		return getHL7InArchiveByState(state, null);
 	}
-	
+
 	/**
 	 * limits results of getHL7InArchiveByState
 	 */
-	@SuppressWarnings("unchecked")
 	private List<HL7InArchive> getHL7InArchiveByState(Integer state, Integer maxResults) throws DAOException {
-		Query q = sessionFactory.getCurrentSession().createQuery("from HL7InArchive where messageState = ?1").setParameter(1,
-		    state, StandardBasicTypes.INTEGER);
+		TypedQuery<HL7InArchive> q = sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InArchive where messageState = :state",
+						HL7InArchive.class)
+				.setParameter("state", state);
+
 		if (maxResults != null) {
 			q.setMaxResults(maxResults);
 		}
 		return q.getResultList();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InQueueByState(Integer stateId)
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<HL7InQueue> getHL7InQueueByState(Integer state) throws DAOException {
-		return sessionFactory.getCurrentSession().createQuery("from HL7InQueue where messageState = ?1").setParameter(1,
-		    state, StandardBasicTypes.INTEGER).list();
+		return sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InQueue where messageState = :state",
+						HL7InQueue.class)
+				.setParameter("state", state)
+				.getResultList();
+
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getAllHL7InArchives()
 	 */
@@ -291,37 +303,40 @@ public class HibernateHL7DAO implements HL7DAO {
 	public List<HL7InArchive> getAllHL7InArchives() throws DAOException {
 		return getAllHL7InArchives(null);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getAllHL7InArchives(Integer)
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<HL7InArchive> getAllHL7InArchives(Integer maxResults) {
-		Query q = sessionFactory.getCurrentSession().createQuery("from HL7InArchive order by hl7InArchiveId");
+		TypedQuery<HL7InArchive> q = sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InArchive order by hl7InArchiveId",
+						HL7InArchive.class);
+
 		if (maxResults != null) {
 			q.setMaxResults(maxResults);
 		}
 		return q.getResultList();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#deleteHL7InArchive(org.openmrs.hl7.HL7InArchive)
 	 */
 	@Override
 	public void deleteHL7InArchive(HL7InArchive hl7InArchive) throws DAOException {
-		sessionFactory.getCurrentSession().delete(hl7InArchive);
+		sessionFactory.getCurrentSession().remove(hl7InArchive);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#saveHL7InError(HL7InError)
 	 */
 	@Override
 	public HL7InError saveHL7InError(HL7InError hl7InError) throws DAOException {
-		sessionFactory.getCurrentSession().save(hl7InError);
+		sessionFactory.getCurrentSession().persist(hl7InError);
 		return hl7InError;
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InError(Integer)
 	 */
@@ -329,29 +344,32 @@ public class HibernateHL7DAO implements HL7DAO {
 	public HL7InError getHL7InError(Integer hl7InErrorId) throws DAOException {
 		return sessionFactory.getCurrentSession().get(HL7InError.class, hl7InErrorId);
 	}
-	
+
 	@Override
 	public HL7InError getHL7InErrorByUuid(String uuid) throws DAOException {
 		return HibernateUtil.getUniqueEntityByUUID(sessionFactory, HL7InError.class, uuid);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getAllHL7InErrors()
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public List<HL7InError> getAllHL7InErrors() throws DAOException {
-		return sessionFactory.getCurrentSession().createQuery("from HL7InError order by hl7InErrorId").list();
+		return sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InError order by hl7InErrorId",
+						HL7InError.class)
+				.getResultList();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#deleteHL7InError(HL7InError)
 	 */
 	@Override
 	public void deleteHL7InError(HL7InError hl7InError) throws DAOException {
-		sessionFactory.getCurrentSession().delete(hl7InError);
+		sessionFactory.getCurrentSession().remove(hl7InError);
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#garbageCollect()
 	 */
@@ -359,21 +377,25 @@ public class HibernateHL7DAO implements HL7DAO {
 	public void garbageCollect() {
 		Context.clearSession();
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InArchiveByUuid(java.lang.String)
 	 */
 	@Override
 	public HL7InArchive getHL7InArchiveByUuid(String uuid) throws DAOException {
-		Query query = sessionFactory.getCurrentSession().createQuery("from HL7InArchive where uuid = ?1").setParameter(1,
-		    uuid, StandardBasicTypes.STRING);
+		TypedQuery<HL7InArchive> query = sessionFactory.getCurrentSession()
+				.createQuery(
+						"from HL7InArchive where uuid = :uuid",
+						HL7InArchive.class)
+				.setParameter("uuid", uuid);
+
 		Object record = JpaUtils.getSingleResultOrNull(query);
 		if (record == null) {
 			return null;
 		}
 		return (HL7InArchive) record;
 	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.db.HL7DAO#getHL7InArchivesToMigrate()
 	 */
@@ -385,7 +407,8 @@ public class HibernateHL7DAO implements HL7DAO {
 		CriteriaQuery<HL7InArchive> cq = cb.createQuery(HL7InArchive.class);
 		Root<HL7InArchive> root = cq.from(HL7InArchive.class);
 
-		List<Predicate> predicates = getHL7SearchCriteria(cb, root, HL7InArchive.class, HL7Constants.HL7_STATUS_PROCESSED, null);
+		List<Predicate> predicates = getHL7SearchCriteria(cb, root, HL7InArchive.class,
+				HL7Constants.HL7_STATUS_PROCESSED, null);
 
 		if (daysToKeep != null) {
 			Calendar cal = Calendar.getInstance();
@@ -393,10 +416,10 @@ public class HibernateHL7DAO implements HL7DAO {
 			predicates.add(cb.lessThan(root.get("dateCreated"), cal.getTime()));
 		}
 
-		cq.where(predicates.toArray(new Predicate[]{}));
+		cq.where(predicates.toArray(new Predicate[] {}));
 		return session.createQuery(cq)
-			.setMaxResults(HL7Constants.MIGRATION_MAX_BATCH_SIZE)
-			.getResultList();
+				.setMaxResults(HL7Constants.MIGRATION_MAX_BATCH_SIZE)
+				.getResultList();
 	}
-	
+
 }

--- a/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
+++ b/api/src/main/java/org/openmrs/hl7/db/hibernate/HibernateHL7DAO.java
@@ -47,6 +47,7 @@ import org.springframework.stereotype.Repository;
 public class HibernateHL7DAO implements HL7DAO {
 
 	private final SessionFactory sessionFactory;
+	private static final String PARAM_STATE = "state";
 
 	@Autowired
 	public HibernateHL7DAO(SessionFactory sessionFactory) {
@@ -132,7 +133,7 @@ public class HibernateHL7DAO implements HL7DAO {
 				.createQuery(
 						"from HL7InQueue where messageState = :state order by hl7InQueueId",
 						HL7InQueue.class)
-				.setParameter("state", HL7Constants.HL7_STATUS_PENDING)
+				.setParameter(PARAM_STATE, HL7Constants.HL7_STATUS_PENDING)
 				.getResultList();
 
 	}
@@ -224,7 +225,7 @@ public class HibernateHL7DAO implements HL7DAO {
 				.createQuery(
 						"from HL7InQueue hiq where hiq.messageState = :state order by hiq.hl7InQueueId",
 						HL7InQueue.class)
-				.setParameter("state", HL7Constants.HL7_STATUS_PENDING)
+				.setParameter(PARAM_STATE, HL7Constants.HL7_STATUS_PENDING)
 				.setMaxResults(1);
 
 		if (query == null) {
@@ -274,7 +275,7 @@ public class HibernateHL7DAO implements HL7DAO {
 				.createQuery(
 						"from HL7InArchive where messageState = :state",
 						HL7InArchive.class)
-				.setParameter("state", state);
+				.setParameter(PARAM_STATE, state);
 
 		if (maxResults != null) {
 			q.setMaxResults(maxResults);
@@ -291,7 +292,7 @@ public class HibernateHL7DAO implements HL7DAO {
 				.createQuery(
 						"from HL7InQueue where messageState = :state",
 						HL7InQueue.class)
-				.setParameter("state", state)
+				.setParameter(PARAM_STATE, state)
 				.getResultList();
 
 	}


### PR DESCRIPTION
This PR refactors HibernateHL7DAO to be compatible with Hibernate 6 and Jakarta Persistence.

Changes include:
- Migrated legacy Hibernate APIs to typed JPA queries
- Removed positional parameters and deprecated list() usage
- Improved type safety in Criteria-based queries
- Updated DAO interface generics accordingly

No functional behavior changes intended.
