### PR TITLE
TRUNK-6543: Add explicit @Deprecated annotation to HISTORY_OF enum co…

### DIFF
--- a/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
+++ b/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
@@ -41,6 +41,8 @@ public enum ConditionClinicalStatus {
 	 * 
 	 * @deprecated as of 2.6.0
 	 * */
+
+	@Deprecated(since = "2.6.0", forRemoval = false)
 	HISTORY_OF,
 	
 	/**


### PR DESCRIPTION
TRUNK-6543: Add explicit @Deprecated annotation to HISTORY_OF enum constant

## Description of what I changed
Added an explicit `@Deprecated(since = "2.6.0", forRemoval = false)` annotation to the `HISTORY_OF` enum constant in `ConditionClinicalStatus`.

The enum constant was previously marked deprecated only via Javadoc. This change aligns Javadoc-based deprecation with compiler-level metadata to improve IDE warnings and API clarity.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6543

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [ ] I have added tests to cover my changes. (Not applicable — this change only adds deprecation metadata and does not modify behavior.)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [ ] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

