### PR TITLE
O3-5430: Validate obs datetime against patient DOB

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ObsValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ObsValidator.java
@@ -104,7 +104,12 @@ public class ObsValidator implements Validator {
 		if (obs.getObsDatetime() == null) {
 			errors.rejectValue("obsDatetime", "error.null");
 		}
-		
+		if (obs.getObsDatetime() != null && obs.getPerson() != null && obs.getPerson().getBirthdate() != null
+		        && obs.getObsDatetime().before(obs.getPerson().getBirthdate())) {
+			errors.rejectValue("obsDatetime", "Obs.error.obsDatetimeBeforePatientBirthdate",
+			    "Obs datetime cannot be before the patient's date of birth");
+		}
+
 		boolean isObsGroup = obs.hasGroupMembers(true);
 		// if this is an obs group (i.e., parent) make sure that it has no values (other than valueGroupId) set
 		if (isObsGroup) {

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1462,6 +1462,7 @@ Obs.voidedSuccessfully=Obs deleted successfully
 Obs.unvoidedSuccessfully=Obs restored successfully
 Obs.answer.drug=Answer Drug
 Obs.error.invalidDrug=The answer concept and the concept associated to the drug should match
+Obs.error.obsDatetimeBeforePatientBirthdate=Obs datetime cannot be before the patient's date of birth
 Obs.drug.search.placeholder=Enter Drug Name
 Obs.invalidImage=The attached file must be a valid image file
 Obs.namespaceAndPathTooLong=The combined length of the namespace and path for the form field should not exceed 254 characters

--- a/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
@@ -960,5 +960,126 @@ public class ObsValidatorTest extends BaseContextSensitiveTest {
 		obs.setObsDatetime(new Date());
 		return obs;
 	}
-	
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	void validate_shouldRejectObsDatetimeBeforePatientBirthdate() {
+		Calendar cal = Calendar.getInstance();
+		cal.add(Calendar.YEAR, -10);
+		Date birthdate = cal.getTime();
+
+		Person person = new Person(7);
+		person.setBirthdate(birthdate);
+
+		cal.add(Calendar.DAY_OF_MONTH, -1);
+
+		Obs obs = new Obs();
+		obs.setPerson(person);
+		obs.setConcept(Context.getConceptService().getConcept(18));
+		obs.setValueBoolean(false);
+		obs.setObsDatetime(cal.getTime());
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertTrue(errors.hasFieldErrors("obsDatetime"));
+		assertTrue(errors.getFieldErrors("obsDatetime").stream()
+		    .anyMatch(fe -> fe.getCode().startsWith("Obs.error.obsDatetimeBeforePatientBirthdate")));
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	void validate_shouldNotRejectObsDatetimeEqualToPatientBirthdate() {
+		Calendar cal = Calendar.getInstance();
+		cal.add(Calendar.YEAR, -10);
+		Date birthdate = cal.getTime();
+
+		Person person = new Person(7);
+		person.setBirthdate(birthdate);
+
+		Obs obs = new Obs();
+		obs.setPerson(person);
+		obs.setConcept(Context.getConceptService().getConcept(18));
+		obs.setValueBoolean(false);
+		obs.setObsDatetime(birthdate);
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	void validate_shouldNotRejectObsDatetimeAfterPatientBirthdate() {
+		Calendar cal = Calendar.getInstance();
+		cal.add(Calendar.YEAR, -10);
+		Date birthdate = cal.getTime();
+
+		Person person = new Person(7);
+		person.setBirthdate(birthdate);
+
+		Obs obs = new Obs();
+		obs.setPerson(person);
+		obs.setConcept(Context.getConceptService().getConcept(18));
+		obs.setValueBoolean(false);
+		obs.setObsDatetime(new Date());
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	void validate_shouldNotRejectNullObsDatetimeForBirthdateCheck() {
+		Calendar cal = Calendar.getInstance();
+		cal.add(Calendar.YEAR, -10);
+		Date birthdate = cal.getTime();
+
+		Person person = new Person(7);
+		person.setBirthdate(birthdate);
+
+		Obs obs = new Obs();
+		obs.setPerson(person);
+		obs.setConcept(Context.getConceptService().getConcept(18));
+		obs.setValueBoolean(false);
+		// obsDatetime intentionally null
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.getFieldErrors("obsDatetime").stream()
+		    .anyMatch(fe -> fe.getCode().startsWith("Obs.error.obsDatetimeBeforePatientBirthdate")));
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	void validate_shouldNotRejectObsDatetimeWhenBirthdateIsNull() {
+		Person person = new Person(7);
+		// birthdate intentionally not set
+
+		Obs obs = new Obs();
+		obs.setPerson(person);
+		obs.setConcept(Context.getConceptService().getConcept(18));
+		obs.setValueBoolean(false);
+		obs.setObsDatetime(new Date());
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
 }


### PR DESCRIPTION
## Description of what I changed

Added DOB lower-bound validation for `obsDatetime` in `ObsValidator`.

The `obsDatetime` field is validated against the patient's date of birth preventing, thus clinically impossible entries.

**Changes:**
- `ObsValidator.java`: Added birthdate lower-bound check for `obsDatetime` using `obs.getPerson().getBirthdate()` with null guards
- `ObsValidatorTest.java`: Added 5 test cases for DOB validation scenarios
- `messages.properties`: Added `Obs.error.obsDatetimeBeforePatientBirthdate` key

**Test scenarios:**
- `obsDatetime` before patient birthdate → validation error
- `obsDatetime` equal to patient birthdate → no error
- `obsDatetime` after patient birthdate → no error
- `obsDatetime` is null → no DOB error
- Patient birthdate is null → no error

Part of the Date Picker Improvements epic (O3-5424).

## Issue I worked on

see https://issues.openmrs.org/browse/O3-5430

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.