### PR TITLE
TRUNK-2853: Fix cumulative progress reporting for update task

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -1574,29 +1574,28 @@ public class InitializationFilter extends StartupFilter {
 							
 							private String message;
                                                    
-                                                   private int totalToRun;
+                            private int totalToRun;
 							
 							public PrintingChangeSetExecutorCallback(String message) {
 								this.message = message;
 							}
                                                    
-                                                   public PrintingChangeSetExecutorCallback(String message, int totalToRun) {
-                                                           this.message = message;
-                                                           this.totalToRun = totalToRun;
-                                                   }
+                            public PrintingChangeSetExecutorCallback(String message,int totalToRun) {
+                                this.message = message;
+                                this.totalToRun = totalToRun;
+                            }
 							
 							/**
 							 * @see ChangeSetExecutorCallback#executing(liquibase.changelog.ChangeSet, int)
 							 */
 							@Override
 							public void executing(ChangeSet changeSet, int numChangeSetsToRun) {
-                                                           int effectiveTotal = totalToRun > 0 ? totalToRun : numChangeSetsToRun;
-                                                           setMessage(message + " (" + i++ + "/" + effectiveTotal + "): Author: "
-									+ changeSet.getAuthor() + " Comments: " + changeSet.getComments() + " Description: "
-									+ changeSet.getDescription());
-                                                           float effectiveTotalFloat = (float) effectiveTotal;
+								int effectiveTotal = totalToRun > 0 ? totalToRun : numChangeSetsToRun;
+								setMessage(message + " (" + i++ + "/" + effectiveTotal + "): Author: " + changeSet.getAuthor() + " Comments: " + changeSet.getComments() + " Description: "
+								+ changeSet.getDescription());
+								float effectiveTotalFloat = (float) effectiveTotal;
 								float j = (float) i;
-                                                           setCompletedPercentage(Math.round(j * 100 / effectiveTotalFloat));
+								setCompletedPercentage(Math.round(j * 100 / effectiveTotalFloat));
 							}
 							
 						}
@@ -1714,9 +1713,8 @@ public class InitializationFilter extends StartupFilter {
 							int totalChangeSets = DatabaseUpdater
 							        .getUnrunDatabaseChanges(changelogs.toArray(new String[0])).size();
 							
-							PrintingChangeSetExecutorCallback updateCallback =
-							        new PrintingChangeSetExecutorCallback("Updating the database",
-							                totalChangeSets);
+							PrintingChangeSetExecutorCallback updateCallback = new PrintingChangeSetExecutorCallback("Updating the database",
+							totalChangeSets);
 							
 							for (String changelog : changelogs) {
 								log.debug("applying Liquibase changelog '{}'", changelog);

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -1591,11 +1591,12 @@ public class InitializationFilter extends StartupFilter {
 							@Override
 							public void executing(ChangeSet changeSet, int numChangeSetsToRun) {
 								int effectiveTotal = totalToRun > 0 ? totalToRun : numChangeSetsToRun;
-								setMessage(message + " (" + i++ + "/" + effectiveTotal + "): Author: " + changeSet.getAuthor() + " Comments: " + changeSet.getComments() + " Description: "
+								setMessage(message + " (" + i + "/" + effectiveTotal + "): Author: " + changeSet.getAuthor() + " Comments: " + changeSet.getComments() + " Description: "
 								+ changeSet.getDescription());
 								float effectiveTotalFloat = (float) effectiveTotal;
 								float j = (float) i;
 								setCompletedPercentage(Math.round(j * 100 / effectiveTotalFloat));
+								i++;
 							}
 							
 						}

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -1580,7 +1580,7 @@ public class InitializationFilter extends StartupFilter {
 								this.message = message;
 							}
                                                    
-                            public PrintingChangeSetExecutorCallback(String message,int totalToRun) {
+                            public PrintingChangeSetExecutorCallback(String message, int totalToRun) {
                                 this.message = message;
                                 this.totalToRun = totalToRun;
                             }

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -1574,7 +1574,7 @@ public class InitializationFilter extends StartupFilter {
 							
 							private String message;
                                                    
-                            private int totalToRun;
+                        	private int totalToRun;
 							
 							public PrintingChangeSetExecutorCallback(String message) {
 								this.message = message;
@@ -1649,8 +1649,14 @@ public class InitializationFilter extends StartupFilter {
 										wizardModel.remoteUrl + RELEASE_TESTING_MODULE_PATH + "generateTestDataSet.form",
 										wizardModel.remoteUsername, wizardModel.remotePassword);
 									
+									setCompletedPercentage(20);
+									setMessage("Downloading test dataset...");
+
 									setCompletedPercentage(40);
-									setMessage("Loading imported test data...");
+									setMessage("Extracting test dataset...");
+									
+									setCompletedPercentage(70);
+									setMessage("Importing test data into database...");
 									importTestDataSet(inData, finalDatabaseConnectionString, connectionUsername,
 										connectionPassword.toString());
 									wizardModel.workLog.add("Imported test data");
@@ -1665,8 +1671,11 @@ public class InitializationFilter extends StartupFilter {
 										wizardModel.remoteUrl + RELEASE_TESTING_MODULE_PATH + "getModules.htm",
 										wizardModel.remoteUsername, wizardModel.remotePassword);
 									
-									setCompletedPercentage(90);
-									setMessage("Adding imported modules...");
+									setCompletedPercentage(50);
+									setMessage("Downloading modules from remote server");
+
+									setCompletedPercentage(80);
+									setMessage("Installing modules...");
 									if (!TestInstallUtil.addZippedTestModules(inModules)) {
 										reportError(ErrorMessageConstants.ERROR_DB_UNABLE_TO_ADD_MODULES, DEFAULT_PAGE, "");
 										return;

--- a/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
+++ b/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
@@ -323,7 +323,7 @@
             
         }, "json");
         
-        setTimeout("showProgress()", 200);
+        setTimeout("showProgress()", 500);
     }
             
     function updateProgressBar(progressBarId, completedPercentage){

--- a/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
+++ b/web/src/main/resources/org/openmrs/web/filter/initialization/progress.vm
@@ -323,7 +323,7 @@
             
         }, "json");
         
-        setTimeout("showProgress()", 1000);
+        setTimeout("showProgress()", 200);
     }
             
     function updateProgressBar(progressBarId, completedPercentage){


### PR DESCRIPTION
## Description of what I changed
Improved the accuracy and perceived smoothness of the installation wizard progress bar, focusing on database updates and test installation tasks.

For the `UPDATE_TO_LATEST` task, progress reporting is now cumulative across all applicable Liquibase update files instead of resetting per file. The total number of unrun changesets is calculated once and a single callback is reused, ensuring that progress advances monotonically from 0% to 100% for the entire update operation.

Additionally, the polling interval in `progress.vm` was reduced to better reflect progress for fast-executing tasks (such as adding core data or applying a small number of update changesets during a fresh install). This addresses cases where progress previously appeared to jump directly from 0% to completion due to coarse polling, even though backend progress reporting was correct.

No changes were made to the overall wizard flow or task ordering.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-2853

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (Not added — this change affects installation-time behavior and UI polling, which is not currently covered by automated tests.)

- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.