### PR TITLE
TRUNK-6543: Add explicit @Deprecated metadata to base API classes

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -108,7 +108,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#getChangedBy()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -118,7 +118,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#setChangedBy(User)
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -128,7 +128,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#getDateChanged()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -138,7 +138,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#setDateChanged(Date)
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}
@@ -148,7 +148,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.Voidable#isVoided()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.0", forRemoval = false)
 	public Boolean isVoided() {
 		return getVoided();
 	}

--- a/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsMetadata.java
@@ -150,7 +150,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @deprecated as of version 2.2
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -160,7 +160,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @deprecated as of version 2.2
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -170,7 +170,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @deprecated as of version 2.2
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -180,7 +180,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @deprecated as of version 2.2
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}
@@ -190,7 +190,7 @@ public abstract class BaseOpenmrsMetadata extends BaseOpenmrsObject implements O
 	 * @see org.openmrs.Retireable#isRetired()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.0", forRemoval = false)
 	public Boolean isRetired() {
 		return getRetired();
 	}

--- a/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
+++ b/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
@@ -36,11 +36,12 @@ public enum ConditionClinicalStatus {
 	/**
 	 * This maps most closely to the "remission" status in FHIR, but we want to be more clear about
 	 * the common OpenMRS use case.
-	 * Remission is where the patient is no longer experiencing the symptoms of the condition, 
+	 * Remission is where the patient is no longer experiencing the symptoms of the condition,
 	 * but there is a risk of the symptoms returning.
-	 * 
+	 *
 	 * @deprecated as of 2.6.0
 	 * */
+	@Deprecated(since = "2.6.0", forRemoval = false)
 	HISTORY_OF,
 	
 	/**


### PR DESCRIPTION
## Summary
This PR adds explicit `@Deprecated` annotations (including `since` and `forRemoval` metadata) to API elements that were already marked as deprecated in Javadoc.

## Changes
- Added `@Deprecated(since = "...", forRemoval = false)` to deprecated methods in:
  - `BaseOpenmrsData`
  - `BaseOpenmrsMetadata`
- Added `@Deprecated` annotation to the `HISTORY_OF` enum constant in `ConditionClinicalStatus`

## Motivation
Some API elements were previously marked as deprecated only in Javadoc without the corresponding `@Deprecated` annotation. This PR aligns documentation with compiler-level deprecation metadata to improve IDE support and developer clarity.

## Impact
- No functional or behavioral changes
- No public API signature changes
- Fully backward-compatible
- Strictly limited to deprecation metadata updates

Fixes: https://openmrs.atlassian.net/browse/TRUNK-6543