### PR TITLE
TRUNK-6541: Fix UnexpectedRollbackException by disabling transaction in validation

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -72,6 +72,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.Errors;
 
@@ -887,7 +888,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	 * @see org.openmrs.api.AdministrationService#validate(java.lang.Object, Errors)
 	 */
 	@Override
-	@Transactional(readOnly = true)
+	@Transactional(propagation = Propagation.NOT_SUPPORTED)
 	public void validate(Object object, Errors errors) throws APIException {
 		if (object == null) {
 			throw new APIException("error.null", (Object[]) null);


### PR DESCRIPTION
**Description of what I changed**

Updated AdministrationServiceImpl.validate() to run outside of a transactional context by changing the annotation from @Transactional(readOnly = true) to @Transactional(propagation = Propagation.NOT_SUPPORTED).

Previously, validation was executed within a transaction, which could lead to the transaction being marked as rollback-only due to internal validator behavior or Hibernate session interactions. This resulted in an UnexpectedRollbackException instead of properly returning validation errors.

With this change, validation executes without participating in a transaction, ensuring that validation errors are correctly captured in the Errors object and no unintended rollback occurs.

**Issue I worked on**

see https://issues.openmrs.org/browse/TRUNK-6541