### PR TITLE
Stop echoing openmrs-server.properties to stdout on startup

### DIFF
--- a/startup-init.sh
+++ b/startup-init.sh
@@ -181,7 +181,6 @@ if [ -f "$OMRS_RUNTIME_PROPERTIES_FILE" ]; then
     echo "Found existing runtime properties file at $OMRS_RUNTIME_PROPERTIES_FILE. Merging with extra properties."
     awk -F= '!a[$1]++' "openmrs-extra.properties" "$OMRS_RUNTIME_PROPERTIES_FILE" > openmrs-merged.properties
     mv openmrs-merged.properties "$OMRS_RUNTIME_PROPERTIES_FILE"
-    cat "$OMRS_RUNTIME_PROPERTIES_FILE"
   fi
 
   # Ensure admin.password.locked is set in runtime properties
@@ -208,7 +207,6 @@ else
 	  cat "openmrs-extra.properties" >> "$OMRS_SERVER_PROPERTIES_FILE"
 	fi
   fi
-  cat "$OMRS_SERVER_PROPERTIES_FILE"
 fi
 
 if [ -f openmrs-extra.properties ]; then


### PR DESCRIPTION
## Summary

`startup-init.sh` writes the rendered `openmrs-server.properties` (and the merged runtime properties) to stdout via `cat`, so operators could see the configuration the container booted with. The file contains DB credentials plus any property supplied via `OMRS_EXTRA_*` / `OMRS_CONFIG_PROPERTY_*` environment variables — API keys, bearer tokens, OAuth client secrets, anything an installation wants in the runtime properties. When that stdout is captured by a log sink (Docker logs, GitHub Actions, ELK, Loki, …), the values are exposed in plaintext.

This was recently observed in the wild: a downstream module's OpenRouter API key, supplied as `OMRS_CONFIG_PROPERTY_CHARTSEARCHAI_LLM_REMOTE_APIKEY`, ended up in a public GitHub Actions log because the container's stdout was captured.

## What this changes

Removes the two `cat` calls in `startup-init.sh` that print the rendered server / merged runtime properties to stdout. Nothing consumes that stdout:

- `startup.sh` simply sources `startup-init.sh`; its output flows to the container log only.
- The Java app reads the file from disk via `-DOPENMRS_INSTALLATION_SCRIPT=${OMRS_SERVER_PROPERTIES_FILE}` (see `startup.sh`), not from stdout.
- No script, Dockerfile, or compose file in the repo parses the output.
- The `cat` was added in TRUNK-6184 (commit 204699d19) as a diagnostic alongside `OMRS_EXTRA_` support, not as an interface.

The file is still written to disk unchanged. Operators who need to inspect the rendered configuration can read it directly inside the container (e.g. `kubectl exec` / `docker exec` then `cat $OMRS_HOME/openmrs-server.properties`).

This replaces the earlier redaction-by-pattern approach: a denylist of credential-shaped substrings would still leak any property whose name doesn't match the regex (e.g. `*.passphrase`, `*.pwd`, `*.auth`, `*.cert`, `*.salt`, embedded credentials inside `connection.url`'s value). Not logging the values in the first place removes the whole class of leak.

## Test plan

- [x] `bash -n startup-init.sh` passes.
- [ ] Build the Docker image and start a container; confirm startup logs no longer print the contents of `openmrs-server.properties` / the runtime properties file, while the file still exists at `$OMRS_HOME/openmrs-server.properties` and OpenMRS still boots normally.
- [ ] Set `OMRS_EXTRA_FOO=bar`; confirm `foo=bar` lands in the on-disk properties file but does not appear in container stdout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)