### PR TITLE
TRUNK-6605: Implement globalPropertyDeleted to reset presentationLocales

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -697,8 +697,9 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	 */
 	@Override
 	public void globalPropertyDeleted(String propertyName) {
-		// TODO Auto-generated method stub
-
+		if (propertyName.equals(OpenmrsConstants.GLOBAL_PROPERTY_LOCALE_ALLOWED_LIST)) {
+			presentationLocales = null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Jira: https://openmrs.atlassian.net/browse/TRUNK-6605

**Description**
Implements the `globalPropertyDeleted()` method in `AdministrationServiceImpl` 
to reset `presentationLocales` when `LOCALE_ALLOWED_LIST` property is deleted, 
consistent with `globalPropertyChanged()` behavior.

**Changes**
- Implemented `globalPropertyDeleted()` to set `presentationLocales = null` 
  when `LOCALE_ALLOWED_LIST` global property is deleted.

 **Related**
- Closes TRUNK-6605