### PR TITLE
 (fix) TRUNK-6132: OpenMRS startup time greatly increased in 2.5+

### DIFF
--- a/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
+++ b/api/src/main/java/org/openmrs/liquibase/ChangeLogDetective.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +52,7 @@ public class ChangeLogDetective {
 
 	private ChangeLogVersionFinder changeLogVersionFinder;
 
-	private String initialSnapshotVersion;
+	private volatile String initialSnapshotVersion;
 
 	private List<String> unrunLiquibaseUpdates;
 
@@ -90,54 +89,58 @@ public class ChangeLogDetective {
 	 * @throws Exception
 	 */
 	public String getInitialLiquibaseSnapshotVersion(String context, LiquibaseProvider liquibaseProvider) throws Exception {
+		String cached = initialSnapshotVersion;
+		if (cached != null) {
+			return cached;
+		}
 
-		if (initialSnapshotVersion != null) {
+		synchronized (this) {
+			cached = initialSnapshotVersion;
+			if (cached != null) {
+				return cached;
+			}
+
+			log.info("identifying the Liquibase snapshot version that had been used to initialize the OpenMRS database...");
+			Map<String, List<String>> snapshotCombinations = changeLogVersionFinder.getSnapshotCombinations();
+
+			if (snapshotCombinations.isEmpty()) {
+				throw new IllegalStateException(
+				        "identifying the Liqubase snapshot version that had been used to initialize the OpenMRS database failed as no candidate change sets were found");
+			}
+
+			List<String> snapshotVersions = getSnapshotVersionsInDescendingOrder(snapshotCombinations);
+
+			for (String version : snapshotVersions) {
+				int unrunChangeSetsCount = 0;
+
+				log.info("looking for un-run change sets in snapshot version '{}'", version);
+				List<String> changeSets = snapshotCombinations.get(version);
+
+				Contexts contexts = new Contexts(context);
+				for (String filename : changeSets) {
+					List<ChangeSet> rawUnrunChangeSets = getUnrunChangeSets(filename, contexts, liquibaseProvider);
+
+					List<ChangeSet> refinedUnrunChangeSets = excludeVintageChangeSets(filename, rawUnrunChangeSets);
+
+					log.info("file '{}' contains {} un-run change sets", filename, refinedUnrunChangeSets.size());
+					logUnRunChangeSetDetails(filename, refinedUnrunChangeSets);
+
+					unrunChangeSetsCount += refinedUnrunChangeSets.size();
+				}
+
+				if (unrunChangeSetsCount == 0) {
+					log.info("the Liquibase snapshot version that had been used to initialize the OpenMRS database is '{}'", version);
+					initialSnapshotVersion = version;
+					return version;
+				}
+			}
+
+			log.info(
+			        "the snapshot version that had been used to initialize the OpenMRS database could not be identified, falling back to the default version '{}'",
+			        DEFAULT_SNAPSHOT_VERSION);
+			initialSnapshotVersion = DEFAULT_SNAPSHOT_VERSION;
 			return initialSnapshotVersion;
 		}
-
-		log.info("identifying the Liquibase snapshot version that had been used to initialize the OpenMRS database...");
-		Map<String, List<String>> snapshotCombinations = changeLogVersionFinder.getSnapshotCombinations();
-
-		if (snapshotCombinations.isEmpty()) {
-			throw new IllegalStateException(
-			        "identifying the Liqubase snapshot version that had been used to initialize the OpenMRS database failed as no candidate change sets were found");
-		}
-
-		List<String> snapshotVersions = getSnapshotVersionsInDescendingOrder(snapshotCombinations);
-
-		for (String version : snapshotVersions) {
-			int unrunChangeSetsCount = 0;
-
-			log.info("looking for un-run change sets in snapshot version '{}'", version);
-			List<String> changeSets = snapshotCombinations.get(version);
-
-			Contexts contexts = new Contexts(context);
-			for (String filename : changeSets) {
-				List<ChangeSet> rawUnrunChangeSets = getUnrunChangeSets(filename, contexts, liquibaseProvider);
-
-				List<ChangeSet> refinedUnrunChangeSets = excludeVintageChangeSets(filename, rawUnrunChangeSets);
-
-				log.info("file '{}' contains {} un-run change sets", filename, refinedUnrunChangeSets.size());
-				logUnRunChangeSetDetails(filename, refinedUnrunChangeSets);
-
-				unrunChangeSetsCount += refinedUnrunChangeSets.size();
-			}
-
-			if (unrunChangeSetsCount == 0) {
-				log.info("the Liquibase snapshot version that had been used to initialize the OpenMRS database is '{}'",
-				    version);
-
-				initialSnapshotVersion = version;
-				return initialSnapshotVersion;
-			}
-		}
-
-		log.info(
-		    "the snapshot version that had been used to initialize the OpenMRS database could not be identified, falling back to the default version '{}'",
-		    DEFAULT_SNAPSHOT_VERSION);
-
-		initialSnapshotVersion = DEFAULT_SNAPSHOT_VERSION;
-		return initialSnapshotVersion;
 	}
 
 	/**
@@ -150,7 +153,6 @@ public class ChangeLogDetective {
 	 */
 	public List<String> getUnrunLiquibaseUpdateFileNames(String snapshotVersion, String context,
 	        LiquibaseProvider liquibaseProvider) throws Exception {
-
 		if (unrunLiquibaseUpdates != null && unrunLiquibaseUpdates.isEmpty()) {
 			return unrunLiquibaseUpdates;
 		}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
Problem: OpenMRS startup was slow because the ChangeLogDetective#getInitialLiquibaseSnapshotVersion(...) could be invoked multiple times during the startup, ie repeatedly running expensive Liquibase “un-run changeset” checks.
  So I made the snapshot-version detection to effectively run once per JVM startup by adding thread-safe memoization/ Memorization

## Issue I worked on
[TRUNK-6132](https://openmrs.atlassian.net/issues?filter=-5&selectedIssue=TRUNK-6132)

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`



[TRUNK-6132]: https://openmrs.atlassian.net/browse/TRUNK-6132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ