### PR TITLE
TRUNK-6612 Add missing future end date validation to PersonAddressValidator

### DIFF
--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -89,9 +89,17 @@ public class PersonAddressValidator implements Validator {
 			    "The Start Date for address '" + addressString + "' shouldn't be in the future");
 		}
 
-		if (OpenmrsUtil.compareWithNullAsEarliest(personAddress.getEndDate(), new Date()) > 0) {
-			errors.rejectValue("endDate", "PersonAddress.error.endDateInFuture", new Object[] { "'" + addressString + "'" },
-			    "The End Date for address '" + addressString + "' shouldn't be in the future");
+		boolean allowFutureEndDate = Boolean.parseBoolean(
+    		Context.getAdministrationService()
+           .getGlobalProperty("personAddress.allowFutureEndDate", "false")
+		);
+
+		if (!allowFutureEndDate &&
+		    OpenmrsUtil.compareWithNullAsEarliest(personAddress.getEndDate(), new Date()) > 0) {
+		    
+		    errors.rejectValue("endDate", "PersonAddress.error.endDateInFuture",
+		        new Object[] { "" + addressString + "" },
+		        "The End Date for address " + addressString + " shouldn't be in the future");
 		}
 
 		if (personAddress.getStartDate() != null

--- a/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
+++ b/api/src/main/java/org/openmrs/validator/PersonAddressValidator.java
@@ -62,7 +62,7 @@ public class PersonAddressValidator implements Validator {
 	 */
 	@Override
 	public void validate(Object object, Errors errors) {
-		//TODO Validate other aspects of the personAddress object
+
 		log.debug("{}.validate...", this.getClass().getName());
 
 		if (object == null) {
@@ -87,6 +87,11 @@ public class PersonAddressValidator implements Validator {
 			errors.rejectValue("startDate", "PersonAddress.error.startDateInFuture",
 			    new Object[] { "'" + addressString + "'" },
 			    "The Start Date for address '" + addressString + "' shouldn't be in the future");
+		}
+
+		if (OpenmrsUtil.compareWithNullAsEarliest(personAddress.getEndDate(), new Date()) > 0) {
+			errors.rejectValue("endDate", "PersonAddress.error.endDateInFuture", new Object[] { "'" + addressString + "'" },
+			    "The End Date for address '" + addressString + "' shouldn't be in the future");
 		}
 
 		if (personAddress.getStartDate() != null

--- a/api/src/test/java/org/openmrs/validator/PersonAddressValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/PersonAddressValidatorTest.java
@@ -84,6 +84,20 @@ public class PersonAddressValidatorTest extends BaseContextSensitiveTest {
 	 * @see PersonAddressValidator#validate(Object,Errors)
 	 */
 	@Test
+	public void validate_shouldFailIfTheEndDateIsInTheFuture() {
+		PersonAddress personAddress = new PersonAddress();
+		Calendar c = Calendar.getInstance();
+		c.add(Calendar.MINUTE, 1);
+		personAddress.setEndDate(c.getTime());
+		Errors errors = new BindException(personAddress, "personAddress");
+		validator.validate(personAddress, errors);
+		assertTrue(errors.hasFieldErrors("endDate"));
+	}
+
+	/**
+	 * @see PersonAddressValidator#validate(Object,Errors)
+	 */
+	@Test
 	public void validate_shouldFailIfTheEndDateIsBeforeTheStartDate() {
 		PersonAddress personAddress = new PersonAddress();
 		Calendar c = Calendar.getInstance();


### PR DESCRIPTION
Currently, `PersonAddressValidator` does not reject cases where `endDate` is set in the future, creating a validation gap despite having an existing message key. This change adds validation to disallow future `endDate` values and includes a unit test to verify the behavior, ensuring consistency with existing date validation rules.

**Jira ticket**: https://openmrs.atlassian.net/browse/TRUNK-6612