### PR TITLE
test: add null guard test for purgePatient with null input

### DIFF
--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -2040,6 +2040,11 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
+    public void purgePatient_shouldThrowIllegalArgumentExceptionWhenPatientIsNull() {
+    assertThrows(IllegalArgumentException.class, () -> patientService.purgePatient(null));
+    }
+
+	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {
 		executeDataSet(FIND_PATIENTS_XML);
 


### PR DESCRIPTION
Added a unit test to verify that purgePatient() throws IllegalArgumentException when null is passed. This test documents and protects the null guard behavior added in the related fix PR #5992.

