### PR TITLE
TRUNK-6607: Validate required user fields before password validation in UserServi…

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -50,6 +50,7 @@ import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 import org.openmrs.util.Security;
+import org.openmrs.validator.ValidateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -120,7 +121,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
 		}
 
-		// TODO Check required fields for user!!
+		ValidateUtil.validate(user);
 		OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
 
 		return dao.saveUser(user, password);

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -116,12 +116,12 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 			throw new APIException("User.creating.password.required", (Object[]) null);
 		}
 
+		ValidateUtil.validate(user);
 		if (hasDuplicateUsername(user)) {
 			throw new DAOException(
 			        "Username " + user.getUsername() + " or system id " + user.getSystemId() + " is already in use.");
 		}
 
-		ValidateUtil.validate(user);
 		OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId());
 
 		return dao.saveUser(user, password);

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -50,6 +50,7 @@ import org.openmrs.util.Security;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -200,6 +201,16 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 		User unsavedUser = new User();
 
 		assertThrows(ValidationException.class, () -> userService.createUser(unsavedUser, null));
+	}
+
+	@Test
+	public void createUser_shouldValidateUserBeforePassword() {
+		User newUser = userWithValidPerson();
+		newUser.setPerson(null);
+
+		ValidationException exception = assertThrows(ValidationException.class,
+		    () -> userService.createUser(newUser, "short"));
+		assertThat(exception.getMessage(), containsString("person: Cannot be empty or null"));
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -210,7 +210,7 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 
 		ValidationException exception = assertThrows(ValidationException.class,
 		    () -> userService.createUser(newUser, "short"));
-		assertThat(exception.getMessage(), containsString("person: Cannot be empty or null"));
+		assertTrue(exception.getErrors().hasFieldErrors("person"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses an issue in **`UserServiceImpl#createUser`** where the password policy is evaluated before the **User** object is validated. This ordering causes requests with missing required user data to fail with password-related exceptions rather than the expected **`ValidationException`**.

I am updating the method to ensure that the user payload is checked for completeness and validity before any password policy logic is triggered.

### Technical Scope

- **Refactor Logic**: I will add `ValidateUtil.validate(user)` at the beginning of `UserServiceImpl#createUser`, ensuring it executes before `OpenmrsUtil.validatePassword(user.getUsername(), password, user.getSystemId())`.

- **Regression Testing**: I will implement a test case that attempts to create a user with both missing required fields and a weak password to verify that the `ValidationException` takes precedence.

### Acceptance Criteria

- **Validation Order**: `createUser` must validate the `User` object prior to checking the password policy.

- **Error Accuracy**: Creating a user with missing required fields must return a `ValidationException`, even if the password provided is invalid.

- **Consistency**: Password policy enforcement must remain unchanged for all otherwise valid `User` objects.

**Jira ticket** : https://openmrs.atlassian.net/browse/TRUNK-6607