### PR TITLE
TRUNK-6605: Implement globalPropertyDeleted in AdministrationServiceImpl

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -697,8 +697,10 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	 */
 	@Override
 	public void globalPropertyDeleted(String propertyName) {
-		// TODO Auto-generated method stub
-
+		if (propertyName.equals(
+			OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST)) {
+			presentationLocales = null;
+		}
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -1180,4 +1180,28 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		// verify hook methods must be called
 		verify(activator).setupOnVersionChange(previousCoreVersion, previousModuleVersion);
 	}
+
+	@Test
+	public void globalPropertyDeleted_shouldResetPresentationLocalesWhenLocaleAllowedListDeleted() {
+		// First get presentation locales to initialize them
+		AdministrationService as = Context.getAdministrationService();
+
+		// Set allowed locales so presentationLocales gets initialized
+		GlobalProperty gp = new GlobalProperty(
+			OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST, "en_GB");
+		as.saveGlobalProperty(gp);
+
+		// Initialize presentationLocales by calling getPresentationLocales
+		as.getPresentationLocales();
+
+		// Now delete the global property
+		((GlobalPropertyListener) as).globalPropertyDeleted(
+			OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST);
+
+		// presentationLocales should be reset to null
+		// Calling getPresentationLocales again should 
+		// reinitialize it from scratch
+		assertNotNull(as.getPresentationLocales());
+	}
+
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
@@ -49,6 +50,7 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		        .getForms(null, false, Collections.emptyList(), null, formFields, formFields, Arrays.asList(new Field(3)))
 		        .size());
 
+		
 	}
 
 	@Test
@@ -63,5 +65,28 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		for (FormField formField : formFields) {
 			assertEquals(form.getFormId(), formField.getForm().getFormId());
 		}
+	}
+
+	@Test
+	public void getForms_shouldReturnFormsContainingAnyFormField() {
+		// Create a list with a single FormField
+		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
+
+		// Get forms containing ANY of these form fields
+		List<Form> forms = dao.getForms(
+			null,                           // partialName
+			false,                          // published
+			Collections.emptyList(),        // encounterTypes
+			null,                           // retired
+			anyFormFields,                  // containingAnyFormField
+			Collections.emptyList(),        // containingAllFormFields
+			Collections.emptyList()         // fields
+		);
+
+		// Assert that forms were found
+		assertNotNull(forms);
+
+		// Assert at least one form contains this form field
+		assertTrue(forms.size() > 0);
 	}
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
@@ -49,6 +50,7 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		        .getForms(null, false, Collections.emptyList(), null, formFields, formFields, Arrays.asList(new Field(3)))
 		        .size());
 
+		
 	}
 
 	@Test
@@ -56,12 +58,57 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		Form form = new Form(2);
 		List<FormField> formFields = dao.getFormFields(form);
 
-		assertNotNull(formFields);
+		
+}
 
-		final int EXPECTED_SIZE = 2;
-		assertEquals(EXPECTED_SIZE, formFields.size());
-		for (FormField formField : formFields) {
-			assertEquals(form.getFormId(), formField.getForm().getFormId());
-		}
+	@Test
+	public void getForms_shouldReturnFormsContainingAnyFormField() {
+		// Test 1 - Basic: should return forms containing any form field
+		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
+		List<Form> forms = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			anyFormFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(forms);
+		assertTrue(forms.size() > 0);
+
+		// Test 2 - Empty list: should return all forms
+		List<Form> formsWithEmpty = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsWithEmpty);
+
+		// Test 3 - Multiple fields: should return forms with any field
+		List<FormField> multipleFields = Arrays.asList(
+			new FormField(2), new FormField(3));
+		List<Form> formsMultiple = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultiple);
+		assertTrue(formsMultiple.size() > 0);
+
+		// Test 4 - Non existent field: should return empty list
+		List<FormField> invalidFields = Arrays.asList(new FormField(999));
+		List<Form> formsInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			invalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsInvalid);
+		assertTrue(formsInvalid.isEmpty());
+
+		// Edge case: multiple non-existent fields
+		List<FormField> multipleInvalidFields = Arrays.asList(
+			new FormField(997),
+			new FormField(998),
+			new FormField(999));
+		List<Form> formsMultipleInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleInvalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultipleInvalid);
+		assertTrue(formsMultipleInvalid.isEmpty());
 	}
+
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -58,14 +58,14 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		Form form = new Form(2);
 		List<FormField> formFields = dao.getFormFields(form);
 
-		assertNotNull(formFields);
+		
+}
 
-		final int EXPECTED_SIZE = 2;
-		assertEquals(EXPECTED_SIZE, formFields.size());
-		for (FormField formField : formFields) {
-			assertEquals(form.getFormId(), formField.getForm().getFormId());
-		}
-	}
+@Test
+@@ -64,4 +66,43 @@
+assertEquals(form.getFormId(), formField.getForm().getFormId());
+}
+}
 
 	@Test
 	public void getForms_shouldReturnFormsContainingAnyFormField() {
@@ -106,3 +106,13 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 	}
 
 }
+//A would-be fix for that
+List<FormField> multipleInvalidFields = Arrays.asList(
+	new FormField(998), 
+	new FormField(999));
+List<Form> formsMultipleInvalid = dao.getForms(null, false,
+	Collections.emptyList(), null,
+	multipleInvalidFields, Collections.emptyList(),
+	Collections.emptyList());
+assertNotNull(formsMultipleInvalid);
+assertTrue(formsMultipleInvalid.isEmpty());

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -69,24 +69,40 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void getForms_shouldReturnFormsContainingAnyFormField() {
-		// Create a list with a single FormField
+		// Test 1 - Basic: should return forms containing any form field
 		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
-
-		// Get forms containing ANY of these form fields
-		List<Form> forms = dao.getForms(
-			null,                           // partialName
-			false,                          // published
-			Collections.emptyList(),        // encounterTypes
-			null,                           // retired
-			anyFormFields,                  // containingAnyFormField
-			Collections.emptyList(),        // containingAllFormFields
-			Collections.emptyList()         // fields
-		);
-
-		// Assert that forms were found
+		List<Form> forms = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			anyFormFields, Collections.emptyList(),
+			Collections.emptyList());
 		assertNotNull(forms);
-
-		// Assert at least one form contains this form field
 		assertTrue(forms.size() > 0);
+
+		// Test 2 - Empty list: should return all forms
+		List<Form> formsWithEmpty = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			Collections.emptyList(), Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsWithEmpty);
+
+		// Test 3 - Multiple fields: should return forms with any field
+		List<FormField> multipleFields = Arrays.asList(
+			new FormField(2), new FormField(3));
+		List<Form> formsMultiple = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultiple);
+		assertTrue(formsMultiple.size() > 0);
+
+		// Test 4 - Non existent field: should return empty list
+		List<FormField> invalidFields = Arrays.asList(new FormField(999));
+		List<Form> formsInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			invalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsInvalid);
+		assertTrue(formsInvalid.isEmpty());
 	}
+
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -103,6 +103,18 @@ assertEquals(form.getFormId(), formField.getForm().getFormId());
 			Collections.emptyList());
 		assertNotNull(formsInvalid);
 		assertTrue(formsInvalid.isEmpty());
+
+		// Edge case: multiple non-existent fields
+		List<FormField> multipleInvalidFields = Arrays.asList(
+			new FormField(997),
+			new FormField(998),
+			new FormField(999));
+		List<Form> formsMultipleInvalid = dao.getForms(null, false,
+			Collections.emptyList(), null,
+			multipleInvalidFields, Collections.emptyList(),
+			Collections.emptyList());
+		assertNotNull(formsMultipleInvalid);
+		assertTrue(formsMultipleInvalid.isEmpty());
 	}
 
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateFormDAOTest.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 
@@ -50,7 +49,6 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		        .getForms(null, false, Collections.emptyList(), null, formFields, formFields, Arrays.asList(new Field(3)))
 		        .size());
 
-		
 	}
 
 	@Test
@@ -58,57 +56,12 @@ public class HibernateFormDAOTest extends BaseContextSensitiveTest {
 		Form form = new Form(2);
 		List<FormField> formFields = dao.getFormFields(form);
 
-		
-}
+		assertNotNull(formFields);
 
-	@Test
-	public void getForms_shouldReturnFormsContainingAnyFormField() {
-		// Test 1 - Basic: should return forms containing any form field
-		List<FormField> anyFormFields = Arrays.asList(new FormField(2));
-		List<Form> forms = dao.getForms(null, false,
-			Collections.emptyList(), null,
-			anyFormFields, Collections.emptyList(),
-			Collections.emptyList());
-		assertNotNull(forms);
-		assertTrue(forms.size() > 0);
-
-		// Test 2 - Empty list: should return all forms
-		List<Form> formsWithEmpty = dao.getForms(null, false,
-			Collections.emptyList(), null,
-			Collections.emptyList(), Collections.emptyList(),
-			Collections.emptyList());
-		assertNotNull(formsWithEmpty);
-
-		// Test 3 - Multiple fields: should return forms with any field
-		List<FormField> multipleFields = Arrays.asList(
-			new FormField(2), new FormField(3));
-		List<Form> formsMultiple = dao.getForms(null, false,
-			Collections.emptyList(), null,
-			multipleFields, Collections.emptyList(),
-			Collections.emptyList());
-		assertNotNull(formsMultiple);
-		assertTrue(formsMultiple.size() > 0);
-
-		// Test 4 - Non existent field: should return empty list
-		List<FormField> invalidFields = Arrays.asList(new FormField(999));
-		List<Form> formsInvalid = dao.getForms(null, false,
-			Collections.emptyList(), null,
-			invalidFields, Collections.emptyList(),
-			Collections.emptyList());
-		assertNotNull(formsInvalid);
-		assertTrue(formsInvalid.isEmpty());
-
-		// Edge case: multiple non-existent fields
-		List<FormField> multipleInvalidFields = Arrays.asList(
-			new FormField(997),
-			new FormField(998),
-			new FormField(999));
-		List<Form> formsMultipleInvalid = dao.getForms(null, false,
-			Collections.emptyList(), null,
-			multipleInvalidFields, Collections.emptyList(),
-			Collections.emptyList());
-		assertNotNull(formsMultipleInvalid);
-		assertTrue(formsMultipleInvalid.isEmpty());
+		final int EXPECTED_SIZE = 2;
+		assertEquals(EXPECTED_SIZE, formFields.size());
+		for (FormField formField : formFields) {
+			assertEquals(form.getFormId(), formField.getForm().getFormId());
+		}
 	}
-
 }


### PR DESCRIPTION
Implements globalPropertyDeleted() to reset presentationLocales when LOCALE_ALLOWED_LIST 
property is deleted, consistent with globalPropertyChanged() behavior. Added unit test to verify the behavior.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6605

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style
- [x] I have added tests to cover my changes
- [x] I ran mvn clean package
- [x] All new and existing tests passed
- [x] My pull request is based on latest master

 

