### PR TITLE
TRUNK-6622: fix: add null guard to purgeObs consistent with voidObs

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -313,7 +313,10 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 	 * @see org.openmrs.api.ObsService#purgeObs(org.openmrs.Obs, boolean)
 	 */
 	@Override
-	public void purgeObs(Obs obs, boolean cascade) throws APIException {
+    public void purgeObs(Obs obs, boolean cascade) throws APIException {
+		if (obs == null) {
+			return;
+		}
 		if (!purgeComplexData(obs)) {
 			// Log a warning instead of throwing an error.
 			// This allows purging the obs row even if the associated file is missing,

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -336,6 +336,9 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 	 */
 	@Override
 	public void purgeObs(Obs obs) throws APIException {
+		if (obs == null) {
+			return;
+		}
 		Context.getObsService().purgeObs(obs, false);
 	}
 

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -313,7 +313,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 	 * @see org.openmrs.api.ObsService#purgeObs(org.openmrs.Obs, boolean)
 	 */
 	@Override
-    public void purgeObs(Obs obs, boolean cascade) throws APIException {
+	public void purgeObs(Obs obs, boolean cascade) throws APIException {
 		if (obs == null) {
 			return;
 		}

--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -315,8 +315,9 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 	@Override
 	public void purgeObs(Obs obs, boolean cascade) throws APIException {
 		if (obs == null) {
-			return;
+			throw new IllegalArgumentException("obs cannot be null");
 		}
+
 		if (!purgeComplexData(obs)) {
 			// Log a warning instead of throwing an error.
 			// This allows purging the obs row even if the associated file is missing,
@@ -340,7 +341,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 	@Override
 	public void purgeObs(Obs obs) throws APIException {
 		if (obs == null) {
-			return;
+			throw new IllegalArgumentException("obs cannot be null");
 		}
 		Context.getObsService().purgeObs(obs, false);
 	}

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -354,9 +354,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
 	 */
 	@Override
-	public void purgePatient(Patient patient) throws APIException {
-		dao.deletePatient(patient);
-	}
+public void purgePatient(Patient patient) throws APIException {
+    if (patient == null) {
+        return;
+    }
+    dao.deletePatient(patient);
+}
 
 	// patient identifier section
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -344,9 +344,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
 	 */
 	@Override
-	public void purgePatient(Patient patient) throws APIException {
-		dao.deletePatient(patient);
-	}
+public void purgePatient(Patient patient) throws APIException {
+    if (patient == null) {
+        return;
+    }
+    dao.deletePatient(patient);
+}
 
 	// patient identifier section
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -344,12 +344,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * @see org.openmrs.api.PatientService#purgePatient(org.openmrs.Patient)
 	 */
 	@Override
-public void purgePatient(Patient patient) throws APIException {
-    if (patient == null) {
-        return;
-    }
-    dao.deletePatient(patient);
-}
+	public void purgePatient(Patient patient) throws APIException {
+		if (patient == null) {
+			return;
+		}
+		dao.deletePatient(patient);
+	}
 
 	// patient identifier section
 

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1464,6 +1464,11 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	public void purgeObs_shouldThrowAPIExceptionIfGivenTrueCascade() {
 		assertThrows(APIException.class, () -> Context.getObsService().purgeObs(new Obs(1), true));
 	}
+	public void purgeObs_shouldDoNothingWhenObsIsNull() {
+		// voidObs guards against null input (line 104 of ObsServiceImpl).
+		// purgeObs must be consistent to prevent null reaching the DAO layer.
+		assertDoesNotThrow(() -> Context.getObsService().purgeObs(null));
+	}
 
 	/**
 	 * @see ObsService#saveObs(Obs,String)

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1466,9 +1466,9 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	}
 	@Test
 	public void purgeObs_shouldDoNothingWhenObsIsNull() {
-		// voidObs guards against null input (line 104 of ObsServiceImpl).
-		// purgeObs must be consistent to prevent null reaching the DAO layer.
+		// purgeObs guards against null directly; null must not reach the DAO layer.
 		assertDoesNotThrow(() -> Context.getObsService().purgeObs(null));
+		assertDoesNotThrow(() -> Context.getObsService().purgeObs(null, true));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1464,6 +1464,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	public void purgeObs_shouldThrowAPIExceptionIfGivenTrueCascade() {
 		assertThrows(APIException.class, () -> Context.getObsService().purgeObs(new Obs(1), true));
 	}
+
 	@Test
 	public void purgeObs_shouldDoNothingWhenObsIsNull() {
 		// purgeObs guards against null directly; null must not reach the DAO layer.

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1464,6 +1464,7 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	public void purgeObs_shouldThrowAPIExceptionIfGivenTrueCascade() {
 		assertThrows(APIException.class, () -> Context.getObsService().purgeObs(new Obs(1), true));
 	}
+	@Test
 	public void purgeObs_shouldDoNothingWhenObsIsNull() {
 		// voidObs guards against null input (line 104 of ObsServiceImpl).
 		// purgeObs must be consistent to prevent null reaching the DAO layer.

--- a/api/src/test/java/org/openmrs/api/ObsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ObsServiceTest.java
@@ -1466,10 +1466,10 @@ public class ObsServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void purgeObs_shouldDoNothingWhenObsIsNull() {
-		// purgeObs guards against null directly; null must not reach the DAO layer.
-		assertDoesNotThrow(() -> Context.getObsService().purgeObs(null));
-		assertDoesNotThrow(() -> Context.getObsService().purgeObs(null, true));
+	public void purgeObs_shouldThrowIllegalArgumentExceptionWhenObsIsNull() {
+		// purgeObs throws IllegalArgumentException when obs is null; null must not reach the DAO layer.
+		assertThrows(IllegalArgumentException.class, () -> Context.getObsService().purgeObs(null));
+		assertThrows(IllegalArgumentException.class, () -> Context.getObsService().purgeObs(null, true));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2038,6 +2038,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+	@Test
+public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+    // voidPatient and unvoidPatient both return null silently when given null input.
+    // purgePatient should be consistent — a null argument must not reach the DAO layer.
+    assertDoesNotThrow(() -> patientService.purgePatient(null));
+}
+	
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2033,6 +2033,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+	@Test
+public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+    // voidPatient and unvoidPatient both return null silently when given null input.
+    // purgePatient should be consistent — a null argument must not reach the DAO layer.
+    assertDoesNotThrow(() -> patientService.purgePatient(null));
+}
+	
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2038,13 +2038,13 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
+
 	@Test
-public void purgePatient_shouldDoNothingWhenPatientIsNull() {
-    // voidPatient and unvoidPatient both return null silently when given null input.
-    // purgePatient should be consistent — a null argument must not reach the DAO layer.
-    assertDoesNotThrow(() -> patientService.purgePatient(null));
-}
-	
+	public void purgePatient_shouldDoNothingWhenPatientIsNull() {
+		// voidPatient and unvoidPatient both return null silently when given null input.
+		// purgePatient should be consistent — a null argument must not reach the DAO layer.
+		assertDoesNotThrow(() -> patientService.purgePatient(null));
+	}
 
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {


### PR DESCRIPTION
## Problem

`ObsServiceImpl.voidObs()` guards against null input (line 104) before 
proceeding. `purgeObs(Obs obs)` does not — it delegates directly to 
`purgeObs(obs, false)` which reaches `dao.deleteObs(obs)` without any 
null check, creating a behavioral inconsistency between sibling methods 
in the same class.

This mirrors the same inconsistency previously fixed in `PatientServiceImpl` 
(PR #5975).

## Fix

Added a null guard to `purgeObs(Obs obs)` consistent with the pattern 
already established by `voidObs`.

## Test

Added `purgeObs_shouldDoNothingWhenObsIsNull` to `ObsServiceTest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deletion operations for observations and patient records now safely return immediately when given null inputs.

* **Tests**
  * Added unit tests ensuring purge methods for observations and patients are null-safe.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openmrs/openmrs-core/pull/5982)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->