### PR TITLE
Add unit tests for OpenmrsUtil.stringStartsWith

### DIFF
--- a/api/src/test/java/org/openmrs/util/OpenmrsUtilUnitTest.java
+++ b/api/src/test/java/org/openmrs/util/OpenmrsUtilUnitTest.java
@@ -168,6 +168,28 @@ public class OpenmrsUtilUnitTest {
 	}
 
 	@Test
+	public void stringStartsWith_shouldReturnTrueIfStringStartsWithOneOfTheGivenPrefixes() {
+
+		String[] prefixes = new String[] { "foo", "bar", "baz" };
+
+		assertTrue(OpenmrsUtil.stringStartsWith("barbecue", prefixes));
+	}
+
+	@Test
+	public void stringStartsWith_shouldReturnFalseIfStringStartsWithNoneOfTheGivenPrefixes() {
+
+		String[] prefixes = new String[] { "foo", "bar", "baz" };
+
+		assertFalse(OpenmrsUtil.stringStartsWith("hello", prefixes));
+	}
+
+	@Test
+	public void stringStartsWith_shouldReturnFalseIfPrefixArrayIsEmpty() {
+
+		assertFalse(OpenmrsUtil.stringStartsWith("hello", new String[0]));
+	}
+
+	@Test
 	public void isInNormalNumericRange_shouldReturnFalseIfHiNormalIsNull() {
 
 		ConceptNumeric concept = new ConceptNumeric();


### PR DESCRIPTION
## Summary

`OpenmrsUtil.stringStartsWith(String, String[])` had no test coverage. This PR adds three unit tests covering its main behaviors:

- returns `true` when the input starts with one of the given prefixes
- returns `false` when the input matches none of the prefixes
- returns `false` when the prefix array is empty

The tests live in `OpenmrsUtilUnitTest` (no Spring context required) and follow the style of the existing `isStringInArray` tests immediately above them.

## Test plan

- [x] `./mvnw -pl api -am test -Dtest=OpenmrsUtilUnitTest` runs all 52 tests green locally