### PR TITLE
TRUNK-6599: Refactor containsAllergen() using Stream API

### DIFF
--- a/api/src/main/java/org/openmrs/Allergies.java
+++ b/api/src/main/java/org/openmrs/Allergies.java
@@ -327,12 +327,7 @@ public class Allergies implements List<Allergy> {
 	 * @return true if the same allergen exists, else false
 	 */
 	public boolean containsAllergen(Allergy allergy, Collection<? extends Allergy> allergies) {
-		for (Allergy alg : allergies) {
-			if (alg.hasSameAllergen(allergy)) {
-				return true;
-			}
-		}
-		return false;
+		return allergies.stream().anyMatch(a -> a.hasSameAllergen(allergy));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/AllergiesTest.java
+++ b/api/src/test/java/org/openmrs/AllergiesTest.java
@@ -512,4 +512,16 @@ public class AllergiesTest extends BaseContextSensitiveTest {
 
 		assertThrows(APIException.class, () -> new Allergies().addAll(0, allergies));
 	}
+
+	/**
+	 * @see {@link Allergies#containsAllergen(Allergy, java.util.Collection)}
+	 */
+	@Test
+	public void containsAllergen_shouldThrowExceptionWhenAllergiesIsNull() {
+		Allergy allergy = new Allergy();
+
+		assertThrows(NullPointerException.class, () -> {
+			allergies.containsAllergen(allergy, null);
+		});
+	}
 }


### PR DESCRIPTION
### Jira Ticket

https://openmrs.atlassian.net/browse/TRUNK-6599

### Description

The current implementation of `containsAllergen()` in `Allergies.java` uses a manual loop to check if a given allergy exists in a collection.

This PR refactors the method to use the Java Stream API, improving readability and reducing boilerplate code while preserving the existing behavior.

### Changes

* Replaced manual loop with `stream().anyMatch()` for a more declarative and concise implementation
* Added a unit test to document the current behavior when the allergies collection is `null` (throws `NullPointerException`)

### Behavior

No functional changes. The method retains its original behavior, including throwing a `NullPointerException` when the allergies collection is `null`.

### Verification

* All existing tests pass
* Added test ensures current null-handling behavior is explicitly documented
