### PR TITLE
TRUNK-4988: Convenience method to allow us to change the configuration more easily

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -64,7 +64,6 @@ import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.module.ModuleMustStartException;
 import org.openmrs.module.ModuleUtil;
 import org.openmrs.notification.AlertService;
-import org.openmrs.notification.MessageException;
 import org.openmrs.notification.MessagePreparator;
 import org.openmrs.notification.MessageSender;
 import org.openmrs.notification.MessageService;
@@ -570,19 +569,21 @@ public class Context {
 				List<MessagePreparator> preparators = getRegisteredComponents(MessagePreparator.class);
 				if (preparators != null && !preparators.isEmpty()) {
 					if (preparators.size() > 1) {
-						log.warn("Multiple MessagePreparators found. Using the first one: {}", preparators.get(0).getClass().getName());
+						log.warn("Multiple MessagePreparators found. Using the first one: {}",
+						    preparators.get(0).getClass().getName());
 					}
 					ms.setMessagePreparator(preparators.get(0));
 				} else {
 					ms.setMessagePreparator(new VelocityMessagePreparator());
 				}
 			}
-			
+
 			if (ms.getMessageSender() == null) {
 				List<MessageSender> senders = getRegisteredComponents(MessageSender.class);
 				if (senders != null && !senders.isEmpty()) {
 					if (senders.size() > 1) {
-						log.warn("Multiple MessageSenders found. Using the first one: {}", senders.get(0).getClass().getName());
+						log.warn("Multiple MessageSenders found. Using the first one: {}",
+						    senders.get(0).getClass().getName());
 					}
 					ms.setMessageSender(senders.get(0));
 				} else {
@@ -657,7 +658,7 @@ public class Context {
 		}
 		return mailSession;
 	}
-	
+
 	/**
 	 * @return "active" user who has been authenticated, otherwise <code>null</code>
 	 */

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -566,35 +566,35 @@ public class Context {
 		try {
 			// Dynamically pull from Spring, falling back to defaults if missing
 			if (ms.getMessagePreparator() == null) {
-				List<MessagePreparator> preparators = getRegisteredComponents(MessagePreparator.class);
-				if (preparators != null && !preparators.isEmpty()) {
-					if (preparators.size() > 1) {
-						log.warn("Multiple MessagePreparators found. Using the first one: {}",
-						    preparators.get(0).getClass().getName());
-					}
-					ms.setMessagePreparator(preparators.get(0));
-				} else {
-					ms.setMessagePreparator(new VelocityMessagePreparator());
-				}
+				MessagePreparator preparator = getSingleRegisteredComponent(MessagePreparator.class);
+				ms.setMessagePreparator(preparator != null ? preparator : new VelocityMessagePreparator());
 			}
 
 			if (ms.getMessageSender() == null) {
-				List<MessageSender> senders = getRegisteredComponents(MessageSender.class);
-				if (senders != null && !senders.isEmpty()) {
-					if (senders.size() > 1) {
-						log.warn("Multiple MessageSenders found. Using the first one: {}",
-						    senders.get(0).getClass().getName());
-					}
-					ms.setMessageSender(senders.get(0));
-				} else {
-					ms.setMessageSender(new MailMessageSender(getMailSession()));
-				}
+				MessageSender sender = getSingleRegisteredComponent(MessageSender.class);
+				ms.setMessageSender(sender != null ? sender : new MailMessageSender(getMailSession()));
 			}
 
 		} catch (Exception e) {
 			log.error("Unable to create message service due", e);
 		}
 		return ms;
+	}
+
+	/**
+	 * Helper method to fetch a single registered component of a given type from the Spring context.
+	 * Logs a warning if multiple components are found and returns the first one.
+	 */
+	private static <T> T getSingleRegisteredComponent(Class<T> type) {
+		List<T> components = getRegisteredComponents(type);
+		if (components != null && !components.isEmpty()) {
+			if (components.size() > 1) {
+				log.warn("Multiple {}s found. Using the first one: {}", type.getSimpleName(),
+				    components.get(0).getClass().getName());
+			}
+			return components.get(0);
+		}
+		return null;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -565,13 +565,29 @@ public class Context {
 	public static MessageService getMessageService() {
 		MessageService ms = getServiceContext().getMessageService();
 		try {
-			// Message service dependencies
+			// Dynamically pull from Spring, falling back to defaults if missing
 			if (ms.getMessagePreparator() == null) {
-				ms.setMessagePreparator(getMessagePreparator());
+				List<MessagePreparator> preparators = getRegisteredComponents(MessagePreparator.class);
+				if (preparators != null && !preparators.isEmpty()) {
+					if (preparators.size() > 1) {
+						log.warn("Multiple MessagePreparators found. Using the first one: {}", preparators.get(0).getClass().getName());
+					}
+					ms.setMessagePreparator(preparators.get(0));
+				} else {
+					ms.setMessagePreparator(new VelocityMessagePreparator());
+				}
 			}
-
+			
 			if (ms.getMessageSender() == null) {
-				ms.setMessageSender(getMessageSender());
+				List<MessageSender> senders = getRegisteredComponents(MessageSender.class);
+				if (senders != null && !senders.isEmpty()) {
+					if (senders.size() > 1) {
+						log.warn("Multiple MessageSenders found. Using the first one: {}", senders.get(0).getClass().getName());
+					}
+					ms.setMessageSender(senders.get(0));
+				} else {
+					ms.setMessageSender(new MailMessageSender(getMailSession()));
+				}
 			}
 
 		} catch (Exception e) {
@@ -641,27 +657,7 @@ public class Context {
 		}
 		return mailSession;
 	}
-
-	/**
-	 * Convenience method to allow us to change the configuration more easily. TODO Ideally, we would be
-	 * using Spring's method injection to set the dependencies for the message service.
-	 *
-	 * @return the ServiceContext
-	 */
-	private static MessageSender getMessageSender() {
-		return new MailMessageSender(getMailSession());
-	}
-
-	/**
-	 * Convenience method to allow us to change the configuration more easily. TODO See todo for message
-	 * sender.
-	 *
-	 * @return
-	 */
-	private static MessagePreparator getMessagePreparator() throws MessageException {
-		return new VelocityMessagePreparator();
-	}
-
+	
 	/**
 	 * @return "active" user who has been authenticated, otherwise <code>null</code>
 	 */

--- a/api/src/test/java/org/openmrs/api/context/ContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ContextTest.java
@@ -451,18 +451,20 @@ public class ContextTest extends BaseContextSensitiveTest {
 			authenticate();
 		}
 	}
-	
+
 	/**
 	 * Dummy implementations used strictly for testing dynamic Spring bean loading.
 	 */
 	class DummyTestMessageSender implements MessageSender {
+
 		@Override
 		public void send(Message message) throws MessageException {
 			// No operation required for the test
 		}
 	}
-	
+
 	class DummyTestMessagePreparator implements MessagePreparator {
+
 		@Override
 		public Message prepare(Template template) throws MessageException {
 			// No operation required for the test, returning null is perfectly fine
@@ -470,34 +472,44 @@ public class ContextTest extends BaseContextSensitiveTest {
 			return null;
 		}
 	}
-	
+
 	/**
 	 * @see Context#getMessageService()
 	 */
 	@Test
 	public void getMessageService_shouldDynamicallyLoadMessageSenderAndPreparatorFromSpringContext() {
-		
+
 		MessageService service = Context.getMessageService();
 		service.setMessageSender(null);
 		service.setMessagePreparator(null);
-		
-		ConfigurableApplicationContext appContext =
-			(ConfigurableApplicationContext) Context.getServiceContext().getApplicationContext();
-		
-		DefaultListableBeanFactory beanFactory =
-			(DefaultListableBeanFactory) appContext.getBeanFactory();
-		
+
+		ConfigurableApplicationContext appContext = (ConfigurableApplicationContext) Context.getServiceContext()
+		        .getApplicationContext();
+
+		DefaultListableBeanFactory beanFactory = (DefaultListableBeanFactory) appContext.getBeanFactory();
+
 		DummyTestMessageSender dummySender = new DummyTestMessageSender();
 		DummyTestMessagePreparator dummyPreparator = new DummyTestMessagePreparator();
-		
-		beanFactory.registerSingleton("dummyTestMessageSender", dummySender);
-		beanFactory.registerSingleton("dummyTestMessagePreparator", dummyPreparator);
-		
-		MessageService reinitializedService = Context.getMessageService();
-		MessagePreparator activePreparator = reinitializedService.getMessagePreparator();
-		
-		MessageSender activeSender = reinitializedService.getMessageSender();
-		assertEquals(dummySender, activeSender, "The MessageService should use the dynamically registered DummyTestMessageSender");
-		assertEquals(dummyPreparator, activePreparator, "The MessageService should use the dynamically registered DummyTestMessagePreparator");
+
+		try {
+			beanFactory.registerSingleton("dummyTestMessageSender", dummySender);
+			beanFactory.registerSingleton("dummyTestMessagePreparator", dummyPreparator);
+
+			MessageService reinitializedService = Context.getMessageService();
+			MessagePreparator activePreparator = reinitializedService.getMessagePreparator();
+
+			MessageSender activeSender = reinitializedService.getMessageSender();
+			assertEquals(dummySender, activeSender,
+			    "The MessageService should use the dynamically registered DummyTestMessageSender");
+			assertEquals(dummyPreparator, activePreparator,
+			    "The MessageService should use the dynamically registered DummyTestMessagePreparator");
+
+		} finally {
+			beanFactory.destroySingleton("dummyTestMessageSender");
+			beanFactory.destroySingleton("dummyTestMessagePreparator");
+
+			Context.getMessageService().setMessageSender(null);
+			Context.getMessageService().setMessagePreparator(null);
+		}
 	}
 }

--- a/api/src/test/java/org/openmrs/api/context/ContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ContextTest.java
@@ -32,6 +32,8 @@ import org.openmrs.notification.MessagePreparator;
 import org.openmrs.notification.MessageSender;
 import org.openmrs.notification.MessageService;
 import org.openmrs.notification.Template;
+import org.openmrs.notification.mail.MailMessageSender;
+import org.openmrs.notification.mail.velocity.VelocityMessagePreparator;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
@@ -508,6 +510,35 @@ public class ContextTest extends BaseContextSensitiveTest {
 			beanFactory.destroySingleton("dummyTestMessageSender");
 			beanFactory.destroySingleton("dummyTestMessagePreparator");
 
+			Context.getMessageService().setMessageSender(null);
+			Context.getMessageService().setMessagePreparator(null);
+		}
+	}
+
+	/**
+	 * @see Context#getMessageService()
+	 */
+	@Test
+	public void getMessageService_shouldFallbackToDefaultSenderAndPreparatorWhenNoBeansRegistered() {
+		MessageService service = Context.getMessageService();
+
+		// Clear the current instances to force the Context to run its initialization logic
+		service.setMessageSender(null);
+		service.setMessagePreparator(null);
+
+		try {
+			// Call getMessageService() again to trigger the lookup.
+			// Since we haven't registered any dummy beans in this test, it should use the defaults.
+			MessageService reinitializedService = Context.getMessageService();
+
+			assertTrue(reinitializedService.getMessageSender() instanceof MailMessageSender,
+			    "The MessageService should fallback to MailMessageSender when no custom beans are registered.");
+
+			assertTrue(reinitializedService.getMessagePreparator() instanceof VelocityMessagePreparator,
+			    "The MessageService should fallback to VelocityMessagePreparator when no custom beans are registered.");
+
+		} finally {
+			// CLEANUP: Reset the MessageService so the next tests start with a clean slate
 			Context.getMessageService().setMessageSender(null);
 			Context.getMessageService().setMessagePreparator(null);
 		}

--- a/api/src/test/java/org/openmrs/api/context/ContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ContextTest.java
@@ -26,10 +26,18 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.handler.EncounterVisitHandler;
 import org.openmrs.api.handler.ExistingOrNewVisitAssignmentHandler;
+import org.openmrs.notification.Message;
+import org.openmrs.notification.MessageException;
+import org.openmrs.notification.MessagePreparator;
+import org.openmrs.notification.MessageSender;
+import org.openmrs.notification.MessageService;
+import org.openmrs.notification.Template;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.validation.Validator;
 
@@ -442,5 +450,54 @@ public class ContextTest extends BaseContextSensitiveTest {
 			Context.removeProxyPrivilege("Some Test Privilege");
 			authenticate();
 		}
+	}
+	
+	/**
+	 * Dummy implementations used strictly for testing dynamic Spring bean loading.
+	 */
+	class DummyTestMessageSender implements MessageSender {
+		@Override
+		public void send(Message message) throws MessageException {
+			// No operation required for the test
+		}
+	}
+	
+	class DummyTestMessagePreparator implements MessagePreparator {
+		@Override
+		public Message prepare(Template template) throws MessageException {
+			// No operation required for the test, returning null is perfectly fine
+			// because the test only checks if the object is loaded, not if it runs.
+			return null;
+		}
+	}
+	
+	/**
+	 * @see Context#getMessageService()
+	 */
+	@Test
+	public void getMessageService_shouldDynamicallyLoadMessageSenderAndPreparatorFromSpringContext() {
+		
+		MessageService service = Context.getMessageService();
+		service.setMessageSender(null);
+		service.setMessagePreparator(null);
+		
+		ConfigurableApplicationContext appContext =
+			(ConfigurableApplicationContext) Context.getServiceContext().getApplicationContext();
+		
+		DefaultListableBeanFactory beanFactory =
+			(DefaultListableBeanFactory) appContext.getBeanFactory();
+		
+		DummyTestMessageSender dummySender = new DummyTestMessageSender();
+		DummyTestMessagePreparator dummyPreparator = new DummyTestMessagePreparator();
+		
+		beanFactory.registerSingleton("dummyTestMessageSender", dummySender);
+		beanFactory.registerSingleton("dummyTestMessagePreparator", dummyPreparator);
+		
+		MessageService reinitializedService = Context.getMessageService();
+		MessagePreparator activePreparator = reinitializedService.getMessagePreparator();
+		
+		MessageSender activeSender = reinitializedService.getMessageSender();
+		assertEquals(dummySender, activeSender, "The MessageService should use the dynamically registered DummyTestMessageSender");
+		assertEquals(dummyPreparator, activePreparator, "The MessageService should use the dynamically registered DummyTestMessagePreparator");
 	}
 }


### PR DESCRIPTION
## Description of what I changed
I have implemented dynamic Spring dependency injection for `MessageService` in `Context.java` to allow easier configuration of message senders and preparators.

**Why the change was needed:**
Previously, the `MessageService` dependencies (`MessageSender` and `MessagePreparator`) were strictly hardcoded to instantiate `MailMessageSender` and `VelocityMessagePreparator`. This rigid coupling prevented hospitals or developers from easily swapping in custom modules (such as an SMS sender) without modifying and recompiling the core Java code.

**Specific changes include:**
* Replaced the manual instantiations in `Context.getMessageService()` with dynamic Spring bean lookups using `getRegisteredComponents()`.
* Added fallback defensive logic to preserve backward compatibility: if no custom beans are registered in the Spring context, it safely defaults to the original `MailMessageSender` and `VelocityMessagePreparator`.
* Added a warning log if multiple beans of the same type are registered, ensuring developers know which bean was selected.
* Removed the outdated private static helper methods for creating the default senders.
* Added comprehensive JUnit integration tests in `ContextTest.java` to verify that dynamically registered `MessageSender` and `MessagePreparator` beans are successfully discovered and loaded from the `ApplicationContext`.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-4988

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.