### PR TITLE
TRUNK-6623: fix: add null guard to purgePatient consistent with voidPatient and unvoidPatient

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -352,6 +352,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 
 	/**
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
+	 * @implNote If the patient argument is null, this method is a no-op.
 	 */
 	@Override
 public void purgePatient(Patient patient) throws APIException {

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -354,9 +354,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
 	 */
 	@Override
-	public void purgePatient(Patient patient) throws APIException {
-		dao.deletePatient(patient);
-	}
+public void purgePatient(Patient patient) throws APIException {
+    if (patient == null) {
+        return;
+    }
+    dao.deletePatient(patient);
+}
 
 	// patient identifier section
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -344,9 +344,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
 	 */
 	@Override
-	public void purgePatient(Patient patient) throws APIException {
-		dao.deletePatient(patient);
-	}
+public void purgePatient(Patient patient) throws APIException {
+    if (patient == null) {
+        return;
+    }
+    dao.deletePatient(patient);
+}
 
 	// patient identifier section
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -342,6 +342,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 
 	/**
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
+	 * @implNote If the patient argument is null, this method is a no-op.
 	 */
 	@Override
 public void purgePatient(Patient patient) throws APIException {

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -345,12 +345,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @implNote If the patient argument is null, this method is a no-op.
 	 */
 	@Override
-public void purgePatient(Patient patient) throws APIException {
-    if (patient == null) {
-        return;
-    }
-    dao.deletePatient(patient);
-}
+	public void purgePatient(Patient patient) throws APIException {
+		if (patient == null) {
+			return;
+		}
+		dao.deletePatient(patient);
+	}
 
 	// patient identifier section
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -353,7 +353,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Override
 	public void purgePatient(Patient patient) throws APIException {
 		if (patient == null) {
-			return;
+			throw new IllegalArgumentException("patient cannot be null");
 		}
 		dao.deletePatient(patient);
 	}

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2038,6 +2038,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+	@Test
+public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+    // voidPatient and unvoidPatient both return null silently when given null input.
+    // purgePatient should be consistent — a null argument must not reach the DAO layer.
+    assertDoesNotThrow(() -> patientService.purgePatient(null));
+}
+	
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2033,6 +2033,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+	@Test
+public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+    // voidPatient and unvoidPatient both return null silently when given null input.
+    // purgePatient should be consistent — a null argument must not reach the DAO layer.
+    assertDoesNotThrow(() -> patientService.purgePatient(null));
+}
+	
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2039,11 +2039,10 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertNull(patientService.getPatient(2));
 	}
 	@Test
-public void purgePatient_shouldDoNothingWhenPatientIsNull() {
-    // voidPatient and unvoidPatient both return null silently when given null input.
-    // purgePatient should be consistent — a null argument must not reach the DAO layer.
-    assertDoesNotThrow(() -> patientService.purgePatient(null));
-}
+	public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+		// purgePatient is a no-op when patient is null; null must not reach the DAO layer.
+		assertDoesNotThrow(() -> patientService.purgePatient(null));
+	}
 	
 
 	@Test

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2038,12 +2038,12 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+
 	@Test
 	public void purgePatient_shouldDoNothingWhenPatientIsNull() {
 		// purgePatient is a no-op when patient is null; null must not reach the DAO layer.
 		assertDoesNotThrow(() -> patientService.purgePatient(null));
 	}
-	
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2062,9 +2062,9 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void purgePatient_shouldDoNothingWhenPatientIsNull() {
-		// purgePatient is a no-op when patient is null; null must not reach the DAO layer.
-		assertDoesNotThrow(() -> patientService.purgePatient(null));
+	public void purgePatient_shouldThrowIllegalArgumentExceptionWhenPatientIsNull() {
+		// purgePatient throws IllegalArgumentException when patient is null; null must not reach the DAO layer.
+		assertThrows(IllegalArgumentException.class, () -> patientService.purgePatient(null));
 	}
 
 	@Test


### PR DESCRIPTION
## What

PatientServiceImpl has three patient lifecycle methods:

- voidPatient → handles null
- unvoidPatient → handles null
- purgePatient → did not handle null

This PR adds a null guard to purgePatient.

## Changes

- Added null check in purgePatient
- Added test for null input case

## Testing

mvn test -pl api -Dtest=PatientServiceTest

All tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Patient deletion now safely ignores null inputs, preventing failures when deletion requests are empty or missing; normal deletion behavior for valid patients is unchanged.

* **Tests**
  * Added test coverage to verify deletion remains safe and is a no-op when given a null input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmrs/openmrs-core/pull/5975)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmrs/openmrs-core/pull/5975)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->