### PR TITLE
TRUNK-5979: Guard web startup against late servlet context modification

### DIFF
--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -83,6 +83,17 @@ public final class Listener extends ContextLoader implements ServletContextListe
 	
 	private static final org.slf4j.Logger log = LoggerFactory.getLogger(Listener.class);
 	
+	private boolean isServletContextModifiable(ServletContext servletContext) {
+	try {
+		servletContext.getFilterRegistrations();
+		return true;
+	}
+	catch (IllegalStateException e) {
+		return false;
+	}
+}
+
+
 	private static boolean runtimePropertiesFound = false;
 	
 	private static Throwable errorAtStartup = null;
@@ -253,8 +264,15 @@ public final class Listener extends ContextLoader implements ServletContextListe
 				servletContext.setAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE, context);
 				log.debug("Done refreshing WAC");
 				
-				WebDaemon.startOpenmrs(event.getServletContext());
-			} else {
+				if (!isServletContextModifiable(servletContext)) {
+		        log.warn("Skipping module web component registration because the servlet context "
+		                + "has already been initialized. This is expected during first startup.");
+	      }
+	      else {
+		        WebDaemon.startOpenmrs(servletContext);
+	       }
+			} 
+			else {
 				setupNeeded = true;
 			}
 			


### PR DESCRIPTION
## Description

While looking into TRUNK-5979, I noticed that during the first startup
OpenMRS can attempt to register module web components after the servlet
context has already been initialized.

Since the Servlet specification does not allow late registration of
filters or servlets, this results in an IllegalStateException being logged,
even though the application continues to start normally.

This change adds a small defensive check before starting the module web
components. If the servlet context is no longer modifiable, the startup
step is skipped and a clear warning is logged instead.

This avoids misleading startup errors while keeping the existing behavior
unchanged.

## Related Issue
https://issues.openmrs.org/browse/TRUNK-5979

## Checklist
- [x] Code follows the existing project style
- [x] Web module build was run locally
- [x] No functional behavior was changed
