### PR TITLE
docs: Update README to specify Java 21 requirement for master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,22 @@ The mission of OpenMRS is to improve health care delivery in resource-constraine
 
 ### Prerequisites
 
+
 #### Java
 
-OpenMRS is a Java application which is why you need to install a Java JDK.
+OpenMRS is a Java application, so you must install a Java JDK. The required version depends on your goal and the specific branch or tag you are building:
 
-If you want to build the master branch you will need a Java JDK of minimum version 8.
+| Goal | Branch / Tag | Java Version |
+| :--- | :--- | :--- |
+| **Active Development** | `master` | **Java 21** |
+| **Stable Releases** | `x.y.z`* | **Java 8 or 11** |
+
+*\*Check the [Releases](https://github.com/openmrs/openmrs-core/releases) section for the latest stable version.*
+
+> [!IMPORTANT]
+> The **current development version on `master`** targets **Java 21**. Attempting to build with older JDKs (8, 11, or 17) will result in a `release version 21 not supported` compilation error.
+
+
 
 #### Maven
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The mission of OpenMRS is to improve health care delivery in resource-constraine
 
 ### Prerequisites
 
-
 #### Java
 
 OpenMRS is a Java application, so you must install a Java JDK. The required version depends on your goal and the specific branch or tag you are building:
@@ -48,14 +47,12 @@ OpenMRS is a Java application, so you must install a Java JDK. The required vers
 | Goal | Branch / Tag | Java Version |
 | :--- | :--- | :--- |
 | **Active Development** | `master` | **Java 21** |
-| **Stable Releases** | `x.y.z`* | **Java 8 or 11** |
+| **Stable Releases** | `x.y.z`* | **Java 8+** (varies by release) |
 
 *\*Check the [Releases](https://github.com/openmrs/openmrs-core/releases) section for the latest stable version.*
 
 > [!IMPORTANT]
-> The **current development version on `master`** targets **Java 21**. Attempting to build with older JDKs (8, 11, or 17) will result in a `release version 21 not supported` compilation error.
-
-
+> The **current development version on `master`** targets **Java 21**. If you build **`master`** with older JDKs (8, 11, or 17), you will get `release version 21 not supported`.
 
 #### Maven
 


### PR DESCRIPTION
### Description
The current README states that a minimum of Java 8 is required for the `master` branch. However, since the move to version `3.0.0-SNAPSHOT`, the compiler configuration now explicitly targets Java 21.

I verified that attempting to build `master` with Java 11 or 17 results in a `Fatal error compiling: error: release version 21 not supported`. I also verified that stable release `2.7.6` still builds correctly on Java 8.

### Changes
- Updated the Java Prerequisites section.
- Added a scannable table to clarify the JDK requirements for both development (master) and stable releases.
- Added a note regarding the specific compilation error triggered by older JDKs.


