### PR TITLE
TRUNK-6543: Add explicit @Deprecated metadata to core API elements

### DIFF
--- a/api/src/main/java/org/openmrs/BaseOpenmrsData.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsData.java
@@ -108,7 +108,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#getChangedBy()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public User getChangedBy() {
 		return changedBy;
 	}
@@ -118,7 +118,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#setChangedBy(User)
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setChangedBy(User changedBy) {
 		this.changedBy = changedBy;
 	}
@@ -128,7 +128,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#getDateChanged()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public Date getDateChanged() {
 		return dateChanged;
 	}
@@ -138,7 +138,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.OpenmrsData#setDateChanged(Date)
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.2", forRemoval = false)
 	public void setDateChanged(Date dateChanged) {
 		this.dateChanged = dateChanged;
 	}
@@ -148,7 +148,7 @@ public abstract class BaseOpenmrsData extends BaseOpenmrsObject implements Openm
 	 * @see org.openmrs.Voidable#isVoided()
 	 */
 	@Override
-	@Deprecated
+	@Deprecated(since = "2.0", forRemoval = false)
 	public Boolean isVoided() {
 		return getVoided();
 	}

--- a/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
+++ b/api/src/main/java/org/openmrs/ConditionClinicalStatus.java
@@ -41,6 +41,7 @@ public enum ConditionClinicalStatus {
 	 * 
 	 * @deprecated as of 2.6.0
 	 * */
+	@Deprecated(since = "2.6.0", forRemoval = false)
 	HISTORY_OF,
 	
 	/**


### PR DESCRIPTION
## Description of what I changed
Added explicit `@Deprecated` annotations (including `since` and `forRemoval` attributes)
to API elements that were previously deprecated only via Javadoc.

Updated:
- BaseOpenmrsData
- ConditionClinicalStatus (HISTORY_OF enum constant)

No behavioral changes were introduced. This ensures consistency between
Javadoc deprecation and compiler-level deprecation metadata.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6543

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style of this project.
- [ ] I have added tests to cover my changes. (Not applicable: this change only adds deprecation metadata.)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.