### PR TITLE
PoC: PasswordEncoder migration using DelegatingPasswordEncoder

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -86,6 +86,11 @@
 			<artifactId>spring-context-support</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-crypto</artifactId>
+			<version>6.5.6</version>
+		</dependency>
+		<dependency>
 			<groupId>org.infinispan</groupId>
 			<artifactId>infinispan-spring6-embedded</artifactId>
 		</dependency>

--- a/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
+++ b/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
@@ -50,8 +50,8 @@ import ca.uhn.hl7v2.app.MessageTypeRouter;
 import ca.uhn.hl7v2.parser.GenericParser;
 
 /**
- * Provides OpenMRS Application Context Spring Configuration. It's a replacement
- * for applicationContext-service.xml from which we gradually migrate away.
+ * Provides OpenMRS Application Context Spring Configuration. It's a replacement for
+ * applicationContext-service.xml from which we gradually migrate away.
  *
  * @see org.openmrs.aop.AOPConfig
  * @see org.openmrs.api.cache.CacheConfig
@@ -60,114 +60,114 @@ import ca.uhn.hl7v2.parser.GenericParser;
 @Configuration
 public class OpenmrsApplicationContextConfig {
 
-    @Bean
-    public TransactionManager transactionManager(SessionFactory sessionFactory) {
-        return new HibernateTransactionManager(sessionFactory);
-    }
+	@Bean
+	public TransactionManager transactionManager(SessionFactory sessionFactory) {
+		return new HibernateTransactionManager(sessionFactory);
+	}
 
-    @Bean
-    public TaskExecutor taskExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(1);
-        executor.setMaxPoolSize(20);
-        executor.setQueueCapacity(1000);
-        return executor;
-    }
+	@Bean
+	public TaskExecutor taskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(20);
+		executor.setQueueCapacity(1000);
+		return executor;
+	}
 
-    @Bean
-    public Map<String, ComplexObsHandler> handlers(ImageHandler imageHandler, TextHandler textHandler,
-            BinaryDataHandler binaryDataHandler, BinaryStreamHandler binaryStreamHandler) {
-        Map<String, ComplexObsHandler> map = new LinkedHashMap<>();
-        map.put("ImageHandler", imageHandler);
-        map.put("TextHandler", textHandler);
-        map.put("BinaryDataHandler", binaryDataHandler);
-        map.put("BinaryStreamHandler", binaryStreamHandler);
-        return map;
-    }
+	@Bean
+	public Map<String, ComplexObsHandler> handlers(ImageHandler imageHandler, TextHandler textHandler,
+	        BinaryDataHandler binaryDataHandler, BinaryStreamHandler binaryStreamHandler) {
+		Map<String, ComplexObsHandler> map = new LinkedHashMap<>();
+		map.put("ImageHandler", imageHandler);
+		map.put("TextHandler", textHandler);
+		map.put("BinaryDataHandler", binaryDataHandler);
+		map.put("BinaryStreamHandler", binaryStreamHandler);
+		return map;
+	}
 
-    @Bean
-    public Map<Class<?>, IdentifierValidator> identifierValidators(LuhnIdentifierValidator luhnIdentifierValidator,
-            VerhoeffIdentifierValidator verhoeffIdentifierValidator) {
-        Map<Class<?>, IdentifierValidator> map = new LinkedHashMap<>();
-        map.put(LuhnIdentifierValidator.class, luhnIdentifierValidator);
-        map.put(VerhoeffIdentifierValidator.class, verhoeffIdentifierValidator);
-        return map;
-    }
+	@Bean
+	public Map<Class<?>, IdentifierValidator> identifierValidators(LuhnIdentifierValidator luhnIdentifierValidator,
+	        VerhoeffIdentifierValidator verhoeffIdentifierValidator) {
+		Map<Class<?>, IdentifierValidator> map = new LinkedHashMap<>();
+		map.put(LuhnIdentifierValidator.class, luhnIdentifierValidator);
+		map.put(VerhoeffIdentifierValidator.class, verhoeffIdentifierValidator);
+		return map;
+	}
 
-    @Bean
-    public List<OpenmrsSerializer> serializerList(SimpleXStreamSerializer simpleXStreamSerializer) {
-        List<OpenmrsSerializer> serializers = new ArrayList<>();
-        serializers.add(simpleXStreamSerializer);
-        return serializers;
-    }
+	@Bean
+	public List<OpenmrsSerializer> serializerList(SimpleXStreamSerializer simpleXStreamSerializer) {
+		List<OpenmrsSerializer> serializers = new ArrayList<>();
+		serializers.add(simpleXStreamSerializer);
+		return serializers;
+	}
 
-    @Bean
-    public MutableResourceBundleMessageSource mutableResourceBundleMessageSource() {
-        MutableResourceBundleMessageSource messageSource = new MutableResourceBundleMessageSource();
-        messageSource.setBasenames("classpath:custom_messages", "classpath:messages");
-        messageSource.setUseCodeAsDefaultMessage(true);
-        messageSource.setCacheSeconds(5);
-        messageSource.setDefaultEncoding("UTF-8");
-        return messageSource;
-    }
+	@Bean
+	public MutableResourceBundleMessageSource mutableResourceBundleMessageSource() {
+		MutableResourceBundleMessageSource messageSource = new MutableResourceBundleMessageSource();
+		messageSource.setBasenames("classpath:custom_messages", "classpath:messages");
+		messageSource.setUseCodeAsDefaultMessage(true);
+		messageSource.setCacheSeconds(5);
+		messageSource.setDefaultEncoding("UTF-8");
+		return messageSource;
+	}
 
-    /**
-     * Provides a PropertySourcesPlaceholderConfigurer that uses
-     * OpenmrsUtil.getApplicationDataDirectory() to resolve the runtime
-     * properties file location, ensuring the property is always set.
-     *
-     * @return configurer
-     */
-    @Bean
-    public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-        PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
-        String appDataDir = OpenmrsUtil.getApplicationDataDirectory();
-        Properties props = new Properties();
-        props.setProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY, appDataDir);
-        configurer.setProperties(props);
-        configurer.setLocations(new ClassPathResource("hibernate.default.properties"),
-                new ClassPathResource("application.properties"),
-                new FileSystemResource(appDataDir + "/openmrs-runtime.properties"));
-        configurer.setIgnoreResourceNotFound(true);
-        configurer.setLocalOverride(true);
-        return configurer;
-    }
+	/**
+	 * Provides a PropertySourcesPlaceholderConfigurer that uses
+	 * OpenmrsUtil.getApplicationDataDirectory() to resolve the runtime properties file location,
+	 * ensuring the property is always set.
+	 *
+	 * @return configurer
+	 */
+	@Bean
+	public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+		PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+		String appDataDir = OpenmrsUtil.getApplicationDataDirectory();
+		Properties props = new Properties();
+		props.setProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY, appDataDir);
+		configurer.setProperties(props);
+		configurer.setLocations(new ClassPathResource("hibernate.default.properties"),
+		    new ClassPathResource("application.properties"),
+		    new FileSystemResource(appDataDir + "/openmrs-runtime.properties"));
+		configurer.setIgnoreResourceNotFound(true);
+		configurer.setLocalOverride(true);
+		return configurer;
+	}
 
-    @Bean
-    public GenericParser hL7Parser() {
-        return new GenericParser();
-    }
+	@Bean
+	public GenericParser hL7Parser() {
+		return new GenericParser();
+	}
 
-    @Bean
-    public MessageTypeRouter hL7Router() {
-        return new MessageTypeRouter();
-    }
+	@Bean
+	public MessageTypeRouter hL7Router() {
+		return new MessageTypeRouter();
+	}
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        Map<String, PasswordEncoder> encoders = new LinkedHashMap<>();
-        encoders.put("bcrypt", new BCryptPasswordEncoder());
-        encoders.put("sha512", new PasswordEncoder() {
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		Map<String, PasswordEncoder> encoders = new LinkedHashMap<>();
+		encoders.put("bcrypt", new BCryptPasswordEncoder());
+		encoders.put("sha512", new PasswordEncoder() {
 
-            @Override
-            public String encode(CharSequence rawPassword) {
-                return Security.encodeString(rawPassword.toString());
-            }
+			@Override
+			public String encode(CharSequence rawPassword) {
+				return Security.encodeString(rawPassword.toString());
+			}
 
-            @Override
-            public boolean matches(CharSequence rawPassword, String encodedPassword) {
-                return encode(rawPassword).equals(encodedPassword);
-            }
-        });
+			@Override
+			public boolean matches(CharSequence rawPassword, String encodedPassword) {
+				return encode(rawPassword).equals(encodedPassword);
+			}
+		});
 
-        return new DelegatingPasswordEncoder("bcrypt", encoders);
-    }
+		return new DelegatingPasswordEncoder("bcrypt", encoders);
+	}
 
-    @Bean
-    public Map<String, Application> hL7Handlers(ORUR01Handler orur01Handler, ADTA28Handler adta28Handler) {
-        Map<String, Application> map = new LinkedHashMap<>();
-        map.put("ORU_R01", orur01Handler);
-        map.put("ADT_A28", adta28Handler);
-        return map;
-    }
+	@Bean
+	public Map<String, Application> hL7Handlers(ORUR01Handler orur01Handler, ADTA28Handler adta28Handler) {
+		Map<String, Application> map = new LinkedHashMap<>();
+		map.put("ORU_R01", orur01Handler);
+		map.put("ADT_A28", adta28Handler);
+		return map;
+	}
 }

--- a/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
+++ b/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
@@ -31,6 +31,7 @@ import org.openmrs.serialization.OpenmrsSerializer;
 import org.openmrs.serialization.SimpleXStreamSerializer;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.Security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
@@ -39,6 +40,9 @@ import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.orm.jpa.hibernate.HibernateTransactionManager;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.TransactionManager;
 
 import ca.uhn.hl7v2.app.Application;
@@ -46,8 +50,8 @@ import ca.uhn.hl7v2.app.MessageTypeRouter;
 import ca.uhn.hl7v2.parser.GenericParser;
 
 /**
- * Provides OpenMRS Application Context Spring Configuration. It's a replacement for
- * applicationContext-service.xml from which we gradually migrate away.
+ * Provides OpenMRS Application Context Spring Configuration. It's a replacement
+ * for applicationContext-service.xml from which we gradually migrate away.
  *
  * @see org.openmrs.aop.AOPConfig
  * @see org.openmrs.api.cache.CacheConfig
@@ -56,94 +60,114 @@ import ca.uhn.hl7v2.parser.GenericParser;
 @Configuration
 public class OpenmrsApplicationContextConfig {
 
-	@Bean
-	public TransactionManager transactionManager(SessionFactory sessionFactory) {
-		return new HibernateTransactionManager(sessionFactory);
-	}
+    @Bean
+    public TransactionManager transactionManager(SessionFactory sessionFactory) {
+        return new HibernateTransactionManager(sessionFactory);
+    }
 
-	@Bean
-	public TaskExecutor taskExecutor() {
-		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-		executor.setCorePoolSize(1);
-		executor.setMaxPoolSize(20);
-		executor.setQueueCapacity(1000);
-		return executor;
-	}
+    @Bean
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(1000);
+        return executor;
+    }
 
-	@Bean
-	public Map<String, ComplexObsHandler> handlers(ImageHandler imageHandler, TextHandler textHandler,
-	        BinaryDataHandler binaryDataHandler, BinaryStreamHandler binaryStreamHandler) {
-		Map<String, ComplexObsHandler> map = new LinkedHashMap<>();
-		map.put("ImageHandler", imageHandler);
-		map.put("TextHandler", textHandler);
-		map.put("BinaryDataHandler", binaryDataHandler);
-		map.put("BinaryStreamHandler", binaryStreamHandler);
-		return map;
-	}
+    @Bean
+    public Map<String, ComplexObsHandler> handlers(ImageHandler imageHandler, TextHandler textHandler,
+            BinaryDataHandler binaryDataHandler, BinaryStreamHandler binaryStreamHandler) {
+        Map<String, ComplexObsHandler> map = new LinkedHashMap<>();
+        map.put("ImageHandler", imageHandler);
+        map.put("TextHandler", textHandler);
+        map.put("BinaryDataHandler", binaryDataHandler);
+        map.put("BinaryStreamHandler", binaryStreamHandler);
+        return map;
+    }
 
-	@Bean
-	public Map<Class<?>, IdentifierValidator> identifierValidators(LuhnIdentifierValidator luhnIdentifierValidator,
-	        VerhoeffIdentifierValidator verhoeffIdentifierValidator) {
-		Map<Class<?>, IdentifierValidator> map = new LinkedHashMap<>();
-		map.put(LuhnIdentifierValidator.class, luhnIdentifierValidator);
-		map.put(VerhoeffIdentifierValidator.class, verhoeffIdentifierValidator);
-		return map;
-	}
+    @Bean
+    public Map<Class<?>, IdentifierValidator> identifierValidators(LuhnIdentifierValidator luhnIdentifierValidator,
+            VerhoeffIdentifierValidator verhoeffIdentifierValidator) {
+        Map<Class<?>, IdentifierValidator> map = new LinkedHashMap<>();
+        map.put(LuhnIdentifierValidator.class, luhnIdentifierValidator);
+        map.put(VerhoeffIdentifierValidator.class, verhoeffIdentifierValidator);
+        return map;
+    }
 
-	@Bean
-	public List<OpenmrsSerializer> serializerList(SimpleXStreamSerializer simpleXStreamSerializer) {
-		List<OpenmrsSerializer> serializers = new ArrayList<>();
-		serializers.add(simpleXStreamSerializer);
-		return serializers;
-	}
+    @Bean
+    public List<OpenmrsSerializer> serializerList(SimpleXStreamSerializer simpleXStreamSerializer) {
+        List<OpenmrsSerializer> serializers = new ArrayList<>();
+        serializers.add(simpleXStreamSerializer);
+        return serializers;
+    }
 
-	@Bean
-	public MutableResourceBundleMessageSource mutableResourceBundleMessageSource() {
-		MutableResourceBundleMessageSource messageSource = new MutableResourceBundleMessageSource();
-		messageSource.setBasenames("classpath:custom_messages", "classpath:messages");
-		messageSource.setUseCodeAsDefaultMessage(true);
-		messageSource.setCacheSeconds(5);
-		messageSource.setDefaultEncoding("UTF-8");
-		return messageSource;
-	}
+    @Bean
+    public MutableResourceBundleMessageSource mutableResourceBundleMessageSource() {
+        MutableResourceBundleMessageSource messageSource = new MutableResourceBundleMessageSource();
+        messageSource.setBasenames("classpath:custom_messages", "classpath:messages");
+        messageSource.setUseCodeAsDefaultMessage(true);
+        messageSource.setCacheSeconds(5);
+        messageSource.setDefaultEncoding("UTF-8");
+        return messageSource;
+    }
 
-	/**
-	 * Provides a PropertySourcesPlaceholderConfigurer that uses
-	 * OpenmrsUtil.getApplicationDataDirectory() to resolve the runtime properties file location,
-	 * ensuring the property is always set.
-	 *
-	 * @return configurer
-	 */
-	@Bean
-	public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
-		PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
-		String appDataDir = OpenmrsUtil.getApplicationDataDirectory();
-		Properties props = new Properties();
-		props.setProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY, appDataDir);
-		configurer.setProperties(props);
-		configurer.setLocations(new ClassPathResource("hibernate.default.properties"),
-		    new ClassPathResource("application.properties"),
-		    new FileSystemResource(appDataDir + "/openmrs-runtime.properties"));
-		configurer.setIgnoreResourceNotFound(true);
-		configurer.setLocalOverride(true);
-		return configurer;
-	}
+    /**
+     * Provides a PropertySourcesPlaceholderConfigurer that uses
+     * OpenmrsUtil.getApplicationDataDirectory() to resolve the runtime
+     * properties file location, ensuring the property is always set.
+     *
+     * @return configurer
+     */
+    @Bean
+    public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        PropertySourcesPlaceholderConfigurer configurer = new PropertySourcesPlaceholderConfigurer();
+        String appDataDir = OpenmrsUtil.getApplicationDataDirectory();
+        Properties props = new Properties();
+        props.setProperty(OpenmrsConstants.KEY_OPENMRS_APPLICATION_DATA_DIRECTORY, appDataDir);
+        configurer.setProperties(props);
+        configurer.setLocations(new ClassPathResource("hibernate.default.properties"),
+                new ClassPathResource("application.properties"),
+                new FileSystemResource(appDataDir + "/openmrs-runtime.properties"));
+        configurer.setIgnoreResourceNotFound(true);
+        configurer.setLocalOverride(true);
+        return configurer;
+    }
 
-	@Bean
-	public GenericParser hL7Parser() {
-		return new GenericParser();
-	}
+    @Bean
+    public GenericParser hL7Parser() {
+        return new GenericParser();
+    }
 
-	@Bean
-	public MessageTypeRouter hL7Router() {
-		return new MessageTypeRouter();
-	}
+    @Bean
+    public MessageTypeRouter hL7Router() {
+        return new MessageTypeRouter();
+    }
 
-	@Bean
-	public Map<String, Application> hL7Handlers(ORUR01Handler orur01Handler, ADTA28Handler adta28Handler) {
-		Map<String, Application> map = new LinkedHashMap<>();
-		map.put("ORU_R01", orur01Handler);
-		map.put("ADT_A28", adta28Handler);
-		return map;
-	}
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        Map<String, PasswordEncoder> encoders = new LinkedHashMap<>();
+        encoders.put("bcrypt", new BCryptPasswordEncoder());
+        encoders.put("sha512", new PasswordEncoder() {
+
+            @Override
+            public String encode(CharSequence rawPassword) {
+                return Security.encodeString(rawPassword.toString());
+            }
+
+            @Override
+            public boolean matches(CharSequence rawPassword, String encodedPassword) {
+                return encode(rawPassword).equals(encodedPassword);
+            }
+        });
+
+        return new DelegatingPasswordEncoder("bcrypt", encoders);
+    }
+
+    @Bean
+    public Map<String, Application> hL7Handlers(ORUR01Handler orur01Handler, ADTA28Handler adta28Handler) {
+        Map<String, Application> map = new LinkedHashMap<>();
+        map.put("ORU_R01", orur01Handler);
+        map.put("ADT_A28", adta28Handler);
+        return map;
+    }
 }

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -75,8 +75,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
     @Autowired
     protected UserDAO dao;
 
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     private static final int MAX_VALID_TIME = 12 * 60 * 60 * 1000; //Period of 12 hours
 
@@ -84,7 +83,9 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 
     private static final int DEFAULT_VALID_TIME = 10 * 60 * 1000; //Default time of 10 minute
 
-    public UserServiceImpl() {
+    @Autowired
+    public UserServiceImpl(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
     }
 
     public void setUserDAO(UserDAO dao) {

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -54,12 +54,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Default implementation of the user service. This class should not be used on its own. The current
- * OpenMRS implementation should be fetched from the Context
+ * Default implementation of the user service. This class should not be used on
+ * its own. The current OpenMRS implementation should be fetched from the
+ * Context
  *
  * @see org.openmrs.api.UserService
  * @see org.openmrs.api.context.Context
@@ -68,777 +70,801 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserServiceImpl extends BaseOpenmrsService implements UserService, RefByUuid {
 
-	private static final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
-
-	@Autowired
-	protected UserDAO dao;
-
-	private static final int MAX_VALID_TIME = 12 * 60 * 60 * 1000; //Period of 12 hours
-
-	private static final int MIN_VALID_TIME = 60 * 1000; //Period of 1 minute
-
-	private static final int DEFAULT_VALID_TIME = 10 * 60 * 1000; //Default time of 10 minute
-
-	public UserServiceImpl() {
-	}
-
-	public void setUserDAO(UserDAO dao) {
-		this.dao = dao;
-	}
-
-	/**
-	 * @return the validTime for which the password reset activation key will be valid
-	 */
-	private int getValidTime() {
-		String validTimeGp = Context.getAdministrationService()
-		        .getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_VALIDTIME);
-		final int validTime = StringUtils.isBlank(validTimeGp) ? DEFAULT_VALID_TIME : Integer.parseInt(validTimeGp);
-		//if valid time is less that a minute or greater than 12hrs reset valid time to 1 minutes else set it to the required time.
-		return (validTime < MIN_VALID_TIME) || (validTime > MAX_VALID_TIME) ? DEFAULT_VALID_TIME : validTime;
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#createUser(org.openmrs.User, java.lang.String)
-	 */
-	@Override
-	public User createUser(User user, String password) throws APIException {
-		if (user.getUserId() != null) {
-			throw new APIException("This method can be used for only creating new users");
-		}
-
-		Context.requirePrivilege(PrivilegeConstants.ADD_USERS);
-
-		checkPrivileges(user);
-
-		// if a password wasn't supplied, throw an error
-		if (password == null || password.isEmpty()) {
-			throw new APIException("User.creating.password.required", (Object[]) null);
-		}
-
-		if (hasDuplicateUsername(user)) {
-			throw new DAOException(
-			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
-		}
-
-		// TODO Check required fields for user!!
-		OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
-
-		return dao.saveUser(user, password);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUser(java.lang.Integer)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public User getUser(Integer userId) throws APIException {
-		return dao.getUser(userId);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUserByUsername(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public User getUserByUsername(String username) throws APIException {
-		return dao.getUserByUsername(username);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#hasDuplicateUsername(org.openmrs.User)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public boolean hasDuplicateUsername(User user) throws APIException {
-		return dao.hasDuplicateUsername(user.getUsername(), user.getSystemId(), user.getUserId());
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUsersByRole(org.openmrs.Role)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getUsersByRole(Role role) throws APIException {
-		List<Role> roles = new ArrayList<>();
-		roles.add(role);
-
-		return Context.getUserService().getUsers(null, roles, false);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User)
-	 */
-	@Override
-	@CacheEvict(value = "userSearchLocales", allEntries = true)
-	public User saveUser(User user) throws APIException {
-		if (user.getUserId() == null) {
-			throw new APIException("This method can be called only to update existing users");
-		}
-
-		Context.requirePrivilege(PrivilegeConstants.EDIT_USERS);
-
-		checkPrivileges(user);
-
-		if (hasDuplicateUsername(user)) {
-			throw new DAOException(
-			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
-		}
-
-		return dao.saveUser(user, null);
-	}
-
-	public User voidUser(User user, String reason) throws APIException {
-		return Context.getUserService().retireUser(user, reason);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#retireUser(org.openmrs.User, java.lang.String)
-	 */
-	@Override
-	public User retireUser(User user, String reason) throws APIException {
-		user.setRetired(true);
-		user.setRetireReason(reason);
-		user.setRetiredBy(Context.getAuthenticatedUser());
-		user.setDateRetired(new Date());
-
-		return saveUser(user);
-	}
-
-	public User unvoidUser(User user) throws APIException {
-		return Context.getUserService().unretireUser(user);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#unretireUser(org.openmrs.User)
-	 */
-	@Override
-	public User unretireUser(User user) throws APIException {
-		user.setRetired(false);
-		user.setRetireReason(null);
-		user.setRetiredBy(null);
-		user.setDateRetired(null);
-
-		return saveUser(user);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getAllUsers()
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getAllUsers() throws APIException {
-		return dao.getAllUsers();
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getAllPrivileges()
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<Privilege> getAllPrivileges() throws APIException {
-		return dao.getAllPrivileges();
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getPrivilege(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Privilege getPrivilege(String p) throws APIException {
-		return dao.getPrivilege(p);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
-	 */
-	@Override
-	public void purgePrivilege(Privilege privilege) throws APIException {
-		if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
-			throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
-		}
-
-		dao.deletePrivilege(privilege);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
-	 */
-	@Override
-	public Privilege savePrivilege(Privilege privilege) throws APIException {
-		return dao.savePrivilege(privilege);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getAllRoles()
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<Role> getAllRoles() throws APIException {
-		return dao.getAllRoles();
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getRole(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Role getRole(String r) throws APIException {
-		return dao.getRole(r);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
-	 */
-	@Override
-	public void purgeRole(Role role) throws APIException {
-		if (role == null || role.getRole() == null) {
-			return;
-		}
-
-		if (OpenmrsUtil.getCoreRoles().keySet().contains(role.getRole())) {
-			throw new APIException("Role.cannot.delete.core", (Object[]) null);
-		}
-
-		if (role.hasChildRoles()) {
-			throw new CannotDeleteRoleWithChildrenException();
-		}
-
-		dao.deleteRole(role);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
-	 */
-	@Override
-	public Role saveRole(Role role) throws APIException {
-		// make sure one of the parents of this role isn't itself...this would
-		// cause an infinite loop
-		if (role.getAllParentRoles().contains(role)) {
-			throw new APIException("Role.cannot.inherit.descendant", (Object[]) null);
-		}
-
-		checkPrivileges(role);
-
-		return dao.saveRole(role);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#changePassword(java.lang.String, java.lang.String)
-	 */
-	@Override
-	public void changePassword(String oldPassword, String newPassword) throws APIException {
-		User user = Context.getAuthenticatedUser();
-		changePassword(user, oldPassword, newPassword);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#changeHashedPassword(User, String, String)
-	 */
-	@Override
-	public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException {
-		dao.changeHashedPassword(user, hashedPassword, salt);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#changeQuestionAnswer(User, String, String)
-	 */
-	@Override
-	public void changeQuestionAnswer(User u, String question, String answer) throws APIException {
-		dao.changeQuestionAnswer(u, question, answer);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#changeQuestionAnswer(java.lang.String, java.lang.String,
-	 *      java.lang.String)
-	 */
-	@Override
-	public void changeQuestionAnswer(String pw, String q, String a) {
-		dao.changeQuestionAnswer(pw, q, a);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#isSecretAnswer(org.openmrs.User, java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public boolean isSecretAnswer(User u, String answer) {
-		return dao.isSecretAnswer(u, answer);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUsersByName(java.lang.String, java.lang.String, boolean)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getUsersByName(String givenName, String familyName, boolean includeVoided) throws APIException {
-		return dao.getUsersByName(givenName, familyName, includeVoided);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUsersByPerson(org.openmrs.Person, boolean)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException {
-		return dao.getUsersByPerson(person, includeRetired);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUsers(java.lang.String, java.util.List, boolean)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException {
-		return Context.getUserService().getUsers(nameSearch, roles, includeVoided, null, null);
-	}
-
-	/**
-	 * Convenience method to check if the authenticated user has all privileges they are giving out
-	 *
-	 * @param user user that has privileges
-	 */
-	private void checkPrivileges(User user) {
-		List<String> requiredPrivs = user.getAllRoles().stream().peek(this::checkSuperUserPrivilege).map(Role::getPrivileges)
-		        .filter(Objects::nonNull).flatMap(Collection::stream).map(Privilege::getPrivilege)
-		        .filter(p -> !Context.hasPrivilege(p)).sorted().collect(Collectors.toList());
-		if (requiredPrivs.size() == 1) {
-			throw new APIException("User.you.must.have.privilege", new Object[] { requiredPrivs.get(0) });
-		} else if (requiredPrivs.size() > 1) {
-			throw new APIException("User.you.must.have.privileges", new Object[] { String.join(", ", requiredPrivs) });
-		}
-	}
-
-	private void checkSuperUserPrivilege(Role r) {
-		if (r.getRole().equals(RoleConstants.SUPERUSER)
-		        && !Context.hasPrivilege(PrivilegeConstants.ASSIGN_SYSTEM_DEVELOPER_ROLE)) {
-			throw new APIException("User.you.must.have.role", new Object[] { RoleConstants.SUPERUSER });
-		}
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#setUserProperty(User, String, String)
-	 */
-	@Override
-	public User setUserProperty(User user, String key, String value) {
-		if (user != null) {
-			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
-				throw new APIException("you.are.not.authorized.change.properties", new Object[] { user.getUserId() });
-			}
-
-			user.setUserProperty(key, value);
-			try {
-				Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-				Context.getUserService().saveUser(user);
-			} finally {
-				Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-			}
-		}
-
-		return user;
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#removeUserProperty(org.openmrs.User, java.lang.String)
-	 */
-	@Override
-	public User removeUserProperty(User user, String key) {
-		if (user != null) {
-
-			// if the current user isn't allowed to edit users and
-			// the user being edited is not the current user, throw an
-			// exception
-			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
-				throw new APIException("you.are.not.authorized.change.properties", new Object[] { user.getUserId() });
-			}
-
-			user.removeUserProperty(key);
-
-			try {
-				Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-				Context.getUserService().saveUser(user);
-			} finally {
-				Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-			}
-		}
-
-		return user;
-	}
-
-	/**
-	 * Generates system ids based on the following algorithm scheme: user_id-check digit
-	 *
-	 * @see org.openmrs.api.UserService#generateSystemId()
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public String generateSystemId() {
-		// Hardcoding Luhn algorithm since all existing openmrs user ids have
-		// had check digits generated this way.
-		LuhnIdentifierValidator liv = new LuhnIdentifierValidator();
-
-		String systemId;
-		Integer offset = 0;
-		do {
-			// generate and increment the system id if necessary
-			Integer generatedId = dao.generateSystemId() + offset++;
-
-			systemId = generatedId.toString();
-
-			try {
-				systemId = liv.getValidIdentifier(systemId);
-			} catch (Exception e) {
-				log.error("error getting check digit", e);
-				return systemId;
-			}
-
-			// loop until we find a system id that no one has
-		} while (dao.hasDuplicateUsername(null, systemId, null));
-
-		return systemId;
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User)
-	 */
-	@Override
-	public void purgeUser(User user) throws APIException {
-		dao.deleteUser(user);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User, boolean)
-	 */
-	@Override
-	public void purgeUser(User user, boolean cascade) throws APIException {
-		if (cascade) {
-			throw new APIException("cascade.do.not.think", (Object[]) null);
-		}
-
-		dao.deleteUser(user);
-	}
-
-	/**
-	 * Convenience method to check if the authenticated user has all privileges they are giving out to
-	 * the new role
-	 *
-	 * @param role
-	 */
-	private void checkPrivileges(Role role) {
-		Optional.ofNullable(role.getPrivileges()).map(p -> p.stream().filter(pr -> !Context.hasPrivilege(pr.getPrivilege()))
-		        .map(Privilege::getPrivilege).distinct().collect(Collectors.joining(", "))).ifPresent(missing -> {
-			        if (StringUtils.isNotBlank(missing)) {
-				        throw new APIException("Role.you.must.have.privileges", new Object[] { missing });
-			        }
-		        });
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getPrivilegeByUuid(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Privilege getPrivilegeByUuid(String uuid) throws APIException {
-		return dao.getPrivilegeByUuid(uuid);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getRoleByUuid(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Role getRoleByUuid(String uuid) throws APIException {
-		return dao.getRoleByUuid(uuid);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUserByUuid(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public User getUserByUuid(String uuid) throws APIException {
-		return dao.getUserByUuid(uuid);
-	}
-
-	/**
-	 * @see UserService#getCountOfUsers(String, List, boolean)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
-		if (name != null) {
-			name = StringUtils.replace(name, ", ", " ");
-		}
-
-		// if the authenticated role is in the list of searched roles, then all
-		// persons should be searched
-		Role authRole = getRole(RoleConstants.AUTHENTICATED);
-		if (roles.contains(authRole)) {
-			return dao.getCountOfUsers(name, new ArrayList<>(), includeRetired);
-		}
-
-		return dao.getCountOfUsers(name, roles, includeRetired);
-	}
-
-	/**
-	 * @see UserService#getUsers(String, List, boolean, Integer, Integer)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
-	        throws APIException {
-		if (name != null) {
-			name = StringUtils.replace(name, ", ", " ");
-		}
-
-		if (roles == null) {
-			roles = new ArrayList<>();
-		}
-
-		// if the authenticated role is in the list of searched roles, then all
-		// persons should be searched
-		Role authRole = getRole(RoleConstants.AUTHENTICATED);
-		if (roles.contains(authRole)) {
-			return dao.getUsers(name, new ArrayList<>(), includeRetired, start, length);
-		}
-
-		// add the requested roles and all child roles for consideration
-		Set<Role> allRoles = new HashSet<>();
-		for (Role r : roles) {
-			allRoles.add(r);
-			allRoles.addAll(r.getAllChildRoles());
-		}
-
-		return dao.getUsers(name, new ArrayList<>(allRoles), includeRetired, start, length);
-	}
-
-	@Override
-	public User saveUserProperty(String key, String value) {
-		User user = Context.getAuthenticatedUser();
-		if (user == null) {
-			throw new APIException("no.authenticated.user.found", (Object[]) null);
-		}
-		user.setUserProperty(key, value);
-		return dao.saveUser(user, null);
-	}
-
-	@Override
-	public User saveUserProperties(Map<String, String> properties) {
-		User user = Context.getAuthenticatedUser();
-		if (user == null) {
-			throw new APIException("no.authenticated.user.found", (Object[]) null);
-		}
-		user.getUserProperties().clear();
-		for (Map.Entry<String, String> entry : properties.entrySet()) {
-			user.setUserProperty(entry.getKey(), entry.getValue());
-		}
-		return dao.saveUser(user, null);
-	}
-
-	/**
-	 * @see UserService#changePassword(User, String, String)
-	 */
-	@Override
-	@Authorized(PrivilegeConstants.EDIT_USER_PASSWORDS)
-	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changePassword(User user, String oldPassword, String newPassword) throws APIException {
-		if (user.getUserId() == null) {
-			throw new APIException("user.must.exist", (Object[]) null);
-		}
-
-		if (oldPassword == null) {
-			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS)) {
-				throw new APIException("null.old.password.privilege.required", (Object[]) null);
-			}
-		} else if (!dao.getLoginCredential(user).checkPassword(oldPassword)) {
-			throw new APIException("old.password.not.correct", (Object[]) null);
-
-		} else if (oldPassword.equals(newPassword)) {
-			throw new APIException("new.password.equal.to.old", (Object[]) null);
-		}
-
-		if (("admin".equals(user.getSystemId()) || "admin".equals(user.getUsername())) && Boolean
-		        .parseBoolean(Context.getRuntimeProperties().getProperty(ADMIN_PASSWORD_LOCKED_PROPERTY, "false"))) {
-			throw new APIException("admin.password.is.locked");
-		}
-
-		updatePassword(user, newPassword);
-	}
-
-	@Override
-	@Logging(ignoredArgumentIndexes = { 1 })
-	public void changePassword(User user, String newPassword) {
-		Context.getUserService().changePassword(user, null, newPassword);
-	}
-
-	@Override
-	@Logging(ignoredArgumentIndexes = { 1, 2 })
-	public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException {
-		User user = Context.getAuthenticatedUser();
-
-		if (!isSecretAnswer(user, secretAnswer)) {
-			throw new APIException("secret.answer.not.correct", (Object[]) null);
-		}
-
-		updatePassword(user, pw);
-	}
-
-	private void updatePassword(User user, String newPassword) {
-		OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
-		dao.changePassword(user, newPassword);
-	}
-
-	@Override
-	public String getSecretQuestion(User user) throws APIException {
-		if (user.getUserId() != null) {
-			LoginCredential loginCredential = dao.getLoginCredential(user);
-			return loginCredential.getSecretQuestion();
-		} else {
-			return null;
-		}
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUserByUsernameOrEmail(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public User getUserByUsernameOrEmail(String usernameOrEmail) {
-		if (StringUtils.isNotBlank(usernameOrEmail)) {
-			User user = dao.getUserByEmail(usernameOrEmail);
-			if (user == null) {
-				return getUserByUsername(usernameOrEmail);
-			}
-			return user;
-		}
-		throw new APIException("error.usernameOrEmail.notNullOrBlank", (Object[]) null);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getUserByActivationKey(java.lang.String)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public User getUserByActivationKey(String activationKey) {
-		LoginCredential loginCred = dao.getLoginCredentialByActivationKey(activationKey);
-		if (loginCred != null) {
-			String[] credTokens = loginCred.getActivationKey().split(":");
-			if (System.currentTimeMillis() <= Long.parseLong(credTokens[1])) {
-				return getUser(loginCred.getUserId());
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * @throws APIException
-	 * @throws MessageException
-	 * @see org.openmrs.api.UserService#setUserActivationKey(org.openmrs.User)
-	 */
-	@Override
-	public User setUserActivationKey(User user) throws MessageException {
-		String token = RandomStringUtils.secureStrong().nextAlphanumeric(20);
-		long time = System.currentTimeMillis() + getValidTime();
-		String hashedKey = Security.encodeString(token);
-		String activationKey = hashedKey + ":" + time;
-		LoginCredential credentials = dao.getLoginCredential(user);
-		credentials.setActivationKey(activationKey);
-		dao.setUserActivationKey(credentials);
-
-		MessageSourceService messages = Context.getMessageSourceService();
-		AdministrationService adminService = Context.getAdministrationService();
-		Locale locale = getDefaultLocaleForUser(user);
-
-		//		Delete this method call when removing {@link OpenmrsConstants#GP_HOST_URL}
-		copyHostURLGlobalPropertyToPasswordResetGlobalProperty(adminService);
-
-		String link = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL).replace("{activationKey}",
-		    token);
-
-		Properties mailProperties = Context.getMailProperties();
-
-		String sender = mailProperties.getProperty("mail.from");
-
-		String subject = messages.getMessage("mail.passwordreset.subject", null, locale);
-
-		String msg = messages.getMessage("mail.passwordreset.content", null, locale).replace("{name}", user.getUsername())
-		        .replace("{link}", link).replace("{time}", String.valueOf(getValidTime() / 60000));
-
-		Context.getMessageService().sendMessage(user.getEmail(), sender, subject, msg);
-
-		return user;
-	}
-
-	/**
-	 * Delete this method when deleting {@link OpenmrsConstants#GP_HOST_URL}
-	 */
-	private void copyHostURLGlobalPropertyToPasswordResetGlobalProperty(AdministrationService adminService) {
-		String hostURLGP = adminService.getGlobalProperty(OpenmrsConstants.GP_HOST_URL);
-		String passwordResetGP = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL);
-		if (StringUtils.isNotBlank(hostURLGP) && StringUtils.isBlank(passwordResetGP)) {
-			adminService.setGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL, hostURLGP);
-		}
-	}
-
-	/**
-	 * @see UserService#getDefaultLocaleForUser(User)
-	 */
-	@Override
-	public Locale getDefaultLocaleForUser(User user) {
-		Locale locale = null;
-		if (user != null) {
-			try {
-				String preferredLocale = user.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE);
-				if (StringUtils.isNotBlank(preferredLocale)) {
-					locale = LocaleUtility.fromSpecification(preferredLocale);
-				}
-			} catch (Exception e) {
-				log.warn("Unable to parse user locale into a Locale", e);
-			}
-		}
-		if (locale == null) {
-			locale = Context.getLocale();
-		}
-		return locale;
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#changePasswordUsingActivationKey(String, String);
-	 */
-	@Override
-	public void changePasswordUsingActivationKey(String activationKey, String newPassword) {
-		User user = getUserByActivationKey(activationKey);
-		if (user == null) {
-			throw new InvalidActivationKeyException("activation.key.not.correct");
-		}
-
-		updatePassword(user, newPassword);
-	}
-
-	/**
-	 * @see org.openmrs.api.UserService#getLastLoginTime(User)
-	 */
-	public String getLastLoginTime(User user) {
-		return dao.getLastLoginTime(user);
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public <T> T getRefByUuid(Class<T> type, String uuid) {
-		if (Role.class.equals(type)) {
-			return (T) getRoleByUuid(uuid);
-		}
-		if (Privilege.class.equals(type)) {
-			return (T) getPrivilegeByUuid(uuid);
-		}
-		if (User.class.equals(type)) {
-			return (T) getUserByUuid(uuid);
-		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
-	}
-
-	@Override
-	public List<Class<?>> getRefTypes() {
-		return Arrays.asList(Role.class, Privilege.class, User.class);
-	}
+    private static final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
+
+    @Autowired
+    protected UserDAO dao;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private static final int MAX_VALID_TIME = 12 * 60 * 60 * 1000; //Period of 12 hours
+
+    private static final int MIN_VALID_TIME = 60 * 1000; //Period of 1 minute
+
+    private static final int DEFAULT_VALID_TIME = 10 * 60 * 1000; //Default time of 10 minute
+
+    public UserServiceImpl() {
+    }
+
+    public void setUserDAO(UserDAO dao) {
+        this.dao = dao;
+    }
+
+    /**
+     * @return the validTime for which the password reset activation key will be
+     * valid
+     */
+    private int getValidTime() {
+        String validTimeGp = Context.getAdministrationService()
+                .getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_VALIDTIME);
+        final int validTime = StringUtils.isBlank(validTimeGp) ? DEFAULT_VALID_TIME : Integer.parseInt(validTimeGp);
+        //if valid time is less that a minute or greater than 12hrs reset valid time to 1 minutes else set it to the required time.
+        return (validTime < MIN_VALID_TIME) || (validTime > MAX_VALID_TIME) ? DEFAULT_VALID_TIME : validTime;
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#createUser(org.openmrs.User,
+     * java.lang.String)
+     */
+    @Override
+    public User createUser(User user, String password) throws APIException {
+        if (user.getUserId() != null) {
+            throw new APIException("This method can be used for only creating new users");
+        }
+
+        Context.requirePrivilege(PrivilegeConstants.ADD_USERS);
+
+        checkPrivileges(user);
+
+        // if a password wasn't supplied, throw an error
+        if (password == null || password.isEmpty()) {
+            throw new APIException("User.creating.password.required", (Object[]) null);
+        }
+
+        if (hasDuplicateUsername(user)) {
+            throw new DAOException(
+                    "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
+        }
+
+        // TODO Check required fields for user!!
+        OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
+
+        return dao.saveUser(user, password);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUser(java.lang.Integer)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public User getUser(Integer userId) throws APIException {
+        return dao.getUser(userId);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUserByUsername(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByUsername(String username) throws APIException {
+        return dao.getUserByUsername(username);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#hasDuplicateUsername(org.openmrs.User)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasDuplicateUsername(User user) throws APIException {
+        return dao.hasDuplicateUsername(user.getUsername(), user.getSystemId(), user.getUserId());
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUsersByRole(org.openmrs.Role)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsersByRole(Role role) throws APIException {
+        List<Role> roles = new ArrayList<>();
+        roles.add(role);
+
+        return Context.getUserService().getUsers(null, roles, false);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#saveUser(org.openmrs.User)
+     */
+    @Override
+    @CacheEvict(value = "userSearchLocales", allEntries = true)
+    public User saveUser(User user) throws APIException {
+        if (user.getUserId() == null) {
+            throw new APIException("This method can be called only to update existing users");
+        }
+
+        Context.requirePrivilege(PrivilegeConstants.EDIT_USERS);
+
+        checkPrivileges(user);
+
+        if (hasDuplicateUsername(user)) {
+            throw new DAOException(
+                    "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
+        }
+
+        return dao.saveUser(user, null);
+    }
+
+    public User voidUser(User user, String reason) throws APIException {
+        return Context.getUserService().retireUser(user, reason);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#retireUser(org.openmrs.User,
+     * java.lang.String)
+     */
+    @Override
+    public User retireUser(User user, String reason) throws APIException {
+        user.setRetired(true);
+        user.setRetireReason(reason);
+        user.setRetiredBy(Context.getAuthenticatedUser());
+        user.setDateRetired(new Date());
+
+        return saveUser(user);
+    }
+
+    public User unvoidUser(User user) throws APIException {
+        return Context.getUserService().unretireUser(user);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#unretireUser(org.openmrs.User)
+     */
+    @Override
+    public User unretireUser(User user) throws APIException {
+        user.setRetired(false);
+        user.setRetireReason(null);
+        user.setRetiredBy(null);
+        user.setDateRetired(null);
+
+        return saveUser(user);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getAllUsers()
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getAllUsers() throws APIException {
+        return dao.getAllUsers();
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getAllPrivileges()
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<Privilege> getAllPrivileges() throws APIException {
+        return dao.getAllPrivileges();
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getPrivilege(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Privilege getPrivilege(String p) throws APIException {
+        return dao.getPrivilege(p);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
+     */
+    @Override
+    public void purgePrivilege(Privilege privilege) throws APIException {
+        if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
+            throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
+        }
+
+        dao.deletePrivilege(privilege);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
+     */
+    @Override
+    public Privilege savePrivilege(Privilege privilege) throws APIException {
+        return dao.savePrivilege(privilege);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getAllRoles()
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<Role> getAllRoles() throws APIException {
+        return dao.getAllRoles();
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getRole(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Role getRole(String r) throws APIException {
+        return dao.getRole(r);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
+     */
+    @Override
+    public void purgeRole(Role role) throws APIException {
+        if (role == null || role.getRole() == null) {
+            return;
+        }
+
+        if (OpenmrsUtil.getCoreRoles().keySet().contains(role.getRole())) {
+            throw new APIException("Role.cannot.delete.core", (Object[]) null);
+        }
+
+        if (role.hasChildRoles()) {
+            throw new CannotDeleteRoleWithChildrenException();
+        }
+
+        dao.deleteRole(role);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
+     */
+    @Override
+    public Role saveRole(Role role) throws APIException {
+        // make sure one of the parents of this role isn't itself...this would
+        // cause an infinite loop
+        if (role.getAllParentRoles().contains(role)) {
+            throw new APIException("Role.cannot.inherit.descendant", (Object[]) null);
+        }
+
+        checkPrivileges(role);
+
+        return dao.saveRole(role);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#changePassword(java.lang.String,
+     * java.lang.String)
+     */
+    @Override
+    public void changePassword(String oldPassword, String newPassword) throws APIException {
+        User user = Context.getAuthenticatedUser();
+        changePassword(user, oldPassword, newPassword);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#changeHashedPassword(User, String,
+     * String)
+     */
+    @Override
+    public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException {
+        dao.changeHashedPassword(user, hashedPassword, salt);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#changeQuestionAnswer(User, String,
+     * String)
+     */
+    @Override
+    public void changeQuestionAnswer(User u, String question, String answer) throws APIException {
+        dao.changeQuestionAnswer(u, question, answer);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#changeQuestionAnswer(java.lang.String,
+     * java.lang.String, java.lang.String)
+     */
+    @Override
+    public void changeQuestionAnswer(String pw, String q, String a) {
+        dao.changeQuestionAnswer(pw, q, a);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#isSecretAnswer(org.openmrs.User,
+     * java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isSecretAnswer(User u, String answer) {
+        return dao.isSecretAnswer(u, answer);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUsersByName(java.lang.String,
+     * java.lang.String, boolean)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsersByName(String givenName, String familyName, boolean includeVoided) throws APIException {
+        return dao.getUsersByName(givenName, familyName, includeVoided);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUsersByPerson(org.openmrs.Person,
+     * boolean)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException {
+        return dao.getUsersByPerson(person, includeRetired);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUsers(java.lang.String,
+     * java.util.List, boolean)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException {
+        return Context.getUserService().getUsers(nameSearch, roles, includeVoided, null, null);
+    }
+
+    /**
+     * Convenience method to check if the authenticated user has all privileges
+     * they are giving out
+     *
+     * @param user user that has privileges
+     */
+    private void checkPrivileges(User user) {
+        List<String> requiredPrivs = user.getAllRoles().stream().peek(this::checkSuperUserPrivilege).map(Role::getPrivileges)
+                .filter(Objects::nonNull).flatMap(Collection::stream).map(Privilege::getPrivilege)
+                .filter(p -> !Context.hasPrivilege(p)).sorted().collect(Collectors.toList());
+        if (requiredPrivs.size() == 1) {
+            throw new APIException("User.you.must.have.privilege", new Object[]{requiredPrivs.get(0)});
+        } else if (requiredPrivs.size() > 1) {
+            throw new APIException("User.you.must.have.privileges", new Object[]{String.join(", ", requiredPrivs)});
+        }
+    }
+
+    private void checkSuperUserPrivilege(Role r) {
+        if (r.getRole().equals(RoleConstants.SUPERUSER)
+                && !Context.hasPrivilege(PrivilegeConstants.ASSIGN_SYSTEM_DEVELOPER_ROLE)) {
+            throw new APIException("User.you.must.have.role", new Object[]{RoleConstants.SUPERUSER});
+        }
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#setUserProperty(User, String, String)
+     */
+    @Override
+    public User setUserProperty(User user, String key, String value) {
+        if (user != null) {
+            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
+                throw new APIException("you.are.not.authorized.change.properties", new Object[]{user.getUserId()});
+            }
+
+            user.setUserProperty(key, value);
+            try {
+                Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+                Context.getUserService().saveUser(user);
+            } finally {
+                Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+            }
+        }
+
+        return user;
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#removeUserProperty(org.openmrs.User,
+     * java.lang.String)
+     */
+    @Override
+    public User removeUserProperty(User user, String key) {
+        if (user != null) {
+
+            // if the current user isn't allowed to edit users and
+            // the user being edited is not the current user, throw an
+            // exception
+            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
+                throw new APIException("you.are.not.authorized.change.properties", new Object[]{user.getUserId()});
+            }
+
+            user.removeUserProperty(key);
+
+            try {
+                Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+                Context.getUserService().saveUser(user);
+            } finally {
+                Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+            }
+        }
+
+        return user;
+    }
+
+    /**
+     * Generates system ids based on the following algorithm scheme:
+     * user_id-check digit
+     *
+     * @see org.openmrs.api.UserService#generateSystemId()
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public String generateSystemId() {
+        // Hardcoding Luhn algorithm since all existing openmrs user ids have
+        // had check digits generated this way.
+        LuhnIdentifierValidator liv = new LuhnIdentifierValidator();
+
+        String systemId;
+        Integer offset = 0;
+        do {
+            // generate and increment the system id if necessary
+            Integer generatedId = dao.generateSystemId() + offset++;
+
+            systemId = generatedId.toString();
+
+            try {
+                systemId = liv.getValidIdentifier(systemId);
+            } catch (Exception e) {
+                log.error("error getting check digit", e);
+                return systemId;
+            }
+
+            // loop until we find a system id that no one has
+        } while (dao.hasDuplicateUsername(null, systemId, null));
+
+        return systemId;
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User)
+     */
+    @Override
+    public void purgeUser(User user) throws APIException {
+        dao.deleteUser(user);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User, boolean)
+     */
+    @Override
+    public void purgeUser(User user, boolean cascade) throws APIException {
+        if (cascade) {
+            throw new APIException("cascade.do.not.think", (Object[]) null);
+        }
+
+        dao.deleteUser(user);
+    }
+
+    /**
+     * Convenience method to check if the authenticated user has all privileges
+     * they are giving out to the new role
+     *
+     * @param role
+     */
+    private void checkPrivileges(Role role) {
+        Optional.ofNullable(role.getPrivileges()).map(p -> p.stream().filter(pr -> !Context.hasPrivilege(pr.getPrivilege()))
+                .map(Privilege::getPrivilege).distinct().collect(Collectors.joining(", "))).ifPresent(missing -> {
+            if (StringUtils.isNotBlank(missing)) {
+                throw new APIException("Role.you.must.have.privileges", new Object[]{missing});
+            }
+        });
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getPrivilegeByUuid(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Privilege getPrivilegeByUuid(String uuid) throws APIException {
+        return dao.getPrivilegeByUuid(uuid);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getRoleByUuid(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Role getRoleByUuid(String uuid) throws APIException {
+        return dao.getRoleByUuid(uuid);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUserByUuid(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByUuid(String uuid) throws APIException {
+        return dao.getUserByUuid(uuid);
+    }
+
+    /**
+     * @see UserService#getCountOfUsers(String, List, boolean)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
+        if (name != null) {
+            name = StringUtils.replace(name, ", ", " ");
+        }
+
+        // if the authenticated role is in the list of searched roles, then all
+        // persons should be searched
+        Role authRole = getRole(RoleConstants.AUTHENTICATED);
+        if (roles.contains(authRole)) {
+            return dao.getCountOfUsers(name, new ArrayList<>(), includeRetired);
+        }
+
+        return dao.getCountOfUsers(name, roles, includeRetired);
+    }
+
+    /**
+     * @see UserService#getUsers(String, List, boolean, Integer, Integer)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
+            throws APIException {
+        if (name != null) {
+            name = StringUtils.replace(name, ", ", " ");
+        }
+
+        if (roles == null) {
+            roles = new ArrayList<>();
+        }
+
+        // if the authenticated role is in the list of searched roles, then all
+        // persons should be searched
+        Role authRole = getRole(RoleConstants.AUTHENTICATED);
+        if (roles.contains(authRole)) {
+            return dao.getUsers(name, new ArrayList<>(), includeRetired, start, length);
+        }
+
+        // add the requested roles and all child roles for consideration
+        Set<Role> allRoles = new HashSet<>();
+        for (Role r : roles) {
+            allRoles.add(r);
+            allRoles.addAll(r.getAllChildRoles());
+        }
+
+        return dao.getUsers(name, new ArrayList<>(allRoles), includeRetired, start, length);
+    }
+
+    @Override
+    public User saveUserProperty(String key, String value) {
+        User user = Context.getAuthenticatedUser();
+        if (user == null) {
+            throw new APIException("no.authenticated.user.found", (Object[]) null);
+        }
+        user.setUserProperty(key, value);
+        return dao.saveUser(user, null);
+    }
+
+    @Override
+    public User saveUserProperties(Map<String, String> properties) {
+        User user = Context.getAuthenticatedUser();
+        if (user == null) {
+            throw new APIException("no.authenticated.user.found", (Object[]) null);
+        }
+        user.getUserProperties().clear();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            user.setUserProperty(entry.getKey(), entry.getValue());
+        }
+        return dao.saveUser(user, null);
+    }
+
+    /**
+     * @see UserService#changePassword(User, String, String)
+     */
+    @Override
+    @Authorized(PrivilegeConstants.EDIT_USER_PASSWORDS)
+    @Logging(ignoredArgumentIndexes = {1, 2})
+    public void changePassword(User user, String oldPassword, String newPassword) throws APIException {
+        if (user.getUserId() == null) {
+            throw new APIException("user.must.exist", (Object[]) null);
+        }
+
+        if (oldPassword == null) {
+            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS)) {
+                throw new APIException("null.old.password.privilege.required", (Object[]) null);
+            }
+        } else if (!dao.getLoginCredential(user).checkPassword(oldPassword)) {
+            throw new APIException("old.password.not.correct", (Object[]) null);
+
+        } else if (oldPassword.equals(newPassword)) {
+            throw new APIException("new.password.equal.to.old", (Object[]) null);
+        }
+
+        if (("admin".equals(user.getSystemId()) || "admin".equals(user.getUsername())) && Boolean
+                .parseBoolean(Context.getRuntimeProperties().getProperty(ADMIN_PASSWORD_LOCKED_PROPERTY, "false"))) {
+            throw new APIException("admin.password.is.locked");
+        }
+
+        updatePassword(user, newPassword);
+    }
+
+    @Override
+    @Logging(ignoredArgumentIndexes = {1})
+    public void changePassword(User user, String newPassword) {
+        Context.getUserService().changePassword(user, null, newPassword);
+    }
+
+    @Override
+    @Logging(ignoredArgumentIndexes = {1, 2})
+    public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException {
+        User user = Context.getAuthenticatedUser();
+
+        if (!isSecretAnswer(user, secretAnswer)) {
+            throw new APIException("secret.answer.not.correct", (Object[]) null);
+        }
+
+        updatePassword(user, pw);
+    }
+
+    private void updatePassword(User user, String newPassword) {
+        OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
+        LoginCredential credentials = dao.getLoginCredential(user);
+        String salt = credentials.getSalt();
+        if (StringUtils.isBlank(salt)) {
+            salt = Security.getRandomToken();
+        }
+        String hashedPassword = passwordEncoder.encode(newPassword + salt);
+        dao.changeHashedPassword(user, hashedPassword, salt);
+    }
+
+    @Override
+    public String getSecretQuestion(User user) throws APIException {
+        if (user.getUserId() != null) {
+            LoginCredential loginCredential = dao.getLoginCredential(user);
+            return loginCredential.getSecretQuestion();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @see
+     * org.openmrs.api.UserService#getUserByUsernameOrEmail(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByUsernameOrEmail(String usernameOrEmail) {
+        if (StringUtils.isNotBlank(usernameOrEmail)) {
+            User user = dao.getUserByEmail(usernameOrEmail);
+            if (user == null) {
+                return getUserByUsername(usernameOrEmail);
+            }
+            return user;
+        }
+        throw new APIException("error.usernameOrEmail.notNullOrBlank", (Object[]) null);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getUserByActivationKey(java.lang.String)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public User getUserByActivationKey(String activationKey) {
+        LoginCredential loginCred = dao.getLoginCredentialByActivationKey(activationKey);
+        if (loginCred != null) {
+            String[] credTokens = loginCred.getActivationKey().split(":");
+            if (System.currentTimeMillis() <= Long.parseLong(credTokens[1])) {
+                return getUser(loginCred.getUserId());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @throws APIException
+     * @throws MessageException
+     * @see org.openmrs.api.UserService#setUserActivationKey(org.openmrs.User)
+     */
+    @Override
+    public User setUserActivationKey(User user) throws MessageException {
+        String token = RandomStringUtils.secureStrong().nextAlphanumeric(20);
+        long time = System.currentTimeMillis() + getValidTime();
+        String hashedKey = Security.encodeString(token);
+        String activationKey = hashedKey + ":" + time;
+        LoginCredential credentials = dao.getLoginCredential(user);
+        credentials.setActivationKey(activationKey);
+        dao.setUserActivationKey(credentials);
+
+        MessageSourceService messages = Context.getMessageSourceService();
+        AdministrationService adminService = Context.getAdministrationService();
+        Locale locale = getDefaultLocaleForUser(user);
+
+        //		Delete this method call when removing {@link OpenmrsConstants#GP_HOST_URL}
+        copyHostURLGlobalPropertyToPasswordResetGlobalProperty(adminService);
+
+        String link = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL).replace("{activationKey}",
+                token);
+
+        Properties mailProperties = Context.getMailProperties();
+
+        String sender = mailProperties.getProperty("mail.from");
+
+        String subject = messages.getMessage("mail.passwordreset.subject", null, locale);
+
+        String msg = messages.getMessage("mail.passwordreset.content", null, locale).replace("{name}", user.getUsername())
+                .replace("{link}", link).replace("{time}", String.valueOf(getValidTime() / 60000));
+
+        Context.getMessageService().sendMessage(user.getEmail(), sender, subject, msg);
+
+        return user;
+    }
+
+    /**
+     * Delete this method when deleting {@link OpenmrsConstants#GP_HOST_URL}
+     */
+    private void copyHostURLGlobalPropertyToPasswordResetGlobalProperty(AdministrationService adminService) {
+        String hostURLGP = adminService.getGlobalProperty(OpenmrsConstants.GP_HOST_URL);
+        String passwordResetGP = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL);
+        if (StringUtils.isNotBlank(hostURLGP) && StringUtils.isBlank(passwordResetGP)) {
+            adminService.setGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL, hostURLGP);
+        }
+    }
+
+    /**
+     * @see UserService#getDefaultLocaleForUser(User)
+     */
+    @Override
+    public Locale getDefaultLocaleForUser(User user) {
+        Locale locale = null;
+        if (user != null) {
+            try {
+                String preferredLocale = user.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE);
+                if (StringUtils.isNotBlank(preferredLocale)) {
+                    locale = LocaleUtility.fromSpecification(preferredLocale);
+                }
+            } catch (Exception e) {
+                log.warn("Unable to parse user locale into a Locale", e);
+            }
+        }
+        if (locale == null) {
+            locale = Context.getLocale();
+        }
+        return locale;
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#changePasswordUsingActivationKey(String,
+     * String);
+     */
+    @Override
+    public void changePasswordUsingActivationKey(String activationKey, String newPassword) {
+        User user = getUserByActivationKey(activationKey);
+        if (user == null) {
+            throw new InvalidActivationKeyException("activation.key.not.correct");
+        }
+
+        updatePassword(user, newPassword);
+    }
+
+    /**
+     * @see org.openmrs.api.UserService#getLastLoginTime(User)
+     */
+    public String getLastLoginTime(User user) {
+        return dao.getLastLoginTime(user);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T getRefByUuid(Class<T> type, String uuid) {
+        if (Role.class.equals(type)) {
+            return (T) getRoleByUuid(uuid);
+        }
+        if (Privilege.class.equals(type)) {
+            return (T) getPrivilegeByUuid(uuid);
+        }
+        if (User.class.equals(type)) {
+            return (T) getUserByUuid(uuid);
+        }
+        throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+    }
+
+    @Override
+    public List<Class<?>> getRefTypes() {
+        return Arrays.asList(Role.class, Privilege.class, User.class);
+    }
 
 }

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -461,7 +461,6 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
     @Override
     public User removeUserProperty(User user, String key) {
         if (user != null) {
-
             // if the current user isn't allowed to edit users and
             // the user being edited is not the current user, throw an
             // exception

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -59,9 +59,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Default implementation of the user service. This class should not be used on
- * its own. The current OpenMRS implementation should be fetched from the
- * Context
+ * Default implementation of the user service. This class should not be used on its own. The current
+ * OpenMRS implementation should be fetched from the Context
  *
  * @see org.openmrs.api.UserService
  * @see org.openmrs.api.context.Context
@@ -70,801 +69,786 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class UserServiceImpl extends BaseOpenmrsService implements UserService, RefByUuid {
 
-    private static final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
-
-    @Autowired
-    protected UserDAO dao;
-
-    private final PasswordEncoder passwordEncoder;
-
-    private static final int MAX_VALID_TIME = 12 * 60 * 60 * 1000; //Period of 12 hours
-
-    private static final int MIN_VALID_TIME = 60 * 1000; //Period of 1 minute
-
-    private static final int DEFAULT_VALID_TIME = 10 * 60 * 1000; //Default time of 10 minute
-
-    @Autowired
-    public UserServiceImpl(PasswordEncoder passwordEncoder) {
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    public void setUserDAO(UserDAO dao) {
-        this.dao = dao;
-    }
-
-    /**
-     * @return the validTime for which the password reset activation key will be
-     * valid
-     */
-    private int getValidTime() {
-        String validTimeGp = Context.getAdministrationService()
-                .getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_VALIDTIME);
-        final int validTime = StringUtils.isBlank(validTimeGp) ? DEFAULT_VALID_TIME : Integer.parseInt(validTimeGp);
-        //if valid time is less that a minute or greater than 12hrs reset valid time to 1 minutes else set it to the required time.
-        return (validTime < MIN_VALID_TIME) || (validTime > MAX_VALID_TIME) ? DEFAULT_VALID_TIME : validTime;
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#createUser(org.openmrs.User,
-     * java.lang.String)
-     */
-    @Override
-    public User createUser(User user, String password) throws APIException {
-        if (user.getUserId() != null) {
-            throw new APIException("This method can be used for only creating new users");
-        }
-
-        Context.requirePrivilege(PrivilegeConstants.ADD_USERS);
-
-        checkPrivileges(user);
-
-        // if a password wasn't supplied, throw an error
-        if (password == null || password.isEmpty()) {
-            throw new APIException("User.creating.password.required", (Object[]) null);
-        }
-
-        if (hasDuplicateUsername(user)) {
-            throw new DAOException(
-                    "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
-        }
-
-        // TODO Check required fields for user!!
-        OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
-
-        return dao.saveUser(user, password);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUser(java.lang.Integer)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public User getUser(Integer userId) throws APIException {
-        return dao.getUser(userId);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUserByUsername(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public User getUserByUsername(String username) throws APIException {
-        return dao.getUserByUsername(username);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#hasDuplicateUsername(org.openmrs.User)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public boolean hasDuplicateUsername(User user) throws APIException {
-        return dao.hasDuplicateUsername(user.getUsername(), user.getSystemId(), user.getUserId());
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUsersByRole(org.openmrs.Role)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUsersByRole(Role role) throws APIException {
-        List<Role> roles = new ArrayList<>();
-        roles.add(role);
-
-        return Context.getUserService().getUsers(null, roles, false);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#saveUser(org.openmrs.User)
-     */
-    @Override
-    @CacheEvict(value = "userSearchLocales", allEntries = true)
-    public User saveUser(User user) throws APIException {
-        if (user.getUserId() == null) {
-            throw new APIException("This method can be called only to update existing users");
-        }
-
-        Context.requirePrivilege(PrivilegeConstants.EDIT_USERS);
-
-        checkPrivileges(user);
-
-        if (hasDuplicateUsername(user)) {
-            throw new DAOException(
-                    "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
-        }
-
-        return dao.saveUser(user, null);
-    }
-
-    public User voidUser(User user, String reason) throws APIException {
-        return Context.getUserService().retireUser(user, reason);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#retireUser(org.openmrs.User,
-     * java.lang.String)
-     */
-    @Override
-    public User retireUser(User user, String reason) throws APIException {
-        user.setRetired(true);
-        user.setRetireReason(reason);
-        user.setRetiredBy(Context.getAuthenticatedUser());
-        user.setDateRetired(new Date());
-
-        return saveUser(user);
-    }
-
-    public User unvoidUser(User user) throws APIException {
-        return Context.getUserService().unretireUser(user);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#unretireUser(org.openmrs.User)
-     */
-    @Override
-    public User unretireUser(User user) throws APIException {
-        user.setRetired(false);
-        user.setRetireReason(null);
-        user.setRetiredBy(null);
-        user.setDateRetired(null);
-
-        return saveUser(user);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getAllUsers()
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getAllUsers() throws APIException {
-        return dao.getAllUsers();
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getAllPrivileges()
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<Privilege> getAllPrivileges() throws APIException {
-        return dao.getAllPrivileges();
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getPrivilege(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Privilege getPrivilege(String p) throws APIException {
-        return dao.getPrivilege(p);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
-     */
-    @Override
-    public void purgePrivilege(Privilege privilege) throws APIException {
-        if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
-            throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
-        }
-
-        dao.deletePrivilege(privilege);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
-     */
-    @Override
-    public Privilege savePrivilege(Privilege privilege) throws APIException {
-        return dao.savePrivilege(privilege);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getAllRoles()
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<Role> getAllRoles() throws APIException {
-        return dao.getAllRoles();
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getRole(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Role getRole(String r) throws APIException {
-        return dao.getRole(r);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
-     */
-    @Override
-    public void purgeRole(Role role) throws APIException {
-        if (role == null || role.getRole() == null) {
-            return;
-        }
-
-        if (OpenmrsUtil.getCoreRoles().keySet().contains(role.getRole())) {
-            throw new APIException("Role.cannot.delete.core", (Object[]) null);
-        }
-
-        if (role.hasChildRoles()) {
-            throw new CannotDeleteRoleWithChildrenException();
-        }
-
-        dao.deleteRole(role);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
-     */
-    @Override
-    public Role saveRole(Role role) throws APIException {
-        // make sure one of the parents of this role isn't itself...this would
-        // cause an infinite loop
-        if (role.getAllParentRoles().contains(role)) {
-            throw new APIException("Role.cannot.inherit.descendant", (Object[]) null);
-        }
-
-        checkPrivileges(role);
-
-        return dao.saveRole(role);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#changePassword(java.lang.String,
-     * java.lang.String)
-     */
-    @Override
-    public void changePassword(String oldPassword, String newPassword) throws APIException {
-        User user = Context.getAuthenticatedUser();
-        changePassword(user, oldPassword, newPassword);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#changeHashedPassword(User, String,
-     * String)
-     */
-    @Override
-    public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException {
-        dao.changeHashedPassword(user, hashedPassword, salt);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#changeQuestionAnswer(User, String,
-     * String)
-     */
-    @Override
-    public void changeQuestionAnswer(User u, String question, String answer) throws APIException {
-        dao.changeQuestionAnswer(u, question, answer);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#changeQuestionAnswer(java.lang.String,
-     * java.lang.String, java.lang.String)
-     */
-    @Override
-    public void changeQuestionAnswer(String pw, String q, String a) {
-        dao.changeQuestionAnswer(pw, q, a);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#isSecretAnswer(org.openmrs.User,
-     * java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public boolean isSecretAnswer(User u, String answer) {
-        return dao.isSecretAnswer(u, answer);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUsersByName(java.lang.String,
-     * java.lang.String, boolean)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUsersByName(String givenName, String familyName, boolean includeVoided) throws APIException {
-        return dao.getUsersByName(givenName, familyName, includeVoided);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUsersByPerson(org.openmrs.Person,
-     * boolean)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException {
-        return dao.getUsersByPerson(person, includeRetired);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUsers(java.lang.String,
-     * java.util.List, boolean)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException {
-        return Context.getUserService().getUsers(nameSearch, roles, includeVoided, null, null);
-    }
-
-    /**
-     * Convenience method to check if the authenticated user has all privileges
-     * they are giving out
-     *
-     * @param user user that has privileges
-     */
-    private void checkPrivileges(User user) {
-        List<String> requiredPrivs = user.getAllRoles().stream().peek(this::checkSuperUserPrivilege).map(Role::getPrivileges)
-                .filter(Objects::nonNull).flatMap(Collection::stream).map(Privilege::getPrivilege)
-                .filter(p -> !Context.hasPrivilege(p)).sorted().collect(Collectors.toList());
-        if (requiredPrivs.size() == 1) {
-            throw new APIException("User.you.must.have.privilege", new Object[]{requiredPrivs.get(0)});
-        } else if (requiredPrivs.size() > 1) {
-            throw new APIException("User.you.must.have.privileges", new Object[]{String.join(", ", requiredPrivs)});
-        }
-    }
-
-    private void checkSuperUserPrivilege(Role r) {
-        if (r.getRole().equals(RoleConstants.SUPERUSER)
-                && !Context.hasPrivilege(PrivilegeConstants.ASSIGN_SYSTEM_DEVELOPER_ROLE)) {
-            throw new APIException("User.you.must.have.role", new Object[]{RoleConstants.SUPERUSER});
-        }
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#setUserProperty(User, String, String)
-     */
-    @Override
-    public User setUserProperty(User user, String key, String value) {
-        if (user != null) {
-            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
-                throw new APIException("you.are.not.authorized.change.properties", new Object[]{user.getUserId()});
-            }
-
-            user.setUserProperty(key, value);
-            try {
-                Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-                Context.getUserService().saveUser(user);
-            } finally {
-                Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-            }
-        }
-
-        return user;
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#removeUserProperty(org.openmrs.User,
-     * java.lang.String)
-     */
-    @Override
-    public User removeUserProperty(User user, String key) {
-        if (user != null) {
-            // if the current user isn't allowed to edit users and
-            // the user being edited is not the current user, throw an
-            // exception
-            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
-                throw new APIException("you.are.not.authorized.change.properties", new Object[]{user.getUserId()});
-            }
-
-            user.removeUserProperty(key);
-
-            try {
-                Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-                Context.getUserService().saveUser(user);
-            } finally {
-                Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
-            }
-        }
-
-        return user;
-    }
-
-    /**
-     * Generates system ids based on the following algorithm scheme:
-     * user_id-check digit
-     *
-     * @see org.openmrs.api.UserService#generateSystemId()
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public String generateSystemId() {
-        // Hardcoding Luhn algorithm since all existing openmrs user ids have
-        // had check digits generated this way.
-        LuhnIdentifierValidator liv = new LuhnIdentifierValidator();
-
-        String systemId;
-        Integer offset = 0;
-        do {
-            // generate and increment the system id if necessary
-            Integer generatedId = dao.generateSystemId() + offset++;
-
-            systemId = generatedId.toString();
-
-            try {
-                systemId = liv.getValidIdentifier(systemId);
-            } catch (Exception e) {
-                log.error("error getting check digit", e);
-                return systemId;
-            }
-
-            // loop until we find a system id that no one has
-        } while (dao.hasDuplicateUsername(null, systemId, null));
-
-        return systemId;
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User)
-     */
-    @Override
-    public void purgeUser(User user) throws APIException {
-        dao.deleteUser(user);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User, boolean)
-     */
-    @Override
-    public void purgeUser(User user, boolean cascade) throws APIException {
-        if (cascade) {
-            throw new APIException("cascade.do.not.think", (Object[]) null);
-        }
-
-        dao.deleteUser(user);
-    }
-
-    /**
-     * Convenience method to check if the authenticated user has all privileges
-     * they are giving out to the new role
-     *
-     * @param role
-     */
-    private void checkPrivileges(Role role) {
-        Optional.ofNullable(role.getPrivileges()).map(p -> p.stream().filter(pr -> !Context.hasPrivilege(pr.getPrivilege()))
-                .map(Privilege::getPrivilege).distinct().collect(Collectors.joining(", "))).ifPresent(missing -> {
-            if (StringUtils.isNotBlank(missing)) {
-                throw new APIException("Role.you.must.have.privileges", new Object[]{missing});
-            }
-        });
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getPrivilegeByUuid(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Privilege getPrivilegeByUuid(String uuid) throws APIException {
-        return dao.getPrivilegeByUuid(uuid);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getRoleByUuid(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Role getRoleByUuid(String uuid) throws APIException {
-        return dao.getRoleByUuid(uuid);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUserByUuid(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public User getUserByUuid(String uuid) throws APIException {
-        return dao.getUserByUuid(uuid);
-    }
-
-    /**
-     * @see UserService#getCountOfUsers(String, List, boolean)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
-        if (name != null) {
-            name = StringUtils.replace(name, ", ", " ");
-        }
-
-        // if the authenticated role is in the list of searched roles, then all
-        // persons should be searched
-        Role authRole = getRole(RoleConstants.AUTHENTICATED);
-        if (roles.contains(authRole)) {
-            return dao.getCountOfUsers(name, new ArrayList<>(), includeRetired);
-        }
-
-        return dao.getCountOfUsers(name, roles, includeRetired);
-    }
-
-    /**
-     * @see UserService#getUsers(String, List, boolean, Integer, Integer)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
-            throws APIException {
-        if (name != null) {
-            name = StringUtils.replace(name, ", ", " ");
-        }
-
-        if (roles == null) {
-            roles = new ArrayList<>();
-        }
-
-        // if the authenticated role is in the list of searched roles, then all
-        // persons should be searched
-        Role authRole = getRole(RoleConstants.AUTHENTICATED);
-        if (roles.contains(authRole)) {
-            return dao.getUsers(name, new ArrayList<>(), includeRetired, start, length);
-        }
-
-        // add the requested roles and all child roles for consideration
-        Set<Role> allRoles = new HashSet<>();
-        for (Role r : roles) {
-            allRoles.add(r);
-            allRoles.addAll(r.getAllChildRoles());
-        }
-
-        return dao.getUsers(name, new ArrayList<>(allRoles), includeRetired, start, length);
-    }
-
-    @Override
-    public User saveUserProperty(String key, String value) {
-        User user = Context.getAuthenticatedUser();
-        if (user == null) {
-            throw new APIException("no.authenticated.user.found", (Object[]) null);
-        }
-        user.setUserProperty(key, value);
-        return dao.saveUser(user, null);
-    }
-
-    @Override
-    public User saveUserProperties(Map<String, String> properties) {
-        User user = Context.getAuthenticatedUser();
-        if (user == null) {
-            throw new APIException("no.authenticated.user.found", (Object[]) null);
-        }
-        user.getUserProperties().clear();
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            user.setUserProperty(entry.getKey(), entry.getValue());
-        }
-        return dao.saveUser(user, null);
-    }
-
-    /**
-     * @see UserService#changePassword(User, String, String)
-     */
-    @Override
-    @Authorized(PrivilegeConstants.EDIT_USER_PASSWORDS)
-    @Logging(ignoredArgumentIndexes = {1, 2})
-    public void changePassword(User user, String oldPassword, String newPassword) throws APIException {
-        if (user.getUserId() == null) {
-            throw new APIException("user.must.exist", (Object[]) null);
-        }
-
-        if (oldPassword == null) {
-            if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS)) {
-                throw new APIException("null.old.password.privilege.required", (Object[]) null);
-            }
-        } else if (!dao.getLoginCredential(user).checkPassword(oldPassword)) {
-            throw new APIException("old.password.not.correct", (Object[]) null);
-
-        } else if (oldPassword.equals(newPassword)) {
-            throw new APIException("new.password.equal.to.old", (Object[]) null);
-        }
-
-        if (("admin".equals(user.getSystemId()) || "admin".equals(user.getUsername())) && Boolean
-                .parseBoolean(Context.getRuntimeProperties().getProperty(ADMIN_PASSWORD_LOCKED_PROPERTY, "false"))) {
-            throw new APIException("admin.password.is.locked");
-        }
-
-        updatePassword(user, newPassword);
-    }
-
-    @Override
-    @Logging(ignoredArgumentIndexes = {1})
-    public void changePassword(User user, String newPassword) {
-        Context.getUserService().changePassword(user, null, newPassword);
-    }
-
-    @Override
-    @Logging(ignoredArgumentIndexes = {1, 2})
-    public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException {
-        User user = Context.getAuthenticatedUser();
-
-        if (!isSecretAnswer(user, secretAnswer)) {
-            throw new APIException("secret.answer.not.correct", (Object[]) null);
-        }
-
-        updatePassword(user, pw);
-    }
-
-    private void updatePassword(User user, String newPassword) {
-        OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
-        LoginCredential credentials = dao.getLoginCredential(user);
-        String salt = credentials.getSalt();
-        if (StringUtils.isBlank(salt)) {
-            salt = Security.getRandomToken();
-        }
-        String hashedPassword = passwordEncoder.encode(newPassword + salt);
-        dao.changeHashedPassword(user, hashedPassword, salt);
-    }
-
-    @Override
-    public String getSecretQuestion(User user) throws APIException {
-        if (user.getUserId() != null) {
-            LoginCredential loginCredential = dao.getLoginCredential(user);
-            return loginCredential.getSecretQuestion();
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * @see
-     * org.openmrs.api.UserService#getUserByUsernameOrEmail(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public User getUserByUsernameOrEmail(String usernameOrEmail) {
-        if (StringUtils.isNotBlank(usernameOrEmail)) {
-            User user = dao.getUserByEmail(usernameOrEmail);
-            if (user == null) {
-                return getUserByUsername(usernameOrEmail);
-            }
-            return user;
-        }
-        throw new APIException("error.usernameOrEmail.notNullOrBlank", (Object[]) null);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getUserByActivationKey(java.lang.String)
-     */
-    @Override
-    @Transactional(readOnly = true)
-    public User getUserByActivationKey(String activationKey) {
-        LoginCredential loginCred = dao.getLoginCredentialByActivationKey(activationKey);
-        if (loginCred != null) {
-            String[] credTokens = loginCred.getActivationKey().split(":");
-            if (System.currentTimeMillis() <= Long.parseLong(credTokens[1])) {
-                return getUser(loginCred.getUserId());
-            }
-        }
-        return null;
-    }
-
-    /**
-     * @throws APIException
-     * @throws MessageException
-     * @see org.openmrs.api.UserService#setUserActivationKey(org.openmrs.User)
-     */
-    @Override
-    public User setUserActivationKey(User user) throws MessageException {
-        String token = RandomStringUtils.secureStrong().nextAlphanumeric(20);
-        long time = System.currentTimeMillis() + getValidTime();
-        String hashedKey = Security.encodeString(token);
-        String activationKey = hashedKey + ":" + time;
-        LoginCredential credentials = dao.getLoginCredential(user);
-        credentials.setActivationKey(activationKey);
-        dao.setUserActivationKey(credentials);
-
-        MessageSourceService messages = Context.getMessageSourceService();
-        AdministrationService adminService = Context.getAdministrationService();
-        Locale locale = getDefaultLocaleForUser(user);
-
-        //		Delete this method call when removing {@link OpenmrsConstants#GP_HOST_URL}
-        copyHostURLGlobalPropertyToPasswordResetGlobalProperty(adminService);
-
-        String link = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL).replace("{activationKey}",
-                token);
-
-        Properties mailProperties = Context.getMailProperties();
-
-        String sender = mailProperties.getProperty("mail.from");
-
-        String subject = messages.getMessage("mail.passwordreset.subject", null, locale);
-
-        String msg = messages.getMessage("mail.passwordreset.content", null, locale).replace("{name}", user.getUsername())
-                .replace("{link}", link).replace("{time}", String.valueOf(getValidTime() / 60000));
-
-        Context.getMessageService().sendMessage(user.getEmail(), sender, subject, msg);
-
-        return user;
-    }
-
-    /**
-     * Delete this method when deleting {@link OpenmrsConstants#GP_HOST_URL}
-     */
-    private void copyHostURLGlobalPropertyToPasswordResetGlobalProperty(AdministrationService adminService) {
-        String hostURLGP = adminService.getGlobalProperty(OpenmrsConstants.GP_HOST_URL);
-        String passwordResetGP = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL);
-        if (StringUtils.isNotBlank(hostURLGP) && StringUtils.isBlank(passwordResetGP)) {
-            adminService.setGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL, hostURLGP);
-        }
-    }
-
-    /**
-     * @see UserService#getDefaultLocaleForUser(User)
-     */
-    @Override
-    public Locale getDefaultLocaleForUser(User user) {
-        Locale locale = null;
-        if (user != null) {
-            try {
-                String preferredLocale = user.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE);
-                if (StringUtils.isNotBlank(preferredLocale)) {
-                    locale = LocaleUtility.fromSpecification(preferredLocale);
-                }
-            } catch (Exception e) {
-                log.warn("Unable to parse user locale into a Locale", e);
-            }
-        }
-        if (locale == null) {
-            locale = Context.getLocale();
-        }
-        return locale;
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#changePasswordUsingActivationKey(String,
-     * String);
-     */
-    @Override
-    public void changePasswordUsingActivationKey(String activationKey, String newPassword) {
-        User user = getUserByActivationKey(activationKey);
-        if (user == null) {
-            throw new InvalidActivationKeyException("activation.key.not.correct");
-        }
-
-        updatePassword(user, newPassword);
-    }
-
-    /**
-     * @see org.openmrs.api.UserService#getLastLoginTime(User)
-     */
-    public String getLastLoginTime(User user) {
-        return dao.getLastLoginTime(user);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public <T> T getRefByUuid(Class<T> type, String uuid) {
-        if (Role.class.equals(type)) {
-            return (T) getRoleByUuid(uuid);
-        }
-        if (Privilege.class.equals(type)) {
-            return (T) getPrivilegeByUuid(uuid);
-        }
-        if (User.class.equals(type)) {
-            return (T) getUserByUuid(uuid);
-        }
-        throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
-    }
-
-    @Override
-    public List<Class<?>> getRefTypes() {
-        return Arrays.asList(Role.class, Privilege.class, User.class);
-    }
+	private static final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
+
+	@Autowired
+	protected UserDAO dao;
+
+	private final PasswordEncoder passwordEncoder;
+
+	private static final int MAX_VALID_TIME = 12 * 60 * 60 * 1000; //Period of 12 hours
+
+	private static final int MIN_VALID_TIME = 60 * 1000; //Period of 1 minute
+
+	private static final int DEFAULT_VALID_TIME = 10 * 60 * 1000; //Default time of 10 minute
+
+	@Autowired
+	public UserServiceImpl(PasswordEncoder passwordEncoder) {
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	public void setUserDAO(UserDAO dao) {
+		this.dao = dao;
+	}
+
+	/**
+	 * @return the validTime for which the password reset activation key will be valid
+	 */
+	private int getValidTime() {
+		String validTimeGp = Context.getAdministrationService()
+		        .getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_VALIDTIME);
+		final int validTime = StringUtils.isBlank(validTimeGp) ? DEFAULT_VALID_TIME : Integer.parseInt(validTimeGp);
+		//if valid time is less that a minute or greater than 12hrs reset valid time to 1 minutes else set it to the required time.
+		return (validTime < MIN_VALID_TIME) || (validTime > MAX_VALID_TIME) ? DEFAULT_VALID_TIME : validTime;
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#createUser(org.openmrs.User, java.lang.String)
+	 */
+	@Override
+	public User createUser(User user, String password) throws APIException {
+		if (user.getUserId() != null) {
+			throw new APIException("This method can be used for only creating new users");
+		}
+
+		Context.requirePrivilege(PrivilegeConstants.ADD_USERS);
+
+		checkPrivileges(user);
+
+		// if a password wasn't supplied, throw an error
+		if (password == null || password.isEmpty()) {
+			throw new APIException("User.creating.password.required", (Object[]) null);
+		}
+
+		if (hasDuplicateUsername(user)) {
+			throw new DAOException(
+			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
+		}
+
+		// TODO Check required fields for user!!
+		OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
+
+		return dao.saveUser(user, password);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUser(java.lang.Integer)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public User getUser(Integer userId) throws APIException {
+		return dao.getUser(userId);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUserByUsername(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public User getUserByUsername(String username) throws APIException {
+		return dao.getUserByUsername(username);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#hasDuplicateUsername(org.openmrs.User)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public boolean hasDuplicateUsername(User user) throws APIException {
+		return dao.hasDuplicateUsername(user.getUsername(), user.getSystemId(), user.getUserId());
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUsersByRole(org.openmrs.Role)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getUsersByRole(Role role) throws APIException {
+		List<Role> roles = new ArrayList<>();
+		roles.add(role);
+
+		return Context.getUserService().getUsers(null, roles, false);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#saveUser(org.openmrs.User)
+	 */
+	@Override
+	@CacheEvict(value = "userSearchLocales", allEntries = true)
+	public User saveUser(User user) throws APIException {
+		if (user.getUserId() == null) {
+			throw new APIException("This method can be called only to update existing users");
+		}
+
+		Context.requirePrivilege(PrivilegeConstants.EDIT_USERS);
+
+		checkPrivileges(user);
+
+		if (hasDuplicateUsername(user)) {
+			throw new DAOException(
+			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
+		}
+
+		return dao.saveUser(user, null);
+	}
+
+	public User voidUser(User user, String reason) throws APIException {
+		return Context.getUserService().retireUser(user, reason);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#retireUser(org.openmrs.User, java.lang.String)
+	 */
+	@Override
+	public User retireUser(User user, String reason) throws APIException {
+		user.setRetired(true);
+		user.setRetireReason(reason);
+		user.setRetiredBy(Context.getAuthenticatedUser());
+		user.setDateRetired(new Date());
+
+		return saveUser(user);
+	}
+
+	public User unvoidUser(User user) throws APIException {
+		return Context.getUserService().unretireUser(user);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#unretireUser(org.openmrs.User)
+	 */
+	@Override
+	public User unretireUser(User user) throws APIException {
+		user.setRetired(false);
+		user.setRetireReason(null);
+		user.setRetiredBy(null);
+		user.setDateRetired(null);
+
+		return saveUser(user);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getAllUsers()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getAllUsers() throws APIException {
+		return dao.getAllUsers();
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getAllPrivileges()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Privilege> getAllPrivileges() throws APIException {
+		return dao.getAllPrivileges();
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getPrivilege(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Privilege getPrivilege(String p) throws APIException {
+		return dao.getPrivilege(p);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
+	 */
+	@Override
+	public void purgePrivilege(Privilege privilege) throws APIException {
+		if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
+			throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
+		}
+
+		dao.deletePrivilege(privilege);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
+	 */
+	@Override
+	public Privilege savePrivilege(Privilege privilege) throws APIException {
+		return dao.savePrivilege(privilege);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getAllRoles()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<Role> getAllRoles() throws APIException {
+		return dao.getAllRoles();
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getRole(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Role getRole(String r) throws APIException {
+		return dao.getRole(r);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
+	 */
+	@Override
+	public void purgeRole(Role role) throws APIException {
+		if (role == null || role.getRole() == null) {
+			return;
+		}
+
+		if (OpenmrsUtil.getCoreRoles().keySet().contains(role.getRole())) {
+			throw new APIException("Role.cannot.delete.core", (Object[]) null);
+		}
+
+		if (role.hasChildRoles()) {
+			throw new CannotDeleteRoleWithChildrenException();
+		}
+
+		dao.deleteRole(role);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
+	 */
+	@Override
+	public Role saveRole(Role role) throws APIException {
+		// make sure one of the parents of this role isn't itself...this would
+		// cause an infinite loop
+		if (role.getAllParentRoles().contains(role)) {
+			throw new APIException("Role.cannot.inherit.descendant", (Object[]) null);
+		}
+
+		checkPrivileges(role);
+
+		return dao.saveRole(role);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#changePassword(java.lang.String, java.lang.String)
+	 */
+	@Override
+	public void changePassword(String oldPassword, String newPassword) throws APIException {
+		User user = Context.getAuthenticatedUser();
+		changePassword(user, oldPassword, newPassword);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#changeHashedPassword(User, String, String)
+	 */
+	@Override
+	public void changeHashedPassword(User user, String hashedPassword, String salt) throws APIException {
+		dao.changeHashedPassword(user, hashedPassword, salt);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#changeQuestionAnswer(User, String, String)
+	 */
+	@Override
+	public void changeQuestionAnswer(User u, String question, String answer) throws APIException {
+		dao.changeQuestionAnswer(u, question, answer);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#changeQuestionAnswer(java.lang.String, java.lang.String,
+	 *      java.lang.String)
+	 */
+	@Override
+	public void changeQuestionAnswer(String pw, String q, String a) {
+		dao.changeQuestionAnswer(pw, q, a);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#isSecretAnswer(org.openmrs.User, java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public boolean isSecretAnswer(User u, String answer) {
+		return dao.isSecretAnswer(u, answer);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUsersByName(java.lang.String, java.lang.String, boolean)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getUsersByName(String givenName, String familyName, boolean includeVoided) throws APIException {
+		return dao.getUsersByName(givenName, familyName, includeVoided);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUsersByPerson(org.openmrs.Person, boolean)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getUsersByPerson(Person person, boolean includeRetired) throws APIException {
+		return dao.getUsersByPerson(person, includeRetired);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUsers(java.lang.String, java.util.List, boolean)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getUsers(String nameSearch, List<Role> roles, boolean includeVoided) throws APIException {
+		return Context.getUserService().getUsers(nameSearch, roles, includeVoided, null, null);
+	}
+
+	/**
+	 * Convenience method to check if the authenticated user has all privileges they are giving out
+	 *
+	 * @param user user that has privileges
+	 */
+	private void checkPrivileges(User user) {
+		List<String> requiredPrivs = user.getAllRoles().stream().peek(this::checkSuperUserPrivilege).map(Role::getPrivileges)
+		        .filter(Objects::nonNull).flatMap(Collection::stream).map(Privilege::getPrivilege)
+		        .filter(p -> !Context.hasPrivilege(p)).sorted().collect(Collectors.toList());
+		if (requiredPrivs.size() == 1) {
+			throw new APIException("User.you.must.have.privilege", new Object[] { requiredPrivs.get(0) });
+		} else if (requiredPrivs.size() > 1) {
+			throw new APIException("User.you.must.have.privileges", new Object[] { String.join(", ", requiredPrivs) });
+		}
+	}
+
+	private void checkSuperUserPrivilege(Role r) {
+		if (r.getRole().equals(RoleConstants.SUPERUSER)
+		        && !Context.hasPrivilege(PrivilegeConstants.ASSIGN_SYSTEM_DEVELOPER_ROLE)) {
+			throw new APIException("User.you.must.have.role", new Object[] { RoleConstants.SUPERUSER });
+		}
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#setUserProperty(User, String, String)
+	 */
+	@Override
+	public User setUserProperty(User user, String key, String value) {
+		if (user != null) {
+			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
+				throw new APIException("you.are.not.authorized.change.properties", new Object[] { user.getUserId() });
+			}
+
+			user.setUserProperty(key, value);
+			try {
+				Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+				Context.getUserService().saveUser(user);
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+			}
+		}
+
+		return user;
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#removeUserProperty(org.openmrs.User, java.lang.String)
+	 */
+	@Override
+	public User removeUserProperty(User user, String key) {
+		if (user != null) {
+			// if the current user isn't allowed to edit users and
+			// the user being edited is not the current user, throw an
+			// exception
+			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USERS) && !user.equals(Context.getAuthenticatedUser())) {
+				throw new APIException("you.are.not.authorized.change.properties", new Object[] { user.getUserId() });
+			}
+
+			user.removeUserProperty(key);
+
+			try {
+				Context.addProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+				Context.getUserService().saveUser(user);
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USERS);
+			}
+		}
+
+		return user;
+	}
+
+	/**
+	 * Generates system ids based on the following algorithm scheme: user_id-check digit
+	 *
+	 * @see org.openmrs.api.UserService#generateSystemId()
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public String generateSystemId() {
+		// Hardcoding Luhn algorithm since all existing openmrs user ids have
+		// had check digits generated this way.
+		LuhnIdentifierValidator liv = new LuhnIdentifierValidator();
+
+		String systemId;
+		Integer offset = 0;
+		do {
+			// generate and increment the system id if necessary
+			Integer generatedId = dao.generateSystemId() + offset++;
+
+			systemId = generatedId.toString();
+
+			try {
+				systemId = liv.getValidIdentifier(systemId);
+			} catch (Exception e) {
+				log.error("error getting check digit", e);
+				return systemId;
+			}
+
+			// loop until we find a system id that no one has
+		} while (dao.hasDuplicateUsername(null, systemId, null));
+
+		return systemId;
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User)
+	 */
+	@Override
+	public void purgeUser(User user) throws APIException {
+		dao.deleteUser(user);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#purgeUser(org.openmrs.User, boolean)
+	 */
+	@Override
+	public void purgeUser(User user, boolean cascade) throws APIException {
+		if (cascade) {
+			throw new APIException("cascade.do.not.think", (Object[]) null);
+		}
+
+		dao.deleteUser(user);
+	}
+
+	/**
+	 * Convenience method to check if the authenticated user has all privileges they are giving out to
+	 * the new role
+	 *
+	 * @param role
+	 */
+	private void checkPrivileges(Role role) {
+		Optional.ofNullable(role.getPrivileges()).map(p -> p.stream().filter(pr -> !Context.hasPrivilege(pr.getPrivilege()))
+		        .map(Privilege::getPrivilege).distinct().collect(Collectors.joining(", "))).ifPresent(missing -> {
+			        if (StringUtils.isNotBlank(missing)) {
+				        throw new APIException("Role.you.must.have.privileges", new Object[] { missing });
+			        }
+		        });
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getPrivilegeByUuid(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Privilege getPrivilegeByUuid(String uuid) throws APIException {
+		return dao.getPrivilegeByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getRoleByUuid(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Role getRoleByUuid(String uuid) throws APIException {
+		return dao.getRoleByUuid(uuid);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUserByUuid(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public User getUserByUuid(String uuid) throws APIException {
+		return dao.getUserByUuid(uuid);
+	}
+
+	/**
+	 * @see UserService#getCountOfUsers(String, List, boolean)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public Integer getCountOfUsers(String name, List<Role> roles, boolean includeRetired) {
+		if (name != null) {
+			name = StringUtils.replace(name, ", ", " ");
+		}
+
+		// if the authenticated role is in the list of searched roles, then all
+		// persons should be searched
+		Role authRole = getRole(RoleConstants.AUTHENTICATED);
+		if (roles.contains(authRole)) {
+			return dao.getCountOfUsers(name, new ArrayList<>(), includeRetired);
+		}
+
+		return dao.getCountOfUsers(name, roles, includeRetired);
+	}
+
+	/**
+	 * @see UserService#getUsers(String, List, boolean, Integer, Integer)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public List<User> getUsers(String name, List<Role> roles, boolean includeRetired, Integer start, Integer length)
+	        throws APIException {
+		if (name != null) {
+			name = StringUtils.replace(name, ", ", " ");
+		}
+
+		if (roles == null) {
+			roles = new ArrayList<>();
+		}
+
+		// if the authenticated role is in the list of searched roles, then all
+		// persons should be searched
+		Role authRole = getRole(RoleConstants.AUTHENTICATED);
+		if (roles.contains(authRole)) {
+			return dao.getUsers(name, new ArrayList<>(), includeRetired, start, length);
+		}
+
+		// add the requested roles and all child roles for consideration
+		Set<Role> allRoles = new HashSet<>();
+		for (Role r : roles) {
+			allRoles.add(r);
+			allRoles.addAll(r.getAllChildRoles());
+		}
+
+		return dao.getUsers(name, new ArrayList<>(allRoles), includeRetired, start, length);
+	}
+
+	@Override
+	public User saveUserProperty(String key, String value) {
+		User user = Context.getAuthenticatedUser();
+		if (user == null) {
+			throw new APIException("no.authenticated.user.found", (Object[]) null);
+		}
+		user.setUserProperty(key, value);
+		return dao.saveUser(user, null);
+	}
+
+	@Override
+	public User saveUserProperties(Map<String, String> properties) {
+		User user = Context.getAuthenticatedUser();
+		if (user == null) {
+			throw new APIException("no.authenticated.user.found", (Object[]) null);
+		}
+		user.getUserProperties().clear();
+		for (Map.Entry<String, String> entry : properties.entrySet()) {
+			user.setUserProperty(entry.getKey(), entry.getValue());
+		}
+		return dao.saveUser(user, null);
+	}
+
+	/**
+	 * @see UserService#changePassword(User, String, String)
+	 */
+	@Override
+	@Authorized(PrivilegeConstants.EDIT_USER_PASSWORDS)
+	@Logging(ignoredArgumentIndexes = { 1, 2 })
+	public void changePassword(User user, String oldPassword, String newPassword) throws APIException {
+		if (user.getUserId() == null) {
+			throw new APIException("user.must.exist", (Object[]) null);
+		}
+
+		if (oldPassword == null) {
+			if (!Context.hasPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS)) {
+				throw new APIException("null.old.password.privilege.required", (Object[]) null);
+			}
+		} else if (!dao.getLoginCredential(user).checkPassword(oldPassword)) {
+			throw new APIException("old.password.not.correct", (Object[]) null);
+
+		} else if (oldPassword.equals(newPassword)) {
+			throw new APIException("new.password.equal.to.old", (Object[]) null);
+		}
+
+		if (("admin".equals(user.getSystemId()) || "admin".equals(user.getUsername())) && Boolean
+		        .parseBoolean(Context.getRuntimeProperties().getProperty(ADMIN_PASSWORD_LOCKED_PROPERTY, "false"))) {
+			throw new APIException("admin.password.is.locked");
+		}
+
+		updatePassword(user, newPassword);
+	}
+
+	@Override
+	@Logging(ignoredArgumentIndexes = { 1 })
+	public void changePassword(User user, String newPassword) {
+		Context.getUserService().changePassword(user, null, newPassword);
+	}
+
+	@Override
+	@Logging(ignoredArgumentIndexes = { 1, 2 })
+	public void changePasswordUsingSecretAnswer(String secretAnswer, String pw) throws APIException {
+		User user = Context.getAuthenticatedUser();
+
+		if (!isSecretAnswer(user, secretAnswer)) {
+			throw new APIException("secret.answer.not.correct", (Object[]) null);
+		}
+
+		updatePassword(user, pw);
+	}
+
+	private void updatePassword(User user, String newPassword) {
+		OpenmrsUtil.validatePassword(user.getUsername(), newPassword, user.getSystemId());
+		LoginCredential credentials = dao.getLoginCredential(user);
+		String salt = credentials.getSalt();
+		if (StringUtils.isBlank(salt)) {
+			salt = Security.getRandomToken();
+		}
+		String hashedPassword = passwordEncoder.encode(newPassword + salt);
+		dao.changeHashedPassword(user, hashedPassword, salt);
+	}
+
+	@Override
+	public String getSecretQuestion(User user) throws APIException {
+		if (user.getUserId() != null) {
+			LoginCredential loginCredential = dao.getLoginCredential(user);
+			return loginCredential.getSecretQuestion();
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUserByUsernameOrEmail(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public User getUserByUsernameOrEmail(String usernameOrEmail) {
+		if (StringUtils.isNotBlank(usernameOrEmail)) {
+			User user = dao.getUserByEmail(usernameOrEmail);
+			if (user == null) {
+				return getUserByUsername(usernameOrEmail);
+			}
+			return user;
+		}
+		throw new APIException("error.usernameOrEmail.notNullOrBlank", (Object[]) null);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getUserByActivationKey(java.lang.String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public User getUserByActivationKey(String activationKey) {
+		LoginCredential loginCred = dao.getLoginCredentialByActivationKey(activationKey);
+		if (loginCred != null) {
+			String[] credTokens = loginCred.getActivationKey().split(":");
+			if (System.currentTimeMillis() <= Long.parseLong(credTokens[1])) {
+				return getUser(loginCred.getUserId());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @throws APIException
+	 * @throws MessageException
+	 * @see org.openmrs.api.UserService#setUserActivationKey(org.openmrs.User)
+	 */
+	@Override
+	public User setUserActivationKey(User user) throws MessageException {
+		String token = RandomStringUtils.secureStrong().nextAlphanumeric(20);
+		long time = System.currentTimeMillis() + getValidTime();
+		String hashedKey = Security.encodeString(token);
+		String activationKey = hashedKey + ":" + time;
+		LoginCredential credentials = dao.getLoginCredential(user);
+		credentials.setActivationKey(activationKey);
+		dao.setUserActivationKey(credentials);
+
+		MessageSourceService messages = Context.getMessageSourceService();
+		AdministrationService adminService = Context.getAdministrationService();
+		Locale locale = getDefaultLocaleForUser(user);
+
+		//		Delete this method call when removing {@link OpenmrsConstants#GP_HOST_URL}
+		copyHostURLGlobalPropertyToPasswordResetGlobalProperty(adminService);
+
+		String link = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL).replace("{activationKey}",
+		    token);
+
+		Properties mailProperties = Context.getMailProperties();
+
+		String sender = mailProperties.getProperty("mail.from");
+
+		String subject = messages.getMessage("mail.passwordreset.subject", null, locale);
+
+		String msg = messages.getMessage("mail.passwordreset.content", null, locale).replace("{name}", user.getUsername())
+		        .replace("{link}", link).replace("{time}", String.valueOf(getValidTime() / 60000));
+
+		Context.getMessageService().sendMessage(user.getEmail(), sender, subject, msg);
+
+		return user;
+	}
+
+	/**
+	 * Delete this method when deleting {@link OpenmrsConstants#GP_HOST_URL}
+	 */
+	private void copyHostURLGlobalPropertyToPasswordResetGlobalProperty(AdministrationService adminService) {
+		String hostURLGP = adminService.getGlobalProperty(OpenmrsConstants.GP_HOST_URL);
+		String passwordResetGP = adminService.getGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL);
+		if (StringUtils.isNotBlank(hostURLGP) && StringUtils.isBlank(passwordResetGP)) {
+			adminService.setGlobalProperty(OpenmrsConstants.GP_PASSWORD_RESET_URL, hostURLGP);
+		}
+	}
+
+	/**
+	 * @see UserService#getDefaultLocaleForUser(User)
+	 */
+	@Override
+	public Locale getDefaultLocaleForUser(User user) {
+		Locale locale = null;
+		if (user != null) {
+			try {
+				String preferredLocale = user.getUserProperty(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE);
+				if (StringUtils.isNotBlank(preferredLocale)) {
+					locale = LocaleUtility.fromSpecification(preferredLocale);
+				}
+			} catch (Exception e) {
+				log.warn("Unable to parse user locale into a Locale", e);
+			}
+		}
+		if (locale == null) {
+			locale = Context.getLocale();
+		}
+		return locale;
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#changePasswordUsingActivationKey(String, String);
+	 */
+	@Override
+	public void changePasswordUsingActivationKey(String activationKey, String newPassword) {
+		User user = getUserByActivationKey(activationKey);
+		if (user == null) {
+			throw new InvalidActivationKeyException("activation.key.not.correct");
+		}
+
+		updatePassword(user, newPassword);
+	}
+
+	/**
+	 * @see org.openmrs.api.UserService#getLastLoginTime(User)
+	 */
+	public String getLastLoginTime(User user) {
+		return dao.getLastLoginTime(user);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T> T getRefByUuid(Class<T> type, String uuid) {
+		if (Role.class.equals(type)) {
+			return (T) getRoleByUuid(uuid);
+		}
+		if (Privilege.class.equals(type)) {
+			return (T) getPrivilegeByUuid(uuid);
+		}
+		if (User.class.equals(type)) {
+			return (T) getUserByUuid(uuid);
+		}
+		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+	}
+
+	@Override
+	public List<Class<?>> getRefTypes() {
+		return Arrays.asList(Role.class, Privilege.class, User.class);
+	}
 
 }

--- a/api/src/main/java/org/openmrs/util/Security.java
+++ b/api/src/main/java/org/openmrs/util/Security.java
@@ -16,7 +16,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
-
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -35,321 +34,315 @@ import org.springframework.util.StringUtils;
  */
 public class Security {
 
-    /**
-     * encryption settings
-     */
-    private static final Logger log = LoggerFactory.getLogger(Security.class);
+	/**
+	 * encryption settings
+	 */
+	private static final Logger log = LoggerFactory.getLogger(Security.class);
 
-    private static final Random RANDOM = new SecureRandom();
+	private static final Random RANDOM = new SecureRandom();
 
-    private Security() {
-    }
+	private Security() {
+	}
 
-    /**
-     * Compare the given hash and the given string-to-hash to see if they are
-     * equal. The string-to-hash is usually of the form password + salt. <br>
-     * <br>
-     * This should be used so that this class can compare against the new
-     * correct hashing algorithm and the old incorrect hashing algorithm.
-     * <p>
-     * <strong>Should</strong> match strings hashed with incorrect sha1
-     * algorithm<br/>
-     * <strong>Should</strong> match strings hashed with sha1 algorithm<br/>
-     * <strong>Should</strong> match strings hashed with sha512 algorithm and
-     * 128 characters salt
-     *
-     * @param hashedPassword a stored password that has been hashed previously
-     * @param passwordToHash a string to encode/hash and compare to
-     * hashedPassword
-     * @return true/false whether the two are equal
-     * @since 1.5
-     */
-    public static boolean hashMatches(String hashedPassword, String passwordToHash) {
-        if (hashedPassword == null || passwordToHash == null) {
-            throw new APIException("password.cannot.be.null", (Object[]) null);
-        }
+	/**
+	 * Compare the given hash and the given string-to-hash to see if they are equal. The string-to-hash
+	 * is usually of the form password + salt. <br>
+	 * <br>
+	 * This should be used so that this class can compare against the new correct hashing algorithm and
+	 * the old incorrect hashing algorithm.
+	 * <p>
+	 * <strong>Should</strong> match strings hashed with incorrect sha1 algorithm<br/>
+	 * <strong>Should</strong> match strings hashed with sha1 algorithm<br/>
+	 * <strong>Should</strong> match strings hashed with sha512 algorithm and 128 characters salt
+	 *
+	 * @param hashedPassword a stored password that has been hashed previously
+	 * @param passwordToHash a string to encode/hash and compare to hashedPassword
+	 * @return true/false whether the two are equal
+	 * @since 1.5
+	 */
+	public static boolean hashMatches(String hashedPassword, String passwordToHash) {
+		if (hashedPassword == null || passwordToHash == null) {
+			throw new APIException("password.cannot.be.null", (Object[]) null);
+		}
 
-        if (hashedPassword.startsWith("{")) {
-            try {
-                PasswordEncoder passwordEncoder = Context.getRegisteredComponent("passwordEncoder", PasswordEncoder.class);
-                if (passwordEncoder != null && passwordEncoder.matches(passwordToHash, hashedPassword)) {
-                    return true;
-                }
-            } catch (Exception e) {
-                log.debug("Unable to evaluate delegated password hash. Falling back to legacy matchers.", e);
-            }
-        }
+		if (hashedPassword.startsWith("{")) {
+			try {
+				PasswordEncoder passwordEncoder = Context.getRegisteredComponent("passwordEncoder", PasswordEncoder.class);
+				if (passwordEncoder != null && passwordEncoder.matches(passwordToHash, hashedPassword)) {
+					return true;
+				}
+			} catch (Exception e) {
+				log.debug("Unable to evaluate delegated password hash. Falling back to legacy matchers.", e);
+			}
+		}
 
-        return hashedPassword.equals(encodeString(passwordToHash)) || hashedPassword.equals(encodeStringSHA1(passwordToHash))
-                || hashedPassword.equals(incorrectlyEncodeString(passwordToHash));
-    }
+		return hashedPassword.equals(encodeString(passwordToHash)) || hashedPassword.equals(encodeStringSHA1(passwordToHash))
+		        || hashedPassword.equals(incorrectlyEncodeString(passwordToHash));
+	}
 
-    /**
-     * /** This method will hash <code>strToEncode</code> using the preferred
-     * algorithm. Currently, OpenMRS's preferred algorithm is hard coded to be
-     * SHA-512.
-     * <p>
-     * <strong>Should</strong> encode strings to 128 characters
-     *
-     * @param strToEncode string to encode
-     * @return the SHA-512 encryption of a given string
-     */
-    public static String encodeString(String strToEncode) throws APIException {
-        return encodeString(strToEncode, "SHA-512");
-    }
+	/**
+	 * /** This method will hash <code>strToEncode</code> using the preferred algorithm. Currently,
+	 * OpenMRS's preferred algorithm is hard coded to be SHA-512.
+	 * <p>
+	 * <strong>Should</strong> encode strings to 128 characters
+	 *
+	 * @param strToEncode string to encode
+	 * @return the SHA-512 encryption of a given string
+	 */
+	public static String encodeString(String strToEncode) throws APIException {
+		return encodeString(strToEncode, "SHA-512");
+	}
 
-    /**
-     * This method will hash <code>strToEncode</code> using the old SHA-1
-     * algorithm.
-     *
-     * @param strToEncode string to encode
-     * @return the SHA-1 encryption of a given string
-     */
-    private static String encodeStringSHA1(String strToEncode) throws APIException {
-        return encodeString(strToEncode, "SHA-1");
-    }
+	/**
+	 * This method will hash <code>strToEncode</code> using the old SHA-1 algorithm.
+	 *
+	 * @param strToEncode string to encode
+	 * @return the SHA-1 encryption of a given string
+	 */
+	private static String encodeStringSHA1(String strToEncode) throws APIException {
+		return encodeString(strToEncode, "SHA-1");
+	}
 
-    private static String encodeString(String strToEncode, String algorithm) {
-        return hexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), algorithm));
-    }
+	private static String encodeString(String strToEncode, String algorithm) {
+		return hexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), algorithm));
+	}
 
-    private static byte[] digest(byte[] input, String algorithm) {
-        MessageDigest md;
-        try {
-            md = MessageDigest.getInstance(algorithm);
-        } catch (NoSuchAlgorithmException e) {
-            // Yikes! Can't encode password...what to do?
-            log.error("Can't encode password because the given algorithm: " + algorithm + " was not found! (fail)", e);
-            throw new APIException("system.cannot.find.encryption.algorithm", null, e);
-        }
+	private static byte[] digest(byte[] input, String algorithm) {
+		MessageDigest md;
+		try {
+			md = MessageDigest.getInstance(algorithm);
+		} catch (NoSuchAlgorithmException e) {
+			// Yikes! Can't encode password...what to do?
+			log.error("Can't encode password because the given algorithm: " + algorithm + " was not found! (fail)", e);
+			throw new APIException("system.cannot.find.encryption.algorithm", null, e);
+		}
 
-        return md.digest(input);
-    }
+		return md.digest(input);
+	}
 
-    /**
-     * Convenience method to convert a byte array to a string
-     *
-     * @param block Byte array to convert to HexString
-     * @return Hexadecimal string encoding the byte array
-     */
-    private static String hexString(byte[] block) {
-        StringBuilder buf = new StringBuilder();
-        char[] hexChars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-        int high;
-        int low;
-        for (byte aBlock : block) {
-            high = ((aBlock & 0xf0) >> 4);
-            low = (aBlock & 0x0f);
-            buf.append(hexChars[high]);
-            buf.append(hexChars[low]);
-        }
+	/**
+	 * Convenience method to convert a byte array to a string
+	 *
+	 * @param block Byte array to convert to HexString
+	 * @return Hexadecimal string encoding the byte array
+	 */
+	private static String hexString(byte[] block) {
+		StringBuilder buf = new StringBuilder();
+		char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
+		int high;
+		int low;
+		for (byte aBlock : block) {
+			high = ((aBlock & 0xf0) >> 4);
+			low = (aBlock & 0x0f);
+			buf.append(hexChars[high]);
+			buf.append(hexChars[low]);
+		}
 
-        return buf.toString();
-    }
+		return buf.toString();
+	}
 
-    /**
-     * This method will hash <code>strToEncode</code> using SHA-1 and the
-     * incorrect hashing method that sometimes dropped out leading zeros.
-     *
-     * @param strToEncode string to encode
-     * @return the SHA-1 encryption of a given string
-     */
-    private static String incorrectlyEncodeString(String strToEncode) throws APIException {
-        return incorrectHexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), "SHA-1"));
-    }
+	/**
+	 * This method will hash <code>strToEncode</code> using SHA-1 and the incorrect hashing method that
+	 * sometimes dropped out leading zeros.
+	 *
+	 * @param strToEncode string to encode
+	 * @return the SHA-1 encryption of a given string
+	 */
+	private static String incorrectlyEncodeString(String strToEncode) throws APIException {
+		return incorrectHexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), "SHA-1"));
+	}
 
-    /**
-     * This method used to be the simple hexString method, however, as pointed
-     * out in ticket http://dev.openmrs.org/ticket/1178, it was not working
-     * correctly. Authenticated still needs to occur against both this method
-     * and the correct hex string, so this wrong implementation will remain
-     * until we either force users to change their passwords, or we just decide
-     * to invalidate them.
-     *
-     * @param b the byte array to encode
-     * @return the old possibly less than 40 characters hashed string
-     */
-    private static String incorrectHexString(byte[] b) {
-        if (b == null || b.length < 1) {
-            return "";
-        }
-        StringBuilder s = new StringBuilder();
-        for (byte aB : b) {
-            s.append(Integer.toHexString(aB & 0xFF));
-        }
-        return new String(s);
-    }
+	/**
+	 * This method used to be the simple hexString method, however, as pointed out in ticket
+	 * http://dev.openmrs.org/ticket/1178, it was not working correctly. Authenticated still needs to
+	 * occur against both this method and the correct hex string, so this wrong implementation will
+	 * remain until we either force users to change their passwords, or we just decide to invalidate
+	 * them.
+	 *
+	 * @param b the byte array to encode
+	 * @return the old possibly less than 40 characters hashed string
+	 */
+	private static String incorrectHexString(byte[] b) {
+		if (b == null || b.length < 1) {
+			return "";
+		}
+		StringBuilder s = new StringBuilder();
+		for (byte aB : b) {
+			s.append(Integer.toHexString(aB & 0xFF));
+		}
+		return new String(s);
+	}
 
-    /**
-     * This method will generate a random string
-     *
-     * @return a secure random token.
-     */
-    public static String getRandomToken() throws APIException {
-        byte[] token = new byte[64];
-        RANDOM.nextBytes(token);
-        return hexString(digest(token, "SHA-512"));
-    }
+	/**
+	 * This method will generate a random string
+	 *
+	 * @return a secure random token.
+	 */
+	public static String getRandomToken() throws APIException {
+		byte[] token = new byte[64];
+		RANDOM.nextBytes(token);
+		return hexString(digest(token, "SHA-512"));
+	}
 
-    /**
-     * encrypt text to a string with specific initVector and secretKey; rarely
-     * used except in testing and where specifically necessary
-     *
-     * @see #encrypt(String)
-     * @param text string to be encrypted
-     * @param initVector custom init vector byte array
-     * @param secretKey custom secret key byte array
-     * @return encrypted text
-     * @since 1.9
-     */
-    public static String encrypt(String text, byte[] initVector, byte[] secretKey) {
-        IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
-        SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-        byte[] encrypted;
-        String result;
+	/**
+	 * encrypt text to a string with specific initVector and secretKey; rarely used except in testing
+	 * and where specifically necessary
+	 *
+	 * @see #encrypt(String)
+	 * @param text string to be encrypted
+	 * @param initVector custom init vector byte array
+	 * @param secretKey custom secret key byte array
+	 * @return encrypted text
+	 * @since 1.9
+	 */
+	public static String encrypt(String text, byte[] initVector, byte[] secretKey) {
+		IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
+		SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+		byte[] encrypted;
+		String result;
 
-        try {
-            Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
-            cipher.init(Cipher.ENCRYPT_MODE, secret, initVectorSpec);
-            encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
-            result = new String(Base64.getEncoder().encode(encrypted), StandardCharsets.UTF_8);
-        } catch (GeneralSecurityException e) {
-            throw new APIException("could.not.encrypt.text", null, e);
-        }
+		try {
+			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
+			cipher.init(Cipher.ENCRYPT_MODE, secret, initVectorSpec);
+			encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+			result = new String(Base64.getEncoder().encode(encrypted), StandardCharsets.UTF_8);
+		} catch (GeneralSecurityException e) {
+			throw new APIException("could.not.encrypt.text", null, e);
+		}
 
-        return result;
-    }
+		return result;
+	}
 
-    /**
-     * encrypt text using stored initVector and securityKey
-     * <p>
-     * <strong>Should</strong> encrypt short and long text
-     *
-     * @param text the text to encrypt
-     * @return encrypted text
-     * @since 1.9
-     * @deprecated As of version 2.4.0, this method is not referenced in
-     * openmrs-core or any other projects under the GitHub OpenMRS organisation.
-     */
-    @Deprecated
-    public static String encrypt(String text) {
-        return Security.encrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
-    }
+	/**
+	 * encrypt text using stored initVector and securityKey
+	 * <p>
+	 * <strong>Should</strong> encrypt short and long text
+	 *
+	 * @param text the text to encrypt
+	 * @return encrypted text
+	 * @since 1.9
+	 * @deprecated As of version 2.4.0, this method is not referenced in openmrs-core or any other
+	 *             projects under the GitHub OpenMRS organisation.
+	 */
+	@Deprecated
+	public static String encrypt(String text) {
+		return Security.encrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
+	}
 
-    /**
-     * decrypt text to a string with specific initVector and secretKey; rarely
-     * used except in testing and where specifically necessary
-     *
-     * @see #decrypt(String)
-     * @param text text to be decrypted
-     * @param initVector custom init vector byte array
-     * @param secretKey custom secret key byte array
-     * @return decrypted text
-     * @since 1.9
-     */
-    public static String decrypt(String text, byte[] initVector, byte[] secretKey) {
-        IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
-        SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-        String decrypted;
+	/**
+	 * decrypt text to a string with specific initVector and secretKey; rarely used except in testing
+	 * and where specifically necessary
+	 *
+	 * @see #decrypt(String)
+	 * @param text text to be decrypted
+	 * @param initVector custom init vector byte array
+	 * @param secretKey custom secret key byte array
+	 * @return decrypted text
+	 * @since 1.9
+	 */
+	public static String decrypt(String text, byte[] initVector, byte[] secretKey) {
+		IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
+		SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+		String decrypted;
 
-        try {
-            Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
-            cipher.init(Cipher.DECRYPT_MODE, secret, initVectorSpec);
-            byte[] original = cipher.doFinal(Base64.getDecoder().decode(text));
-            decrypted = new String(original, StandardCharsets.UTF_8);
-        } catch (GeneralSecurityException e) {
-            throw new APIException("could.not.decrypt.text", null, e);
-        }
+		try {
+			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
+			cipher.init(Cipher.DECRYPT_MODE, secret, initVectorSpec);
+			byte[] original = cipher.doFinal(Base64.getDecoder().decode(text));
+			decrypted = new String(original, StandardCharsets.UTF_8);
+		} catch (GeneralSecurityException e) {
+			throw new APIException("could.not.decrypt.text", null, e);
+		}
 
-        return decrypted;
-    }
+		return decrypted;
+	}
 
-    /**
-     * decrypt text using stored initVector and securityKey
-     * <p>
-     * <strong>Should</strong> decrypt short and long text
-     *
-     * @param text text to be decrypted
-     * @return decrypted text
-     * @since 1.9
-     * @deprecated As of version 2.4.0, this method is not referenced in
-     * openmrs-core or any other projects under the GitHub OpenMRS organisation.
-     */
-    @Deprecated
-    public static String decrypt(String text) {
-        return Security.decrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
-    }
+	/**
+	 * decrypt text using stored initVector and securityKey
+	 * <p>
+	 * <strong>Should</strong> decrypt short and long text
+	 *
+	 * @param text text to be decrypted
+	 * @return decrypted text
+	 * @since 1.9
+	 * @deprecated As of version 2.4.0, this method is not referenced in openmrs-core or any other
+	 *             projects under the GitHub OpenMRS organisation.
+	 */
+	@Deprecated
+	public static String decrypt(String text) {
+		return Security.decrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
+	}
 
-    /**
-     * retrieve the stored init vector from runtime properties
-     *
-     * @return stored init vector byte array
-     * @since 1.9
-     */
-    public static byte[] getSavedInitVector() {
-        String initVectorText = Context.getRuntimeProperties().getProperty(
-                OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, OpenmrsConstants.ENCRYPTION_VECTOR_DEFAULT);
+	/**
+	 * retrieve the stored init vector from runtime properties
+	 *
+	 * @return stored init vector byte array
+	 * @since 1.9
+	 */
+	public static byte[] getSavedInitVector() {
+		String initVectorText = Context.getRuntimeProperties().getProperty(
+		    OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, OpenmrsConstants.ENCRYPTION_VECTOR_DEFAULT);
 
-        if (StringUtils.hasText(initVectorText)) {
-            return Base64.getDecoder().decode(initVectorText);
-        }
+		if (StringUtils.hasText(initVectorText)) {
+			return Base64.getDecoder().decode(initVectorText);
+		}
 
-        throw new APIException("no.encryption.initialization.vector.found", (Object[]) null);
-    }
+		throw new APIException("no.encryption.initialization.vector.found", (Object[]) null);
+	}
 
-    /**
-     * generate a new cipher initialization vector; should only be called once
-     * in order to not invalidate all encrypted data
-     *
-     * @return a random array of 16 bytes
-     * @since 1.9
-     */
-    public static byte[] generateNewInitVector() {
-        // initialize the init vector with 16 random bytes
-        byte[] initVector = new byte[16];
-        RANDOM.nextBytes(initVector);
+	/**
+	 * generate a new cipher initialization vector; should only be called once in order to not
+	 * invalidate all encrypted data
+	 *
+	 * @return a random array of 16 bytes
+	 * @since 1.9
+	 */
+	public static byte[] generateNewInitVector() {
+		// initialize the init vector with 16 random bytes
+		byte[] initVector = new byte[16];
+		RANDOM.nextBytes(initVector);
 
-        return initVector;
-    }
+		return initVector;
+	}
 
-    /**
-     * retrieve the secret key from runtime properties
-     *
-     * @return stored secret key byte array
-     * @since 1.9
-     */
-    public static byte[] getSavedSecretKey() {
-        String keyText = Context.getRuntimeProperties().getProperty(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY,
-                OpenmrsConstants.ENCRYPTION_KEY_DEFAULT);
+	/**
+	 * retrieve the secret key from runtime properties
+	 *
+	 * @return stored secret key byte array
+	 * @since 1.9
+	 */
+	public static byte[] getSavedSecretKey() {
+		String keyText = Context.getRuntimeProperties().getProperty(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY,
+		    OpenmrsConstants.ENCRYPTION_KEY_DEFAULT);
 
-        if (StringUtils.hasText(keyText)) {
-            return Base64.getDecoder().decode(keyText);
-        }
+		if (StringUtils.hasText(keyText)) {
+			return Base64.getDecoder().decode(keyText);
+		}
 
-        throw new APIException("no.encryption.secret.key.found", (Object[]) null);
-    }
+		throw new APIException("no.encryption.secret.key.found", (Object[]) null);
+	}
 
-    /**
-     * generate a new secret key; should only be called once in order to not
-     * invalidate all encrypted data
-     *
-     * @return generated secret key byte array
-     * @since 1.9
-     */
-    public static byte[] generateNewSecretKey() {
-        // Get the KeyGenerator
-        KeyGenerator kgen;
-        try {
-            kgen = KeyGenerator.getInstance(OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-        } catch (NoSuchAlgorithmException e) {
-            throw new APIException("could.not.generate.cipher.key", null, e);
-        }
-        kgen.init(128); // 192 and 256 bits may not be available
+	/**
+	 * generate a new secret key; should only be called once in order to not invalidate all encrypted
+	 * data
+	 *
+	 * @return generated secret key byte array
+	 * @since 1.9
+	 */
+	public static byte[] generateNewSecretKey() {
+		// Get the KeyGenerator
+		KeyGenerator kgen;
+		try {
+			kgen = KeyGenerator.getInstance(OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+		} catch (NoSuchAlgorithmException e) {
+			throw new APIException("could.not.generate.cipher.key", null, e);
+		}
+		kgen.init(128); // 192 and 256 bits may not be available
 
-        // Generate the secret key specs.
-        SecretKey skey = kgen.generateKey();
+		// Generate the secret key specs.
+		SecretKey skey = kgen.generateKey();
 
-        return skey.getEncoded();
-    }
+		return skey.getEncoded();
+	}
 
 }

--- a/api/src/main/java/org/openmrs/util/Security.java
+++ b/api/src/main/java/org/openmrs/util/Security.java
@@ -16,6 +16,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
+
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -26,6 +27,7 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.util.StringUtils;
 
 /**
@@ -33,304 +35,321 @@ import org.springframework.util.StringUtils;
  */
 public class Security {
 
-	/**
-	 * encryption settings
-	 */
-	private static final Logger log = LoggerFactory.getLogger(Security.class);
+    /**
+     * encryption settings
+     */
+    private static final Logger log = LoggerFactory.getLogger(Security.class);
 
-	private static final Random RANDOM = new SecureRandom();
+    private static final Random RANDOM = new SecureRandom();
 
-	private Security() {
-	}
+    private Security() {
+    }
 
-	/**
-	 * Compare the given hash and the given string-to-hash to see if they are equal. The string-to-hash
-	 * is usually of the form password + salt. <br>
-	 * <br>
-	 * This should be used so that this class can compare against the new correct hashing algorithm and
-	 * the old incorrect hashing algorithm.
-	 * <p>
-	 * <strong>Should</strong> match strings hashed with incorrect sha1 algorithm<br/>
-	 * <strong>Should</strong> match strings hashed with sha1 algorithm<br/>
-	 * <strong>Should</strong> match strings hashed with sha512 algorithm and 128 characters salt
-	 *
-	 * @param hashedPassword a stored password that has been hashed previously
-	 * @param passwordToHash a string to encode/hash and compare to hashedPassword
-	 * @return true/false whether the two are equal
-	 * @since 1.5
-	 */
-	public static boolean hashMatches(String hashedPassword, String passwordToHash) {
-		if (hashedPassword == null || passwordToHash == null) {
-			throw new APIException("password.cannot.be.null", (Object[]) null);
-		}
+    /**
+     * Compare the given hash and the given string-to-hash to see if they are
+     * equal. The string-to-hash is usually of the form password + salt. <br>
+     * <br>
+     * This should be used so that this class can compare against the new
+     * correct hashing algorithm and the old incorrect hashing algorithm.
+     * <p>
+     * <strong>Should</strong> match strings hashed with incorrect sha1
+     * algorithm<br/>
+     * <strong>Should</strong> match strings hashed with sha1 algorithm<br/>
+     * <strong>Should</strong> match strings hashed with sha512 algorithm and
+     * 128 characters salt
+     *
+     * @param hashedPassword a stored password that has been hashed previously
+     * @param passwordToHash a string to encode/hash and compare to
+     * hashedPassword
+     * @return true/false whether the two are equal
+     * @since 1.5
+     */
+    public static boolean hashMatches(String hashedPassword, String passwordToHash) {
+        if (hashedPassword == null || passwordToHash == null) {
+            throw new APIException("password.cannot.be.null", (Object[]) null);
+        }
 
-		return hashedPassword.equals(encodeString(passwordToHash)) || hashedPassword.equals(encodeStringSHA1(passwordToHash))
-		        || hashedPassword.equals(incorrectlyEncodeString(passwordToHash));
-	}
+        if (hashedPassword.startsWith("{")) {
+            try {
+                PasswordEncoder passwordEncoder = Context.getRegisteredComponent("passwordEncoder", PasswordEncoder.class);
+                if (passwordEncoder != null && passwordEncoder.matches(passwordToHash, hashedPassword)) {
+                    return true;
+                }
+            } catch (Exception e) {
+                log.debug("Unable to evaluate delegated password hash. Falling back to legacy matchers.", e);
+            }
+        }
 
-	/**
-	 * /** This method will hash <code>strToEncode</code> using the preferred algorithm. Currently,
-	 * OpenMRS's preferred algorithm is hard coded to be SHA-512.
-	 * <p>
-	 * <strong>Should</strong> encode strings to 128 characters
-	 *
-	 * @param strToEncode string to encode
-	 * @return the SHA-512 encryption of a given string
-	 */
-	public static String encodeString(String strToEncode) throws APIException {
-		return encodeString(strToEncode, "SHA-512");
-	}
+        return hashedPassword.equals(encodeString(passwordToHash)) || hashedPassword.equals(encodeStringSHA1(passwordToHash))
+                || hashedPassword.equals(incorrectlyEncodeString(passwordToHash));
+    }
 
-	/**
-	 * This method will hash <code>strToEncode</code> using the old SHA-1 algorithm.
-	 *
-	 * @param strToEncode string to encode
-	 * @return the SHA-1 encryption of a given string
-	 */
-	private static String encodeStringSHA1(String strToEncode) throws APIException {
-		return encodeString(strToEncode, "SHA-1");
-	}
+    /**
+     * /** This method will hash <code>strToEncode</code> using the preferred
+     * algorithm. Currently, OpenMRS's preferred algorithm is hard coded to be
+     * SHA-512.
+     * <p>
+     * <strong>Should</strong> encode strings to 128 characters
+     *
+     * @param strToEncode string to encode
+     * @return the SHA-512 encryption of a given string
+     */
+    public static String encodeString(String strToEncode) throws APIException {
+        return encodeString(strToEncode, "SHA-512");
+    }
 
-	private static String encodeString(String strToEncode, String algorithm) {
-		return hexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), algorithm));
-	}
+    /**
+     * This method will hash <code>strToEncode</code> using the old SHA-1
+     * algorithm.
+     *
+     * @param strToEncode string to encode
+     * @return the SHA-1 encryption of a given string
+     */
+    private static String encodeStringSHA1(String strToEncode) throws APIException {
+        return encodeString(strToEncode, "SHA-1");
+    }
 
-	private static byte[] digest(byte[] input, String algorithm) {
-		MessageDigest md;
-		try {
-			md = MessageDigest.getInstance(algorithm);
-		} catch (NoSuchAlgorithmException e) {
-			// Yikes! Can't encode password...what to do?
-			log.error("Can't encode password because the given algorithm: " + algorithm + " was not found! (fail)", e);
-			throw new APIException("system.cannot.find.encryption.algorithm", null, e);
-		}
+    private static String encodeString(String strToEncode, String algorithm) {
+        return hexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), algorithm));
+    }
 
-		return md.digest(input);
-	}
+    private static byte[] digest(byte[] input, String algorithm) {
+        MessageDigest md;
+        try {
+            md = MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            // Yikes! Can't encode password...what to do?
+            log.error("Can't encode password because the given algorithm: " + algorithm + " was not found! (fail)", e);
+            throw new APIException("system.cannot.find.encryption.algorithm", null, e);
+        }
 
-	/**
-	 * Convenience method to convert a byte array to a string
-	 *
-	 * @param block Byte array to convert to HexString
-	 * @return Hexadecimal string encoding the byte array
-	 */
-	private static String hexString(byte[] block) {
-		StringBuilder buf = new StringBuilder();
-		char[] hexChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-		int high;
-		int low;
-		for (byte aBlock : block) {
-			high = ((aBlock & 0xf0) >> 4);
-			low = (aBlock & 0x0f);
-			buf.append(hexChars[high]);
-			buf.append(hexChars[low]);
-		}
+        return md.digest(input);
+    }
 
-		return buf.toString();
-	}
+    /**
+     * Convenience method to convert a byte array to a string
+     *
+     * @param block Byte array to convert to HexString
+     * @return Hexadecimal string encoding the byte array
+     */
+    private static String hexString(byte[] block) {
+        StringBuilder buf = new StringBuilder();
+        char[] hexChars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+        int high;
+        int low;
+        for (byte aBlock : block) {
+            high = ((aBlock & 0xf0) >> 4);
+            low = (aBlock & 0x0f);
+            buf.append(hexChars[high]);
+            buf.append(hexChars[low]);
+        }
 
-	/**
-	 * This method will hash <code>strToEncode</code> using SHA-1 and the incorrect hashing method that
-	 * sometimes dropped out leading zeros.
-	 *
-	 * @param strToEncode string to encode
-	 * @return the SHA-1 encryption of a given string
-	 */
-	private static String incorrectlyEncodeString(String strToEncode) throws APIException {
-		return incorrectHexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), "SHA-1"));
-	}
+        return buf.toString();
+    }
 
-	/**
-	 * This method used to be the simple hexString method, however, as pointed out in ticket
-	 * http://dev.openmrs.org/ticket/1178, it was not working correctly. Authenticated still needs to
-	 * occur against both this method and the correct hex string, so this wrong implementation will
-	 * remain until we either force users to change their passwords, or we just decide to invalidate
-	 * them.
-	 *
-	 * @param b the byte array to encode
-	 * @return the old possibly less than 40 characters hashed string
-	 */
-	private static String incorrectHexString(byte[] b) {
-		if (b == null || b.length < 1) {
-			return "";
-		}
-		StringBuilder s = new StringBuilder();
-		for (byte aB : b) {
-			s.append(Integer.toHexString(aB & 0xFF));
-		}
-		return new String(s);
-	}
+    /**
+     * This method will hash <code>strToEncode</code> using SHA-1 and the
+     * incorrect hashing method that sometimes dropped out leading zeros.
+     *
+     * @param strToEncode string to encode
+     * @return the SHA-1 encryption of a given string
+     */
+    private static String incorrectlyEncodeString(String strToEncode) throws APIException {
+        return incorrectHexString(digest(strToEncode.getBytes(StandardCharsets.UTF_8), "SHA-1"));
+    }
 
-	/**
-	 * This method will generate a random string
-	 *
-	 * @return a secure random token.
-	 */
-	public static String getRandomToken() throws APIException {
-		byte[] token = new byte[64];
-		RANDOM.nextBytes(token);
-		return hexString(digest(token, "SHA-512"));
-	}
+    /**
+     * This method used to be the simple hexString method, however, as pointed
+     * out in ticket http://dev.openmrs.org/ticket/1178, it was not working
+     * correctly. Authenticated still needs to occur against both this method
+     * and the correct hex string, so this wrong implementation will remain
+     * until we either force users to change their passwords, or we just decide
+     * to invalidate them.
+     *
+     * @param b the byte array to encode
+     * @return the old possibly less than 40 characters hashed string
+     */
+    private static String incorrectHexString(byte[] b) {
+        if (b == null || b.length < 1) {
+            return "";
+        }
+        StringBuilder s = new StringBuilder();
+        for (byte aB : b) {
+            s.append(Integer.toHexString(aB & 0xFF));
+        }
+        return new String(s);
+    }
 
-	/**
-	 * encrypt text to a string with specific initVector and secretKey; rarely used except in testing
-	 * and where specifically necessary
-	 *
-	 * @see #encrypt(String)
-	 * @param text string to be encrypted
-	 * @param initVector custom init vector byte array
-	 * @param secretKey custom secret key byte array
-	 * @return encrypted text
-	 * @since 1.9
-	 */
-	public static String encrypt(String text, byte[] initVector, byte[] secretKey) {
-		IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
-		SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-		byte[] encrypted;
-		String result;
+    /**
+     * This method will generate a random string
+     *
+     * @return a secure random token.
+     */
+    public static String getRandomToken() throws APIException {
+        byte[] token = new byte[64];
+        RANDOM.nextBytes(token);
+        return hexString(digest(token, "SHA-512"));
+    }
 
-		try {
-			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
-			cipher.init(Cipher.ENCRYPT_MODE, secret, initVectorSpec);
-			encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
-			result = new String(Base64.getEncoder().encode(encrypted), StandardCharsets.UTF_8);
-		} catch (GeneralSecurityException e) {
-			throw new APIException("could.not.encrypt.text", null, e);
-		}
+    /**
+     * encrypt text to a string with specific initVector and secretKey; rarely
+     * used except in testing and where specifically necessary
+     *
+     * @see #encrypt(String)
+     * @param text string to be encrypted
+     * @param initVector custom init vector byte array
+     * @param secretKey custom secret key byte array
+     * @return encrypted text
+     * @since 1.9
+     */
+    public static String encrypt(String text, byte[] initVector, byte[] secretKey) {
+        IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
+        SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+        byte[] encrypted;
+        String result;
 
-		return result;
-	}
+        try {
+            Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
+            cipher.init(Cipher.ENCRYPT_MODE, secret, initVectorSpec);
+            encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
+            result = new String(Base64.getEncoder().encode(encrypted), StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new APIException("could.not.encrypt.text", null, e);
+        }
 
-	/**
-	 * encrypt text using stored initVector and securityKey
-	 * <p>
-	 * <strong>Should</strong> encrypt short and long text
-	 *
-	 * @param text the text to encrypt
-	 * @return encrypted text
-	 * @since 1.9
-	 * @deprecated As of version 2.4.0, this method is not referenced in openmrs-core or any other
-	 *             projects under the GitHub OpenMRS organisation.
-	 */
-	@Deprecated
-	public static String encrypt(String text) {
-		return Security.encrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
-	}
+        return result;
+    }
 
-	/**
-	 * decrypt text to a string with specific initVector and secretKey; rarely used except in testing
-	 * and where specifically necessary
-	 *
-	 * @see #decrypt(String)
-	 * @param text text to be decrypted
-	 * @param initVector custom init vector byte array
-	 * @param secretKey custom secret key byte array
-	 * @return decrypted text
-	 * @since 1.9
-	 */
-	public static String decrypt(String text, byte[] initVector, byte[] secretKey) {
-		IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
-		SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-		String decrypted;
+    /**
+     * encrypt text using stored initVector and securityKey
+     * <p>
+     * <strong>Should</strong> encrypt short and long text
+     *
+     * @param text the text to encrypt
+     * @return encrypted text
+     * @since 1.9
+     * @deprecated As of version 2.4.0, this method is not referenced in
+     * openmrs-core or any other projects under the GitHub OpenMRS organisation.
+     */
+    @Deprecated
+    public static String encrypt(String text) {
+        return Security.encrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
+    }
 
-		try {
-			Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
-			cipher.init(Cipher.DECRYPT_MODE, secret, initVectorSpec);
-			byte[] original = cipher.doFinal(Base64.getDecoder().decode(text));
-			decrypted = new String(original, StandardCharsets.UTF_8);
-		} catch (GeneralSecurityException e) {
-			throw new APIException("could.not.decrypt.text", null, e);
-		}
+    /**
+     * decrypt text to a string with specific initVector and secretKey; rarely
+     * used except in testing and where specifically necessary
+     *
+     * @see #decrypt(String)
+     * @param text text to be decrypted
+     * @param initVector custom init vector byte array
+     * @param secretKey custom secret key byte array
+     * @return decrypted text
+     * @since 1.9
+     */
+    public static String decrypt(String text, byte[] initVector, byte[] secretKey) {
+        IvParameterSpec initVectorSpec = new IvParameterSpec(initVector);
+        SecretKeySpec secret = new SecretKeySpec(secretKey, OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+        String decrypted;
 
-		return decrypted;
-	}
+        try {
+            Cipher cipher = Cipher.getInstance(OpenmrsConstants.ENCRYPTION_CIPHER_CONFIGURATION);
+            cipher.init(Cipher.DECRYPT_MODE, secret, initVectorSpec);
+            byte[] original = cipher.doFinal(Base64.getDecoder().decode(text));
+            decrypted = new String(original, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException e) {
+            throw new APIException("could.not.decrypt.text", null, e);
+        }
 
-	/**
-	 * decrypt text using stored initVector and securityKey
-	 * <p>
-	 * <strong>Should</strong> decrypt short and long text
-	 *
-	 * @param text text to be decrypted
-	 * @return decrypted text
-	 * @since 1.9
-	 * @deprecated As of version 2.4.0, this method is not referenced in openmrs-core or any other
-	 *             projects under the GitHub OpenMRS organisation.
-	 */
-	@Deprecated
-	public static String decrypt(String text) {
-		return Security.decrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
-	}
+        return decrypted;
+    }
 
-	/**
-	 * retrieve the stored init vector from runtime properties
-	 *
-	 * @return stored init vector byte array
-	 * @since 1.9
-	 */
-	public static byte[] getSavedInitVector() {
-		String initVectorText = Context.getRuntimeProperties().getProperty(
-		    OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, OpenmrsConstants.ENCRYPTION_VECTOR_DEFAULT);
+    /**
+     * decrypt text using stored initVector and securityKey
+     * <p>
+     * <strong>Should</strong> decrypt short and long text
+     *
+     * @param text text to be decrypted
+     * @return decrypted text
+     * @since 1.9
+     * @deprecated As of version 2.4.0, this method is not referenced in
+     * openmrs-core or any other projects under the GitHub OpenMRS organisation.
+     */
+    @Deprecated
+    public static String decrypt(String text) {
+        return Security.decrypt(text, Security.getSavedInitVector(), Security.getSavedSecretKey());
+    }
 
-		if (StringUtils.hasText(initVectorText)) {
-			return Base64.getDecoder().decode(initVectorText);
-		}
+    /**
+     * retrieve the stored init vector from runtime properties
+     *
+     * @return stored init vector byte array
+     * @since 1.9
+     */
+    public static byte[] getSavedInitVector() {
+        String initVectorText = Context.getRuntimeProperties().getProperty(
+                OpenmrsConstants.ENCRYPTION_VECTOR_RUNTIME_PROPERTY, OpenmrsConstants.ENCRYPTION_VECTOR_DEFAULT);
 
-		throw new APIException("no.encryption.initialization.vector.found", (Object[]) null);
-	}
+        if (StringUtils.hasText(initVectorText)) {
+            return Base64.getDecoder().decode(initVectorText);
+        }
 
-	/**
-	 * generate a new cipher initialization vector; should only be called once in order to not
-	 * invalidate all encrypted data
-	 *
-	 * @return a random array of 16 bytes
-	 * @since 1.9
-	 */
-	public static byte[] generateNewInitVector() {
-		// initialize the init vector with 16 random bytes
-		byte[] initVector = new byte[16];
-		RANDOM.nextBytes(initVector);
+        throw new APIException("no.encryption.initialization.vector.found", (Object[]) null);
+    }
 
-		return initVector;
-	}
+    /**
+     * generate a new cipher initialization vector; should only be called once
+     * in order to not invalidate all encrypted data
+     *
+     * @return a random array of 16 bytes
+     * @since 1.9
+     */
+    public static byte[] generateNewInitVector() {
+        // initialize the init vector with 16 random bytes
+        byte[] initVector = new byte[16];
+        RANDOM.nextBytes(initVector);
 
-	/**
-	 * retrieve the secret key from runtime properties
-	 *
-	 * @return stored secret key byte array
-	 * @since 1.9
-	 */
-	public static byte[] getSavedSecretKey() {
-		String keyText = Context.getRuntimeProperties().getProperty(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY,
-		    OpenmrsConstants.ENCRYPTION_KEY_DEFAULT);
+        return initVector;
+    }
 
-		if (StringUtils.hasText(keyText)) {
-			return Base64.getDecoder().decode(keyText);
-		}
+    /**
+     * retrieve the secret key from runtime properties
+     *
+     * @return stored secret key byte array
+     * @since 1.9
+     */
+    public static byte[] getSavedSecretKey() {
+        String keyText = Context.getRuntimeProperties().getProperty(OpenmrsConstants.ENCRYPTION_KEY_RUNTIME_PROPERTY,
+                OpenmrsConstants.ENCRYPTION_KEY_DEFAULT);
 
-		throw new APIException("no.encryption.secret.key.found", (Object[]) null);
-	}
+        if (StringUtils.hasText(keyText)) {
+            return Base64.getDecoder().decode(keyText);
+        }
 
-	/**
-	 * generate a new secret key; should only be called once in order to not invalidate all encrypted
-	 * data
-	 *
-	 * @return generated secret key byte array
-	 * @since 1.9
-	 */
-	public static byte[] generateNewSecretKey() {
-		// Get the KeyGenerator
-		KeyGenerator kgen;
-		try {
-			kgen = KeyGenerator.getInstance(OpenmrsConstants.ENCRYPTION_KEY_SPEC);
-		} catch (NoSuchAlgorithmException e) {
-			throw new APIException("could.not.generate.cipher.key", null, e);
-		}
-		kgen.init(128); // 192 and 256 bits may not be available
+        throw new APIException("no.encryption.secret.key.found", (Object[]) null);
+    }
 
-		// Generate the secret key specs.
-		SecretKey skey = kgen.generateKey();
+    /**
+     * generate a new secret key; should only be called once in order to not
+     * invalidate all encrypted data
+     *
+     * @return generated secret key byte array
+     * @since 1.9
+     */
+    public static byte[] generateNewSecretKey() {
+        // Get the KeyGenerator
+        KeyGenerator kgen;
+        try {
+            kgen = KeyGenerator.getInstance(OpenmrsConstants.ENCRYPTION_KEY_SPEC);
+        } catch (NoSuchAlgorithmException e) {
+            throw new APIException("could.not.generate.cipher.key", null, e);
+        }
+        kgen.init(128); // 192 and 256 bits may not be available
 
-		return skey.getEncoded();
-	}
+        // Generate the secret key specs.
+        SecretKey skey = kgen.generateKey();
+
+        return skey.getEncoded();
+    }
 
 }

--- a/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
@@ -9,23 +9,24 @@
  */
 package org.openmrs.api;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.openmrs.util.Security;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class OpenmrsApplicationContextConfigTest {
 
-    @Test
-    void passwordEncoder_shouldEncodeWithBcryptAndMatchSha512LegacyFormat() {
-        PasswordEncoder passwordEncoder = new OpenmrsApplicationContextConfig().passwordEncoder();
-        String rawPassword = "rawPasswordWithSalt";
+	@Test
+	void passwordEncoder_shouldEncodeWithBcryptAndMatchSha512LegacyFormat() {
+		PasswordEncoder passwordEncoder = new OpenmrsApplicationContextConfig().passwordEncoder();
+		String rawPassword = "rawPasswordWithSalt";
 
-        String bcryptEncoded = passwordEncoder.encode(rawPassword);
-        assertTrue(bcryptEncoded.startsWith("{bcrypt}"));
-        assertTrue(passwordEncoder.matches(rawPassword, bcryptEncoded));
+		String bcryptEncoded = passwordEncoder.encode(rawPassword);
+		assertTrue(bcryptEncoded.startsWith("{bcrypt}"));
+		assertTrue(passwordEncoder.matches(rawPassword, bcryptEncoded));
 
-        String sha512Legacy = "{sha512}" + Security.encodeString(rawPassword);
-        assertTrue(passwordEncoder.matches(rawPassword, sha512Legacy));
-    }
+		String sha512Legacy = "{sha512}" + Security.encodeString(rawPassword);
+		assertTrue(passwordEncoder.matches(rawPassword, sha512Legacy));
+	}
 }

--- a/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
@@ -14,10 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.util.Security;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class OpenmrsApplicationContextConfigTest {
+class OpenmrsApplicationContextConfigTest {
 
     @Test
-    public void passwordEncoder_shouldEncodeWithBcryptAndMatchSha512LegacyFormat() {
+    void passwordEncoder_shouldEncodeWithBcryptAndMatchSha512LegacyFormat() {
         PasswordEncoder passwordEncoder = new OpenmrsApplicationContextConfig().passwordEncoder();
         String rawPassword = "rawPasswordWithSalt";
 

--- a/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsApplicationContextConfigTest.java
@@ -1,0 +1,31 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.openmrs.util.Security;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class OpenmrsApplicationContextConfigTest {
+
+    @Test
+    public void passwordEncoder_shouldEncodeWithBcryptAndMatchSha512LegacyFormat() {
+        PasswordEncoder passwordEncoder = new OpenmrsApplicationContextConfig().passwordEncoder();
+        String rawPassword = "rawPasswordWithSalt";
+
+        String bcryptEncoded = passwordEncoder.encode(rawPassword);
+        assertTrue(bcryptEncoded.startsWith("{bcrypt}"));
+        assertTrue(passwordEncoder.matches(rawPassword, bcryptEncoded));
+
+        String sha512Legacy = "{sha512}" + Security.encodeString(rawPassword);
+        assertTrue(passwordEncoder.matches(rawPassword, sha512Legacy));
+    }
+}


### PR DESCRIPTION
TRUNK-5362: Minimal PoC for PasswordEncoder migration using DelegatingPasswordEncoder

## Description of what I changed

This pull request introduces a minimal proof-of-concept for password hashing migration in OpenMRS Core, aligned with the proposed Password Authentication Re-work.

Changes included:

- Added spring-security-crypto dependency
- Introduced DelegatingPasswordEncoder configuration
- Set BCrypt as default encoder for newly encoded passwords
- Added legacy sha512 encoder mapping for backward compatibility
- Applied PasswordEncoder in one password write path as migration signal
- Updated Security.hashMatches to support delegated hashes while keeping legacy verification
- Added a focused test verifying bcrypt + legacy sha512 compatibility

Scope:

This PR is intentionally small and non-breaking.  
It demonstrates the migration direction without refactoring all password flows.

Migration approach (phase-by-phase):

- Keep legacy hash verification working
- Encode new passwords using DelegatingPasswordEncoder (bcrypt default)
- Expand encoder usage to all password write paths later
- Support transparent rehash-on-login in a follow-up phase

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-5362

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.