### PR TITLE
O3-4616: Add permission check for placing retrospective orders on behalf of another provider

### DIFF
--- a/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
+++ b/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
@@ -287,7 +287,10 @@ public class PrivilegeConstants {
 	
 	@AddOnStartup(description = "Able to add orders")
 	public static final String ADD_ORDERS = "Add Orders";
-	
+
+	@AddOnStartup(description = "Able to place orders on behalf of another provider")
+  public static final String PLACE_ORDERS_ON_BEHALF = "Place Orders on Behalf";
+
 	@AddOnStartup(description = "Able to edit orders")
 	public static final String EDIT_ORDERS = "Edit Orders";
 	

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -4492,4 +4492,26 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 
 	// Test-only subclass
 	public static class MyTestOrder extends TestOrder { }
+
+@Test
+public void saveOrder_shouldThrowExceptionWhenPlacingOrderOnBehalfWithoutPrivilege() {
+
+    Patient patient = patientService.getPatient(2);
+
+    // Use a known provider from test dataset
+    Provider anotherProvider = providerService.getProvider(1);
+    assertNotNull(anotherProvider);
+
+    Order order = new Order();
+    order.setPatient(patient);
+    order.setOrderType(orderService.getOrderType(1));
+    order.setConcept(conceptService.getConcept(88));
+    order.setCareSetting(orderService.getCareSetting(1));
+    order.setOrderer(anotherProvider);
+    order.setDateActivated(new Date());
+
+    OrderContext orderContext = new OrderContext();
+
+    assertThrows(APIException.class, () -> orderService.saveOrder(order, orderContext));
+}
 }


### PR DESCRIPTION
## Description

While working on RDE-related order flows, I noticed that during retrospective order creation, there is currently no explicit permission check when an order is placed on behalf of another provider.

This PR adds a small but important authorization check to handle that case more safely.

### What this PR changes
- Introduces a new privilege: `PLACE_ORDERS_ON_BEHALF`
- Adds a backend check in `OrderServiceImpl` during retrospective order saving
- If the authenticated provider is different from the orderer, the user must have this privilege
- An `APIException` is thrown if the privilege is missing

The existing behavior remains unchanged for normal (non-retrospective) order flows.

### Why this is needed
In real-world RDE workflows, retrospective data entry is often done by data entry staff, not clinicians.  
Without an explicit privilege check, any authenticated user could place orders on behalf of another provider, which does not feel safe or intentional.

This change makes that behavior explicit and configurable through roles and privileges.

---

## Issue
- https://issues.openmrs.org/browse/O3-4616

---

## Notes
This PR focuses only on backend enforcement. A follow-up frontend PR can handle hiding or disabling RDE-related UI elements based on the same privilege.

