### PR TITLE
TRUNK-6603: throw APIException in getProviderByUuid when provider not found

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
@@ -121,7 +121,11 @@ public class ProviderServiceImpl extends BaseOpenmrsService implements ProviderS
 	@Override
 	@Transactional(readOnly = true)
 	public Provider getProviderByUuid(String uuid) {
-		return dao.getProviderByUuid(uuid);
+		Provider provider = dao.getProviderByUuid(uuid);
+		if (provider == null) {
+			throw new APIException("Provider not found for uuid: " + uuid);
+		}
+		return provider;
 	}
 
 	/**


### PR DESCRIPTION
## Description
Previously, getProviderByUuid returned null when no provider was found, which can lead to unexpected behavior.

This change ensures that an APIException is thrown when a provider is not found for the given UUID, improving API safety and consistency.

## Changes
- Added null check for provider
- Throws APIException when provider is not found

## Impact
- Prevents silent null returns
- Improves service layer reliability