### PR TITLE
TRUNK-6510: Add priority field to ConceptReferenceRange for range selection

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptReferenceRange.java
+++ b/api/src/main/java/org/openmrs/ConceptReferenceRange.java
@@ -54,7 +54,7 @@ public class ConceptReferenceRange extends BaseReferenceRange implements Openmrs
 	 * priority (descending order) is selected. A null priority falls back to the legacy "strictest
 	 * bounds" merging behaviour for backward compatibility.
 	 *
-	 * @since 2.9.0
+	 * @since 3.0.0
 	 */
 	@Column(name = "priority")
 	private Integer priority;

--- a/api/src/main/java/org/openmrs/ConceptReferenceRange.java
+++ b/api/src/main/java/org/openmrs/ConceptReferenceRange.java
@@ -49,6 +49,16 @@ public class ConceptReferenceRange extends BaseReferenceRange implements Openmrs
 	@Column(name = "criteria", length = 65535)
 	private String criteria;
 
+	/**
+	 * Priority for this reference range. When multiple ranges match a patient, the one with the highest
+	 * priority (descending order) is selected. A null priority falls back to the legacy "strictest
+	 * bounds" merging behaviour for backward compatibility.
+	 *
+	 * @since 2.9.0
+	 */
+	@Column(name = "priority")
+	private Integer priority;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "concept_id", nullable = false)
 	private ConceptNumeric conceptNumeric;
@@ -90,6 +100,25 @@ public class ConceptReferenceRange extends BaseReferenceRange implements Openmrs
 	 */
 	public void setCriteria(String criteria) {
 		this.criteria = criteria;
+	}
+
+	/**
+	 * Gets the priority of this conceptReferenceRange. Higher values take precedence when multiple
+	 * ranges match a patient. A null priority uses legacy "strictest bounds" logic.
+	 *
+	 * @return the priority, or null if not set
+	 */
+	public Integer getPriority() {
+		return priority;
+	}
+
+	/**
+	 * Sets the priority of this conceptReferenceRange.
+	 *
+	 * @param priority the priority to set
+	 */
+	public void setPriority(Integer priority) {
+		this.priority = priority;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/ConceptReferenceRange.java
+++ b/api/src/main/java/org/openmrs/ConceptReferenceRange.java
@@ -54,7 +54,7 @@ public class ConceptReferenceRange extends BaseReferenceRange implements Openmrs
 	 * priority (descending order) is selected. A null priority falls back to the legacy "strictest
 	 * bounds" merging behaviour for backward compatibility.
 	 *
-	 * @since 3.0.0
+	 * @since 3.0.0, 2.9.0
 	 */
 	@Column(name = "priority")
 	private Integer priority;

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -2139,7 +2140,36 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			return null;
 		}
 
-		return findStrictestReferenceRange(validRanges);
+		return selectReferenceRange(validRanges);
+	}
+
+	/**
+	 * Selects the applicable reference range from the list of matching ranges.
+	 * <p>
+	 * Selection rules (per TRUNK-6510):
+	 * <ol>
+	 * <li>If all matching ranges have a null priority, the legacy "strictest bounds" merging is used
+	 * (backward compatible).</li>
+	 * <li>If any matching range has a priority set, only the ranges with the highest priority value are
+	 * considered (null-priority ranges are ignored in this case). If several ranges share the same
+	 * highest priority, the strictest bounds are applied among them.</li>
+	 * </ol>
+	 */
+	private static ConceptReferenceRange selectReferenceRange(List<ConceptReferenceRange> conceptReferenceRanges) {
+		List<ConceptReferenceRange> prioritizedRanges = conceptReferenceRanges.stream().filter(r -> r.getPriority() != null)
+		        .collect(Collectors.toList());
+
+		if (prioritizedRanges.isEmpty()) {
+			// All priorities are null — use legacy strictest-bounds logic
+			return findStrictestReferenceRange(conceptReferenceRanges);
+		}
+
+		int maxPriority = prioritizedRanges.stream().mapToInt(ConceptReferenceRange::getPriority).max().getAsInt();
+
+		List<ConceptReferenceRange> highestPriorityRanges = prioritizedRanges.stream()
+		        .filter(r -> r.getPriority() == maxPriority).collect(Collectors.toList());
+
+		return findStrictestReferenceRange(highestPriorityRanges);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -2167,7 +2167,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		int maxPriority = prioritizedRanges.stream().mapToInt(ConceptReferenceRange::getPriority).max().getAsInt();
 
 		List<ConceptReferenceRange> highestPriorityRanges = prioritizedRanges.stream()
-		        .filter(r -> r.getPriority() == maxPriority).collect(Collectors.toList());
+		        .filter(r -> r.getPriority().equals(maxPriority)).collect(Collectors.toList());
 
 		return findStrictestReferenceRange(highestPriorityRanges);
 	}

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
@@ -141,6 +141,18 @@
 			<column name="description" type="varchar(255)"/>
 		</addColumn>
 	</changeSet>
-	
+
+	<changeSet id="TRUNK-6510-2026-04-14" author="Binayak490-cyber">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<columnExists tableName="concept_reference_range" columnName="priority"/>
+			</not>
+		</preConditions>
+		<comment>Add priority column to concept_reference_range for TRUNK-6510: higher value wins when multiple ranges match a patient</comment>
+		<addColumn tableName="concept_reference_range">
+			<column name="priority" type="INT"/>
+		</addColumn>
+	</changeSet>
+
 </databaseChangeLog>
 

--- a/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
@@ -1176,6 +1176,117 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 		    () -> conceptService.getConceptReferenceRange((ConceptReferenceRangeContext) null));
 	}
 
+	/**
+	 * TRUNK-6510: when multiple matching ranges carry explicit priorities, the one with the highest
+	 * priority value should win (descending order — higher number = higher precedence). Concept 4090
+	 * already has two null-priority ranges in the dataset; the priority=2 range must win over the
+	 * priority=1 range and the existing null-priority ranges.
+	 *
+	 * @see ConceptServiceImpl#getConceptReferenceRange(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptReferenceRange_shouldReturnHighestPriorityRangeWhenPrioritiesAreSet() {
+		// Concept 4090 is numeric and has existing null-priority ranges in the test dataset
+		Concept concept = conceptService.getConcept(4090);
+		ConceptNumeric conceptNumeric = (ConceptNumeric) concept;
+
+		ConceptReferenceRange lowPriorityRange = new ConceptReferenceRange();
+		lowPriorityRange.setConceptNumeric(conceptNumeric);
+		lowPriorityRange.setCriteria(TEST_CRITERIA);
+		lowPriorityRange.setHiNormal(120.0);
+		lowPriorityRange.setPriority(1);
+		conceptService.saveConceptReferenceRange(lowPriorityRange);
+
+		ConceptReferenceRange highPriorityRange = new ConceptReferenceRange();
+		highPriorityRange.setConceptNumeric(conceptNumeric);
+		highPriorityRange.setCriteria(TEST_CRITERIA);
+		highPriorityRange.setHiNormal(159.0);
+		highPriorityRange.setPriority(2);
+		conceptService.saveConceptReferenceRange(highPriorityRange);
+
+		Person person = new Person();
+		person.setBirthdate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).minusYears(6).toInstant()));
+
+		ConceptReferenceRangeContext context = new ConceptReferenceRangeContext(person, concept, new Date());
+		ConceptReferenceRange range = conceptService.getConceptReferenceRange(context);
+
+		assertNotNull(range);
+		// priority=2 range wins; its hiNormal of 159 is returned, not the stricter 120
+		assertEquals(159.0, range.getHiNormal());
+	}
+
+	/**
+	 * TRUNK-6510: when matching ranges have mixed priorities (some set, some null), the explicitly
+	 * prioritized ranges should take precedence and null-priority ranges are ignored. Concept 4090
+	 * already has two null-priority ranges in the dataset; adding a priority=1 range should make it win
+	 * over those existing null-priority ranges.
+	 *
+	 * @see ConceptServiceImpl#getConceptReferenceRange(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptReferenceRange_shouldPreferPrioritizedRangeOverNullPriorityRange() {
+		// Concept 4090 is numeric and already has existing null-priority ranges in the test dataset
+		Concept concept = conceptService.getConcept(4090);
+		ConceptNumeric conceptNumeric = (ConceptNumeric) concept;
+
+		ConceptReferenceRange prioritizedRange = new ConceptReferenceRange();
+		prioritizedRange.setConceptNumeric(conceptNumeric);
+		prioritizedRange.setCriteria(TEST_CRITERIA);
+		prioritizedRange.setHiNormal(159.0);
+		prioritizedRange.setPriority(1);
+		conceptService.saveConceptReferenceRange(prioritizedRange);
+
+		Person person = new Person();
+		person.setBirthdate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).minusYears(6).toInstant()));
+
+		ConceptReferenceRangeContext context = new ConceptReferenceRangeContext(person, concept, new Date());
+		ConceptReferenceRange range = conceptService.getConceptReferenceRange(context);
+
+		assertNotNull(range);
+		// prioritized range (priority=1) wins over the existing null-priority dataset ranges
+		assertEquals(159.0, range.getHiNormal());
+	}
+
+	/**
+	 * TRUNK-6510: when multiple matching ranges share the same highest priority, the strictest bounds
+	 * are applied among them (same tie-breaking behaviour as the legacy algorithm).
+	 *
+	 * @see ConceptServiceImpl#getConceptReferenceRange(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptReferenceRange_shouldApplyStrictestBoundsAmongRangesWithSamePriority() {
+		// Concept 4090 is numeric and already has existing null-priority ranges in the test dataset
+		Concept concept = conceptService.getConcept(4090);
+		ConceptNumeric conceptNumeric = (ConceptNumeric) concept;
+
+		ConceptReferenceRange range1 = new ConceptReferenceRange();
+		range1.setConceptNumeric(conceptNumeric);
+		range1.setCriteria(TEST_CRITERIA);
+		range1.setHiNormal(150.0);
+		range1.setLowNormal(70.0);
+		range1.setPriority(2);
+		conceptService.saveConceptReferenceRange(range1);
+
+		ConceptReferenceRange range2 = new ConceptReferenceRange();
+		range2.setConceptNumeric(conceptNumeric);
+		range2.setCriteria(TEST_CRITERIA);
+		range2.setHiNormal(140.0);
+		range2.setLowNormal(80.0);
+		range2.setPriority(2);
+		conceptService.saveConceptReferenceRange(range2);
+
+		Person person = new Person();
+		person.setBirthdate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).minusYears(6).toInstant()));
+
+		ConceptReferenceRangeContext context = new ConceptReferenceRangeContext(person, concept, new Date());
+		ConceptReferenceRange range = conceptService.getConceptReferenceRange(context);
+
+		assertNotNull(range);
+		// priority=2 beats the existing null-priority ranges; strictest among the two priority=2 ranges
+		assertEquals(140.0, range.getHiNormal());
+		assertEquals(80.0, range.getLowNormal());
+	}
+
 	private ConceptNumeric createConceptNumeric() {
 		ConceptNumeric conceptNumeric = new ConceptNumeric();
 		ConceptName fullySpecifiedName = new ConceptName("concept name", new Locale("fr", "CA"));

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -32,7 +32,7 @@ public class DatabaseUpdaterDatabaseIT extends DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 915;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 916;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 


### PR DESCRIPTION
## Description of what I changed

This PR adds priority-based selection to the concept reference range functionality:

* Added an `Integer priority` field to `ConceptReferenceRange` (nullable, with getter/setter). A `null` priority preserves full backward compatibility with the existing "strictest bounds" merging behaviour.
* Updated `ConceptServiceImpl.selectReferenceRange()` to implement the agreed selection logic (higher number = higher precedence, descending order):

  * If all matching ranges have `priority = null` → legacy "strictest bounds" merging is used (backward compatible).
  * If any matching range has a priority set → the range(s) with the highest priority value are selected; null-priority ranges are ignored in this case.
  * If multiple ranges share the same highest priority → strictest bounds are applied among them as a tie-breaker.
* Added a Liquibase migration (`liquibase-update-to-latest-3.0.x.xml`) to add a nullable `INT priority` column to the `concept_reference_range` table.
* Added 3 new tests covering: highest priority wins, prioritized range beats null-priority range, and strictest-among-tied behaviour.

One thing is to be **Noted on the mixed-priority edge case:** The ticket marks as TBD what should happen when some matching ranges have a priority and some don't. In this PR I treated null-priority ranges as lower than any explicitly set priority, which aligns with the spirit of the design discussed in the ticket.



## Issue I worked on

https://openmrs.atlassian.net/browse/TRUNK-6510




## Checklist: I completed these to help reviewers :)

* [x] My IDE is configured to follow the code style of this project
* [x] I have added tests to cover my changes
* [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit
* [x] All new and existing tests passed
* [x] My pull request is based on the latest changes of the master branch