### PR TITLE
Fix OWASP Dependency-Check CI failures

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -105,7 +105,7 @@
 		<!-- Database -->
 		<mysqlConnectorVersion>9.7.0</mysqlConnectorVersion>
 		<mariadbClientVersion>3.5.8</mariadbClientVersion>
-		<postgresqlVersion>42.7.10</postgresqlVersion>
+		<postgresqlVersion>42.7.11</postgresqlVersion>
 		<liquibaseVersion>4.32.0</liquibaseVersion>
 		<liquibaseExtTypeConverterVersion>1.0.1</liquibaseExtTypeConverterVersion>
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -26,4 +26,32 @@
 	   <packageUrl regex="true">^pkg:javascript/jquery@.*$</packageUrl>
 	   <vulnerabilityName regex="true">^jquery issue:.*$</vulnerabilityName>
 	</suppress>
+	<suppress>
+	   <notes><![CDATA[
+	   False positives: these CVEs are matched against the openmrs.war file via CPE
+	   cpe:2.3:a:openmrs:openmrs but refer to vulnerabilities in older OpenMRS releases
+	   or the OpenMRS Reference Application, not the current openmrs-core codebase.
+
+	   CVE-2026-40076 (Zip Slip during .omod extraction) is already fixed here: both
+	   ModuleUtil.expandJar and ModuleUtil.expand reject entries that normalize outside
+	   the target directory.
+	   CVE-2026-40075 (ModuleResourcesServlet path traversal) is already fixed here:
+	   ModuleResourcesServlet.getFile rejects paths that do not normalize within the
+	   module resources base path.
+	   CVE-2021-43094 (file exfiltration via /images and /initfilter/scripts) is already
+	   fixed here: StartupFilter normalizes the resolved path and rejects requests that
+	   resolve outside the served directory.
+	   The remaining CVEs (CVE-2017-12796, CVE-2025-25928, CVE-2014-8073, CVE-2025-25927)
+	   target the legacy admin UI / Reference Application (e.g. /admin/users/user.form),
+	   which is not part of openmrs-core.
+	   ]]></notes>
+	   <cpe>cpe:2.3:a:openmrs:openmrs</cpe>
+	   <cve>CVE-2026-40076</cve>
+	   <cve>CVE-2026-40075</cve>
+	   <cve>CVE-2021-43094</cve>
+	   <cve>CVE-2017-12796</cve>
+	   <cve>CVE-2025-25928</cve>
+	   <cve>CVE-2014-8073</cve>
+	   <cve>CVE-2025-25927</cve>
+	</suppress>
 </suppressions>


### PR DESCRIPTION
## Description

The `OWASP Dependency Check` workflow on `master` is failing ([run 26472129345](https://github.com/openmrs/openmrs-core/actions/runs/26472129345/job/77948077753)) because dependencies were flagged at CVSS ≥ 6.2. This PR addresses every flagged CVE.

### Real fix
- **CVE-2026-42198** (7.5) in `postgresql-42.7.10.jar` — client-side DoS during SCRAM-SHA-256 auth (unbounded PBKDF2 iterations). Bumped pgjdbc to **42.7.11**, the release that patches it (adds `scramMaxIterations`, default 100,000). This clears the CVE on both the standalone jar and the copy bundled in `openmrs.war`.

### Suppressed false positives (openmrs.war, `cpe:2.3:a:openmrs:openmrs`)
These CVEs match the war by CPE but are either already fixed in openmrs-core or apply to the legacy admin UI / Reference Application. Each is suppressed by **specific CVE ID** (not a blanket CPE suppression), so genuinely new openmrs CVEs still fail the build.

| CVE | Why it's a false positive for openmrs-core 3.x |
|-----|-----|
| CVE-2026-40076 (9.4, Zip Slip in `.omod` extraction) | Fixed: `ModuleUtil.expandJar`/`expand` reject entries that normalize outside the target dir |
| CVE-2026-40075 (8.2, `ModuleResourcesServlet` path traversal) | Fixed: `ModuleResourcesServlet.getFile` rejects paths not normalizing within the resources base |
| CVE-2021-43094 (9.8, file exfiltration via `/images`, `/initfilter/scripts`) | Fixed: `StartupFilter` normalizes and `startsWith`-checks the resolved path |
| CVE-2017-12796, CVE-2025-25928, CVE-2014-8073, CVE-2025-25927 | Target the legacy admin UI / Reference Application (e.g. `/admin/users/user.form`), not openmrs-core |

## Verification
- `org.postgresql:postgresql:42.7.11` resolves from Maven Central; version propagates to `api`/`test`/the war via the BOM `dependencyManagement`.
- Suppression file validates against the official dependency-check 1.3 XSD.
- Confirmed against dependency-check's `SuppressionRule` source that the `<cve>` entries suppress by CVE name, so the rule fires regardless of CPE format.
- Definitive check is this PR's own `OWASP Dependency Check` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)