### PR TITLE
TRUNK-6624 : Add since and forRemoval arguments to deprecated annotations in Allergy

### DIFF
--- a/api/src/main/java/org/openmrs/Allergy.java
+++ b/api/src/main/java/org/openmrs/Allergy.java
@@ -111,6 +111,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 * @see org.openmrs.OpenmrsObject#getId()
 	 */
 	@Override
+	@Deprecated(since = "2.3.0", forRemoval = false)
 	public Integer getId() {
 		return allergyId;
 	}
@@ -119,6 +120,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 * @see org.openmrs.OpenmrsObject#setId(java.lang.Integer)
 	 */
 	@Override
+	@Deprecated(since = "2.3.0", forRemoval = false)
 	public void setId(Integer allergyId) {
 		this.allergyId = allergyId;
 	}
@@ -191,7 +193,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 * @return Returns the comment
 	 * @deprecated as of 2.3.0, replaced by {@link #getComments()}
 	 */
-	@Deprecated
+	@Deprecated(since = "2.3.0", forRemoval = false)
 	public String getComment() {
 		return getComments();
 	}
@@ -200,7 +202,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 * @param comment the comment to set
 	 * @deprecated as of 2.3.0, replaced by {@link #setComments(String)}
 	 */
-	@Deprecated
+	@Deprecated(since = "2.3.0", forRemoval = false)
 	public void setComment(String comment) {
 		setComments(comment);
 	}

--- a/api/src/main/java/org/openmrs/Allergy.java
+++ b/api/src/main/java/org/openmrs/Allergy.java
@@ -106,9 +106,10 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
     public void setAllergyId(Integer allergyId) {
     	this.allergyId = allergyId;
     }
-
+	
 	/**
 	 * @see org.openmrs.OpenmrsObject#getId()
+	 * @deprecated as of 2.3.0, use {@link #getAllergyId()} instead
 	 */
 	@Override
 	@Deprecated(since = "2.3.0", forRemoval = false)
@@ -118,6 +119,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	
 	/**
 	 * @see org.openmrs.OpenmrsObject#setId(java.lang.Integer)
+	 * @deprecated as of 2.3.0, use {@link #setAllergyId(Integer)} instead
 	 */
 	@Override
 	@Deprecated(since = "2.3.0", forRemoval = false)


### PR DESCRIPTION
Update deprecated methods in the Allergy class to include since and forRemoval arguments in the @Deprecated annotation.

This change improves compatibility with newer Java standards and resolves static analysis warnings.

**Updated methods:**

● getId()
● setId(Integer allergyId)
● getComment()
● setComment(String comment)

**All deprecated methods now use:**

@Deprecated(since = "2.3.0", forRemoval = false)

https://openmrs.atlassian.net/browse/TRUNK-6624