### PR TITLE
TRUNK-6529: Ensure patient has all required identifiers

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -10,10 +10,15 @@
 package org.openmrs.validator;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
 import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,7 +62,14 @@ public class PatientValidator extends PersonValidator {
 	 * voided patients<br/>
 	 * <strong>Should</strong> not fail when patient has only one identifier and its not preferred<br/>
 	 * <strong>Should</strong> pass validation if field lengths are correct<br/>
-	 * <strong>Should</strong> fail validation if field lengths are not correct
+	 * <strong>Should</strong> fail validation if field lengths are not correct<br/>
+	 * <strong>Should</strong> fail validation if a required patient identifier is missing<br/>
+	 * <strong>Should</strong> pass validation if a required patient identifier is present<br/>
+	 * <strong>Should</strong> fail validation if the only identifier for a required type is voided<br/>
+	 * <strong>Should</strong> pass validation if a voided required identifier is replaced by an active
+	 * one<br/>
+	 * <strong>Should</strong> ignore retired identifier types when checking required identifiers<br/>
+	 * <strong>Should</strong> not fail validation for voided patients missing required identifiers
 	 *
 	 * @param obj The patient to validate.
 	 * @param errors Errors
@@ -78,30 +90,71 @@ public class PatientValidator extends PersonValidator {
 
 		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "gender", "Person.gender.required");
 
-		// Make sure they chose a preferred ID
-		Boolean preferredIdentifierChosen = false;
-		//Voided patients have only voided identifiers since they were voided with the patient,
-		//so get all otherwise get the active ones
-		Collection<PatientIdentifier> identifiers = patient.getVoided() ? patient.getIdentifiers()
+		validatePreferredIdentifier(patient, errors);
+
+		if (!Boolean.TRUE.equals(patient.getVoided())) {
+			validateRequiredIdentifiers(patient, errors);
+		}
+
+		validatePatientIdentifiers(patient, errors);
+
+		ValidateUtil.validateFieldLengths(errors, obj.getClass(), "voidReason");
+	}
+
+	private void validatePreferredIdentifier(Patient patient, Errors errors) {
+		boolean preferredIdentifierChosen = false;
+
+		Collection<PatientIdentifier> identifiers = Boolean.TRUE.equals(patient.getVoided()) ? patient.getIdentifiers()
 		        : patient.getActiveIdentifiers();
+
 		for (PatientIdentifier pi : identifiers) {
-			if (pi.getPreferred()) {
+			if (Boolean.TRUE.equals(pi.getPreferred())) {
 				preferredIdentifierChosen = true;
 			}
 		}
+
 		if (!preferredIdentifierChosen && identifiers.size() != 1) {
 			errors.reject("error.preferredIdentifier");
 		}
-		int index = 0;
-		if (!errors.hasErrors() && patient.getIdentifiers() != null) {
-			// Validate PatientIdentifers
-			for (PatientIdentifier identifier : patient.getIdentifiers()) {
-				errors.pushNestedPath("identifiers[" + index + "]");
-				patientIdentifierValidator.validate(identifier, errors);
-				errors.popNestedPath();
-				index++;
+	}
+
+	private void validateRequiredIdentifiers(Patient patient, Errors errors) {
+		Collection<PatientIdentifierType> identifierTypes = Context.getPatientService().getAllPatientIdentifierTypes(false);
+
+		Set<PatientIdentifierType> requiredTypes = new HashSet<>();
+
+		for (PatientIdentifierType type : identifierTypes) {
+			if (Boolean.TRUE.equals(type.getRequired())) {
+				requiredTypes.add(type);
 			}
 		}
-		ValidateUtil.validateFieldLengths(errors, obj.getClass(), "voidReason");
+
+		for (PatientIdentifier pi : patient.getActiveIdentifiers()) {
+			if (pi.getIdentifierType() != null) {
+				requiredTypes.remove(pi.getIdentifierType());
+			}
+		}
+
+		if (!requiredTypes.isEmpty()) {
+			List<String> missingRequiredIdentifiers = requiredTypes.stream().map(PatientIdentifierType::getName).toList();
+
+			errors.rejectValue("identifiers", "Patient.missingRequiredIdentifier",
+			    new Object[] { String.join(", ", missingRequiredIdentifiers) }, null);
+		}
+	}
+
+	private void validatePatientIdentifiers(Patient patient, Errors errors) {
+		if (errors.hasErrors() || patient.getIdentifiers() == null) {
+			return;
+		}
+
+		int index = 0;
+
+		for (PatientIdentifier identifier : patient.getIdentifiers()) {
+			errors.pushNestedPath("identifiers[" + index + "]");
+			patientIdentifierValidator.validate(identifier, errors);
+			errors.popNestedPath();
+			index++;
+		}
 	}
 }

--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -18,7 +18,7 @@ import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.annotation.Handler;
-import org.openmrs.api.context.Context;
+import org.openmrs.api.PatientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,8 +33,15 @@ public class PatientValidator extends PersonValidator {
 
 	private static final Logger log = LoggerFactory.getLogger(PersonNameValidator.class);
 
+	private final PatientIdentifierValidator patientIdentifierValidator;
+
+	private final PatientService patientService;
+
 	@Autowired
-	private PatientIdentifierValidator patientIdentifierValidator;
+	public PatientValidator(PatientIdentifierValidator patientIdentifierValidator, PatientService patientService) {
+		this.patientIdentifierValidator = patientIdentifierValidator;
+		this.patientService = patientService;
+	}
 
 	/**
 	 * Returns whether or not this validator supports validating a given class.
@@ -90,54 +97,43 @@ public class PatientValidator extends PersonValidator {
 
 		ValidationUtils.rejectIfEmptyOrWhitespace(errors, "gender", "Person.gender.required");
 
-		validatePreferredIdentifier(patient, errors);
-
-		if (!Boolean.TRUE.equals(patient.getVoided())) {
-			validateRequiredIdentifiers(patient, errors);
-		}
+		validatePreferredAndRequiredIdentifiers(patient, errors);
 
 		validatePatientIdentifiers(patient, errors);
 
 		ValidateUtil.validateFieldLengths(errors, obj.getClass(), "voidReason");
 	}
 
-	private void validatePreferredIdentifier(Patient patient, Errors errors) {
-		boolean preferredIdentifierChosen = false;
-
-		Collection<PatientIdentifier> identifiers = Boolean.TRUE.equals(patient.getVoided()) ? patient.getIdentifiers()
+	private void validatePreferredAndRequiredIdentifiers(Patient patient, Errors errors) {
+		boolean isVoidedPatient = Boolean.TRUE.equals(patient.getVoided());
+		Collection<PatientIdentifier> identifiers = isVoidedPatient ? patient.getIdentifiers()
 		        : patient.getActiveIdentifiers();
 
+		Set<PatientIdentifierType> requiredTypes = new HashSet<>();
+		if (!isVoidedPatient) {
+			for (PatientIdentifierType type : patientService.getAllPatientIdentifierTypes(false)) {
+				if (Boolean.TRUE.equals(type.getRequired())) {
+					requiredTypes.add(type);
+				}
+			}
+		}
+
+		boolean preferredIdentifierChosen = false;
 		for (PatientIdentifier pi : identifiers) {
 			if (Boolean.TRUE.equals(pi.getPreferred())) {
 				preferredIdentifierChosen = true;
+			}
+			if (pi.getIdentifierType() != null) {
+				requiredTypes.remove(pi.getIdentifierType());
 			}
 		}
 
 		if (!preferredIdentifierChosen && identifiers.size() != 1) {
 			errors.reject("error.preferredIdentifier");
 		}
-	}
-
-	private void validateRequiredIdentifiers(Patient patient, Errors errors) {
-		Collection<PatientIdentifierType> identifierTypes = Context.getPatientService().getAllPatientIdentifierTypes(false);
-
-		Set<PatientIdentifierType> requiredTypes = new HashSet<>();
-
-		for (PatientIdentifierType type : identifierTypes) {
-			if (Boolean.TRUE.equals(type.getRequired())) {
-				requiredTypes.add(type);
-			}
-		}
-
-		for (PatientIdentifier pi : patient.getActiveIdentifiers()) {
-			if (pi.getIdentifierType() != null) {
-				requiredTypes.remove(pi.getIdentifierType());
-			}
-		}
 
 		if (!requiredTypes.isEmpty()) {
 			List<String> missingRequiredIdentifiers = requiredTypes.stream().map(PatientIdentifierType::getName).toList();
-
 			errors.rejectValue("identifiers", "Patient.missingRequiredIdentifier",
 			    new Object[] { String.join(", ", missingRequiredIdentifiers) }, null);
 		}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1629,6 +1629,7 @@ Patient.patientCareExitDate=Exit Date
 Patient.patientCareExitReason=Exit Reason
 patient.birthdate=Birthdate
 patient.deathDate=Deathdate
+Patient.missingRequiredIdentifier=Missing required patient identifier: {0}
 
 error.names.length=Must have 1 or more names defined
 error.addresses.length=Must have 1 or more addresses defined

--- a/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.validator;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -194,5 +196,263 @@ public class PatientValidatorTest extends PersonValidatorTest {
 		validator.validate(patient, errors);
 
 		assertTrue(errors.hasFieldErrors("voidReason"));
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldFailIfRequiredIdentifierIsMissing() {
+		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+		patientIdentifierType.setRequired(true);
+		patientIdentifierType.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(patientIdentifierType);
+
+		Patient patient = new Patient();
+
+		PersonName pName = new PersonName();
+		pName.setGivenName("Tom");
+		pName.setMiddleName("E.");
+		pName.setFamilyName("Patient");
+		patient.addName(pName);
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PersonAddress pAddress = new PersonAddress();
+		pAddress.setAddress1("123 My street");
+		pAddress.setAddress2("Apt 402");
+		pAddress.setCityVillage("Anywhere city");
+		pAddress.setCountry("Some Country");
+		patient.addAddress(pAddress);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertTrue(errors.hasFieldErrors("identifiers"));
+		assertEquals("Patient.missingRequiredIdentifier", errors.getFieldError("identifiers").getCode());
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldPassIfRequiredIdentifierIsPresent() {
+		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+		patientIdentifierType.setRequired(true);
+		patientIdentifierType.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(patientIdentifierType);
+
+		Patient patient = new Patient();
+
+		PersonName pName = new PersonName();
+		pName.setGivenName("Tom");
+		pName.setMiddleName("E.");
+		pName.setFamilyName("Patient");
+		patient.addName(pName);
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PersonAddress pAddress = new PersonAddress();
+		pAddress.setAddress1("123 My street");
+		pAddress.setAddress2("Apt 402");
+		pAddress.setCityVillage("Anywhere city");
+		pAddress.setCountry("Some Country");
+		patient.addAddress(pAddress);
+
+		PatientIdentifier patientIdentifier = new PatientIdentifier();
+		patientIdentifier.setLocation(new Location(1));
+		patientIdentifier.setIdentifier("012345678");
+		patientIdentifier.setDateCreated(new Date());
+		patientIdentifier.setIdentifierType(patientIdentifierType);
+		patientIdentifier.setPreferred(true);
+		patient.addIdentifier(patientIdentifier);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldIgnoreRetiredRequiredIdentifierTypes() {
+		for (PatientIdentifierType pit : Context.getPatientService().getAllPatientIdentifierTypes(false)) {
+			pit.setRequired(false);
+			pit.setRetired(false);
+			Context.getPatientService().savePatientIdentifierType(pit);
+		}
+
+		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+		patientIdentifierType.setRequired(true);
+		patientIdentifierType.setRetired(true);
+		Context.getPatientService().savePatientIdentifierType(patientIdentifierType);
+
+		Patient patient = new Patient();
+
+		PersonName pName = new PersonName();
+		pName.setGivenName("Tom");
+		pName.setMiddleName("E.");
+		pName.setFamilyName("Patient");
+		patient.addName(pName);
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PersonAddress pAddress = new PersonAddress();
+		pAddress.setAddress1("123 My street");
+		pAddress.setAddress2("Apt 402");
+		pAddress.setCityVillage("Anywhere city");
+		pAddress.setCountry("Some Country");
+		patient.addAddress(pAddress);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertFalse(errors.hasFieldErrors("identifiers"));
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldFailIfRequiredIdentifierIsVoided() {
+		PatientIdentifierType patientIdentifierType = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+		patientIdentifierType.setRequired(true);
+		patientIdentifierType.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(patientIdentifierType);
+
+		Patient patient = new Patient();
+
+		PersonName pName = new PersonName();
+		pName.setGivenName("Tom");
+		pName.setMiddleName("E.");
+		pName.setFamilyName("Patient");
+		patient.addName(pName);
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PersonAddress pAddress = new PersonAddress();
+		pAddress.setAddress1("123 My street");
+		pAddress.setAddress2("Apt 402");
+		pAddress.setCityVillage("Anywhere city");
+		pAddress.setCountry("Some Country");
+		patient.addAddress(pAddress);
+
+		PatientIdentifier patientIdentifier = new PatientIdentifier();
+		patientIdentifier.setLocation(new Location(1));
+		patientIdentifier.setIdentifier("012345678");
+		patientIdentifier.setDateCreated(new Date());
+		patientIdentifier.setIdentifierType(patientIdentifierType);
+		patientIdentifier.setVoided(true);
+		patient.addIdentifier(patientIdentifier);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertTrue(errors.hasFieldErrors("identifiers"));
+		assertEquals("Patient.missingRequiredIdentifier", errors.getFieldError("identifiers").getCode());
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldPassWithRequiredAndNonRequiredIdentifiers() {
+
+		List<PatientIdentifierType> types = Context.getPatientService().getAllPatientIdentifierTypes(false);
+
+		PatientIdentifierType requiredType = types.get(0);
+		requiredType.setRequired(true);
+		requiredType.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(requiredType);
+
+		PatientIdentifierType optionalType = types.get(1);
+		optionalType.setRequired(false);
+		optionalType.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(optionalType);
+
+		Patient patient = new Patient();
+		patient.addName(new PersonName("Tom", "", "Patient"));
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PatientIdentifier requiredIdentifier = new PatientIdentifier();
+		requiredIdentifier.setIdentifier("REQ123");
+		requiredIdentifier.setIdentifierType(requiredType);
+		requiredIdentifier.setLocation(new Location(1));
+		patient.addIdentifier(requiredIdentifier);
+
+		PatientIdentifier optionalIdentifier = new PatientIdentifier();
+		optionalIdentifier.setIdentifier("OPT456");
+		optionalIdentifier.setIdentifierType(optionalType);
+		optionalIdentifier.setLocation(new Location(1));
+		patient.addIdentifier(optionalIdentifier);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertFalse(errors.hasFieldErrors("identifiers"));
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldPassIfVoidedRequiredIdentifierReplaced() {
+
+		PatientIdentifierType type = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+
+		type.setRequired(true);
+		type.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(type);
+
+		Patient patient = new Patient();
+		patient.addName(new PersonName("Tom", "", "Patient"));
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		PatientIdentifier oldIdentifier = new PatientIdentifier();
+		oldIdentifier.setIdentifier("OLD123");
+		oldIdentifier.setIdentifierType(type);
+		oldIdentifier.setLocation(new Location(1));
+		oldIdentifier.setVoided(true);
+		patient.addIdentifier(oldIdentifier);
+
+		PatientIdentifier newIdentifier = new PatientIdentifier();
+		newIdentifier.setIdentifier("NEW456");
+		newIdentifier.setIdentifierType(type);
+		newIdentifier.setLocation(new Location(1));
+		patient.addIdentifier(newIdentifier);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertFalse(errors.hasFieldErrors("identifiers"));
+	}
+
+	/**
+	 * @see PatientValidator#validate(Object,Errors)
+	 */
+
+	@Test
+	public void validate_shouldNotFailForVoidedPatientWithoutRequiredIdentifier() {
+
+		PatientIdentifierType type = Context.getPatientService().getAllPatientIdentifierTypes(false).get(0);
+
+		type.setRequired(true);
+		type.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(type);
+
+		Patient patient = new Patient();
+		patient.setVoided(true);
+		patient.addName(new PersonName("Tom", "", "Patient"));
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertFalse(errors.hasFieldErrors("identifiers"));
 	}
 }

--- a/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PatientValidatorTest.java
@@ -274,6 +274,43 @@ public class PatientValidatorTest extends PersonValidatorTest {
 	}
 
 	/**
+	 * @see PatientValidator#validate(Object, Errors)
+	 */
+	@Test
+	public void validate_shouldFailIfOnlyOneOfTwoRequiredIdentifiersIsPresent() {
+		List<PatientIdentifierType> types = Context.getPatientService().getAllPatientIdentifierTypes(false);
+
+		PatientIdentifierType requiredType1 = types.get(0);
+		requiredType1.setRequired(true);
+		requiredType1.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(requiredType1);
+
+		PatientIdentifierType requiredType2 = types.get(1);
+		requiredType2.setRequired(true);
+		requiredType2.setRetired(false);
+		Context.getPatientService().savePatientIdentifierType(requiredType2);
+
+		Patient patient = new Patient();
+		patient.addName(new PersonName("Tom", "", "Patient"));
+		patient.setGender("male");
+		patient.setBirthdate(new Date());
+
+		// Only assign identifier for the first required type
+		PatientIdentifier identifier = new PatientIdentifier();
+		identifier.setIdentifier("REQ001");
+		identifier.setIdentifierType(requiredType1);
+		identifier.setLocation(new Location(1));
+		identifier.setPreferred(true);
+		patient.addIdentifier(identifier);
+
+		Errors errors = new BindException(patient, "patient");
+		validator.validate(patient, errors);
+
+		assertTrue(errors.hasFieldErrors("identifiers"));
+		assertEquals("Patient.missingRequiredIdentifier", errors.getFieldError("identifiers").getCode());
+	}
+
+	/**
 	 * @see PatientValidator#validate(Object,Errors)
 	 */
 	@Test
@@ -434,7 +471,6 @@ public class PatientValidatorTest extends PersonValidatorTest {
 	/**
 	 * @see PatientValidator#validate(Object,Errors)
 	 */
-
 	@Test
 	public void validate_shouldNotFailForVoidedPatientWithoutRequiredIdentifier() {
 
@@ -449,6 +485,14 @@ public class PatientValidatorTest extends PersonValidatorTest {
 		patient.addName(new PersonName("Tom", "", "Patient"));
 		patient.setGender("male");
 		patient.setBirthdate(new Date());
+
+		// Patient is voided and has no active identifier for the required type
+		PatientIdentifier voidedIdentifier = new PatientIdentifier();
+		voidedIdentifier.setIdentifier("VOIDED123");
+		voidedIdentifier.setIdentifierType(type);
+		voidedIdentifier.setLocation(new Location(1));
+		voidedIdentifier.setVoided(true);
+		patient.addIdentifier(voidedIdentifier);
 
 		Errors errors = new BindException(patient, "patient");
 		validator.validate(patient, errors);


### PR DESCRIPTION
This PR enhances PatientValidator to ensure that a patient must have identifiers for all required and non-retired PatientIdentifierTypes before validation passes.

Changes included:

 Added validation logic to check that every required, non-retired identifier type has a corresponding non-voided patient identifier.

 Updated and added unit tests to cover the following scenarios:

 Patient missing a required identifier (validation fails)

 Patient with required identifier present (validation passes)

 Required identifier is voided (validation fails)

 Required identifier type is retired (validation ignored)

This change ensures data consistency and aligns patient validation with the configured identifier requirements.All tests pass locally.