### PR TITLE
O3-5427: Validate condition onset date against patient DOB

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ConditionValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConditionValidator.java
@@ -10,6 +10,7 @@
 package org.openmrs.validator;
 
 import org.openmrs.Condition;
+import org.openmrs.Patient;
 import org.openmrs.annotation.Handler;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
@@ -52,6 +53,12 @@ public class ConditionValidator implements Validator {
 		if (condition.getClinicalStatus() == null) {
 			errors.rejectValue("clinicalStatus", "Condition.clinicalStatusShouldNotBeNull",
 			    "The clinical status is required");
+		}
+		Patient patient = condition.getPatient();
+		if (condition.getOnsetDate() != null && patient != null && patient.getBirthdate() != null
+		        && condition.getOnsetDate().before(patient.getBirthdate())) {
+			errors.rejectValue("onsetDate", "Condition.error.onsetDateBeforePatientBirthdate",
+			    "Onset date cannot be before patient's date of birth");
 		}
 	}
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -3335,6 +3335,7 @@ Module.error.cyclicDependencies=Could not start some modules because they depend
 
 Condition.conditionShouldNotBeNull=Condition is required
 Condition.clinicalStatusShouldNotBeNull=Clinical status is required
+Condition.error.onsetDateBeforePatientBirthdate=Onset date cannot be before patient's date of birth
 
 mail.passwordreset.subject=Password Reset
 mail.passwordreset.content=Hi {name} \n You recently requested a password reset for your OpenMRS account. To complete the process, click the link below.\n {link} \n  Please disregard this email if you didn't innitiate the password reset process. \n This link will automatically expire after a period of {time} minutes.

--- a/api/src/test/java/org/openmrs/validator/ConditionValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ConditionValidatorTest.java
@@ -9,6 +9,14 @@
  */
 package org.openmrs.validator;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,14 +27,9 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.Condition;
 import org.openmrs.ConditionClinicalStatus;
+import org.openmrs.Patient;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Class to implement tests for {@link ConditionValidator}
@@ -80,5 +83,62 @@ public class ConditionValidatorTest {
 		validator.validate(condition, errors);
 		assertFalse(errors.hasFieldErrors("condition"));
 		assertFalse(errors.hasFieldErrors("clinicalStatus"));
+	}
+
+	private Date date(int year, int month, int day) {
+		Calendar cal = Calendar.getInstance();
+		cal.set(year, month - 1, day, 0, 0, 0);
+		cal.set(Calendar.MILLISECOND, 0);
+		return cal.getTime();
+	}
+
+	@Test
+	void shouldRejectOnsetDateBeforePatientBirthdate() {
+		Patient patient = new Patient();
+		patient.setBirthdate(date(2000, 1, 1));
+		condition.setPatient(patient);
+		condition.setOnsetDate(date(1999, 6, 15));
+		validator.validate(condition, errors);
+		assertTrue(errors.hasFieldErrors("onsetDate"));
+	}
+
+	@Test
+	void shouldNotRejectOnsetDateEqualToPatientBirthdate() {
+		Patient patient = new Patient();
+		patient.setBirthdate(date(2000, 1, 1));
+		condition.setPatient(patient);
+		condition.setOnsetDate(date(2000, 1, 1));
+		validator.validate(condition, errors);
+		assertFalse(errors.hasFieldErrors("onsetDate"));
+	}
+
+	@Test
+	void shouldNotRejectOnsetDateAfterPatientBirthdate() {
+		Patient patient = new Patient();
+		patient.setBirthdate(date(2000, 1, 1));
+		condition.setPatient(patient);
+		condition.setOnsetDate(date(2005, 3, 15));
+		validator.validate(condition, errors);
+		assertFalse(errors.hasFieldErrors("onsetDate"));
+	}
+
+	@Test
+	void shouldNotRejectNullOnsetDate() {
+		Patient patient = new Patient();
+		patient.setBirthdate(date(2000, 1, 1));
+		condition.setPatient(patient);
+		condition.setOnsetDate(null);
+		validator.validate(condition, errors);
+		assertFalse(errors.hasFieldErrors("onsetDate"));
+	}
+
+	@Test
+	void shouldNotRejectWhenPatientBirthdateIsNull() {
+		Patient patient = new Patient();
+		patient.setBirthdate(null);
+		condition.setPatient(patient);
+		condition.setOnsetDate(date(2005, 3, 15));
+		validator.validate(condition, errors);
+		assertFalse(errors.hasFieldErrors("onsetDate"));
 	}
 }


### PR DESCRIPTION
## Description of what I changed

Added DOB lower-bound validation for the Condition onset date in `ConditionValidator`.

When a `Condition` has an `onsetDate` that falls strictly before the associated patient's date of birth, the validator now rejects the value with a field error (`Condition.error.onsetDateBeforePatientBirthdate`). This prevents clinically impossible data entry; a patient cannot have a condition onset before they were born. Onset dates equal to the birthdate are allowed (a condition can be diagnosed at birth).

**Changes:**
- `ConditionValidator.java`: Added birthdate lower-bound check for `onsetDate` after existing required-field validations. Uses triple null guard (`onsetDate`, `patient`, `patient.getBirthdate()`) before comparing dates via `Date.before()`.
- `ConditionValidatorTest.java`: Added 5 JUnit 5 test cases covering all edge cases and a `date()` helper method for concise date construction.

**Test scenarios:**
- `onsetDate` before patient birthdate → validation error
- `onsetDate` equal to patient birthdate → no error (valid: condition at birth)
- `onsetDate` after patient birthdate → no error
- `onsetDate` is `null` → no error
- Patient birthdate is `null` → no error

Part of the Date Picker Improvements epic (O3-5424).

## Issue I worked on

see https://issues.openmrs.org/browse/O3-5427

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.