### PR TITLE
[TRUNK-6521] Add contract verification test for PersonService.getPersonByUuid

### DIFF
--- a/api/src/test/java/org/openmrs/api/PersonServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PersonServiceTest.java
@@ -2459,10 +2459,15 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void getPersonByUuid_shouldReturnNullIfNoPersonFoundWithUuid() {
-	
+
+		Person p = new Person();
+   	    p.setGender("M");
+    	p.addName(new PersonName("Test", "User", "Person"));
+    	personService.savePerson(p);
+		
+		assertNotNull("Should find existing person", personService.getPersonByUuid(p.getUuid()));
 		String nonExistentUuid = "random-uuid-that-does-not-exist";
-		Person person = personService.getPersonByUuid(nonExistentUuid);
-		assertNull(person);
+    	assertNull("Should return null for non-existent UUID", personService.getPersonByUuid(nonExistentUuid));
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/api/PersonServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PersonServiceTest.java
@@ -2451,5 +2451,18 @@ public class PersonServiceTest extends BaseContextSensitiveTest {
 		
 	    assertNotNull(personService.getPersonAddressByUuid("y403fafk-e5k4-42d0-9d11-4f52e89d123r"));
 	}
+
+
+	/**
+	 * @see PersonService#getPersonByUuid(String) 
+	 */
+
+	@Test
+	public void getPersonByUuid_shouldReturnNullIfNoPersonFoundWithUuid() {
+	
+		String nonExistentUuid = "random-uuid-that-does-not-exist";
+		Person person = personService.getPersonByUuid(nonExistentUuid);
+		assertNull(person);
+	}
 	
 }


### PR DESCRIPTION
### JIRA Ticket
https://issues.openmrs.org/browse/TRUNK-6521

### Description
**The Issue:**
The `PersonService` contract implies that querying `getPersonByUuid` with a non-existent UUID should return `null`. However, `PersonServiceTest` currently lacks a test case to enforce this "sad path" behavior.

**Risk:**
Without this coverage, a future regression could cause the service to throw an unhandled exception (e.g., `ObjectNotFoundException`) instead of returning `null`, potentially breaking downstream modules that expect a null check.

**My Solution:**
* Added `getPersonByUuid_shouldReturnNullIfNoPersonFoundWithUuid` to `PersonServiceTest.java`.
* Verifies that the API handles invalid UUIDs gracefully by returning `null` rather than crashing.

### Dev Checklist
- [x] Added unit tests for new functionality
- [x] Ran `mvn test -Dtest=PersonServiceTest` (147 tests passed)