### PR TITLE
(fix) TRUNK-6576 :  Drug entry form should require the dose to be greater than 0 

### DIFF
--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -154,8 +154,6 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 	private void validatePairedFields(DrugOrder order, Errors errors) {
 		if (order.getDose() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "doseUnits", "DrugOrder.error.doseUnitsRequiredWithDose");
-			if (order.getDose() <= 0) {
-				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
 			if (Double.compare(order.getDose(), 0.0) <= 0) {
 +				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
 +			}

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -156,7 +156,9 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 			ValidationUtils.rejectIfEmpty(errors, "doseUnits", "DrugOrder.error.doseUnitsRequiredWithDose");
 			if (order.getDose() <= 0) {
 				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
-			}
+			if (Double.compare(order.getDose(), 0.0) <= 0) {
++				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
++			}
 		}
 		if (order.getQuantity() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "quantityUnits", "DrugOrder.error.quantityUnitsRequiredWithQuantity");

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -154,6 +154,9 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 	private void validatePairedFields(DrugOrder order, Errors errors) {
 		if (order.getDose() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "doseUnits", "DrugOrder.error.doseUnitsRequiredWithDose");
+			if (order.getDose() <= 0) {
+				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
+			}
 		}
 		if (order.getQuantity() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "quantityUnits", "DrugOrder.error.quantityUnitsRequiredWithQuantity");

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -155,8 +155,8 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 		if (order.getDose() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "doseUnits", "DrugOrder.error.doseUnitsRequiredWithDose");
 			if (Double.compare(order.getDose(), 0.0) <= 0) {
-+				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
-+			}
+				errors.rejectValue("dose", "DrugOrder.error.doseZeroOrLess");
+			}
 		}
 		if (order.getQuantity() != null) {
 			ValidationUtils.rejectIfEmpty(errors, "quantityUnits", "DrugOrder.error.quantityUnitsRequiredWithQuantity");

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1008,6 +1008,7 @@ DrugOrder.error.dosingInstructionsIsNullForDosingTypeFreeText=Dosing instruction
 DrugOrder.error.routeNotAmongAllowedConcepts=The route concept must be among allowed concepts as specified by the order.drugRoutesConceptUuid global property
 DrugOrder.error.drugIsRequired=Drug is required
 DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode=Duration units must be mapped to SNOMED CT duration code with the map type set to SAME-AS
+DrugOrder.error.doseZeroOrLess=Dose should be greater than 0
 
 TestOrder.error.specimenSourceNotAmongAllowedConcepts=The specimen source concept must be among allowed concepts as specified by the order.testSpecimenSourcesConceptUuid global property
 

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -272,7 +272,28 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("doseUnits"));
 	}
-	
+
+	/**
+	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailValidationIfDoseIsZeroOrLess() {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(FreeTextDosingInstructions.class);
+		order.setDose(0.0);
+		order.setDoseUnits(Context.getConceptService().getConcept(51));
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		assertTrue(errors.hasFieldErrors("dose"));
+		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
+
+		order.setDose(-1.0);
+		errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		assertTrue(errors.hasFieldErrors("dose"));
+		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
+	}
+
 	/**
 	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
 	 */

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -277,7 +277,7 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
 	 */
 	@Test
-	public void validate_shouldFailValidationIfDoseIsZeroOrLess() {
+	public void validate_shouldFailValidationIfDoseIsZero() {
 		DrugOrder order = new DrugOrder();
 		order.setDosingType(FreeTextDosingInstructions.class);
 		order.setDose(0.0);
@@ -286,12 +286,35 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("dose"));
 		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
-		
+	}
+	
+	/**
+	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailValidationIfDoseIsNegative() {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(FreeTextDosingInstructions.class);
 		order.setDose(-1.0);
-		errors = new BindException(order, "order");
+		order.setDoseUnits(Context.getConceptService().getConcept(51));
+		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("dose"));
 		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
+	}
+	
+	/**
+	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldPassValidationIfDoseIsGreaterThanZero() {
+		DrugOrder order = new DrugOrder();
+		order.setDosingType(FreeTextDosingInstructions.class);
+		order.setDose(1.0);
+		order.setDoseUnits(Context.getConceptService().getConcept(51));
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		assertFalse(errors.hasFieldErrors("dose"));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -272,7 +272,7 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("doseUnits"));
 	}
-
+	
 	/**
 	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
 	 */
@@ -286,14 +286,14 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("dose"));
 		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
-
+		
 		order.setDose(-1.0);
 		errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.hasFieldErrors("dose"));
 		assertEquals("DrugOrder.error.doseZeroOrLess", errors.getFieldError("dose").getCode());
 	}
-
+	
 	/**
 	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
 	 */


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
- configured DrugOrder validator to throw error if dose <= 0
- added test in DrugOrder test validator
- added the error message in message.properties

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6576
see https://openmrs.atlassian.net/browse/O3-5443

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

