### PR TITLE
TRUNK-6590: Both /openmrs and /openmrs/ return 404

### DIFF
--- a/web/src/main/resources/openmrs-servlet.xml
+++ b/web/src/main/resources/openmrs-servlet.xml
@@ -17,9 +17,16 @@
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:mvc="http://www.springframework.org/schema/mvc"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-       		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+           http://www.springframework.org/schema/mvc
+           http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
 
 	<alias name="messageSourceService" alias="messageSource"/>
+
+	<mvc:view-controller path="/" view-name="redirect:/index.htm"/>
+	<mvc:default-servlet-handler/>
+
 </beans>

--- a/web/src/main/resources/openmrs-servlet.xml
+++ b/web/src/main/resources/openmrs-servlet.xml
@@ -17,16 +17,9 @@
 -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:mvc="http://www.springframework.org/schema/mvc"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-           http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-           http://www.springframework.org/schema/mvc
-           http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+       		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<alias name="messageSourceService" alias="messageSource"/>
-
-	<mvc:view-controller path="/" view-name="redirect:/index.htm"/>
-	<mvc:default-servlet-handler/>
-
 </beans>

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -323,6 +323,11 @@
  		<servlet-name>openmrs_static_content</servlet-name>
  		<url-pattern>/scripts/*</url-pattern>
 	</servlet-mapping>
+
+	<servlet-mapping>
+		<servlet-name>openmrs</servlet-name>
+		<url-pattern>/</url-pattern>
+	</servlet-mapping>
 	
 	<servlet-mapping>
  		<servlet-name>openmrs</servlet-name>

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -323,15 +323,15 @@
  		<servlet-name>openmrs_static_content</servlet-name>
  		<url-pattern>/scripts/*</url-pattern>
 	</servlet-mapping>
-
-	<servlet-mapping>
-		<servlet-name>openmrs</servlet-name>
-		<url-pattern>/</url-pattern>
-	</servlet-mapping>
 	
 	<servlet-mapping>
  		<servlet-name>openmrs</servlet-name>
  		<url-pattern>/ws/*</url-pattern>
+	</servlet-mapping>
+
+	<servlet-mapping>
+		<servlet-name>default</servlet-name>
+		<url-pattern>/index.htm</url-pattern>
 	</servlet-mapping>
 	
 	<servlet-mapping>


### PR DESCRIPTION
## Description of what I changed
Fixed the 404 when navigating to `/openmrs` or `/openmrs/` in the Docker/Tomcat 11 environment. 

The `/openmrs` context is configured correctly, and the deployed WAR contains a physical `/index.htm` welcome file. However, because `web.xml` maps `*.htm` requests to the OpenMRS `DispatcherServlet`, `/openmrs/index.htm` was routed to Spring MVC instead of being served as the welcome file, resulting in:

```text
No endpoint GET /openmrs/index.htm
```

Since `/openmrs/` uses `index.htm` as its welcome file, the context root also returned 404.

Specific changes include:

This PR adds an exact `/index.htm` mapping to the container default servlet, allowing only the physical welcome file to be served statically while leaving the existing OpenMRS mappings for `*.htm`, `*.form`, `*.list`, `*.portlet`, `*.field`, and `/ws/*` unchanged.

## Issue I worked on
see https://openmrs.atlassian.net/browse/TRUNK-6590

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (The fix was verified via manual integration testing/curl in the Docker environment as it addresses deployment-level routing).

- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated routing so requests to /ws/* are handled by the designated API handler.
  * Adjusted routing so /index.htm is served by the default handler, improving request resolution and routing clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->