### PR TITLE
TRUNK-6549: Prevent log injection in InitializationFilter

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -209,6 +209,20 @@ public class InitializationFilter extends StartupFilter {
 	}
 
 	/**
+	 * Sanitizes input for logging to prevent log injection attacks. Replaces carriage return and line
+	 * feed characters with underscores.
+	 *
+	 * @param input the string to sanitize for logging
+	 * @return sanitized string safe for logging, or null if input is null
+	 */
+	private static String sanitizeForLog(String input) {
+		if (input == null) {
+			return null;
+		}
+		return input.replaceAll("[\\r\\n]", "_");
+	}
+
+	/**
 	 * Called by {@link #doFilter(ServletRequest, ServletResponse, FilterChain)} on GET requests
 	 *
 	 * @param httpRequest
@@ -474,7 +488,10 @@ public class InitializationFilter extends StartupFilter {
 			checkLocaleAttributes(httpRequest);
 			referenceMap.put(FilterUtil.LOCALE_ATTRIBUTE,
 			    httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE));
-			log.info("Locale stored in session is " + httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE));
+			if (log.isInfoEnabled()) {
+				Object localeAttribute = httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE);
+				log.info("Locale stored in session is {}", sanitizeForLog(String.valueOf(localeAttribute)));
+			}
 
 			httpResponse.setContentType("text/html");
 			// otherwise do step one of the wizard
@@ -969,7 +986,9 @@ public class InitializationFilter extends StartupFilter {
 			// if user has changed locale parameter to new one
 			// or chooses it parameter at first page loading
 			if (storedLocale == null || !storedLocale.equals(localeParameter)) {
-				log.info("Stored locale parameter to session " + localeParameter);
+				if (log.isInfoEnabled()) {
+					log.info("Stored locale parameter to session {}", sanitizeForLog(localeParameter));
+				}
 				httpRequest.getSession().setAttribute(FilterUtil.LOCALE_ATTRIBUTE, localeParameter);
 			}
 			if (rememberLocale) {
@@ -1213,7 +1232,7 @@ public class InitializationFilter extends StartupFilter {
 		} catch (SQLException sqlex) {
 			if (!silent) {
 				// log and add error
-				log.warn("error executing sql: " + sql, sqlex);
+				log.warn("error executing sql: {}", sanitizeForLog(sql), sqlex);
 				errors.put("Error executing sql: " + sql + " - " + sqlex.getMessage(), null);
 			}
 		} catch (InstantiationException | ClassNotFoundException | IllegalAccessException e) {


### PR DESCRIPTION
## Description of what I changed

Fixed a log injection vulnerability (SonarCloud rule `java:S5145`) in `InitializationFilter`. User-controlled values (request parameters and session attributes) were being written directly to logs. Added a private `sanitizeForLog(String input)` helper method that strips CR/LF characters, and wrapped log calls with `isInfoEnabled()` guards to satisfy `java:S2629`.



## Issue I worked on

https://openmrs.atlassian.net/browse/TRUNK-6549



## Checklist: I completed these to help reviewers :)

* [x] IDE is configured to follow the code style of this project
* [x] Added tests to cover the changes (or refactored existing well-tested code)
* [x] Ran `mvn clean package` right before creating the pull request and added all formatting changes
* [x] All new and existing tests passed
* [x] Pull request is based on the latest changes of the master branch
