### PR TITLE
Backport: stop echoing properties to stdout + fix openmrs-extra typo (2.7.x)

### DIFF
--- a/startup-init.sh
+++ b/startup-init.sh
@@ -175,7 +175,6 @@ if [ -f "$OMRS_RUNTIME_PROPERTIES_FILE" ]; then
     echo "Found existing runtime properties file at $OMRS_RUNTIME_PROPERTIES_FILE. Merging with extra properties."
     awk -F= '!a[$1]++' "openmrs-extra.properties" "$OMRS_RUNTIME_PROPERTIES_FILE" > openmrs-merged.properties
     mv openmrs-merged.properties "$OMRS_RUNTIME_PROPERTIES_FILE"
-    cat "$OMRS_RUNTIME_PROPERTIES_FILE"
   fi
 
   # Ensure admin.password.locked is set in runtime properties
@@ -202,7 +201,6 @@ else
 	  cat "openmrs-extra.properties" >> "$OMRS_SERVER_PROPERTIES_FILE"
 	fi
   fi
-  cat "$OMRS_SERVER_PROPERTIES_FILE"
 fi
 
 if [ -f openmrs-extra.properties ]; then

--- a/startup-init.sh
+++ b/startup-init.sh
@@ -194,7 +194,7 @@ else
   	  [[ -n "$line" ]] && echo -e "property.$line" >> openmrs-extra.properties.tmp
 	done < openmrs-extra.properties
 	
-	echo >> openmrs-exta.properties.tmp
+	echo >> openmrs-extra.properties.tmp
 	
 	if [ -f openmrs-extra.properties.tmp ]; then
 	  mv openmrs-extra.properties.tmp openmrs-extra.properties


### PR DESCRIPTION
## Summary

Backport of two related fixes from master to 2.7.x:

1. **Stop echoing `openmrs-server.properties` to stdout on startup** (#6115, merged on master)
   `startup-init.sh` printed the rendered server/runtime properties to stdout, leaking DB credentials and any `OMRS_EXTRA_*` / `OMRS_CONFIG_PROPERTY_*` value (API keys, OAuth secrets, bearer tokens) into container logs. Recently observed in the wild: a downstream module's OpenRouter API key, supplied as `OMRS_CONFIG_PROPERTY_CHARTSEARCHAI_LLM_REMOTE_APIKEY`, ended up in a public GitHub Actions log because the container's stdout was captured. Nothing in the repo consumes that stdout (`startup.sh` sources the script; Java reads the file from disk via `-DOPENMRS_INSTALLATION_SCRIPT`); operators who need to inspect the rendered file can read it directly inside the container.

2. **Fix typo in `openmrs-extra.properties.tmp` path** (follow-up #6117)
   The line that appends a trailing newline to the merged extras tmp file referenced `openmrs-exta.properties.tmp` (missing `r`). At each container startup this created a stray empty file with the typo'd name and the intended trailing newline was never appended to the real tmp file. Silent typo in practice (every line is already `\n`-terminated by `echo -e`), but the wrong file name was clearly unintended.

## Cherry-picks

- `2da03f160` — `Stop echoing openmrs-server.properties to stdout on startup (#6115)`
- `278857c9b` — `Fix typo in openmrs-extra.properties.tmp path` (from #6117)

Both apply cleanly to 2.7.x.

## Test plan

- [x] `bash -n startup-init.sh` passes.
- [ ] Build the 2.7.x Docker image, start a container with `OMRS_EXTRA_FOO=bar`. Confirm: stdout no longer prints the rendered properties; `$OMRS_HOME/openmrs-server.properties` still contains `property.foo=bar`; no stray `openmrs-exta.properties.tmp` file is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)