### PR TITLE
Fix typo in openmrs-extra.properties.tmp path in startup-init.sh

### DIFF
--- a/startup-init.sh
+++ b/startup-init.sh
@@ -200,7 +200,7 @@ else
   	  [[ -n "$line" ]] && echo -e "property.$line" >> openmrs-extra.properties.tmp
 	done < openmrs-extra.properties
 	
-	echo >> openmrs-exta.properties.tmp
+	echo >> openmrs-extra.properties.tmp
 	
 	if [ -f openmrs-extra.properties.tmp ]; then
 	  mv openmrs-extra.properties.tmp openmrs-extra.properties


### PR DESCRIPTION
## Summary

`startup-init.sh:203` appends a trailing newline to the merged extras tmp file, but the file name was typo'd as `openmrs-exta.properties.tmp` (missing `r`) instead of `openmrs-extra.properties.tmp`.

Effect at every container startup:
- A stray empty file named `openmrs-exta.properties.tmp` is created in the working directory.
- The intended trailing newline is never appended to the real `openmrs-extra.properties.tmp`.

In practice the downstream `cat openmrs-extra.properties >> $OMRS_SERVER_PROPERTIES_FILE` is unaffected, because `echo -e "property.$line"` on line 200 already terminates every written line with `\n`, and `$OMRS_SERVER_PROPERTIES_FILE` already ends with a blank line from the heredoc on line 140. So this is a silent typo, not a behavioral bug — but the wrong file name was clearly unintended.

Pre-existing; noticed while reviewing #6115 and deferred as out of slice scope.

## Test plan

- [x] `bash -n startup-init.sh` passes.
- [ ] Build the Docker image, start a container with `OMRS_EXTRA_FOO=bar`. Confirm `$OMRS_HOME/openmrs-server.properties` contains `property.foo=bar` and that no stray `openmrs-exta.properties.tmp` file is created in the working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)