### PR TITLE
AUDIT-28: Port Envers audit table backfill changeset to 2.9.x

### DIFF
--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -183,10 +183,10 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			String inferredSuffix = suffixVotes.entrySet().stream()
 			        .max(Map.Entry.comparingByValue())
 			        .get().getKey();
-			log.info("Inferred audit suffix '{}' from majority vote across {} pairs", inferredSuffix, pairs.size());
+			log.warn("Inferred audit suffix '{}' from majority vote across {} pairs", inferredSuffix, pairs.size());
 			pairs.removeIf(pair -> !pair[1].toLowerCase().substring(pair[0].toLowerCase().length()).equals(inferredSuffix));
 		}
-		log.info("Discovered {} audit table pairs to backfill: {}", pairs.size(),
+		log.warn("Discovered {} audit table pairs to backfill: {}", pairs.size(),
 		    pairs.stream().map(p -> p[0] + " -> " + p[1]).collect(java.util.stream.Collectors.joining(", ")));
 		return pairs;
 	}
@@ -215,16 +215,23 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 	private Integer tryBackfillEntity(Connection connection, String sourceTable, String auditTable, String revisionTableName,
 	        Integer revId) {
 		try {
-			if (!isAuditTableEmpty(connection, auditTable) || isTableEmpty(connection, sourceTable)) {
+			if (!isAuditTableEmpty(connection, auditTable)) {
+				log.warn("Skipping {} - audit table already has data", auditTable);
+				return revId;
+			}
+			if (isTableEmpty(connection, sourceTable)) {
+				log.warn("Skipping {} - source table {} is empty", auditTable, sourceTable);
 				return revId;
 			}
 			if (revId == null) {
 				revId = createBackfillRevision(connection, revisionTableName);
 			}
 			List<String> columns = getAuditTableDataColumns(connection, auditTable, sourceTable);
-			if (!columns.isEmpty()) {
-				backfillTable(connection, sourceTable, auditTable, columns, revId);
+			if (columns.isEmpty()) {
+				log.warn("Skipping {} - no common columns found between {} and {}", auditTable, sourceTable, auditTable);
+				return revId;
 			}
+			backfillTable(connection, sourceTable, auditTable, columns, revId);
 		}
 		catch (SQLException e) {
 			log.warn("Failed to backfill audit table {}: {}", auditTable, e.getMessage());
@@ -398,7 +405,7 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		        + columnList + " FROM " + sourceTable;
 		try (Statement stmt = connection.createStatement()) {
 			int rows = stmt.executeUpdate(sql);
-			log.info("Backfilled {} rows from {} into {}", rows, sourceTable, auditTable);
+			log.warn("Backfilled {} rows from {} into {}", rows, sourceTable, auditTable);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -1,0 +1,294 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util.databasechange;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+
+/**
+ * Liquibase {@link CustomTaskChange} that backfills pre-existing rows into Envers audit tables.
+ * <p>
+ * When Envers auditing is enabled after data already exists, audit tables are empty and Envers
+ * cannot resolve references to those pre-existing entities, causing "Unable to read" errors in the
+ * audit UI. This changeset inserts all existing rows from each source table into the corresponding
+ * {@code *_audit} table with {@code REVTYPE=0} (ADD) under a single backfill revision entry.
+ * <p>
+ * Because this is a Liquibase changeset it is tracked in {@code databasechangelog} and runs exactly
+ * once per database, never on subsequent startups.
+ */
+public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
+
+	private static final Logger log = LoggerFactory.getLogger(BackfillEnversAuditTablesChangeset.class);
+
+	private static final Pattern SAFE_SQL_IDENTIFIER = Pattern.compile("[a-zA-Z_]\\w*");
+
+	private static final String AUDIT_SUFFIX = "_audit";
+
+	@Override
+	public void execute(Database database) throws CustomChangeException {
+		try {
+			Connection connection = ((JdbcConnection) database.getConnection()).getUnderlyingConnection();
+
+			String revisionTableName = findRevisionEntityTable(connection);
+			Integer revId = null;
+
+			DatabaseMetaData metaData = connection.getMetaData();
+			try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
+				while (tables.next()) {
+					String tableName = tables.getString("TABLE_NAME");
+					if (!tableName.endsWith(AUDIT_SUFFIX)) {
+						continue;
+					}
+					String sourceTable = tableName.substring(0, tableName.length() - AUDIT_SUFFIX.length());
+					if (doesTableExist(connection, sourceTable)) {
+						revId = tryBackfillEntity(connection, sourceTable, tableName, revisionTableName, revId);
+					}
+				}
+			}
+
+			if (revId != null) {
+				log.info("Audit table backfill completed successfully with initial revision ID {}", revId);
+			} else {
+				log.debug("No audit tables needed backfilling.");
+			}
+		} catch (Exception e) {
+			throw new CustomChangeException("Failed to backfill Envers audit tables", e);
+		}
+	}
+
+	private Integer tryBackfillEntity(Connection connection, String sourceTable, String auditTable, String revisionTableName,
+	        Integer revId) {
+		try {
+			if (!isAuditTableEmpty(connection, auditTable) || isTableEmpty(connection, sourceTable)) {
+				return revId;
+			}
+			if (revId == null) {
+				revId = createBackfillRevision(connection, revisionTableName);
+			}
+			List<String> columns = getAuditTableDataColumns(connection, auditTable);
+			if (!columns.isEmpty()) {
+				backfillTable(connection, sourceTable, auditTable, columns, revId);
+			}
+		} catch (SQLException e) {
+			log.warn("Failed to backfill audit table {}: {}", auditTable, e.getMessage());
+		}
+		return revId;
+	}
+
+	/**
+	 * Creates a backfill revision entry in the revision entity table. Dynamically discovers the primary
+	 * key and timestamp column names from JDBC metadata to avoid hardcoding Hibernate-version-specific
+	 * names.
+	 *
+	 * @param connection JDBC connection
+	 * @param revisionTableName name of the revision entity table
+	 * @return the generated revision ID
+	 * @throws SQLException if the revision entry cannot be created
+	 */
+	static int createBackfillRevision(Connection connection, String revisionTableName) throws SQLException {
+		String pkColumn = getRevisionPrimaryKeyColumn(connection, revisionTableName);
+		String timestampColumn = getRevisionTimestampColumn(connection, revisionTableName);
+		int nextId;
+		try (Statement stmt = connection.createStatement();
+		        ResultSet rs = stmt.executeQuery("SELECT COALESCE(MAX(" + requireSafeIdentifier(pkColumn) + "), 0) + 1 FROM "
+		                + requireSafeIdentifier(revisionTableName))) {
+			nextId = rs.next() ? rs.getInt(1) : 1;
+		}
+		String sql = "INSERT INTO " + requireSafeIdentifier(revisionTableName) + " (" + requireSafeIdentifier(pkColumn)
+		        + ", " + requireSafeIdentifier(timestampColumn) + ") VALUES (?, ?)";
+		try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
+			pstmt.setInt(1, nextId);
+			pstmt.setLong(2, System.currentTimeMillis());
+			pstmt.executeUpdate();
+			return nextId;
+		}
+	}
+
+	/**
+	 * Discovers the primary key column name of the revision entity table via JDBC metadata.
+	 *
+	 * @param connection JDBC connection
+	 * @param revisionTableName name of the revision entity table
+	 * @return the primary key column name, falling back to "id" if not found
+	 * @throws SQLException if metadata cannot be read
+	 */
+	static String getRevisionPrimaryKeyColumn(Connection connection, String revisionTableName) throws SQLException {
+		DatabaseMetaData metaData = connection.getMetaData();
+		for (String name : new String[] { revisionTableName, revisionTableName.toUpperCase() }) {
+			try (ResultSet rs = metaData.getPrimaryKeys(null, null, name)) {
+				if (rs.next()) {
+					return rs.getString("COLUMN_NAME");
+				}
+			}
+		}
+		return "id";
+	}
+
+	/**
+	 * Discovers the timestamp column name in the revision entity table by finding the first BIGINT
+	 * column that is not the primary key. This avoids hardcoding Hibernate-version-specific names like
+	 * "REVTSTMP" which may differ across Hibernate versions.
+	 *
+	 * @param connection JDBC connection
+	 * @param revisionTableName name of the revision entity table
+	 * @return the timestamp column name, falling back to "REVTSTMP" if not found
+	 * @throws SQLException if metadata cannot be read
+	 */
+	static String getRevisionTimestampColumn(Connection connection, String revisionTableName) throws SQLException {
+		DatabaseMetaData metaData = connection.getMetaData();
+		String pkColumn = null;
+		for (String name : new String[] { revisionTableName, revisionTableName.toUpperCase() }) {
+			try (ResultSet pkRs = metaData.getPrimaryKeys(null, null, name)) {
+				if (pkRs.next()) {
+					pkColumn = pkRs.getString("COLUMN_NAME");
+					break;
+				}
+			}
+		}
+		for (String name : new String[] { revisionTableName, revisionTableName.toUpperCase() }) {
+			try (ResultSet colRs = metaData.getColumns(null, null, name, null)) {
+				while (colRs.next()) {
+					String colName = colRs.getString("COLUMN_NAME");
+					int dataType = colRs.getInt("DATA_TYPE");
+					if (dataType == java.sql.Types.BIGINT && !colName.equalsIgnoreCase(pkColumn)) {
+						return colName;
+					}
+				}
+			}
+		}
+		return "REVTSTMP";
+	}
+
+	/**
+	 * Validates that a SQL identifier (table or column name) contains only safe characters, preventing
+	 * SQL injection when identifiers must be concatenated into queries.
+	 *
+	 * @param identifier the SQL identifier to validate
+	 * @return the identifier unchanged if safe
+	 * @throws IllegalArgumentException if the identifier contains unsafe characters
+	 */
+	static String requireSafeIdentifier(String identifier) {
+		if (identifier == null || !SAFE_SQL_IDENTIFIER.matcher(identifier).matches()) {
+			throw new IllegalArgumentException("Unsafe SQL identifier rejected: " + identifier);
+		}
+		return identifier;
+	}
+
+	/**
+	 * Returns true if the given audit table exists but contains no rows.
+	 */
+	static boolean isAuditTableEmpty(Connection connection, String tableName) {
+		try (Statement stmt = connection.createStatement();
+		        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + requireSafeIdentifier(tableName))) {
+			return rs.next() && rs.getLong(1) == 0;
+		} catch (SQLException e) {
+			log.debug("Audit table {} not accessible, skipping backfill: {}", tableName, e.getMessage());
+			return false;
+		}
+	}
+
+	/**
+	 * Returns true if the given source table has no rows.
+	 */
+	static boolean isTableEmpty(Connection connection, String tableName) throws SQLException {
+		try (Statement stmt = connection.createStatement();
+		        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + requireSafeIdentifier(tableName))) {
+			return rs.next() && rs.getLong(1) == 0;
+		}
+	}
+
+	/**
+	 * Returns the data column names from the given audit table, excluding the Envers metadata columns
+	 * REV and REVTYPE. These are the columns that correspond to the audited entity fields and must
+	 * exist in the source table.
+	 */
+	static List<String> getAuditTableDataColumns(Connection connection, String auditTable) throws SQLException {
+		List<String> columns = new ArrayList<>();
+		DatabaseMetaData metaData = connection.getMetaData();
+		try (ResultSet rs = metaData.getColumns(null, null, auditTable, null)) {
+			while (rs.next()) {
+				String colName = rs.getString("COLUMN_NAME");
+				if (!colName.equalsIgnoreCase("REV") && !colName.equalsIgnoreCase("REVTYPE")) {
+					columns.add(colName);
+				}
+			}
+		}
+		return columns;
+	}
+
+	/**
+	 * Inserts all rows from the source table into the audit table with REVTYPE=0 (ADD).
+	 */
+	static void backfillTable(Connection connection, String sourceTable, String auditTable, List<String> columns, int revId)
+	        throws SQLException {
+		requireSafeIdentifier(sourceTable);
+		requireSafeIdentifier(auditTable);
+		columns.forEach(BackfillEnversAuditTablesChangeset::requireSafeIdentifier);
+		String columnList = String.join(", ", columns);
+		String sql = "INSERT INTO " + auditTable + " (REV, REVTYPE, " + columnList + ") SELECT " + revId + ", 0, "
+		        + columnList + " FROM " + sourceTable;
+		try (Statement stmt = connection.createStatement()) {
+			int rows = stmt.executeUpdate(sql);
+			log.info("Backfilled {} rows from {} into {}", rows, sourceTable, auditTable);
+		}
+	}
+
+	private String findRevisionEntityTable(Connection connection) throws SQLException {
+		for (String name : new String[] { "revision_entity", "REVINFO" }) {
+			if (doesTableExist(connection, name)) {
+				return name;
+			}
+		}
+		return "revision_entity";
+	}
+
+	private boolean doesTableExist(Connection connection, String tableName) throws SQLException {
+		DatabaseMetaData metaData = connection.getMetaData();
+		try (ResultSet rs = metaData.getTables(null, null, tableName, new String[] { "TABLE" })) {
+			return rs.next();
+		}
+	}
+
+	@Override
+	public String getConfirmationMessage() {
+		return "Successfully backfilled pre-existing rows into Envers audit tables";
+	}
+
+	@Override
+	public void setUp() throws SetupException {
+	}
+
+	@Override
+	public void setFileOpener(ResourceAccessor resourceAccessor) {
+	}
+
+	@Override
+	public ValidationErrors validate(Database database) {
+		return null;
+	}
+}

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,10 +38,14 @@ import liquibase.resource.ResourceAccessor;
  * When Envers auditing is enabled after data already exists, audit tables are empty and Envers
  * cannot resolve references to those pre-existing entities, causing "Unable to read" errors in the
  * audit UI. This changeset inserts all existing rows from each source table into the corresponding
- * {@code *_audit} table with {@code REVTYPE=0} (ADD) under a single backfill revision entry.
+ * audit table with {@code REVTYPE=0} (ADD) under a single backfill revision entry.
  * <p>
- * Because this is a Liquibase changeset it is tracked in {@code databasechangelog} and runs exactly
- * once per database, never on subsequent startups.
+ * Audit tables are detected by the presence of {@code REV} and {@code REVTYPE} columns — the
+ * Envers metadata columns always present regardless of the configured audit table suffix or prefix.
+ * This avoids any dependency on runtime properties that may not be loaded when Liquibase runs.
+ * <p>
+ * Because this is a Liquibase changeset it is tracked in {@code liquibasechangelog} and runs
+ * exactly once per database, never on subsequent startups.
  */
 public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 
@@ -55,29 +58,15 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		try {
 			Connection connection = ((JdbcConnection) database.getConnection()).getUnderlyingConnection();
 
-			String auditSuffix = Context.getRuntimeProperties()
-			        .getProperty("org.hibernate.envers.audit_table_suffix", "_audit");
-
 			String revisionTableName = findRevisionEntityTable(connection);
 
-			// Collect all (sourceTable, auditTable) pairs first so we can iterate them
-			// multiple times. A second pass is needed for joined-subclass audit tables
-			// (e.g. patient_aud, drug_order_aud) whose FK to the parent audit table
-			// would otherwise fail when the parent table has not been backfilled yet.
-			List<String[]> auditPairs = new ArrayList<>();
-			DatabaseMetaData metaData = connection.getMetaData();
-			try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
-				while (tables.next()) {
-					String tableName = tables.getString("TABLE_NAME");
-					if (!tableName.endsWith(auditSuffix)) {
-						continue;
-					}
-					String sourceTable = tableName.substring(0, tableName.length() - auditSuffix.length());
-					if (doesTableExist(connection, sourceTable)) {
-						auditPairs.add(new String[] { sourceTable, tableName });
-					}
-				}
-			}
+			// Discover (sourceTable, auditTable) pairs by detecting Envers audit tables via
+			// REV + REVTYPE columns — independent of the configured audit suffix.
+			// Collect all pairs first so we can iterate them multiple times: a second pass
+			// is needed for joined-subclass audit tables (e.g. patient_aud, drug_order_aud)
+			// whose FK to the parent audit table would otherwise fail when the parent has
+			// not been backfilled yet.
+			List<String[]> auditPairs = discoverAuditPairs(connection);
 
 			Integer revId = null;
 			// Two passes: pass 1 populates parent audit tables; pass 2 handles child
@@ -93,8 +82,90 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			} else {
 				log.debug("No audit tables needed backfilling.");
 			}
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new CustomChangeException("Failed to backfill Envers audit tables", e);
+		}
+	}
+
+	/**
+	 * Discovers (sourceTable, auditTable) pairs without relying on the configured audit suffix.
+	 * Identifies Envers audit tables by the presence of {@code REV} and {@code REVTYPE} columns,
+	 * then matches each audit table to its source table using longest-prefix matching.
+	 *
+	 * @param connection JDBC connection
+	 * @return list of [sourceTable, auditTable] pairs
+	 * @throws SQLException if metadata cannot be read
+	 */
+	List<String[]> discoverAuditPairs(Connection connection) throws SQLException {
+		DatabaseMetaData metaData = connection.getMetaData();
+
+		List<String> allTables = new ArrayList<>();
+		try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
+			while (tables.next()) {
+				allTables.add(tables.getString("TABLE_NAME"));
+			}
+		}
+
+		// Partition into audit tables (have REV + REVTYPE) and potential source tables
+		Set<String> auditTableSet = new HashSet<>();
+		for (String tableName : allTables) {
+			if (isEnversAuditTable(connection, tableName)) {
+				auditTableSet.add(tableName);
+			}
+		}
+
+		// Build lowercase set of non-audit table names for prefix matching
+		Set<String> sourceTableNames = new HashSet<>();
+		for (String tableName : allTables) {
+			if (!auditTableSet.contains(tableName)) {
+				sourceTableNames.add(tableName.toLowerCase());
+			}
+		}
+
+		// For each audit table, find the longest-prefix matching source table
+		List<String[]> pairs = new ArrayList<>();
+		for (String auditTable : auditTableSet) {
+			String lowerAudit = auditTable.toLowerCase();
+			String bestMatch = null;
+			for (String sourceTable : sourceTableNames) {
+				if (lowerAudit.startsWith(sourceTable) && lowerAudit.length() > sourceTable.length()) {
+					if (bestMatch == null || sourceTable.length() > bestMatch.length()) {
+						bestMatch = sourceTable;
+					}
+				}
+			}
+			if (bestMatch != null) {
+				// Recover original-case source table name
+				for (String tableName : allTables) {
+					if (tableName.equalsIgnoreCase(bestMatch)) {
+						pairs.add(new String[] { tableName, auditTable });
+						break;
+					}
+				}
+			}
+		}
+		return pairs;
+	}
+
+	/**
+	 * Returns true if the table is an Envers audit table, detected by the presence of both
+	 * {@code REV} and {@code REVTYPE} columns.
+	 */
+	boolean isEnversAuditTable(Connection connection, String tableName) {
+		String safeTableName;
+		try {
+			safeTableName = requireSafeIdentifier(tableName);
+		}
+		catch (IllegalArgumentException e) {
+			return false;
+		}
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("SELECT REV, REVTYPE FROM " + safeTableName + " WHERE 1=0");
+			return true;
+		}
+		catch (Exception e) {
+			return false;
 		}
 	}
 
@@ -111,7 +182,8 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			if (!columns.isEmpty()) {
 				backfillTable(connection, sourceTable, auditTable, columns, revId);
 			}
-		} catch (SQLException e) {
+		}
+		catch (SQLException e) {
 			log.warn("Failed to backfill audit table {}: {}", auditTable, e.getMessage());
 		}
 		return revId;
@@ -223,7 +295,8 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		try (Statement stmt = connection.createStatement();
 		        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + requireSafeIdentifier(tableName))) {
 			return rs.next() && rs.getLong(1) == 0;
-		} catch (SQLException e) {
+		}
+		catch (SQLException e) {
 			log.debug("Audit table {} not accessible, skipping backfill: {}", tableName, e.getMessage());
 			return false;
 		}

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -133,25 +133,32 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			}
 		}
 
-		// Partition into audit tables (have REV + REVTYPE) and potential source tables
-		Set<String> auditTableSet = new HashSet<>();
+		// Phase 1: Find definite Envers audit tables (have both REV and REVTYPE) and
+		// potential subclass audit tables (have REV but not REVTYPE).
+		// In Hibernate Envers with joined-table inheritance, subclass audit tables
+		// (e.g. patient_aud, drug_order_aud) do NOT have their own REVTYPE column —
+		// only the root-class audit table does. So we detect them separately.
+		Set<String> definiteAuditSet = new HashSet<>();
+		Set<String> revOnlySet = new HashSet<>();
 		for (String tableName : allTables) {
 			if (isEnversAuditTable(connection, tableName)) {
-				auditTableSet.add(tableName);
+				definiteAuditSet.add(tableName);
+			} else if (hasRevColumn(connection, tableName)) {
+				revOnlySet.add(tableName);
 			}
 		}
 
-		// Build lowercase set of non-audit table names for prefix matching
+		// Source tables: everything that is not a (potential) audit table
 		Set<String> sourceTableNames = new HashSet<>();
 		for (String tableName : allTables) {
-			if (!auditTableSet.contains(tableName)) {
+			if (!definiteAuditSet.contains(tableName) && !revOnlySet.contains(tableName)) {
 				sourceTableNames.add(tableName.toLowerCase());
 			}
 		}
 
-		// For each audit table, find the longest-prefix matching source table
+		// For each definite audit table, find the longest-prefix matching source table
 		List<String[]> pairs = new ArrayList<>();
-		for (String auditTable : auditTableSet) {
+		for (String auditTable : definiteAuditSet) {
 			String lowerAudit = auditTable.toLowerCase();
 			String bestMatch = null;
 			for (String sourceTable : sourceTableNames) {
@@ -162,7 +169,6 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 				}
 			}
 			if (bestMatch != null) {
-				// Recover original-case source table name
 				for (String tableName : allTables) {
 					if (tableName.equalsIgnoreCase(bestMatch)) {
 						pairs.add(new String[] { tableName, auditTable });
@@ -171,21 +177,43 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 				}
 			}
 		}
-		// Infer the audit suffix by majority vote to filter out false prefix matches.
-		// For example, "Location_LocationAttribute_aud" would match source "location" with
-		// suffix "_locationattribute_aud", which is not the majority suffix "_aud" and is rejected.
+
+		// Infer the audit suffix by majority vote from definite pairs to filter false matches.
+		String inferredSuffix = null;
 		if (!pairs.isEmpty()) {
 			Map<String, Integer> suffixVotes = new HashMap<>();
 			for (String[] pair : pairs) {
 				String suffix = pair[1].toLowerCase().substring(pair[0].toLowerCase().length());
 				suffixVotes.merge(suffix, 1, Integer::sum);
 			}
-			String inferredSuffix = suffixVotes.entrySet().stream()
+			inferredSuffix = suffixVotes.entrySet().stream()
 			        .max(Map.Entry.comparingByValue())
 			        .get().getKey();
 			log.warn("Inferred audit suffix '{}' from majority vote across {} pairs", inferredSuffix, pairs.size());
-			pairs.removeIf(pair -> !pair[1].toLowerCase().substring(pair[0].toLowerCase().length()).equals(inferredSuffix));
+			final String finalSuffix = inferredSuffix;
+			pairs.removeIf(pair -> !pair[1].toLowerCase().substring(pair[0].toLowerCase().length()).equals(finalSuffix));
 		}
+
+		// Phase 2: Add joined-subclass audit tables (have REV but not REVTYPE).
+		// These are matched by checking their name ends with the inferred suffix
+		// and a matching source table exists (e.g. patient_aud → patient).
+		if (inferredSuffix != null) {
+			for (String auditTable : revOnlySet) {
+				String lowerAudit = auditTable.toLowerCase();
+				if (lowerAudit.endsWith(inferredSuffix)) {
+					String sourceTableLower = lowerAudit.substring(0, lowerAudit.length() - inferredSuffix.length());
+					if (sourceTableNames.contains(sourceTableLower)) {
+						for (String tableName : allTables) {
+							if (tableName.equalsIgnoreCase(sourceTableLower)) {
+								pairs.add(new String[] { tableName, auditTable });
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
 		log.warn("Discovered {} audit table pairs to backfill: {}", pairs.size(),
 		    pairs.stream().map(p -> p[0] + " -> " + p[1]).collect(java.util.stream.Collectors.joining(", ")));
 		return pairs;
@@ -205,6 +233,27 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		}
 		try (Statement stmt = connection.createStatement()) {
 			stmt.execute("SELECT REV, REVTYPE FROM " + safeTableName + " WHERE 1=0");
+			return true;
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Returns true if the table has a {@code REV} column but not {@code REVTYPE}.
+	 * Used to detect joined-subclass Envers audit tables which only carry the REV FK.
+	 */
+	boolean hasRevColumn(Connection connection, String tableName) {
+		String safeTableName;
+		try {
+			safeTableName = requireSafeIdentifier(tableName);
+		}
+		catch (IllegalArgumentException e) {
+			return false;
+		}
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("SELECT REV FROM " + safeTableName + " WHERE 1=0");
 			return true;
 		}
 		catch (Exception e) {

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -450,8 +450,21 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		requireSafeIdentifier(auditTable);
 		columns.forEach(BackfillEnversAuditTablesChangeset::requireSafeIdentifier);
 		String columnList = String.join(", ", columns);
-		String sql = "INSERT INTO " + auditTable + " (REV, REVTYPE, " + columnList + ") SELECT " + revId + ", 0, "
-		        + columnList + " FROM " + sourceTable;
+		// Subclass audit tables (e.g. patient_aud, drug_order_aud) do not have a REVTYPE
+		// column — only root-class audit tables do. Check before including it in the INSERT.
+		boolean hasRevtype;
+		try (Statement check = connection.createStatement()) {
+			check.execute("SELECT REVTYPE FROM " + auditTable + " WHERE 1=0");
+			hasRevtype = true;
+		}
+		catch (Exception e) {
+			hasRevtype = false;
+		}
+		String sql = hasRevtype
+		        ? "INSERT INTO " + auditTable + " (REV, REVTYPE, " + columnList + ") SELECT " + revId + ", 0, "
+		                + columnList + " FROM " + sourceTable
+		        : "INSERT INTO " + auditTable + " (REV, " + columnList + ") SELECT " + revId + ", "
+		                + columnList + " FROM " + sourceTable;
 		try (Statement stmt = connection.createStatement()) {
 			int rows = stmt.executeUpdate(sql);
 			log.warn("Backfilled {} rows from {} into {}", rows, sourceTable, auditTable);

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -16,7 +16,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.openmrs.api.context.Context;
@@ -57,8 +59,12 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			        .getProperty("org.hibernate.envers.audit_table_suffix", "_audit");
 
 			String revisionTableName = findRevisionEntityTable(connection);
-			Integer revId = null;
 
+			// Collect all (sourceTable, auditTable) pairs first so we can iterate them
+			// multiple times. A second pass is needed for joined-subclass audit tables
+			// (e.g. patient_aud, drug_order_aud) whose FK to the parent audit table
+			// would otherwise fail when the parent table has not been backfilled yet.
+			List<String[]> auditPairs = new ArrayList<>();
 			DatabaseMetaData metaData = connection.getMetaData();
 			try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
 				while (tables.next()) {
@@ -68,8 +74,17 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 					}
 					String sourceTable = tableName.substring(0, tableName.length() - auditSuffix.length());
 					if (doesTableExist(connection, sourceTable)) {
-						revId = tryBackfillEntity(connection, sourceTable, tableName, revisionTableName, revId);
+						auditPairs.add(new String[] { sourceTable, tableName });
 					}
+				}
+			}
+
+			Integer revId = null;
+			// Two passes: pass 1 populates parent audit tables; pass 2 handles child
+			// audit tables whose FK dependency on the parent is now satisfied.
+			for (int pass = 0; pass < 2; pass++) {
+				for (String[] pair : auditPairs) {
+					revId = tryBackfillEntity(connection, pair[0], pair[1], revisionTableName, revId);
 				}
 			}
 
@@ -92,7 +107,7 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			if (revId == null) {
 				revId = createBackfillRevision(connection, revisionTableName);
 			}
-			List<String> columns = getAuditTableDataColumns(connection, auditTable);
+			List<String> columns = getAuditTableDataColumns(connection, auditTable, sourceTable);
 			if (!columns.isEmpty()) {
 				backfillTable(connection, sourceTable, auditTable, columns, revId);
 			}
@@ -225,17 +240,28 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 	}
 
 	/**
-	 * Returns the data column names from the given audit table, excluding the Envers metadata columns
-	 * REV and REVTYPE. These are the columns that correspond to the audited entity fields and must
-	 * exist in the source table.
+	 * Returns the column names that exist in both the audit table and the source table, excluding the
+	 * Envers metadata columns REV and REVTYPE. Using the intersection avoids INSERT failures caused by
+	 * extra columns in the audit table that have no counterpart in the source table (e.g. columns
+	 * added by Envers for joined-subclass inheritance tracking).
 	 */
-	static List<String> getAuditTableDataColumns(Connection connection, String auditTable) throws SQLException {
-		List<String> columns = new ArrayList<>();
+	static List<String> getAuditTableDataColumns(Connection connection, String auditTable, String sourceTable)
+	        throws SQLException {
 		DatabaseMetaData metaData = connection.getMetaData();
+
+		Set<String> sourceColumns = new HashSet<>();
+		try (ResultSet rs = metaData.getColumns(null, null, sourceTable, null)) {
+			while (rs.next()) {
+				sourceColumns.add(rs.getString("COLUMN_NAME").toLowerCase());
+			}
+		}
+
+		List<String> columns = new ArrayList<>();
 		try (ResultSet rs = metaData.getColumns(null, null, auditTable, null)) {
 			while (rs.next()) {
 				String colName = rs.getString("COLUMN_NAME");
-				if (!colName.equalsIgnoreCase("REV") && !colName.equalsIgnoreCase("REVTYPE")) {
+				if (!colName.equalsIgnoreCase("REV") && !colName.equalsIgnoreCase("REVTYPE")
+				        && sourceColumns.contains(colName.toLowerCase())) {
 					columns.add(colName);
 				}
 			}

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -99,9 +99,12 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 	 */
 	List<String[]> discoverAuditPairs(Connection connection) throws SQLException {
 		DatabaseMetaData metaData = connection.getMetaData();
+		// Restrict to the current catalog so system tables from other databases
+		// (mysql, information_schema, etc.) are not included in the search.
+		String catalog = connection.getCatalog();
 
 		List<String> allTables = new ArrayList<>();
-		try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
+		try (ResultSet tables = metaData.getTables(catalog, null, "%", new String[] { "TABLE" })) {
 			while (tables.next()) {
 				allTables.add(tables.getString("TABLE_NAME"));
 			}
@@ -145,6 +148,8 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 				}
 			}
 		}
+		log.info("Discovered {} audit table pairs to backfill: {}", pairs.size(),
+		    pairs.stream().map(p -> p[0] + " -> " + p[1]).collect(java.util.stream.Collectors.joining(", ")));
 		return pairs;
 	}
 

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -16,8 +16,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -147,6 +149,21 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 					}
 				}
 			}
+		}
+		// Infer the audit suffix by majority vote to filter out false prefix matches.
+		// For example, "Location_LocationAttribute_aud" would match source "location" with
+		// suffix "_locationattribute_aud", which is not the majority suffix "_aud" and is rejected.
+		if (!pairs.isEmpty()) {
+			Map<String, Integer> suffixVotes = new HashMap<>();
+			for (String[] pair : pairs) {
+				String suffix = pair[1].toLowerCase().substring(pair[0].toLowerCase().length());
+				suffixVotes.merge(suffix, 1, Integer::sum);
+			}
+			String inferredSuffix = suffixVotes.entrySet().stream()
+			        .max(Map.Entry.comparingByValue())
+			        .get().getKey();
+			log.info("Inferred audit suffix '{}' from majority vote across {} pairs", inferredSuffix, pairs.size());
+			pairs.removeIf(pair -> !pair[1].toLowerCase().substring(pair[0].toLowerCase().length()).equals(inferredSuffix));
 		}
 		log.info("Discovered {} audit table pairs to backfill: {}", pairs.size(),
 		    pairs.stream().map(p -> p[0] + " -> " + p[1]).collect(java.util.stream.Collectors.joining(", ")));

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,12 +48,13 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 
 	private static final Pattern SAFE_SQL_IDENTIFIER = Pattern.compile("[a-zA-Z_]\\w*");
 
-	private static final String AUDIT_SUFFIX = "_audit";
-
 	@Override
 	public void execute(Database database) throws CustomChangeException {
 		try {
 			Connection connection = ((JdbcConnection) database.getConnection()).getUnderlyingConnection();
+
+			String auditSuffix = Context.getRuntimeProperties()
+			        .getProperty("org.hibernate.envers.audit_table_suffix", "_audit");
 
 			String revisionTableName = findRevisionEntityTable(connection);
 			Integer revId = null;
@@ -61,10 +63,10 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 			try (ResultSet tables = metaData.getTables(null, null, "%", new String[] { "TABLE" })) {
 				while (tables.next()) {
 					String tableName = tables.getString("TABLE_NAME");
-					if (!tableName.endsWith(AUDIT_SUFFIX)) {
+					if (!tableName.endsWith(auditSuffix)) {
 						continue;
 					}
-					String sourceTable = tableName.substring(0, tableName.length() - AUDIT_SUFFIX.length());
+					String sourceTable = tableName.substring(0, tableName.length() - auditSuffix.length());
 					if (doesTableExist(connection, sourceTable)) {
 						revId = tryBackfillEntity(connection, sourceTable, tableName, revisionTableName, revId);
 					}

--- a/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangeset.java
@@ -64,18 +64,29 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 
 			// Discover (sourceTable, auditTable) pairs by detecting Envers audit tables via
 			// REV + REVTYPE columns — independent of the configured audit suffix.
-			// Collect all pairs first so we can iterate them multiple times: a second pass
-			// is needed for joined-subclass audit tables (e.g. patient_aud, drug_order_aud)
-			// whose FK to the parent audit table would otherwise fail when the parent has
-			// not been backfilled yet.
 			List<String[]> auditPairs = discoverAuditPairs(connection);
 
+			// Temporarily disable FK checks on MySQL/MariaDB so that joined-subclass audit
+			// tables (patient_aud → person_aud, drug_order_aud → orders_aud) can be
+			// backfilled regardless of iteration order.
+			boolean mysqlCompatible = isMysqlCompatible(connection);
+			if (mysqlCompatible) {
+				try (Statement stmt = connection.createStatement()) {
+					stmt.execute("SET FOREIGN_KEY_CHECKS=0");
+				}
+			}
+
 			Integer revId = null;
-			// Two passes: pass 1 populates parent audit tables; pass 2 handles child
-			// audit tables whose FK dependency on the parent is now satisfied.
-			for (int pass = 0; pass < 2; pass++) {
+			try {
 				for (String[] pair : auditPairs) {
 					revId = tryBackfillEntity(connection, pair[0], pair[1], revisionTableName, revId);
+				}
+			}
+			finally {
+				if (mysqlCompatible) {
+					try (Statement stmt = connection.createStatement()) {
+						stmt.execute("SET FOREIGN_KEY_CHECKS=1");
+					}
 				}
 			}
 
@@ -87,6 +98,16 @@ public class BackfillEnversAuditTablesChangeset implements CustomTaskChange {
 		}
 		catch (Exception e) {
 			throw new CustomChangeException("Failed to backfill Envers audit tables", e);
+		}
+	}
+
+	private boolean isMysqlCompatible(Connection connection) {
+		try {
+			String productName = connection.getMetaData().getDatabaseProductName().toLowerCase();
+			return productName.contains("mysql") || productName.contains("mariadb");
+		}
+		catch (SQLException e) {
+			return false;
 		}
 	}
 

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
@@ -48,5 +48,10 @@
 			</column>
 		</createTable>
 	</changeSet>
-	
+
+	<changeSet id="AUDIT-28-2026-03-19" author="Binayak490-cyber">
+		<comment>Backfill pre-existing rows into Envers audit tables</comment>
+		<customChange class="org.openmrs.util.databasechange.BackfillEnversAuditTablesChangeset"/>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -32,7 +32,7 @@ public class DatabaseUpdaterDatabaseIT extends DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 	
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 905;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 906;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 

--- a/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
@@ -1,0 +1,214 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util.databasechange;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link BackfillEnversAuditTablesChangeset}, focused on the backfill behaviour
+ * introduced to fix AUDIT-28: "Unable to read" values in audit tables for entities that existed
+ * before auditing was enabled.
+ * <p>
+ * These tests call the package-private helper methods directly against a real H2 in-memory
+ * database.
+ */
+class BackfillEnversAuditTablesChangesetTest {
+
+	private static final String H2_URL = "jdbc:h2:mem:enversbackfilltest;DB_CLOSE_DELAY=-1";
+
+	private static final String REVISION_TABLE = "revision_entity";
+
+	private Connection connection;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		connection = DriverManager.getConnection(H2_URL, "sa", "");
+		connection.setAutoCommit(false);
+	}
+
+	@AfterEach
+	void tearDown() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("DROP ALL OBJECTS");
+		}
+		connection.commit();
+		connection.close();
+	}
+
+	@Test
+	void createBackfillRevision_shouldInsertRevisionAndReturnGeneratedId() throws Exception {
+		createRevisionTable();
+		connection.commit();
+
+		int revId = BackfillEnversAuditTablesChangeset.createBackfillRevision(connection, REVISION_TABLE);
+		connection.commit();
+
+		assertTrue(revId > 0, "Generated revision ID should be positive");
+		try (Statement stmt = connection.createStatement();
+		        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM " + REVISION_TABLE)) {
+			rs.next();
+			assertEquals(1, rs.getInt(1), "Exactly one revision row should be present");
+		}
+	}
+
+	@Test
+	void isAuditTableEmpty_shouldReturnTrueWhenTableHasNoRows() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT)");
+		}
+		connection.commit();
+
+		assertTrue(BackfillEnversAuditTablesChangeset.isAuditTableEmpty(connection, "patient_audit"));
+	}
+
+	@Test
+	void isAuditTableEmpty_shouldReturnFalseWhenTableHasRows() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT)");
+			stmt.execute("INSERT INTO patient_audit VALUES (1, 0, 42)");
+		}
+		connection.commit();
+
+		assertFalse(BackfillEnversAuditTablesChangeset.isAuditTableEmpty(connection, "patient_audit"));
+	}
+
+	@Test
+	void isAuditTableEmpty_shouldReturnFalseWhenTableDoesNotExist() {
+		// Table doesn't exist — should not throw, should return false (skip backfill safely)
+		assertFalse(BackfillEnversAuditTablesChangeset.isAuditTableEmpty(connection, "nonexistent_audit"));
+	}
+
+	@Test
+	void isTableEmpty_shouldReturnTrueForEmptyTable() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY)");
+		}
+		connection.commit();
+
+		assertTrue(BackfillEnversAuditTablesChangeset.isTableEmpty(connection, "patient"));
+	}
+
+	@Test
+	void isTableEmpty_shouldReturnFalseWhenTableHasData() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY)");
+			stmt.execute("INSERT INTO patient VALUES (1)");
+		}
+		connection.commit();
+
+		assertFalse(BackfillEnversAuditTablesChangeset.isTableEmpty(connection, "patient"));
+	}
+
+	@Test
+	void getAuditTableDataColumns_shouldReturnColumnsExcludingRevAndRevtype() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
+		}
+		connection.commit();
+
+		List<String> columns = BackfillEnversAuditTablesChangeset.getAuditTableDataColumns(connection, "PATIENT_AUDIT");
+
+		assertEquals(2, columns.size(), "Should return only non-Envers columns");
+		assertFalse(columns.stream().anyMatch(c -> c.equalsIgnoreCase("REV")), "REV should be excluded");
+		assertFalse(columns.stream().anyMatch(c -> c.equalsIgnoreCase("REVTYPE")), "REVTYPE should be excluded");
+	}
+
+	@Test
+	void backfillTable_shouldInsertAllSourceRowsIntoAuditTableWithRevtype0() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+			stmt.execute("INSERT INTO patient VALUES (1, 'Alice')");
+			stmt.execute("INSERT INTO patient VALUES (2, 'Bob')");
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
+		}
+		connection.commit();
+
+		List<String> columns = Arrays.asList("PATIENT_ID", "NAME");
+		BackfillEnversAuditTablesChangeset.backfillTable(connection, "patient", "patient_audit", columns, 1);
+		connection.commit();
+
+		try (Statement stmt = connection.createStatement()) {
+			try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM patient_audit WHERE REVTYPE = 0")) {
+				rs.next();
+				assertEquals(2, rs.getInt(1), "Both source rows should appear in audit table with REVTYPE=0 (ADD)");
+			}
+			try (ResultSet rs = stmt.executeQuery("SELECT name FROM patient_audit ORDER BY patient_id")) {
+				assertTrue(rs.next());
+				assertEquals("Alice", rs.getString(1));
+				assertTrue(rs.next());
+				assertEquals("Bob", rs.getString(1));
+			}
+		}
+	}
+
+	@Test
+	void backfillTable_shouldUseTheProvidedRevisionId() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY)");
+			stmt.execute("INSERT INTO patient VALUES (99)");
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT)");
+		}
+		connection.commit();
+
+		BackfillEnversAuditTablesChangeset.backfillTable(connection, "patient", "patient_audit", Arrays.asList("PATIENT_ID"), 42);
+		connection.commit();
+
+		try (Statement stmt = connection.createStatement();
+		        ResultSet rs = stmt.executeQuery("SELECT REV FROM patient_audit")) {
+			assertTrue(rs.next());
+			assertEquals(42, rs.getInt(1), "Audit row should carry the supplied revision ID");
+		}
+	}
+
+	@Test
+	void backfillIsSkipped_whenAuditTableAlreadyHasData() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+			stmt.execute("INSERT INTO patient VALUES (1, 'Alice')");
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
+			stmt.execute("INSERT INTO patient_audit VALUES (1, 0, 1, 'Alice')");
+		}
+		connection.commit();
+
+		assertFalse(BackfillEnversAuditTablesChangeset.isAuditTableEmpty(connection, "patient_audit"),
+		    "Audit table with data should not trigger backfill");
+	}
+
+	@Test
+	void backfillIsSkipped_whenSourceTableIsEmpty() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
+		}
+		connection.commit();
+
+		assertTrue(BackfillEnversAuditTablesChangeset.isTableEmpty(connection, "patient"),
+		    "Empty source table should not trigger backfill");
+	}
+
+	private void createRevisionTable() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE " + REVISION_TABLE + " (id INT NOT NULL PRIMARY KEY, timestamp BIGINT NOT NULL)");
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
@@ -122,11 +122,13 @@ class BackfillEnversAuditTablesChangesetTest {
 	@Test
 	void getAuditTableDataColumns_shouldReturnColumnsExcludingRevAndRevtype() throws Exception {
 		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
 			stmt.execute("CREATE TABLE patient_audit (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
 		}
 		connection.commit();
 
-		List<String> columns = BackfillEnversAuditTablesChangeset.getAuditTableDataColumns(connection, "PATIENT_AUDIT");
+		List<String> columns = BackfillEnversAuditTablesChangeset.getAuditTableDataColumns(connection, "PATIENT_AUDIT",
+		    "PATIENT");
 
 		assertEquals(2, columns.size(), "Should return only non-Envers columns");
 		assertFalse(columns.stream().anyMatch(c -> c.equalsIgnoreCase("REV")), "REV should be excluded");

--- a/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/BackfillEnversAuditTablesChangesetTest.java
@@ -208,6 +208,120 @@ class BackfillEnversAuditTablesChangesetTest {
 		    "Empty source table should not trigger backfill");
 	}
 
+	@Test
+	void isEnversAuditTable_shouldReturnTrueForTableWithRevAndRevtype() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient_aud (REV INT, REVTYPE TINYINT, patient_id INT)");
+		}
+		connection.commit();
+
+		BackfillEnversAuditTablesChangeset changeset = new BackfillEnversAuditTablesChangeset();
+		assertTrue(changeset.isEnversAuditTable(connection, "patient_aud"),
+		    "Table with REV and REVTYPE should be identified as an Envers audit table");
+	}
+
+	@Test
+	void isEnversAuditTable_shouldReturnFalseForRegularTable() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+		}
+		connection.commit();
+
+		BackfillEnversAuditTablesChangeset changeset = new BackfillEnversAuditTablesChangeset();
+		assertFalse(changeset.isEnversAuditTable(connection, "patient"),
+		    "Regular table without REV/REVTYPE should not be identified as audit table");
+	}
+
+	@Test
+	void discoverAuditPairs_shouldMatchAuditTableToSourceTable() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+			stmt.execute("CREATE TABLE patient_aud (REV INT, REVTYPE TINYINT, patient_id INT)");
+		}
+		connection.commit();
+
+		BackfillEnversAuditTablesChangeset changeset = new BackfillEnversAuditTablesChangeset();
+		List<String[]> pairs = changeset.discoverAuditPairs(connection);
+
+		assertEquals(1, pairs.size(), "Should discover exactly one audit pair");
+		assertEquals("patient", pairs.get(0)[0].toLowerCase(), "Source table should be patient");
+		assertEquals("patient_aud", pairs.get(0)[1].toLowerCase(), "Audit table should be patient_aud");
+	}
+
+	@Test
+	void discoverAuditPairs_shouldUseLongestPrefixMatch() throws Exception {
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY)");
+			stmt.execute("CREATE TABLE patient_identifier (id INT PRIMARY KEY)");
+			stmt.execute("CREATE TABLE patient_identifier_aud (REV INT, REVTYPE TINYINT, id INT)");
+		}
+		connection.commit();
+
+		BackfillEnversAuditTablesChangeset changeset = new BackfillEnversAuditTablesChangeset();
+		List<String[]> pairs = changeset.discoverAuditPairs(connection);
+
+		assertEquals(1, pairs.size(), "Should discover exactly one audit pair");
+		assertEquals("patient_identifier", pairs.get(0)[0].toLowerCase(),
+		    "Longest prefix match should pick patient_identifier over patient");
+	}
+
+	@Test
+	void endToEnd_shouldBackfillAuditTablesWithCustomSuffix() throws Exception {
+		// Simulate maintainer's setup: tables use _aud suffix, not _audit
+		try (Statement stmt = connection.createStatement()) {
+			stmt.execute("CREATE TABLE " + REVISION_TABLE + " (id INT NOT NULL PRIMARY KEY, timestamp BIGINT NOT NULL)");
+
+			stmt.execute("CREATE TABLE patient (patient_id INT PRIMARY KEY, name VARCHAR(100))");
+			stmt.execute("INSERT INTO patient VALUES (1, 'Alice'), (2, 'Bob')");
+
+			stmt.execute("CREATE TABLE encounter (encounter_id INT PRIMARY KEY, type VARCHAR(50))");
+			stmt.execute("INSERT INTO encounter VALUES (10, 'VISIT')");
+
+			// Audit tables with _aud suffix (empty) — no suffix config needed
+			stmt.execute("CREATE TABLE patient_aud (REV INT, REVTYPE TINYINT, patient_id INT, name VARCHAR(100))");
+			stmt.execute("CREATE TABLE encounter_aud (REV INT, REVTYPE TINYINT, encounter_id INT, type VARCHAR(50))");
+		}
+		connection.commit();
+
+		// Run full backfill flow using the same logic as execute()
+		BackfillEnversAuditTablesChangeset changeset = new BackfillEnversAuditTablesChangeset();
+		List<String[]> pairs = changeset.discoverAuditPairs(connection);
+		assertEquals(2, pairs.size(), "Should discover patient_aud and encounter_aud");
+
+		Integer revId = null;
+		for (int pass = 0; pass < 2; pass++) {
+			for (String[] pair : pairs) {
+				String sourceTable = pair[0];
+				String auditTable = pair[1];
+				if (!BackfillEnversAuditTablesChangeset.isAuditTableEmpty(connection, auditTable)
+				        || BackfillEnversAuditTablesChangeset.isTableEmpty(connection, sourceTable)) {
+					continue;
+				}
+				if (revId == null) {
+					revId = BackfillEnversAuditTablesChangeset.createBackfillRevision(connection, REVISION_TABLE);
+				}
+				List<String> columns = BackfillEnversAuditTablesChangeset.getAuditTableDataColumns(connection, auditTable,
+				    sourceTable);
+				if (!columns.isEmpty()) {
+					BackfillEnversAuditTablesChangeset.backfillTable(connection, sourceTable, auditTable, columns, revId);
+				}
+			}
+		}
+		connection.commit();
+
+		// Verify audit tables are populated
+		try (Statement stmt = connection.createStatement()) {
+			try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM patient_aud")) {
+				rs.next();
+				assertEquals(2, rs.getInt(1), "patient_aud should have 2 backfilled rows");
+			}
+			try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM encounter_aud")) {
+				rs.next();
+				assertEquals(1, rs.getInt(1), "encounter_aud should have 1 backfilled row");
+			}
+		}
+	}
+
 	private void createRevisionTable() throws Exception {
 		try (Statement stmt = connection.createStatement()) {
 			stmt.execute("CREATE TABLE " + REVISION_TABLE + " (id INT NOT NULL PRIMARY KEY, timestamp BIGINT NOT NULL)");


### PR DESCRIPTION
## Summary
This is a port of the backfill changeset from PR #5933 (targeting master/3.0.x) to the 2.9.x branch.

Since the Hibernate Envers commit was also merged into 2.9.x, the backfill changeset needs to be available there as well.

## What this does
- Adds `BackfillEnversAuditTablesChangeset.java` implementing Liquibase `CustomTaskChange`
- Adds changeset `AUDIT-28-2026-03-19` to `liquibase-update-to-latest-2.9.x.xml`
- Backfill runs exactly once per database, tracked in `liquibasechangelog`
- `EnversAuditTableInitializer` is kept as-is for audit table schema creation

## Testing
- Verified locally on a fresh MariaDB instance — changeset `AUDIT-28-2026-03-19` recorded in `liquibasechangelog` and audit tables populated with data
- Note: tables like `patient_audit`, `encounter_audit`, `obs_audit` require an existing database with clinical data to verify — a fresh install has no source data to backfill for those tables

## Related
- Parent PR: #5933