### PR TITLE
TRUNK-6593: Use try-with-resources in getFileAsBytes

### DIFF
--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -238,24 +238,13 @@ public class OpenmrsUtil {
 	 * @throws IOException
 	 */
 	public static byte[] getFileAsBytes(File file) throws IOException {
-		FileInputStream fileInputStream = null;
-		try {
-			fileInputStream = new FileInputStream(file);
+		try (FileInputStream fileInputStream = new FileInputStream(file)) {
 			byte[] b = new byte[fileInputStream.available()];
 			fileInputStream.read(b);
 			return b;
 		} catch (Exception e) {
 			log.error("Unable to get file as byte array", e);
-		} finally {
-			if (fileInputStream != null) {
-				try {
-					fileInputStream.close();
-				} catch (IOException io) {
-					log.warn("Couldn't close fileInputStream: " + io);
-				}
-			}
 		}
-
 		return null;
 	}
 


### PR DESCRIPTION
Replaced manual FileInputStream handling with try-with-resources for better resource management and cleaner code.

This prevents potential resource leaks and follows modern Java best practices.