### PR TITLE
TRUNK-6585: Implement getPresentation and getPresentationsInLocale in MutableResourceBundleMessageSource

### DIFF
--- a/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/MutableResourceBundleMessageSource.java
@@ -352,7 +352,11 @@ public class MutableResourceBundleMessageSource extends ReloadableResourceBundle
 	 */
 	@Override
 	public PresentationMessage getPresentation(String key, Locale forLocale) {
-		// TODO Auto-generated method stub
+		for (PresentationMessage message : getPresentations()) {
+			if (message.getCode().equals(key) && message.getLocale().equals(forLocale)) {
+				return message;
+			}
+		}
 		return null;
 	}
 
@@ -361,8 +365,13 @@ public class MutableResourceBundleMessageSource extends ReloadableResourceBundle
 	 */
 	@Override
 	public Collection<PresentationMessage> getPresentationsInLocale(Locale locale) {
-		// TODO Auto-generated method stub
-		return null;
+		Collection<PresentationMessage> result = new ArrayList<>();
+		for (PresentationMessage message : getPresentations()) {
+			if (message.getLocale().equals(locale)) {
+				result.add(message);
+			}
+		}
+		return result;
 	}
 
 }


### PR DESCRIPTION
TRUNK-6585

Implements two previously unimplemented methods in MutableResourceBundleMessageSource:

- getPresentation(String key, Locale forLocale): searches all presentations 
  and returns the one matching the given key and locale, or null if not found.
  
- getPresentationsInLocale(Locale locale): returns all presentations matching 
  the given locale.

Both methods previously contained only a TODO stub and returned null.