### PR TITLE
TEST: Migrate DrugOrderValidatorTest to JUnit 5

### DIFF
--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -12,19 +12,13 @@ package org.openmrs.validator;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isIn;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
-import org.openmrs.CareSetting;
 import org.openmrs.Concept;
 import org.openmrs.CustomDosingInstructions;
 import org.openmrs.Drug;


### PR DESCRIPTION
## Description of what changed

Migrated `DrugOrderValidatorTest` from JUnit 4 to JUnit 5.

This includes:
- Updating lifecycle annotations to JUnit Jupiter
- Migrating assertions to `org.junit.jupiter.api.Assertions`
- Cleaning up legacy JUnit 4 imports

No production code was modified.

## Issue worked on

N/A (test refactor / maintenance improvement)

## Checklist

- [x] My IDE is configured to follow the OpenMRS Java code style
- [x] I have added or updated tests to cover my changes
- [x] I ran the relevant tests locally before submitting this pull request
