### PR TITLE
TRUNK-6621: fix: add null guard to purgeVisit to prevent NullPointerException on null input

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
@@ -171,14 +171,15 @@ public class HibernateVisitDAO implements VisitDAO {
 	/**
 	 * @see org.openmrs.api.db.VisitDAO#deleteVisit(org.openmrs.Visit)
 	 */
-@Override
-@Transactional
-public void deleteVisit(Visit visit) throws DAOException {
-    if (visit == null) {
-        throw new DAOException("Visit must not be null");
-    }
-    getCurrentSession().remove(visit);
-}
+	@Override
+	@Transactional
+	public void deleteVisit(Visit visit) throws DAOException {
+		if (visit == null) {
+			throw new DAOException("Visit must not be null");
+		}
+		getCurrentSession().remove(visit);
+	}
+
 	/**
 	 * @see org.openmrs.api.db.VisitDAO#getVisits(java.util.Collection, java.util.Collection,
 	 *      java.util.Collection, java.util.Collection, java.util.Date, java.util.Date, java.util.Date,

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
@@ -171,12 +171,14 @@ public class HibernateVisitDAO implements VisitDAO {
 	/**
 	 * @see org.openmrs.api.db.VisitDAO#deleteVisit(org.openmrs.Visit)
 	 */
-	@Override
-	@Transactional
-	public void deleteVisit(Visit visit) throws DAOException {
-		getCurrentSession().remove(visit);
-	}
-
+@Override
+@Transactional
+public void deleteVisit(Visit visit) throws DAOException {
+    if (visit == null) {
+        throw new DAOException("Visit must not be null");
+    }
+    getCurrentSession().remove(visit);
+}
 	/**
 	 * @see org.openmrs.api.db.VisitDAO#getVisits(java.util.Collection, java.util.Collection,
 	 *      java.util.Collection, java.util.Collection, java.util.Date, java.util.Date, java.util.Date,

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
@@ -174,9 +174,6 @@ public class HibernateVisitDAO implements VisitDAO {
 	@Override
 	@Transactional
 	public void deleteVisit(Visit visit) throws DAOException {
-		if (visit == null) {
-			throw new DAOException("Visit must not be null");
-		}
 		getCurrentSession().remove(visit);
 	}
 

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -222,7 +222,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	@Override
 	public void purgeVisit(Visit visit) throws APIException {
     if (visit == null) {
-        return;
+        throw new IllegalArgumentException("visit must not be null");
     }
     if (visit.getVisitId() == null) {
 			return;

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -221,7 +221,10 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public void purgeVisit(Visit visit) throws APIException {
-		if (visit.getVisitId() == null) {
+    if (visit == null) {
+        return;
+    }
+    if (visit.getVisitId() == null) {
 			return;
 		}
 		if (!Context.getEncounterService().getEncountersByVisit(visit, true).isEmpty()) {

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -221,7 +221,6 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public void purgeVisit(Visit visit) throws APIException {
-    throw new IllegalArgumentException("visit must not be null");
     if (visit.getVisitId() == null) {
 			return;
 		}

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -221,9 +221,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public void purgeVisit(Visit visit) throws APIException {
-    if (visit == null) {
-        throw new IllegalArgumentException("visit must not be null");
-    }
+    throw new IllegalArgumentException("visit must not be null");
     if (visit.getVisitId() == null) {
 			return;
 		}

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -221,7 +221,10 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 	 */
 	@Override
 	public void purgeVisit(Visit visit) throws APIException {
-    if (visit.getVisitId() == null) {
+		if (visit == null) {
+			throw new IllegalArgumentException("visit cannot be null");
+		}
+		if (visit.getVisitId() == null) {
 			return;
 		}
 		if (!Context.getEncounterService().getEncountersByVisit(visit, true).isEmpty()) {

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -839,12 +839,10 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	 * @see VisitService#purgeVisit(Visit)
 	 */
 	@Test
-	public void purgeVisit_shouldDoNothingWhenVisitIsNull() {
+	public void purgeVisit_shouldThrowIllegalArgumentExceptionWhenVisitIsNull() {
 		// purgeVisit calls visit.getVisitId() before any null check on visit itself,
 		// which would throw a NullPointerException if null is passed.
-		assertDoesNotThrow(() -> visitService.purgeVisit(null));
-	}
-
+        assertThrows(IllegalArgumentException.class, () -> visitService.purgeVisit(null));	}
 	/**
 	 * @see VisitService#saveVisit(Visit)
 	 */

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -835,6 +835,15 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 
 		assertThrows(APIException.class, () -> visitService.purgeVisit(visit));
 	}
+	/**
+	 * @see VisitService#purgeVisit(Visit)
+	 */
+	@Test
+	public void purgeVisit_shouldDoNothingWhenVisitIsNull() {
+		// purgeVisit calls visit.getVisitId() before any null check on visit itself,
+		// which would throw a NullPointerException if null is passed.
+		assertDoesNotThrow(() -> visitService.purgeVisit(null));
+	}
 
 	/**
 	 * @see VisitService#saveVisit(Visit)

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -840,8 +840,8 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void purgeVisit_shouldThrowIllegalArgumentExceptionWhenVisitIsNull() {
-		// purgeVisit calls visit.getVisitId() before any null check on visit itself,
-		// which would throw a NullPointerException if null is passed.
+		// purgeVisit must reject null explicitly — passing null is a programming error,
+        // not a recoverable condition, so IllegalArgumentException is the correct contract.
         assertThrows(IllegalArgumentException.class, () -> visitService.purgeVisit(null));	}
 	/**
 	 * @see VisitService#saveVisit(Visit)

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -841,8 +841,9 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void purgeVisit_shouldThrowIllegalArgumentExceptionWhenVisitIsNull() {
 		// purgeVisit must reject null explicitly — passing null is a programming error,
-        // not a recoverable condition, so IllegalArgumentException is the correct contract.
-        assertThrows(IllegalArgumentException.class, () -> visitService.purgeVisit(null));	}
+		// not a recoverable condition, so IllegalArgumentException is the correct contract.
+		assertThrows(IllegalArgumentException.class, () -> visitService.purgeVisit(null));
+	}
 	/**
 	 * @see VisitService#saveVisit(Visit)
 	 */

--- a/api/src/test/java/org/openmrs/api/VisitServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/VisitServiceTest.java
@@ -835,6 +835,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 
 		assertThrows(APIException.class, () -> visitService.purgeVisit(visit));
 	}
+
 	/**
 	 * @see VisitService#purgeVisit(Visit)
 	 */
@@ -844,6 +845,7 @@ public class VisitServiceTest extends BaseContextSensitiveTest {
 		// not a recoverable condition, so IllegalArgumentException is the correct contract.
 		assertThrows(IllegalArgumentException.class, () -> visitService.purgeVisit(null));
 	}
+
 	/**
 	 * @see VisitService#saveVisit(Visit)
 	 */


### PR DESCRIPTION
JIRA: https://openmrs.atlassian.net/browse/TRUNK-6621

## Problem

`VisitServiceImpl.purgeVisit(Visit visit)` called `visit.getVisitId()` before checking if `visit` itself was null. Passing null threw a `NullPointerException` before reaching the existing unsaved-visit guard.

Beyond the NPE, all three sibling purge methods (`purgeVisit`, `purgePatient`, `purgeObs`) had inconsistent null contracts — two silently returned on null while this one crashed. Purge is irreversible, so silently accepting null is a worse failure mode than rejecting it loudly.

## Fix

- Added a null guard at the entry point of `purgeVisit` in `VisitServiceImpl` — throws `IllegalArgumentException` before touching the visit object
- Updated `purgePatient` (PR #5975) and `purgeObs` (PR #5982) to throw `IllegalArgumentException` as well, making all three consistent
- Removed the now-redundant null check in `HibernateVisitDAO.deleteVisit` — the service-layer throw already prevents null from reaching the DAO, so that check was dead code with no reachable test path (which was causing the Codecov 0% flag)

## Testing
mvn test -pl api -Dtest=VisitServiceTest

All tests pass.

Added `purgeVisit_shouldThrowIllegalArgumentExceptionWhenVisitIsNull` to `VisitServiceTest`.