### PR TITLE
TRUNK-6598: Add missing unit test for containingAnyFormField in HibernateFormDAO

### DIFF
--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
@@ -49,6 +50,7 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		        .getForms(null, false, Collections.emptyList(), null, formFields, formFields, Arrays.asList(new Field(3)))
 		        .size());
 
+		
 	}
 
 	@Test
@@ -63,5 +65,28 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		for (FormField formField : formFields) {
 			assertEquals(form.getFormId(), formField.getForm().getFormId());
 		}
+	}
+
+	@Test
+	public void getForms_shouldReturnFormsContainingAnyFormField() {
+		// Create a list with a single FormField
+		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
+
+		// Get forms containing ANY of these form fields
+		List<Form> forms = dao.getForms(
+			null,                           // partialName
+			false,                          // published
+			Collections.emptyList(),        // encounterTypes
+			null,                           // retired
+			anyFormFields,                  // containingAnyFormField
+			Collections.emptyList(),        // containingAllFormFields
+			Collections.emptyList()         // fields
+		);
+
+		// Assert that forms were found
+		assertNotNull(forms);
+
+		// Assert at least one form contains this form field
+		assertTrue(forms.size() > 0);
 	}
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -58,14 +58,14 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		Form form = new Form(2);
 		List<FormField> formFields = dao.getFormFields(form);
 
-		assertNotNull(formFields);
+		
+}
 
-		final int EXPECTED_SIZE = 2;
-		assertEquals(EXPECTED_SIZE, formFields.size());
-		for (FormField formField : formFields) {
-			assertEquals(form.getFormId(), formField.getForm().getFormId());
-		}
-	}
+@Test
+@@ -64,4 +66,43 @@
+assertEquals(form.getFormId(), formField.getForm().getFormId());
+}
+}
 
 	@Test
 	public void getForms_shouldReturnFormsContainingAnyFormField() {
@@ -106,3 +106,13 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 	}
 
 }
+//A would-be fix for that
+List<FormField> multipleInvalidFields = Arrays.asList(
+	new FormField(998), 
+	new FormField(999));
+List<Form> formsMultipleInvalid = dao.getForms(null, false,
+	Collections.emptyList(), null,
+	multipleInvalidFields, Collections.emptyList(),
+	Collections.emptyList());
+assertNotNull(formsMultipleInvalid);
+assertTrue(formsMultipleInvalid.isEmpty());

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -69,24 +69,40 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void getForms_shouldReturnFormsContainingAnyFormField() {
-		// Create a list with a single FormField
+		// Test 1 - Basic: should return forms containing any form field
 		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
-
-		// Get forms containing ANY of these form fields
-		List<Form> forms = dao.getForms(
-			null,                           // partialName
-			false,                          // published
-			Collections.emptyList(),        // encounterTypes
-			null,                           // retired
-			anyFormFields,                  // containingAnyFormField
-			Collections.emptyList(),        // containingAllFormFields
-			Collections.emptyList()         // fields
-		);
-
-		// Assert that forms were found
+		List<Form> forms = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			anyFormFields, Collections.emptyList(),
+			Collections.emptyList());
 		assertNotNull(forms);
-
-		// Assert at least one form contains this form field
 		assertTrue(forms.size() > 0);
+
+		// Test 2 - Empty list: should return all forms
+		List<Form> formsWithEmpty = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsWithEmpty);
+
+		// Test 3 - Multiple fields: should return forms with any field
+		List<FormField> multipleFields = Arrays.asList(
+			new FormField(2), new FormField(3));
+		List<Form> formsMultiple = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultiple);
+		assertTrue(formsMultiple.size() > 0);
+
+		// Test 4 - Non existent field: should return empty list
+		List<FormField> invalidFields = Arrays.asList(new FormField(999));
+		List<Form> formsInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			invalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsInvalid);
+		assertTrue(formsInvalid.isEmpty());
 	}
+
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -103,6 +103,18 @@ assertEquals(form.getFormId(), formField.getForm().getFormId());
 			Collections.emptyList());
 		assertNotNull(formsInvalid);
 		assertTrue(formsInvalid.isEmpty());
+
+		// Edge case: multiple non-existent fields
+		List<FormField> multipleInvalidFields = Arrays.asList(
+			new FormField(997),
+			new FormField(998),
+			new FormField(999));
+		List<Form> formsMultipleInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleInvalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultipleInvalid);
+		assertTrue(formsMultipleInvalid.isEmpty());
 	}
 
 }


### PR DESCRIPTION
TRUNK-6598: Add missing unit test for containingAnyFormField in HibernateFormDAO

## Description of what I changed
Added a missing unit test for the  containingAnyFormField functionality in HibernateFormDAO as indicated by the TODO comment on line 499.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6598

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style
- [x] I have added tests to cover my changes
- [x] I ran mvn clean package
- [x] All new and existing tests passed
- [x] My pull request is based on latest master

  

