### PR TITLE
TRUNK-6519: Fix NPE when validating Role with null name

### DIFF
--- a/api/src/main/java/org/openmrs/validator/RoleValidator.java
+++ b/api/src/main/java/org/openmrs/validator/RoleValidator.java
@@ -40,12 +40,9 @@ public class RoleValidator implements Validator {
 	 *      org.springframework.validation.Errors)
 	 *      <strong>Should</strong> fail validation if role is null
 	 *      <strong>Should</strong> fail validation if role is empty or whitespace
-	 *      <strong>Should</strong> pass validation if description is null or empty
-	 *      or whitespace
-	 *      <strong>Should</strong> fail validation if role has leading or trailing
-	 *      space
-	 *      <strong>Should</strong> pass validation if all required fields have
-	 *      proper values
+	 *      <strong>Should</strong> pass validation if description is null or empty or whitespace
+	 *      <strong>Should</strong> fail validation if role has leading or trailing space
+	 *      <strong>Should</strong> pass validation if all required fields have proper values
 	 *      <strong>Should</strong> pass validation if field lengths are correct
 	 *      <strong>Should</strong> fail validation if field lengths are not correct
 	 */

--- a/api/src/main/java/org/openmrs/validator/RoleValidator.java
+++ b/api/src/main/java/org/openmrs/validator/RoleValidator.java
@@ -22,7 +22,7 @@ import org.springframework.validation.Validator;
  */
 @Handler(supports = { Role.class }, order = 50)
 public class RoleValidator implements Validator {
-	
+
 	/**
 	 * Determines if the command object being submitted is a valid type
 	 * 
@@ -32,19 +32,22 @@ public class RoleValidator implements Validator {
 	public boolean supports(Class<?> c) {
 		return c.equals(Role.class);
 	}
-	
+
 	/**
 	 * Checks the form object for any inconsistencies/errors
 	 * 
 	 * @see org.springframework.validation.Validator#validate(java.lang.Object,
 	 *      org.springframework.validation.Errors)
-	 * <strong>Should</strong> throw NullPointerException if role is null
-	 * <strong>Should</strong> fail validation if role is empty or whitespace
-	 * <strong>Should</strong> pass validation if description is null or empty or whitespace
-	 * <strong>Should</strong> fail validation if role has leading or trailing space
-	 * <strong>Should</strong> pass validation if all required fields have proper values
-	 * <strong>Should</strong> pass validation if field lengths are correct
-	 * <strong>Should</strong> fail validation if field lengths are not correct
+	 *      <strong>Should</strong> fail validation if role is null
+	 *      <strong>Should</strong> fail validation if role is empty or whitespace
+	 *      <strong>Should</strong> pass validation if description is null or empty
+	 *      or whitespace
+	 *      <strong>Should</strong> fail validation if role has leading or trailing
+	 *      space
+	 *      <strong>Should</strong> pass validation if all required fields have
+	 *      proper values
+	 *      <strong>Should</strong> pass validation if field lengths are correct
+	 *      <strong>Should</strong> fail validation if field lengths are not correct
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) {
@@ -53,9 +56,9 @@ public class RoleValidator implements Validator {
 			errors.rejectValue("role", "error.general");
 		} else {
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "role", "error.role");
-			
+
 			// reject any role that has a leading or trailing space
-			if (!role.getRole().equals(role.getRole().trim())) {
+			if (role.getRole() != null && !role.getRole().equals(role.getRole().trim())) {
 				errors.rejectValue("role", "error.trailingSpaces");
 			}
 		}
@@ -65,5 +68,5 @@ public class RoleValidator implements Validator {
 			ValidateUtil.validateFieldLengths(errors, obj.getClass(), "role", "description");
 		}
 	}
-	
+
 }

--- a/api/src/main/java/org/openmrs/validator/RoleValidator.java
+++ b/api/src/main/java/org/openmrs/validator/RoleValidator.java
@@ -55,7 +55,8 @@ public class RoleValidator implements Validator {
 			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "role", "error.role");
 
 			// reject any role that has a leading or trailing space
-			if (role.getRole() != null && !role.getRole().equals(role.getRole().trim())) {
+			String roleName = role.getRole();
+			if (roleName != null && !roleName.equals(roleName.trim())) {
 				errors.rejectValue("role", "error.trailingSpaces");
 			}
 		}

--- a/api/src/test/java/org/openmrs/validator/RoleValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/RoleValidatorTest.java
@@ -23,7 +23,7 @@ import org.springframework.validation.Errors;
  * Tests methods on the {@link RoleValidator} class.
  */
 public class RoleValidatorTest extends BaseContextSensitiveTest {
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -32,22 +32,21 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 		Role role = new Role();
 		role.setRole(null);
 		role.setDescription("some text");
-		//TODO: change/fix this test when it is decided whether to change the validator behavior to avoid throwing an NPE
 		Errors errors = new BindException(role, "type");
-		//new RoleValidator().validate(role, errors);
-		//Assert.assertTrue(errors.hasFieldErrors("role"));
-		
+		new RoleValidator().validate(role, errors);
+		assertTrue(errors.hasFieldErrors("role"));
+
 		role.setRole("");
 		errors = new BindException(role, "role");
 		new RoleValidator().validate(role, errors);
 		assertTrue(errors.hasFieldErrors("role"));
-		
+
 		role.setRole(" ");
 		errors = new BindException(role, "role");
 		new RoleValidator().validate(role, errors);
 		assertTrue(errors.hasFieldErrors("role"));
 	}
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -56,22 +55,22 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 		Role role = new Role();
 		role.setRole("Bowling race car driver");
 		role.setDescription(null);
-		
+
 		Errors errors = new BindException(role, "type");
 		new RoleValidator().validate(role, errors);
 		assertFalse(errors.hasFieldErrors("description"));
-		
+
 		role.setDescription("");
 		errors = new BindException(role, "role");
 		new RoleValidator().validate(role, errors);
 		assertFalse(errors.hasFieldErrors("description"));
-		
+
 		role.setDescription(" ");
 		errors = new BindException(role, "role");
 		new RoleValidator().validate(role, errors);
 		assertFalse(errors.hasFieldErrors("description"));
 	}
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -80,19 +79,19 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 		Role role = new Role();
 		role.setDescription("some text");
 		role.setRole(" Bowling race car driver");
-		
+
 		Errors errors = new BindException(role, "type");
 		new RoleValidator().validate(role, errors);
 		assertTrue(errors.hasFieldErrors("role"));
 		assertEquals("error.trailingSpaces", errors.getFieldError("role").getCode());
-		
+
 		role.setRole("Bowling race car driver ");
 		errors = new BindException(role, "role");
 		new RoleValidator().validate(role, errors);
 		assertTrue(errors.hasFieldErrors("role"));
 		assertEquals("error.trailingSpaces", errors.getFieldError("role").getCode());
 	}
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -101,13 +100,13 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 		Role role = new Role();
 		role.setRole("Bowling race car driver");
 		role.setDescription("You don't bowl or race fast cars");
-		
+
 		Errors errors = new BindException(role, "type");
 		new RoleValidator().validate(role, errors);
-		
+
 		assertFalse(errors.hasErrors());
 	}
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -116,13 +115,13 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 		Role role = new Role();
 		role.setRole("Bowling race car driver");
 		role.setDescription("description");
-		
+
 		Errors errors = new BindException(role, "type");
 		new RoleValidator().validate(role, errors);
-		
+
 		assertFalse(errors.hasErrors());
 	}
-	
+
 	/**
 	 * @see RoleValidator#validate(Object,Errors)
 	 */
@@ -130,13 +129,15 @@ public class RoleValidatorTest extends BaseContextSensitiveTest {
 	public void validate_shouldFailValidationIfFieldLengthsAreNotCorrect() {
 		Role role = new Role();
 		role
-		        .setRole("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
+				.setRole(
+						"too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
 		role
-		        .setDescription("too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
-		
+				.setDescription(
+						"too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text too long text");
+
 		Errors errors = new BindException(role, "type");
 		new RoleValidator().validate(role, errors);
-		
+
 		assertTrue(errors.hasFieldErrors("role"));
 	}
 }


### PR DESCRIPTION
## Summary
Fixes a NullPointerException in RoleValidator.validate() when validating a Role with a null role name.

## Changes
- Added null check before trailing-space validation
- Enabled the previously commented unit test
- Updated Javadoc to reflect expected validation behavior

## Testing
- Ran RoleValidatorTest
