### PR TITLE
O3-5429: Validate visit stop date against patient DOB

### DIFF
--- a/api/src/main/java/org/openmrs/validator/VisitValidator.java
+++ b/api/src/main/java/org/openmrs/validator/VisitValidator.java
@@ -34,8 +34,10 @@ import org.springframework.validation.Validator;
 @Handler(supports = { Visit.class }, order = 50)
 public class VisitValidator extends BaseCustomizableValidator implements Validator {
 	
+	private static final String STOP_DATETIME = "stopDatetime";
+
 	private static final double ESTIMATED_BIRTHDATE_ERROR_MARGIN = -0.5;
-	
+
 	private static final int ESTIMATED_BIRTHDATE_ERROR_MARGIN_MINIMUM_YEARS = -1;
 	
 	/**
@@ -81,7 +83,7 @@ public class VisitValidator extends BaseCustomizableValidator implements Validat
 		ValidationUtils.rejectIfEmpty(errors, "startDatetime", "Visit.error.startDate.required");
 		if (visit.getStartDatetime() != null
 		        && OpenmrsUtil.compareWithNullAsLatest(visit.getStartDatetime(), visit.getStopDatetime()) > 0) {
-			errors.rejectValue("stopDatetime", "Visit.error.endDateBeforeStartDate");
+			errors.rejectValue(STOP_DATETIME, "Visit.error.endDateBeforeStartDate");
 		}
 		
 		//If this is not a new visit, validate based on its existing encounters.
@@ -96,7 +98,7 @@ public class VisitValidator extends BaseCustomizableValidator implements Validat
 					    "This visit has encounters whose dates cannot be before the start date of the visit.");
 					break;
 				} else if (stopDateTime != null && encounter.getEncounterDatetime().after(stopDateTime)) {
-					errors.rejectValue("stopDatetime", "Visit.encountersCannotBeAfterStopDate",
+					errors.rejectValue(STOP_DATETIME, "Visit.encountersCannotBeAfterStopDate",
 					    "This visit has encounters whose dates cannot be after the stop date of the visit.");
 					break;
 				}
@@ -139,6 +141,7 @@ public class VisitValidator extends BaseCustomizableValidator implements Validat
 		}
 		
 		validateVisitStartedBeforePatientBirthdate(visit, errors);
+		validateVisitStoppedBeforePatientBirthdate(visit, errors);
 	}
 	
 	/*
@@ -164,6 +167,17 @@ public class VisitValidator extends BaseCustomizableValidator implements Validat
 		}
 	}
 	
+	private void validateVisitStoppedBeforePatientBirthdate(Visit visit, Errors errors) {
+		if (visit.getPatient() == null || visit.getPatient().getBirthdate() == null || visit.getStopDatetime() == null) {
+			return;
+		}
+
+		if (visit.getStopDatetime().before(getPatientBirthdateAdjustedIfEstimated(visit.getPatient()))) {
+			errors.rejectValue(STOP_DATETIME, "Visit.stopDateCannotFallBeforeTheBirthDateOfTheSamePatient",
+			    "Visit stop date cannot fall before the birth date of the same patient");
+		}
+	}
+
 	private Date getPatientBirthdateAdjustedIfEstimated(Patient patient) {
 		Date birthday = patient.getBirthdate();
 		

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -2774,6 +2774,7 @@ Visit.ended=Visit <b>{0}</b> Ended
 Visit.startCannotBeTheSameAsOtherStartDateOfTheSamePatient=Cannot start two different visits at the same time.
 Visit.startDateCannotFallIntoAnotherVisitOfTheSamePatient=This visit has a start date that falls into another visit of the same patient.
 Visit.stopDateCannotFallIntoAnotherVisitOfTheSamePatient=This visit has a stop date that falls into another visit of the same patient.
+Visit.stopDateCannotFallBeforeTheBirthDateOfTheSamePatient=Visit stop date cannot fall before the birth date of the same patient
 Visit.visitCannotOverlapAnotherVisitOfTheSamePatient=This visit overlaps with another visit of the same patient.
 Visit.encountersCannotBeBeforeStartDate=Cannot contain encounters whose dates are before the start of the visit.
 Visit.encountersCannotBeAfterStopDate=Cannot contain encounters whose dates are after the stop of the visit.

--- a/api/src/test/java/org/openmrs/validator/VisitValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/VisitValidatorTest.java
@@ -748,6 +748,132 @@ public class VisitValidatorTest extends BaseContextSensitiveTest {
 		assertThat(errors, hasFieldErrors("startDatetime", "Visit.startDateCannotFallBeforeTheBirthDateOfTheSamePatient"));
 	}
 	
+	@Test
+	void validate_shouldFailValidationIfStopDateBeforeBirthDate() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(1974, 4, 8);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(false);
+		visit.setPatient(patient);
+		visit.setStartDatetime(calendar.getTime());
+		calendar.set(1974, 4, 7);
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, hasFieldErrors("stopDatetime", "Visit.stopDateCannotFallBeforeTheBirthDateOfTheSamePatient"));
+	}
+
+	@Test
+	void validate_shouldPassValidationIfStopDateOnBirthDate() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(1974, 4, 8);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(false);
+		visit.setPatient(patient);
+		visit.setStartDatetime(calendar.getTime());
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, not(hasFieldErrors("stopDatetime")));
+	}
+
+	@Test
+	void validate_shouldPassValidationIfStopDateAfterBirthDate() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(1974, 4, 8);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(false);
+		visit.setPatient(patient);
+		visit.setStartDatetime(calendar.getTime());
+		calendar.set(1974, 4, 9);
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, not(hasFieldErrors("stopDatetime")));
+	}
+
+	@Test
+	void validate_shouldPassValidationIfStopDateIsNull() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(1974, 4, 8);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(false);
+		visit.setPatient(patient);
+		visit.setStartDatetime(calendar.getTime());
+		// stopDatetime intentionally left null
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, not(hasFieldErrors("stopDatetime")));
+	}
+
+	@Test
+	void validate_shouldPassValidationOnStopDateIfPatientBirthDateIsNull() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		// birthdate intentionally left null
+		visit.setPatient(patient);
+		calendar.set(1974, 4, 8);
+		visit.setStartDatetime(calendar.getTime());
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, not(hasFieldErrors("stopDatetime", "Visit.stopDateCannotFallBeforeTheBirthDateOfTheSamePatient")));
+	}
+
+	@Test
+	void validate_shouldPassValidationIfStopDateOnEstimatedBirthDatesGracePeriod() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(2000, 7, 25);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(true);
+		calendar.set(2010, 7, 25);
+		patient.setDeathDate(calendar.getTime());
+		visit.setPatient(patient);
+		calendar.set(1995, 7, 25);
+		visit.setStartDatetime(calendar.getTime());
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, not(hasFieldErrors("stopDatetime")));
+	}
+
+	@Test
+	void validate_shouldFailValidationIfStopDateBeforeEstimatedBirthDatesGracePeriod() {
+		Visit visit = new Visit();
+		Patient patient = new Patient();
+		calendar.set(2000, 7, 25);
+		patient.setBirthdate(calendar.getTime());
+		patient.setBirthdateEstimated(true);
+		calendar.set(2010, 7, 25);
+		patient.setDeathDate(calendar.getTime());
+		visit.setPatient(patient);
+		calendar.set(1995, 7, 24);
+		visit.setStartDatetime(calendar.getTime());
+		visit.setStopDatetime(calendar.getTime());
+		Errors errors = new BindException(visit, "visit");
+
+		new VisitValidator().validate(visit, errors);
+
+		assertThat(errors, hasFieldErrors("stopDatetime", "Visit.stopDateCannotFallBeforeTheBirthDateOfTheSamePatient"));
+	}
+
 	private Date parseIsoDate(String isoDate) {
 		LocalDateTime localDateTime = LocalDateTime.parse(isoDate, DateTimeFormatter.ISO_DATE_TIME);
 		return Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());


### PR DESCRIPTION
## Description of what I changed

Added DOB lower-bound validation for Visit `stopDatetime` in `VisitValidator`.

The existing `startDatetime` birthdate check was already in place. This PR adds the matching validation for `stopDatetime`, when a Visit has a `stopDatetime` that falls before the patient's date of birth (adjusted for estimated birthdates using the existing grace period logic), the validator now rejects it with a field error.

This prevents clinically impossible data entry: a visit cannot end before the patient was born. Stop dates equal to the birthdate are allowed.

**Test scenarios:**
- `stopDatetime` before patient birthdate → validation error
- `stopDatetime` equal to patient birthdate → no error
- `stopDatetime` after patient birthdate → no error
- `stopDatetime` is null → no error
- Patient birthdate is null → no error
- `stopDatetime` within estimated birthdate grace period → no error
- `stopDatetime` before estimated birthdate grace period → validation error

Part of the Date Picker Improvements epic (O3-5424).

## Issue I worked on

see https://issues.openmrs.org/browse/O3-5429

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.