### PR TITLE
TRUNK-6615:Obs setValueAsString should support standard ISO formats

### DIFF
--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -14,6 +14,14 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -1109,8 +1117,27 @@ public class Obs extends BaseFormRecordableOpenmrsData {
 					DateFormat timeFormat = new SimpleDateFormat(TIME_PATTERN);
 					setValueDatetime(timeFormat.parse(s));
 				} else if ("TS".equals(abbrev)) {
-					DateFormat datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
-					setValueDatetime(datetimeFormat.parse(s));
+					if (s.contains("T")) {
+						// ISO 8601 format — handles with/without timezone, and both offset styles (+05:00 and +0500)
+						// ISO_DATE_TIME only accepts +HH:MM offsets, so we build a formatter that also accepts +HHMM (no colon--which is what the REST-WS module uses)
+						DateTimeFormatter isoFormatter = new DateTimeFormatterBuilder()
+							.append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+							.optionalStart().appendPattern("XXX").optionalEnd()  // e.g. +05:00 or Z
+							.optionalStart().appendPattern("XX").optionalEnd()   // e.g. +0500
+							.optionalStart().appendPattern("X").optionalEnd()    // e.g. +05
+							.toFormatter();
+						// Returns a TemporalAccessor — the common supertype for all java.time datetime types
+						TemporalAccessor parsed = isoFormatter.parse(s);
+						// If the string included a timezone/offset, convert using that offset; otherwise assume system timezone
+						Instant instant = parsed.isSupported(ChronoField.OFFSET_SECONDS)
+							? OffsetDateTime.from(parsed).toInstant()
+							: LocalDateTime.from(parsed).atZone(ZoneId.systemDefault()).toInstant();
+						setValueDatetime(Date.from(instant));
+					} else {
+						// Legacy format without T separator (e.g. "2023-06-15 10:30")
+						DateFormat datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
+						setValueDatetime(datetimeFormat.parse(s));
+					}
 				}  else {
 					throw new RuntimeException("Don't know how to handle " + abbrev + " for concept: " + getConcept().getDisplayString());
 				}

--- a/api/src/main/java/org/openmrs/Obs.java
+++ b/api/src/main/java/org/openmrs/Obs.java
@@ -14,14 +14,6 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeFormatterBuilder;
-import java.time.temporal.ChronoField;
-import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -36,6 +28,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
+import org.openmrs.util.DateUtil;
 import org.openmrs.util.Format;
 import org.openmrs.util.Format.FORMAT_TYPE;
 import org.openmrs.util.OpenmrsUtil;
@@ -87,8 +80,6 @@ public class Obs extends BaseFormRecordableOpenmrsData {
 	public enum Status {
 		PRELIMINARY, FINAL, AMENDED
 	}
-	
-	private static final String DATE_TIME_PATTERN = "yyyy-MM-dd HH:mm";
 	
 	private static final String TIME_PATTERN = "HH:mm";
 	
@@ -1117,27 +1108,7 @@ public class Obs extends BaseFormRecordableOpenmrsData {
 					DateFormat timeFormat = new SimpleDateFormat(TIME_PATTERN);
 					setValueDatetime(timeFormat.parse(s));
 				} else if ("TS".equals(abbrev)) {
-					if (s.contains("T")) {
-						// ISO 8601 format — handles with/without timezone, and both offset styles (+05:00 and +0500)
-						// ISO_DATE_TIME only accepts +HH:MM offsets, so we build a formatter that also accepts +HHMM (no colon--which is what the REST-WS module uses)
-						DateTimeFormatter isoFormatter = new DateTimeFormatterBuilder()
-							.append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-							.optionalStart().appendPattern("XXX").optionalEnd()  // e.g. +05:00 or Z
-							.optionalStart().appendPattern("XX").optionalEnd()   // e.g. +0500
-							.optionalStart().appendPattern("X").optionalEnd()    // e.g. +05
-							.toFormatter();
-						// Returns a TemporalAccessor — the common supertype for all java.time datetime types
-						TemporalAccessor parsed = isoFormatter.parse(s);
-						// If the string included a timezone/offset, convert using that offset; otherwise assume system timezone
-						Instant instant = parsed.isSupported(ChronoField.OFFSET_SECONDS)
-							? OffsetDateTime.from(parsed).toInstant()
-							: LocalDateTime.from(parsed).atZone(ZoneId.systemDefault()).toInstant();
-						setValueDatetime(Date.from(instant));
-					} else {
-						// Legacy format without T separator (e.g. "2023-06-15 10:30")
-						DateFormat datetimeFormat = new SimpleDateFormat(DATE_TIME_PATTERN);
-						setValueDatetime(datetimeFormat.parse(s));
-					}
+					setValueDatetime(DateUtil.parseDatetimeString(s));
 				}  else {
 					throw new RuntimeException("Don't know how to handle " + abbrev + " for concept: " + getConcept().getDisplayString());
 				}

--- a/api/src/main/java/org/openmrs/util/DateUtil.java
+++ b/api/src/main/java/org/openmrs/util/DateUtil.java
@@ -9,8 +9,18 @@
  */
 package org.openmrs.util;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 
 /**
@@ -19,7 +29,51 @@ import java.util.Date;
  */
 public class DateUtil {
 	
+	/** Legacy space-separated datetime format used when parsing strings without a {@code T} separator */
+	public static final String DATETIME_PATTERN = "yyyy-MM-dd HH:mm";
+	
 	private DateUtil() {
+	}
+	
+	/**
+	 * Parses a datetime string into a {@link Date}.
+	 *
+	 * <p>Handles both the modern ISO 8601 format (with a {@code T} separator) and the legacy
+	 * space-separated format (e.g. {@code "2023-06-15 10:30:00"}).
+	 *
+	 * <p>For ISO 8601 strings, the following timezone/offset styles are all accepted:
+	 * <ul>
+	 *   <li>{@code Z} — UTC</li>
+	 *   <li>{@code +05:00} — offset with colon (standard ISO 8601)</li>
+	 *   <li>{@code +0500} — offset without colon (used by the REST-WS module)</li>
+	 *   <li>{@code +05} — hour-only offset</li>
+	 *   <li>No offset — interpreted as the system default timezone</li>
+	 * </ul>
+	 *
+	 * @param str the datetime string to parse; must not be null
+	 * @return the parsed {@link Date}
+	 * @throws ParseException if the string cannot be parsed by the legacy formatter
+	 * @since 2.8.7, 2.9.0, 3.0.0
+	 */
+	public static Date parseDatetimeString(String str) throws ParseException {
+		if (str.contains("T")) {
+			// ISO 8601 format — handles with/without timezone, and both offset styles (+05:00 and +0500)
+			// ISO_DATE_TIME only accepts +HH:MM offsets, so we build a formatter that also accepts +HHMM (no colon--which is what the REST-WS module uses)
+			DateTimeFormatter isoFormatter = new DateTimeFormatterBuilder().append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+			        .optionalStart().appendPattern("XXX").optionalEnd() // e.g. +05:00 or Z
+			        .optionalStart().appendPattern("XX").optionalEnd() // e.g. +0500
+			        .optionalStart().appendPattern("X").optionalEnd() // e.g. +05
+			        .toFormatter();
+			// Returns a TemporalAccessor — the common supertype for all java.time datetime types
+			TemporalAccessor parsed = isoFormatter.parse(str);
+			// If the string included a timezone/offset, convert using that offset; otherwise assume system timezone
+			Instant instant = parsed.isSupported(ChronoField.OFFSET_SECONDS) ? OffsetDateTime.from(parsed).toInstant()
+			        : LocalDateTime.from(parsed).atZone(ZoneId.systemDefault()).toInstant();
+			return Date.from(instant);
+		} else {
+			DateFormat legacyFormat = new SimpleDateFormat(DATETIME_PATTERN);
+			return legacyFormat.parse(str);
+		}
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/ObsTest.java
+++ b/api/src/test/java/org/openmrs/ObsTest.java
@@ -365,8 +365,155 @@ public class ObsTest {
 
 		assertThrows(RuntimeException.class, () -> obs.setValueAsString("\r\n"));
 	}
-	
-	
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithoutTimezone() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15T10:30:00");
+
+		Calendar cal = Calendar.getInstance();
+		cal.setTime(obs.getValueDatetime());
+		assertEquals(2023, cal.get(Calendar.YEAR));
+		assertEquals(Calendar.JUNE, cal.get(Calendar.MONTH));
+		assertEquals(15, cal.get(Calendar.DAY_OF_MONTH));
+		assertEquals(10, cal.get(Calendar.HOUR_OF_DAY));
+		assertEquals(30, cal.get(Calendar.MINUTE));
+		assertEquals(0, cal.get(Calendar.SECOND));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithUtcTimezone() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15T10:30:00Z");
+
+		// Z means UTC: assert the stored instant equals 2023-06-15T10:30:00 UTC
+		DateFormat utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+		assertEquals("2023-06-15T10:30:00", utcFormat.format(obs.getValueDatetime()));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithPositiveOffset() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15T10:30:00+05:00");
+
+		// +05:00 means 5 hours ahead of UTC, so UTC instant is 05:30:00
+		DateFormat utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+		assertEquals("2023-06-15T05:30:00", utcFormat.format(obs.getValueDatetime()));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithNegativeOffset() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15T10:30:00-05:00");
+
+		// -05:00 means 5 hours behind UTC, so UTC instant is 15:30:00
+		DateFormat utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+		assertEquals("2023-06-15T15:30:00", utcFormat.format(obs.getValueDatetime()));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithOffsetWithoutColon() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2022-02-19T08:26:00.000-0500");
+
+		// -0500 (no colon) means 5 hours behind UTC, so UTC instant is 13:26:00
+		DateFormat utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+		assertEquals("2022-02-19T13:26:00", utcFormat.format(obs.getValueDatetime()));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseIsoDatetimeWithMilliseconds() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15T10:30:00.123Z");
+
+		DateFormat utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+		utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+		assertEquals("2023-06-15T10:30:00", utcFormat.format(obs.getValueDatetime()));
+	}
+
+	/**
+	 * @see Obs#setValueAsString(String)
+	 */
+	@Test
+	public void setValueAsString_shouldParseLegacyDatetimeFormat() throws Exception {
+		ConceptDatatype cdt = new ConceptDatatype();
+		cdt.setHl7Abbreviation("TS");
+		Concept c = new Concept();
+		c.setDatatype(cdt);
+
+		Obs obs = new Obs();
+		obs.setConcept(c);
+		obs.setValueAsString("2023-06-15 10:30");
+
+		assertNotNull(obs.getValueDatetime());
+		Calendar cal = Calendar.getInstance();
+		cal.setTime(obs.getValueDatetime());
+		assertEquals(2023, cal.get(Calendar.YEAR));
+		assertEquals(Calendar.JUNE, cal.get(Calendar.MONTH));
+		assertEquals(15, cal.get(Calendar.DAY_OF_MONTH));
+		assertEquals(10, cal.get(Calendar.HOUR_OF_DAY));
+		assertEquals(30, cal.get(Calendar.MINUTE));
+	}
+
+
 	/**
 	 * @see Obs#getValueAsBoolean()
 	 */


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed

https://openmrs.atlassian.net/browse/TRUNK-6615

## Issue I worked on

https://openmrs.atlassian.net/browse/TRUNK-6615

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ X] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [X] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [X] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [X] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

