### PR TITLE
Fix ClassCastException for birthtime after Hibernate upgrade

### DIFF
--- a/api/src/main/java/org/openmrs/Person.java
+++ b/api/src/main/java/org/openmrs/Person.java
@@ -147,7 +147,7 @@ public class Person extends BaseChangeableOpenmrsData {
 
 		gender = person.getGender();
 		birthdate = person.getBirthdate();
-		birthtime = person.getBirthDateTime();
+		setBirthtime(person.getBirthDateTime());
 		birthdateEstimated = person.getBirthdateEstimated();
 		deathdateEstimated = person.getDeathdateEstimated();
 		dead = person.getDead();
@@ -267,7 +267,7 @@ public class Person extends BaseChangeableOpenmrsData {
 	 * @param birthtime person's time of birth
 	 */
 	public void setBirthtime(Date birthtime) {
-		this.birthtime = birthtime;
+		this.birthtime = birthtime != null ? new java.sql.Time(birthtime.getTime()) : null;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Fixes the build failure in #6034 caused by `ClassCastException: java.util.Date cannot be cast to java.sql.Time`
- The `birthtime` field in `Person.java` is typed as `java.util.Date`, but the HBM mapping declares `type="java.sql.Time"` — Hibernate 7.3 enforces this more strictly
- `setBirthtime()` now converts the input `Date` to `java.sql.Time`, and the copy constructor uses the setter instead of direct field assignment

## Test plan
- [ ] `HibernatePersonDAOTest.savePerson_shouldSavePersonWithBirthDateTime` should pass
- [ ] All existing person/patient tests should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)