### PR TITLE
Add CodeRabbit configuration for AI code reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,7 +34,7 @@ reviews:
         Tests should use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest as already present in the
         codebase. Flag use of deprecated JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest
         for integration tests that need a Spring context.
-    - path: "liquibase/**/*.xml"
+    - path: "**/liquibase/**/*.xml"
       instructions: |
         Liquibase changesets must be append-only — never edit an existing changeSet id/author.
         Flag any modification to historical changesets. New changesets need a unique id and author,

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,9 @@
 language: en-US
 early_access: false
+tone_instructions: |
+  Be encouraging to first-time and student contributors — OpenMRS has many. Explain *why*
+  a change matters, not just *what* to change. Suggest concrete code rather than abstract
+  principles. Skip nits that checkstyle/SpotBugs already enforce.
 reviews:
   profile: chill
   request_changes_workflow: false
@@ -12,27 +16,36 @@ reviews:
     drafts: false
     base_branches:
       - master
-      - "2\\.x"
+      - "^\\d+\\.\\d+\\.x$"
   path_filters:
     - "!**/target/**"
     - "!initial_test_db.sql"
+    - "!**/messages_*.properties"
   path_instructions:
     - path: "**/*.java"
       instructions: |
-        Follow OpenMRS Java conventions: tabs for indentation, the project's checkstyle.xml rules,
-        and the license header from license-header.txt. Flag missing @since tags on new public API,
-        Hibernate/JPA misuse, missing transaction boundaries on service methods, and any change to
-        public API in the api/ module that could break downstream modules.
+        Include the license header from license-header.txt on new files. Style is enforced
+        by checkstyle.xml — focus on semantic issues, not formatting nits.
+    - path: "**/src/main/**/*.java"
+      instructions: |
+        Flag missing @since tags on new public API in the api/ module, Hibernate/JPA misuse,
+        missing @Transactional on data-modifying service methods, and any change to public
+        API that could break downstream modules.
     - path: "**/src/test/**/*.java"
       instructions: |
-        Tests should use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest as already present in the
-        codebase. Flag use of deprecated JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest
+        Tests should use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest as already present
+        in the codebase. Flag JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest
         for integration tests that need a Spring context.
-    - path: "**/liquibase/**/*.xml"
+    - path: "**/{liquibase/**/*.xml,liquibase-*.xml}"
       instructions: |
         Liquibase changesets must be append-only — never edit an existing changeSet id/author.
-        Flag any modification to historical changesets. New changesets need a unique id and author,
-        and should include a rollback block where feasible.
+        Flag any modification to historical changesets. New changesets need a unique id and
+        author, and should include a rollback block where feasible.
+    - path: "**/*.hbm.xml"
+      instructions: |
+        OpenMRS is migrating Hibernate XML mappings to JPA annotations. New entities or
+        fields should be added to the @Entity class, not these files. Flag new mapping
+        additions and suggest annotation-based equivalents.
     - path: "**/pom.xml"
       instructions: |
         Flag dependency version changes that bypass the BOM, additions of non-Apache-2.0-compatible

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,47 @@
+language: en-US
+early_access: false
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - master
+      - "2\\.x"
+  path_filters:
+    - "!**/target/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!**/generated/**"
+    - "!**/node_modules/**"
+    - "!**/.mvn/**"
+    - "!initial_test_db.sql"
+    - "!**/*.lock"
+  path_instructions:
+    - path: "**/*.java"
+      instructions: |
+        Follow OpenMRS Java conventions: tabs for indentation, the project's checkstyle.xml rules,
+        and the license header from license-header.txt. Flag missing @since tags on new public API,
+        Hibernate/JPA misuse, missing transaction boundaries on service methods, and any change to
+        public API in the api/ module that could break downstream modules.
+    - path: "**/src/test/**/*.java"
+      instructions: |
+        Tests should use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest as already present in the
+        codebase. Flag use of deprecated JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest
+        for integration tests that need a Spring context.
+    - path: "liquibase/**/*.xml"
+      instructions: |
+        Liquibase changesets must be append-only — never edit an existing changeSet id/author.
+        Flag any modification to historical changesets. New changesets need a unique id and author,
+        and should include a rollback block where feasible.
+    - path: "**/pom.xml"
+      instructions: |
+        Flag dependency version changes that bypass the BOM, additions of non-Apache-2.0-compatible
+        licenses, and any new <repository> entries pointing outside Maven Central or OpenMRS infra.
+chat:
+  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,11 +36,13 @@ reviews:
         Tests should use JUnit 5 (org.junit.jupiter) and AssertJ/Hamcrest as already present
         in the codebase. Flag JUnit 4 imports in new tests. Prefer BaseContextSensitiveTest
         for integration tests that need a Spring context.
-    - path: "**/{liquibase/**/*.xml,liquibase-*.xml}"
-      instructions: |
+    - path: "**/liquibase/**/*.xml"
+      instructions: &liquibase-instructions |
         Liquibase changesets must be append-only — never edit an existing changeSet id/author.
         Flag any modification to historical changesets. New changesets need a unique id and
         author, and should include a rollback block where feasible.
+    - path: "**/liquibase-*.xml"
+      instructions: *liquibase-instructions
     - path: "**/*.hbm.xml"
       instructions: |
         OpenMRS is migrating Hibernate XML mappings to JPA annotations. New entities or
@@ -50,5 +52,3 @@ reviews:
       instructions: |
         Flag dependency version changes that bypass the BOM, additions of non-Apache-2.0-compatible
         licenses, and any new <repository> entries pointing outside Maven Central or OpenMRS infra.
-chat:
-  auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,13 +15,7 @@ reviews:
       - "2\\.x"
   path_filters:
     - "!**/target/**"
-    - "!**/*.min.js"
-    - "!**/*.min.css"
-    - "!**/generated/**"
-    - "!**/node_modules/**"
-    - "!**/.mvn/**"
     - "!initial_test_db.sql"
-    - "!**/*.lock"
   path_instructions:
     - path: "**/*.java"
       instructions: |


### PR DESCRIPTION
## Summary
- Adds `.coderabbit.yaml` to configure CodeRabbit's automated PR reviews
- Sets path filters to skip generated artifacts (`target/`, minified files, `initial_test_db.sql`)
- Adds path-specific review guidance for Java sources, JUnit tests, Liquibase changesets, and `pom.xml`
- Uses `chill` profile and disables `request_changes_workflow` so reviews are advisory and don't block merges

## Test plan
- [ ] Confirm CodeRabbit posts a review/summary on this PR (validates the GitHub App is installed correctly)
- [ ] Verify the path-specific instructions are picked up once merged to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated review configuration: English reviews with a "chill" profile, auto-review for non-draft PRs to main/version branches, chat auto-replies, and adjusted presentation (high-level summaries, review status, collapsed walkthroughs).
  * Scoped review rules for Java code, tests, database changelogs, and build descriptors; excluded specified generated/initial test artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->