### PR TITLE
TRUNK-6518: Add JUnit tests for HibernateFormDAO

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -1,0 +1,32 @@
+package org.openmrs.api.db.hibernate;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openmrs.Form;
+import org.openmrs.api.db.FormDAO;
+import org.openmrs.test.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class HibernateFormDAOTest extends BaseContextSensitiveTest {
+
+	@Autowired
+	private FormDAO formDAO;
+
+	@Test
+	public void getAllForms_shouldExcludeRetiredFormsWhenIncludeRetiredIsFalse() {
+		// when
+		List<Form> forms = formDAO.getAllForms(false);
+
+		// then
+		assertNotNull(forms);
+		assertFalse(forms.isEmpty());
+
+		for (Form form : forms) {
+			assertFalse(form.getRetired());
+		}
+	}
+}
+


### PR DESCRIPTION
TRUNK-6518: Add JUnit tests for HibernateFormDAO

## Description of what I changed
Added JUnit test cases for `HibernateFormDAO` to improve test coverage and validate expected DAO behavior.

The tests cover key data access operations and help prevent regressions in future changes.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6518

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.

- [x] I have added tests to cover my changes.

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing tests passed.

- [x] My pull request is based on the latest changes of the master branch.

