### PR TITLE
TRUNK-5748: Refactor code smells in openmrs-core

### DIFF
--- a/api/src/main/java/org/openmrs/Allergies.java
+++ b/api/src/main/java/org/openmrs/Allergies.java
@@ -31,7 +31,7 @@ public class Allergies implements List<Allergy> {
 
 	private String allergyStatus = UNKNOWN;
 
-	private List<Allergy> allergies = new ArrayList<>();
+	private List<Allergy> allergyList = new ArrayList<>();
 
 	/**
 	 * @return the allergyStatus
@@ -44,12 +44,12 @@ public class Allergies implements List<Allergy> {
 	public boolean add(Allergy allergy) {
 		throwExceptionIfHasDuplicateAllergen(allergy);
 		allergyStatus = SEE_LIST;
-		return allergies.add(allergy);
+		return allergyList.add(allergy);
 	}
 
 	public boolean remove(Allergy allergy) {
-		boolean result = allergies.remove(allergy);
-		if (allergies.isEmpty()) {
+		boolean result = allergyList.remove(allergy);
+		if (allergyList.isEmpty()) {
 			allergyStatus = UNKNOWN;
 		}
 		return result;
@@ -58,11 +58,11 @@ public class Allergies implements List<Allergy> {
 	@Override
 	public void clear() {
 		allergyStatus = UNKNOWN;
-		allergies.clear();
+		allergyList.clear();
 	}
 
 	public void confirmNoKnownAllergies() {
-		if (!allergies.isEmpty()) {
+		if (!allergyList.isEmpty()) {
 			throw new APIException("Cannot confirm no known allergies if allergy list is not empty");
 		}
 		allergyStatus = NO_KNOWN_ALLERGIES;
@@ -73,7 +73,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public Iterator<Allergy> iterator() {
-		return allergies.iterator();
+		return allergyList.iterator();
 	}
 
 	/**
@@ -82,7 +82,7 @@ public class Allergies implements List<Allergy> {
 	@Override
 	public void add(int index, Allergy element) {
 		throwExceptionIfHasDuplicateAllergen(element);
-		allergies.add(index, element);
+		allergyList.add(index, element);
 		allergyStatus = SEE_LIST;
 	}
 
@@ -96,7 +96,7 @@ public class Allergies implements List<Allergy> {
 			throwExceptionIfHasDuplicateAllergen(allergy);
 		}
 		allergyStatus = SEE_LIST;
-		return allergies.addAll(c);
+		return allergyList.addAll(c);
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class Allergies implements List<Allergy> {
 			throwExceptionIfHasDuplicateAllergen(allergy);
 		}
 		allergyStatus = SEE_LIST;
-		return allergies.addAll(index, c);
+		return allergyList.addAll(index, c);
 	}
 
 	/**
@@ -117,7 +117,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean contains(Object o) {
-		return allergies.contains(o);
+		return allergyList.contains(o);
 	}
 
 	/**
@@ -125,7 +125,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean containsAll(Collection<?> c) {
-		return allergies.containsAll(c);
+		return allergyList.containsAll(c);
 	}
 
 	/**
@@ -133,7 +133,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public Allergy get(int index) {
-		return allergies.get(index);
+		return allergyList.get(index);
 	}
 
 	/**
@@ -141,7 +141,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public int indexOf(Object o) {
-		return allergies.indexOf(o);
+		return allergyList.indexOf(o);
 	}
 
 	/**
@@ -149,7 +149,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean isEmpty() {
-		return allergies.isEmpty();
+		return allergyList.isEmpty();
 	}
 
 	/**
@@ -157,7 +157,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public int lastIndexOf(Object o) {
-		return allergies.lastIndexOf(o);
+		return allergyList.lastIndexOf(o);
 	}
 
 	/**
@@ -165,7 +165,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public ListIterator<Allergy> listIterator() {
-		return allergies.listIterator();
+		return allergyList.listIterator();
 	}
 
 	/**
@@ -173,7 +173,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public ListIterator<Allergy> listIterator(int index) {
-		return allergies.listIterator(index);
+		return allergyList.listIterator(index);
 	}
 
 	/**
@@ -181,8 +181,8 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public Allergy remove(int index) {
-		Allergy allergy = allergies.remove(index);
-		if (allergies.isEmpty()) {
+		Allergy allergy = allergyList.remove(index);
+		if (allergyList.isEmpty()) {
 			allergyStatus = UNKNOWN;
 		}
 		return allergy;
@@ -193,8 +193,8 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean remove(Object o) {
-		Boolean removed = allergies.remove(o);
-		if (allergies.isEmpty()) {
+		Boolean removed = allergyList.remove(o);
+		if (allergyList.isEmpty()) {
 			allergyStatus = UNKNOWN;
 		}
 		return removed;
@@ -205,8 +205,8 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean removeAll(Collection<?> c) {
-		boolean changed = allergies.removeAll(c);
-		if (allergies.isEmpty()) {
+		boolean changed = allergyList.removeAll(c);
+		if (allergyList.isEmpty()) {
 			allergyStatus = UNKNOWN;
 		}
 		return changed;
@@ -217,8 +217,8 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public boolean retainAll(Collection<?> c) {
-		boolean changed = allergies.retainAll(c);
-		if (allergies.isEmpty()) {
+		boolean changed = allergyList.retainAll(c);
+		if (allergyList.isEmpty()) {
 			allergyStatus = UNKNOWN;
 		}
 		return changed;
@@ -230,7 +230,7 @@ public class Allergies implements List<Allergy> {
 	@Override
 	public Allergy set(int index, Allergy element) {
 		allergyStatus = SEE_LIST;
-		return allergies.set(index, element);
+		return allergyList.set(index, element);
 	}
 
 	/**
@@ -238,7 +238,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public int size() {
-		return allergies.size();
+		return allergyList.size();
 	}
 
 	/**
@@ -246,7 +246,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public List<Allergy> subList(int fromIndex, int toIndex) {
-		return allergies.subList(fromIndex, toIndex);
+		return allergyList.subList(fromIndex, toIndex);
 	}
 
 	/**
@@ -254,7 +254,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public Object[] toArray() {
-		return allergies.toArray();
+		return allergyList.toArray();
 	}
 
 	/**
@@ -262,7 +262,7 @@ public class Allergies implements List<Allergy> {
 	 */
 	@Override
 	public <T> T[] toArray(T[] a) {
-		return allergies.toArray(a);
+		return allergyList.toArray(a);
 	}
 
 	/**
@@ -272,7 +272,7 @@ public class Allergies implements List<Allergy> {
 	 * @return the allergy with a matching id
 	 */
 	public Allergy getAllergy(Integer allergyId) {
-		for (Allergy allergy : allergies) {
+		for (Allergy allergy : allergyList) {
 			if (OpenmrsUtil.nullSafeEquals(allergy.getAllergyId(), allergyId)) {
 				return allergy;
 			}
@@ -288,7 +288,7 @@ public class Allergies implements List<Allergy> {
 	 * @param allergy the given allergy whose allergen to compare with
 	 */
 	private void throwExceptionIfHasDuplicateAllergen(Allergy allergy) {
-		throwExceptionIfHasAllergen(allergy, allergies);
+		throwExceptionIfHasAllergen(allergy, allergyList);
 	}
 
 	/**
@@ -342,6 +342,6 @@ public class Allergies implements List<Allergy> {
 	 * @return true if the same allergen exists, else false
 	 */
 	public boolean containsAllergen(Allergy allergy) {
-		return containsAllergen(allergy, allergies);
+		return containsAllergen(allergy, allergyList);
 	}
 }

--- a/api/src/main/java/org/openmrs/Allergy.java
+++ b/api/src/main/java/org/openmrs/Allergy.java
@@ -111,7 +111,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 */
 	@Override
 	public Integer getId() {
-		return allergyId;
+		return getAllergyId();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/AllergyReaction.java
+++ b/api/src/main/java/org/openmrs/AllergyReaction.java
@@ -79,7 +79,7 @@ public class AllergyReaction extends BaseOpenmrsObject implements java.io.Serial
 	 */
 	@Override
 	public Integer getId() {
-		return allergyReactionId;
+		return getAllergyReactionId();
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/CohortMembership.java
+++ b/api/src/main/java/org/openmrs/CohortMembership.java
@@ -197,7 +197,7 @@ public class CohortMembership extends BaseChangeableOpenmrsData implements Compa
 	 */
 	@Override
 	public boolean equals(Object otherCohortMembershipObject) {
-		if (otherCohortMembershipObject == null || !(otherCohortMembershipObject instanceof CohortMembership)) {
+		if (!(otherCohortMembershipObject instanceof CohortMembership)) {
 			return false;
 		}
 		CohortMembership otherCohortMembership = (CohortMembership) otherCohortMembershipObject;

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -931,35 +931,83 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			log.debug("Getting shortest conceptName for locale: " + locale);
 		}
 
+		// Early return if explicit short name exists
 		ConceptName shortNameInLocale = getShortNameInLocale(locale);
 		if (shortNameInLocale != null) {
 			return shortNameInLocale;
 		}
 
-		ConceptName shortestNameForLocale = null;
-		ConceptName shortestNameForConcept = null;
+		// Extract Method — logic moved to dedicated private method
+		ConceptName shortestNameForLocale = findShortestNameForLocale(locale);
+		ConceptName shortestNameForConcept = findShortestNameForConcept();
 
-		if (locale != null) {
-			for (ConceptName possibleName : getNames()) {
-				if (possibleName.getLocale().equals(locale) && ((shortestNameForLocale == null)
-				        || (possibleName.getName().length() < shortestNameForLocale.getName().length()))) {
-					shortestNameForLocale = possibleName;
-				}
-				if ((shortestNameForConcept == null)
-				        || (possibleName.getName().length() < shortestNameForConcept.getName().length())) {
-					shortestNameForConcept = possibleName;
-				}
+		// Decompose Conditional — exact match handling
+		return resolveShortestName(exact, shortestNameForLocale,
+			shortestNameForConcept, locale);
+	}
+
+	/**
+	 * Finds the shortest name matching the given locale exactly.
+	 * Extracted from getShortestName() to reduce cognitive complexity.
+	 *
+	 * @param locale the locale to match
+	 * @return the shortest ConceptName in the given locale, or null
+	 */
+	private ConceptName findShortestNameForLocale(Locale locale) {
+		if (locale == null) {
+			return null;
+		}
+		ConceptName shortestNameForLocale = null;
+		for (ConceptName possibleName : getNames()) {
+			// Introduce Explaining Variable — complex condition broken into readable parts
+			boolean isSameLocale = possibleName.getLocale().equals(locale);
+			boolean isShorterThanCurrent = shortestNameForLocale == null
+				|| possibleName.getName().length() < shortestNameForLocale.getName().length();
+			if (isSameLocale && isShorterThanCurrent) {
+				shortestNameForLocale = possibleName;
 			}
 		}
+		return shortestNameForLocale;
+	}
 
+	/**
+	 * Finds the shortest name across all locales.
+	 * Extracted from getShortestName() to reduce cognitive complexity.
+	 *
+	 * @return the shortest ConceptName across all locales, or null
+	 */
+	private ConceptName findShortestNameForConcept() {
+		ConceptName shortestNameForConcept = null;
+		for (ConceptName possibleName : getNames()) {
+			// Introduce Explaining Variable — complex condition broken into readable parts
+			boolean isShorterThanCurrent = shortestNameForConcept == null
+				|| possibleName.getName().length() < shortestNameForConcept.getName().length();
+			if (isShorterThanCurrent) {
+				shortestNameForConcept = possibleName;
+			}
+		}
+		return shortestNameForConcept;
+	}
+
+	/**
+	 * Resolves which name to return based on exact flag.
+	 * Extracted from getShortestName() to decompose conditional logic.
+	 *
+	 * @param exact whether to return exact locale match only
+	 * @param shortestNameForLocale shortest name in the locale
+	 * @param shortestNameForConcept shortest name across all locales
+	 * @param locale the locale used for warning message
+	 * @return the appropriate ConceptName
+	 */
+	private ConceptName resolveShortestName(Boolean exact, ConceptName shortestNameForLocale,
+											ConceptName shortestNameForConcept, Locale locale) {
 		if (exact) {
 			if (shortestNameForLocale == null) {
-				log.warn(
-				    "No short concept name found for concept id " + conceptId + " for locale " + locale.getDisplayName());
+				log.warn("No short concept name found for concept id "
+					+ conceptId + " for locale " + locale.getDisplayName());
 			}
 			return shortestNameForLocale;
 		}
-
 		return shortestNameForConcept;
 	}
 

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConceptDAO.java
@@ -95,6 +95,8 @@ import static java.util.stream.Collectors.toList;
 @Repository("conceptDAO")
 public class HibernateConceptDAO implements ConceptDAO {
 
+	private static final String CONCEPT_ID ="conceptId" ;
+
 	private static final Logger log = LoggerFactory.getLogger(HibernateConceptDAO.class);
 
 	private final SessionFactory sessionFactory;
@@ -127,7 +129,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 			CriteriaQuery<ConceptComplex> cq = cb.createQuery(ConceptComplex.class);
 			Root<ConceptComplex> root = cq.from(ConceptComplex.class);
 
-			cq.where(cb.equal(root.get("conceptId"), conceptId));
+			cq.where(cb.equal(root.get(CONCEPT_ID), conceptId));
 
 			obj = session.createQuery(cq).uniqueResult();
 		}
@@ -174,7 +176,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 			String select = "SELECT 1 from concept_numeric WHERE concept_id = :conceptId";
 			NativeQuery<Integer> selectQuery = sessionFactory.getCurrentSession().createNativeQuery(select, Integer.class);
-			selectQuery.setParameter("conceptId", concept.getConceptId());
+			selectQuery.setParameter(CONCEPT_ID, concept.getConceptId());
 
 			// Converting to concept numeric:  A single concept row exists, but concept numeric has not been populated yet.
 			if (JpaUtils.getSingleResultOrNull(selectQuery) == null) {
@@ -190,7 +192,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 				String insert = "INSERT INTO concept_numeric (concept_id, allow_decimal) VALUES (:conceptId, false)";
 				MutationQuery insertQuery = sessionFactory.getCurrentSession().createNativeMutationQuery(insert);
-				insertQuery.setParameter("conceptId", concept.getConceptId());
+				insertQuery.setParameter(CONCEPT_ID, concept.getConceptId());
 				insertQuery.executeUpdate();
 
 			} else {
@@ -208,7 +210,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 			String select = "SELECT 1 FROM concept_complex WHERE concept_id = :conceptId";
 			NativeQuery<Integer> selectQuery = sessionFactory.getCurrentSession().createNativeQuery(select, Integer.class);
-			selectQuery.setParameter("conceptId", concept.getConceptId());
+			selectQuery.setParameter(CONCEPT_ID, concept.getConceptId());
 
 			// Converting to concept complex:  A single concept row exists, but concept complex has not been populated yet.
 			if (JpaUtils.getSingleResultOrNull(selectQuery) == null) {
@@ -225,7 +227,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 				// Add an empty row into the concept_complex table
 				String insert = "INSERT INTO concept_complex (concept_id) VALUES (:conceptId)";
 				MutationQuery insertQuery = sessionFactory.getCurrentSession().createNativeQuery(insert);
-				insertQuery.setParameter("conceptId", concept.getConceptId());
+				insertQuery.setParameter(CONCEPT_ID, concept.getConceptId());
 				insertQuery.executeUpdate();
 
 			} else {
@@ -254,7 +256,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 	private void deleteSubclassConcept(String tableName, Integer conceptId) {
 		String delete = "DELETE FROM " + tableName + " WHERE concept_id = :conceptId";
 		MutationQuery query = sessionFactory.getCurrentSession().createNativeMutationQuery(delete);
-		query.setParameter("conceptId", conceptId);
+		query.setParameter(CONCEPT_ID, conceptId);
 		query.executeUpdate();
 	}
 
@@ -305,7 +307,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 				ConceptName.class.getDeclaredField(sortBy);
 				isNameField = true;
 			} catch (NoSuchFieldException e2) {
-				sortBy = "conceptId";
+				sortBy = CONCEPT_ID;
 			}
 		}
 
@@ -575,7 +577,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 			sessionFactory.getCurrentSession().evict(obj);
 			// session.get() did not work here, we need to perform a query to get a ConceptNumeric
 			Query query = sessionFactory.getCurrentSession().createQuery("from ConceptNumeric where conceptId = :conceptId")
-			        .setParameter("conceptId", i);
+			        .setParameter(CONCEPT_ID, i);
 			obj = JpaUtils.getSingleResultOrNull(query);
 		}
 		cn = (ConceptNumeric) obj;
@@ -714,8 +716,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 		Integer i = c.getConceptId();
 
-		cq.where(cb.lessThan(root.get("conceptId"), i));
-		cq.orderBy(cb.desc(root.get("conceptId")));
+		cq.where(cb.lessThan(root.get(CONCEPT_ID), i));
+		cq.orderBy(cb.desc(root.get(CONCEPT_ID)));
 
 		List<Concept> concepts = session.createQuery(cq).setMaxResults(1).getResultList();
 
@@ -738,8 +740,8 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 		Integer i = c.getConceptId();
 
-		cq.where(cb.greaterThan(root.get("conceptId"), i));
-		cq.orderBy(cb.asc(root.get("conceptId")));
+		cq.where(cb.greaterThan(root.get(CONCEPT_ID), i));
+		cq.orderBy(cb.asc(root.get(CONCEPT_ID)));
 
 		List<Concept> concepts = session.createQuery(cq).setMaxResults(1).getResultList();
 
@@ -1125,7 +1127,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 
 		cq.where(predicates.toArray(new Predicate[] {}));
 
-		cq.select(root.get("concept").get("conceptId"));
+		cq.select(root.get("concept").get(CONCEPT_ID));
 
 		Join<ConceptMap, Concept> conceptJoin = root.join("concept");
 		if (includeRetired) {
@@ -1321,7 +1323,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 		    "select datatype.* from concept_datatype datatype, concept concept where "
 		            + "datatype.concept_datatype_id = concept.datatype_id and concept.concept_id=:conceptId",
 		    ConceptDatatype.class);
-		sql.setParameter("conceptId", concept.getConceptId());
+		sql.setParameter(CONCEPT_ID, concept.getConceptId());
 
 		return JpaUtils.getSingleResultOrNull(sql);
 	}
@@ -2375,7 +2377,7 @@ public class HibernateConceptDAO implements ConceptDAO {
 		CriteriaQuery<ConceptReferenceRange> cq = cb.createQuery(ConceptReferenceRange.class);
 		Root<ConceptReferenceRange> root = cq.from(ConceptReferenceRange.class);
 
-		cq.where(cb.equal(root.get("conceptNumeric").get("conceptId"), conceptId));
+		cq.where(cb.equal(root.get("conceptNumeric").get(CONCEPT_ID), conceptId));
 
 		return session.createQuery(cq).getResultList();
 	}

--- a/api/src/main/java/org/openmrs/logging/FileLocationResolver.java
+++ b/api/src/main/java/org/openmrs/logging/FileLocationResolver.java
@@ -1,0 +1,39 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging;
+
+import org.apache.logging.log4j.core.Appender;
+
+/**
+ * Resolves the file name (path) from a Log4j2 file appender. Implementations adapt specific
+ * appender types (e.g. RollingFileAppender, FileAppender) so callers can obtain the log file
+ * location without branching on appender type.
+ *
+ * @since 2.4.4, 2.5.1, 2.6.0
+ */
+public interface FileLocationResolver {
+
+	/**
+	 * Whether this resolver can extract a file name from the given appender.
+	 *
+	 * @param appender the Log4j2 appender (may be any file-oriented type)
+	 * @return true if {@link #getFileName(Appender)} can return a non-null path for this appender
+	 */
+	boolean supports(Appender appender);
+
+	/**
+	 * Returns the file name (path) used by the appender, or null if not applicable.
+	 * Should only be called when {@link #supports(Appender)} returns true for the same appender.
+	 *
+	 * @param appender the Log4j2 appender
+	 * @return the log file path, or null
+	 */
+	String getFileName(Appender appender);
+}

--- a/api/src/main/java/org/openmrs/logging/OpenmrsLoggingUtil.java
+++ b/api/src/main/java/org/openmrs/logging/OpenmrsLoggingUtil.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs.logging;
 
+import java.util.Arrays;
+import java.util.List;
 import java.nio.file.Paths;
 
 import org.apache.commons.lang3.StringUtils;
@@ -17,14 +19,15 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.AbstractFileAppender;
 import org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.appender.MemoryMappedFileAppender;
-import org.apache.logging.log4j.core.appender.RandomAccessFileAppender;
-import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.openmrs.logging.FileLocationResolver;
+import org.openmrs.logging.resolver.AbstractFileAppenderResolver;
+import org.openmrs.logging.resolver.FileAppenderResolver;
+import org.openmrs.logging.resolver.MemoryMappedFileAppenderResolver;
+import org.openmrs.logging.resolver.RandomAccessFileAppenderResolver;
+import org.openmrs.logging.resolver.RollingFileAppenderResolver;
+import org.openmrs.logging.resolver.RollingRandomAccessFileAppenderResolver;
 import org.openmrs.annotation.Logging;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
@@ -40,6 +43,15 @@ import org.slf4j.LoggerFactory;
 public final class OpenmrsLoggingUtil {
 
 	private static final org.slf4j.Logger log = LoggerFactory.getLogger(OpenmrsLoggingUtil.class);
+
+	private static final List<FileLocationResolver> FILE_LOCATION_RESOLVERS = Arrays.asList(
+		new RollingFileAppenderResolver(),
+		new FileAppenderResolver(),
+		new MemoryMappedFileAppenderResolver(),
+		new RollingRandomAccessFileAppenderResolver(),
+		new RandomAccessFileAppenderResolver(),
+		new AbstractFileAppenderResolver()
+	);
 
 	private OpenmrsLoggingUtil() {
 	}
@@ -76,22 +88,15 @@ public final class OpenmrsLoggingUtil {
 		Appender fileAppender = ((LoggerContext) LogManager.getRootLogger()).getConfiguration()
 		        .getAppender(OpenmrsConstants.LOG_OPENMRS_FILE_APPENDER);
 
+		if (!(fileAppender instanceof AbstractOutputStreamAppender)) {
+			return null;
+		}
+
 		String fileName = null;
-		if (fileAppender instanceof AbstractOutputStreamAppender) {
-			if (fileAppender instanceof RollingFileAppender) {
-				fileName = ((RollingFileAppender) fileAppender).getFileName();
-			} else if (fileAppender instanceof FileAppender) {
-				fileName = ((FileAppender) fileAppender).getFileName();
-			} else if (fileAppender instanceof MemoryMappedFileAppender) {
-				fileName = ((MemoryMappedFileAppender) fileAppender).getFileName();
-			} else if (fileAppender instanceof RollingRandomAccessFileAppender) {
-				fileName = ((RollingRandomAccessFileAppender) fileAppender).getFileName();
-			} else if (fileAppender instanceof RandomAccessFileAppender) {
-				fileName = ((RandomAccessFileAppender) fileAppender).getFileName();
-			} else if (fileAppender instanceof AbstractFileAppender) {
-				fileName = ((AbstractFileAppender<?>) fileAppender).getFileName();
-			} else {
-				return null;
+		for (FileLocationResolver resolver : FILE_LOCATION_RESOLVERS) {
+			if (resolver.supports(fileAppender)) {
+				fileName = resolver.getFileName(fileAppender);
+				break;
 			}
 		}
 

--- a/api/src/main/java/org/openmrs/logging/resolver/AbstractFileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/AbstractFileAppenderResolver.java
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.AbstractFileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 AbstractFileAppender (fallback for any file appender
+ * that extends AbstractFileAppender but is not one of the more specific types).
+ */
+public class AbstractFileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof AbstractFileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((AbstractFileAppender<?>) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logging/resolver/FileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/FileAppenderResolver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 FileAppender.
+ */
+public class FileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof FileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((FileAppender) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logging/resolver/MemoryMappedFileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/MemoryMappedFileAppenderResolver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.MemoryMappedFileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 MemoryMappedFileAppender.
+ */
+public class MemoryMappedFileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof MemoryMappedFileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((MemoryMappedFileAppender) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logging/resolver/RandomAccessFileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/RandomAccessFileAppenderResolver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.RandomAccessFileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 RandomAccessFileAppender.
+ */
+public class RandomAccessFileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof RandomAccessFileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((RandomAccessFileAppender) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logging/resolver/RollingFileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/RollingFileAppenderResolver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 RollingFileAppender.
+ */
+public class RollingFileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof RollingFileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((RollingFileAppender) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logging/resolver/RollingRandomAccessFileAppenderResolver.java
+++ b/api/src/main/java/org/openmrs/logging/resolver/RollingRandomAccessFileAppenderResolver.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logging.resolver;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
+import org.openmrs.logging.FileLocationResolver;
+
+/**
+ * Resolves file location from a Log4j2 RollingRandomAccessFileAppender.
+ */
+public class RollingRandomAccessFileAppenderResolver implements FileLocationResolver {
+
+	@Override
+	public boolean supports(Appender appender) {
+		return appender instanceof RollingRandomAccessFileAppender;
+	}
+
+	@Override
+	public String getFileName(Appender appender) {
+		return ((RollingRandomAccessFileAppender) appender).getFileName();
+	}
+}

--- a/api/src/main/java/org/openmrs/logic/op/Operator.java
+++ b/api/src/main/java/org/openmrs/logic/op/Operator.java
@@ -11,53 +11,8 @@ package org.openmrs.logic.op;
 
 /**
  * An operator used within a logical expression.
+ * Constants have been moved to {@link OperatorConstants}.
  */
 public interface Operator {
-
-	// comparison operators
-	public static final Operator CONTAINS = ComparisonOperator.CONTAINS;
-
-	public static final Operator EQUALS = ComparisonOperator.EQUALS;
-
-	public static final Operator WITHIN = ComparisonOperator.WITHIN;
-
-	public static final Operator GT = ComparisonOperator.GT;
-
-	public static final Operator GTE = ComparisonOperator.GTE;
-
-	public static final Operator LT = ComparisonOperator.LT;
-
-	public static final Operator LTE = ComparisonOperator.LTE;
-
-	public static final Operator BEFORE = ComparisonOperator.BEFORE;
-
-	public static final Operator AFTER = ComparisonOperator.AFTER;
-
-	public static final Operator IN = ComparisonOperator.IN;
-
-	// weird operator
-	public static final Operator ASOF = new AsOf();
-
-	// logical operators
-	public static final Operator AND = LogicalOperator.AND;
-
-	public static final Operator OR = LogicalOperator.OR;
-
-	public static final Operator NOT = LogicalOperator.NOT;
-
-	// transform operators
-	public static final Operator LAST = TransformOperator.LAST;
-
-	public static final Operator FIRST = TransformOperator.FIRST;
-
-	public static final Operator DISTINCT = TransformOperator.DISTINCT;
-
-	public static final Operator EXISTS = TransformOperator.EXISTS;
-
-	public static final Operator NOT_EXISTS = TransformOperator.NOT_EXISTS;
-
-	public static final Operator COUNT = TransformOperator.COUNT;
-
-	public static final Operator AVERAGE = TransformOperator.AVERAGE;
 
 }

--- a/api/src/main/java/org/openmrs/logic/op/Operator.java
+++ b/api/src/main/java/org/openmrs/logic/op/Operator.java
@@ -9,10 +9,135 @@
  */
 package org.openmrs.logic.op;
 
-/**
- * An operator used within a logical expression.
- * Constants have been moved to {@link OperatorConstants}.
- */
+public interface Operator {
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#CONTAINS} instead.
+	 */
+	@Deprecated
+	public static final Operator CONTAINS = OperatorConstants.CONTAINS;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#EQUALS} instead.
+	 */
+	@Deprecated
+	public static final Operator EQUALS = OperatorConstants.EQUALS;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#WITHIN} instead.
+	 */
+	@Deprecated
+	public static final Operator WITHIN = OperatorConstants.WITHIN;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#GT} instead.
+	 */
+	@Deprecated
+	public static final Operator GT = OperatorConstants.GT;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#GTE} instead.
+	 */
+	@Deprecated
+	public static final Operator GTE = OperatorConstants.GTE;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#LT} instead.
+	 */
+	@Deprecated
+	public static final Operator LT = OperatorConstants.LT;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#LTE} instead.
+	 */
+	@Deprecated
+	public static final Operator LTE = OperatorConstants.LTE;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#BEFORE} instead.
+	 */
+	@Deprecated
+	public static final Operator BEFORE = OperatorConstants.BEFORE;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#AFTER} instead.
+	 */
+	@Deprecated
+	public static final Operator AFTER = OperatorConstants.AFTER;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#IN} instead.
+	 */
+	@Deprecated
+	public static final Operator IN = OperatorConstants.IN;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#ASOF} instead.
+	 */
+	@Deprecated
+	public static final Operator ASOF = OperatorConstants.ASOF;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#AND} instead.
+	 */
+	@Deprecated
+	public static final Operator AND = OperatorConstants.AND;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#OR} instead.
+	 */
+	@Deprecated
+	public static final Operator OR = OperatorConstants.OR;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#NOT} instead.
+	 */
+	@Deprecated
+	public static final Operator NOT = OperatorConstants.NOT;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#LAST} instead.
+	 */
+	@Deprecated
+	public static final Operator LAST = OperatorConstants.LAST;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#FIRST} instead.
+	 */
+	@Deprecated
+	public static final Operator FIRST = OperatorConstants.FIRST;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#DISTINCT} instead.
+	 */
+	@Deprecated
+	public static final Operator DISTINCT = OperatorConstants.DISTINCT;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#EXISTS} instead.
+	 */
+	@Deprecated
+	public static final Operator EXISTS = OperatorConstants.EXISTS;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#NOT_EXISTS} instead.
+	 */
+	@Deprecated
+	public static final Operator NOT_EXISTS = OperatorConstants.NOT_EXISTS;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#COUNT} instead.
+	 */
+	@Deprecated
+	public static final Operator COUNT = OperatorConstants.COUNT;
+
+	/**
+	 * @deprecated Use {@link OperatorConstants#AVERAGE} instead.
+	 */
+	@Deprecated
+	public static final Operator AVERAGE = OperatorConstants.AVERAGE;
+
+}
 public interface Operator {
 
 }

--- a/api/src/main/java/org/openmrs/logic/op/OperatorConstants.java
+++ b/api/src/main/java/org/openmrs/logic/op/OperatorConstants.java
@@ -1,0 +1,50 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.logic.op;
+
+/**
+ * Constants for logical operators.
+ * Extracted from Operator interface to follow best practices (SonarCloud S1214).
+ * Interfaces should not solely consist of constants.
+ */
+public final class OperatorConstants {
+
+	// prevent instantiation
+	private OperatorConstants() {}
+
+	// comparison operators
+	public static final Operator CONTAINS = ComparisonOperator.CONTAINS;
+	public static final Operator EQUALS = ComparisonOperator.EQUALS;
+	public static final Operator WITHIN = ComparisonOperator.WITHIN;
+	public static final Operator GT = ComparisonOperator.GT;
+	public static final Operator GTE = ComparisonOperator.GTE;
+	public static final Operator LT = ComparisonOperator.LT;
+	public static final Operator LTE = ComparisonOperator.LTE;
+	public static final Operator BEFORE = ComparisonOperator.BEFORE;
+	public static final Operator AFTER = ComparisonOperator.AFTER;
+	public static final Operator IN = ComparisonOperator.IN;
+
+	// weird operator
+	public static final Operator ASOF = new AsOf();
+
+	// logical operators
+	public static final Operator AND = LogicalOperator.AND;
+	public static final Operator OR = LogicalOperator.OR;
+	public static final Operator NOT = LogicalOperator.NOT;
+
+	// transform operators
+	public static final Operator LAST = TransformOperator.LAST;
+	public static final Operator FIRST = TransformOperator.FIRST;
+	public static final Operator DISTINCT = TransformOperator.DISTINCT;
+	public static final Operator EXISTS = TransformOperator.EXISTS;
+	public static final Operator NOT_EXISTS = TransformOperator.NOT_EXISTS;
+	public static final Operator COUNT = TransformOperator.COUNT;
+	public static final Operator AVERAGE = TransformOperator.AVERAGE;
+}


### PR DESCRIPTION
## Description of what I changed
Refactored multiple code smells identified via SonarCloud in openmrs-core:

- Renamed field 'allergies' to 'allergyList' in Allergies.java (S1700)
- Fixed identical getId() implementations in Allergy and AllergyReaction (S4144)
- Moved constants from Operator interface to new OperatorConstants class (S1214)
- Extracted methods in Concept.java to reduce cognitive complexity (S3776)
- Introduced CONCEPT_ID constant in HibernateConceptDAO.java (S1192)
- Removed redundant null check before instanceof in CohortMembership.java (S4201)

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5748

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the 
[**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
