### PR TITLE
TRUNK-6623: Add null guard to purgePatient for consistency

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -345,6 +345,9 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 */
 	@Override
 	public void purgePatient(Patient patient) throws APIException {
+		if (patient == null) {
+			return;
+		}
 		dao.deletePatient(patient);
 	}
 


### PR DESCRIPTION
## Description
Added a null check (guard clause) in the purgePatient method of PatientServiceImpl to ensure consistent handling of null inputs.

## Problem
Previously, passing a null patient object could lead to unexpected behavior or potential NullPointerException.

## Solution
Introduced a null guard to safely handle null inputs before proceeding with the purge operation.

## Impact
- Improves code robustness
- Prevents runtime errors
- Ensures consistency with similar service methods

## Testing
- Ran existing unit tests
- No test failures observed

## Related Issue
https://issues.openmrs.org/browse/TRUNK-6623