### PR TITLE
TRUNK-0: Improve null safety in PatientIdentifier.DefaultComparator

### DIFF
--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -336,15 +336,14 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 					retValue = OpenmrsUtil.compareWithNullAsLatest(pi1.getDateCreated(), pi2.getDateCreated());
 				}
 				if (pi1.getIdentifierType() == null && pi2.getIdentifierType() == null) {
-                     return 0;
-                }
-                if (pi1.getIdentifierType() == null && pi2.getIdentifierType() != null) {
-                     retValue = 1;
-                }
-                if (pi1.getIdentifierType() != null && pi2.getIdentifierType() == null) {
-                     retValue = -1;
-                }      
-			}
+					return 0;
+				}
+				if (pi1.getIdentifierType() == null && pi2.getIdentifierType() != null) {
+					retValue = 1;
+				}
+				if (pi1.getIdentifierType() != null && pi2.getIdentifierType() == null) {
+					retValue = -1;
+				}
 				if (retValue == 0) {
 					retValue = OpenmrsUtil.compareWithNullAsGreatest(pi1.getIdentifierType().getPatientIdentifierTypeId(),
 					    pi2.getIdentifierType().getPatientIdentifierTypeId());

--- a/api/src/main/java/org/openmrs/PatientIdentifier.java
+++ b/api/src/main/java/org/openmrs/PatientIdentifier.java
@@ -336,14 +336,15 @@ public class PatientIdentifier extends BaseChangeableOpenmrsData implements java
 					retValue = OpenmrsUtil.compareWithNullAsLatest(pi1.getDateCreated(), pi2.getDateCreated());
 				}
 				if (pi1.getIdentifierType() == null && pi2.getIdentifierType() == null) {
-					return 0;
-				}
-				if (pi1.getIdentifierType() == null && pi2.getIdentifierType() != null) {
-					retValue = 1;
-				}
-				if (pi1.getIdentifierType() == null && pi2.getIdentifierType() != null) {
-					retValue = -1;
-				}
+                     return 0;
+                }
+                if (pi1.getIdentifierType() == null && pi2.getIdentifierType() != null) {
+                     retValue = 1;
+                }
+                if (pi1.getIdentifierType() != null && pi2.getIdentifierType() == null) {
+                     retValue = -1;
+                }      
+			}
 				if (retValue == 0) {
 					retValue = OpenmrsUtil.compareWithNullAsGreatest(pi1.getIdentifierType().getPatientIdentifierTypeId(),
 					    pi2.getIdentifierType().getPatientIdentifierTypeId());


### PR DESCRIPTION
## Description of what I changed

Improved null-safety and readability in the `PatientIdentifier.DefaultComparator`
class.

Previously the comparator accessed `pi1.getIdentifierType().getPatientIdentifierTypeId()`
and `pi2.getIdentifierType().getPatientIdentifierTypeId()` without ensuring
`identifierType` was non-null in all execution paths.

This change improves code robustness by ensuring null checks are handled
before accessing nested properties. This prevents potential NullPointerExceptions
during patient identifier comparisons.

Additionally, the change improves readability by keeping null-handling
logic consistent with existing OpenMRS utility comparison methods.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-0

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests or confirmed existing behavior remains unchanged.
- [x] I ran `mvn clean package` before creating this pull request.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.
