### PR TITLE
Add null guard to purgeEncounter to prevent NullPointerException on null input

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -497,6 +497,9 @@ public class EncounterServiceImpl extends BaseOpenmrsService implements Encounte
 	 */
 	@Override
 	public void purgeEncounter(Encounter encounter) throws APIException {
+		if (encounter == null) {
+			return;
+		}
 		// if authenticated user is not supposed to edit encounter of certain type
 		if (!canEditEncounter(encounter, null)) {
 			throw new APIException("Encounter.error.privilege.required.purge",

--- a/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/EncounterServiceTest.java
@@ -555,6 +555,15 @@ public class EncounterServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see EncounterService#purgeEncounter(Encounter)
+	 */
+	@Test
+	public void purgeEncounter_shouldDoNothingWhenEncounterIsNull() {
+		EncounterService es = Context.getEncounterService();
+		es.purgeEncounter(null);
+	}
+
+	/**
 	 * Make sure that purging an encounter removes the row from the database
 	 *
 	 * @see EncounterService#purgeEncounter(Encounter)


### PR DESCRIPTION
## Problem
purgeEncounter(Encounter encounter) calls encounter methods before checking if encounter itself is null. Passing null throws a NullPointerException.

This follows the same pattern fixed in purgePatient (PR #5975), purgeObs (PR #5982), and purgeVisit (PR #5984).

## Fix
Added a null guard at the entry point of purgeEncounter, consistent with the pattern established across other purge methods in the codebase.

## Test
Added purgeEncounter_shouldDoNothingWhenEncounterIsNull to EncounterServiceTest.

## Testing
All tests pass.