### PR TITLE
fix: add null guard to purgePatient consistent with voidPatient

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -355,9 +355,11 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 */
 	@Override
 	public void purgePatient(Patient patient) throws APIException {
+
     if (patient == null) {
         throw new IllegalArgumentException("patient must not be null");
       }
+		
     dao.deletePatient(patient);
     } 
 

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -355,8 +355,11 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 */
 	@Override
 	public void purgePatient(Patient patient) throws APIException {
-		dao.deletePatient(patient);
-	}
+    if (patient == null) {
+        throw new IllegalArgumentException("patient must not be null");
+      }
+    dao.deletePatient(patient);
+    } 
 
 	// patient identifier section
 


### PR DESCRIPTION
This PR adds a null guard to purgePatient() in PatientServiceImpl.java. Previously, passing null would cause a NullPointerException. The fix throws IllegalArgumentException with a clear message, consistent with how voidPatient() and unvoidPatient() handle null input.