### PR TITLE
Add null guard to purgeCondition to prevent NullPointerException on null input

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ConditionServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConditionServiceImpl.java
@@ -182,6 +182,9 @@ public class ConditionServiceImpl extends BaseOpenmrsService implements Conditio
 	 */
 	@Override
 	public void purgeCondition(Condition condition) {
+		if (condition == null) {
+			return;
+		}
 		conditionDAO.deleteCondition(condition);
 	}
 

--- a/api/src/test/java/org/openmrs/api/ConditionServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConditionServiceTest.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+
+public class ConditionServiceTest extends BaseContextSensitiveTest {
+
+	/**
+	 * @see ConditionService#purgeCondition(Condition)
+	 */
+	@Test
+	public void purgeCondition_shouldDoNothingWhenConditionIsNull() {
+		ConditionService cs = Context.getConditionService();
+		cs.purgeCondition(null);
+	}
+}


### PR DESCRIPTION
## Problem
purgeCondition(Condition condition) calls conditionDAO.deleteCondition(condition) without checking if condition is null first. Passing null can cause unexpected behavior.

This follows the same pattern fixed in purgePatient (PR #5975), purgeObs (PR #5982), purgeVisit (PR #5984), and purgeEncounter (PR #5989).

## Fix
Added a null guard at the entry point of purgeCondition, consistent with the pattern established across other purge methods in the codebase.

## Test
Added ConditionServiceTest with purgeCondition_shouldDoNothingWhenConditionIsNull test.

## Testing
All tests pass.