### PR TITLE
TRUNK-6594: Correct Logger class initialization in PatientValidator

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PatientValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PatientValidator.java
@@ -26,7 +26,7 @@ import org.springframework.validation.ValidationUtils;
 @Handler(supports = { Patient.class }, order = 25)
 public class PatientValidator extends PersonValidator {
 
-	private static final Logger log = LoggerFactory.getLogger(PersonNameValidator.class);
+	private static final Logger log = LoggerFactory.getLogger(PatientValidator.class);
 
 	@Autowired
 	private PatientIdentifierValidator patientIdentifierValidator;


### PR DESCRIPTION
## Description of what I changed
I corrected the class reference in the logger initialization for `PatientValidator.java`.

**Why the change was needed:**
The logger was previously initialized with `PersonNameValidator.class` likely due to a copy-paste error. This caused all log messages (debug, info, error) generated by the `PatientValidator` to be incorrectly attributed to the `PersonNameValidator` in the server logs, making production debugging and log filtering difficult.

**Specific changes include:**
* Updated the `LoggerFactory.getLogger()` call to use `PatientValidator.class` instead of `PersonNameValidator.class`.

## Issue I worked on
See [TRUNK-6594](https://issues.openmrs.org/browse/TRUNK-6594)

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have added tests to cover my changes. (Verified locally with a reflection-based unit test to confirm the logger name matches the class).
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.


[TRUNK-6594]: https://openmrs.atlassian.net/browse/TRUNK-6594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ