### PR TITLE
Trunk 6575: Restrict executeSQL to safe SELECT queries when selectOnly is true

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -408,11 +408,35 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	 */
 	@Override
 	public List<List<Object>> executeSQL(String sql, boolean selectOnly) throws APIException {
-		if (sql == null || "".equals(sql.trim())) {
+		if (sql == null || sql.trim().isEmpty()) {
 			return null;
 		}
 
-		return dao.executeSQL(sql, selectOnly);
+		String trimmedSql = sql.trim();
+		String normalized = trimmedSql.toLowerCase();
+
+		if (selectOnly) {
+			// Must start with SELECT
+			if (!normalized.startsWith("select")) {
+				throw new APIException("Only SELECT queries are allowed");
+			}
+
+			// Block dangerous keywords
+			if (normalized.contains(" insert ") ||
+				normalized.contains(" update ") ||
+				normalized.contains(" delete ") ||
+				normalized.contains(" drop ") ||
+				normalized.contains(" alter ") ||
+				normalized.contains(" truncate ") ||
+				normalized.contains(" into outfile ") ||
+				normalized.contains(" into dumpfile ") ||
+				normalized.contains(" load data ")) {
+
+				throw new APIException("Query contains forbidden operations");
+			}
+		}
+
+		return dao.executeSQL(trimmedSql, selectOnly);
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed
Added validation to the `executeSQL` method in `AdministrationServiceImpl` to restrict execution of unsafe SQL queries when `selectOnly` is set to true.

The changes include:
- Ensuring that only queries starting with `SELECT` are allowed
- Blocking potentially dangerous SQL keywords such as INSERT, UPDATE, DELETE, DROP, ALTER, and TRUNCATE
- Preventing file-based data exfiltration by blocking clauses like INTO OUTFILE, INTO DUMPFILE, and LOAD DATA

This improves security by preventing misuse of the API to execute harmful or non-read-only SQL queries.

---

## Issue I worked on
     https://openmrs.atlassian.net/browse/TRUNK-6575
