### PR TITLE
Fix test-compile break after postgresql 42.7.11 dropped checker-qual

### DIFF
--- a/api/src/test/java/org/openmrs/util/databasechange/EnversAuditTableInitializerDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/databasechange/EnversAuditTableInitializerDatabaseIT.java
@@ -20,9 +20,6 @@ import java.util.Set;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
@@ -119,9 +116,8 @@ class EnversAuditTableInitializerDatabaseIT extends DatabaseIT {
 		Integrator enversIntegrator = new Integrator() {
 
 			@Override
-			public void integrate(@UnknownKeyFor @NonNull @Initialized Metadata metadata,
-			        @UnknownKeyFor @NonNull @Initialized BootstrapContext bootstrapContext,
-			        @UnknownKeyFor @NonNull @Initialized SessionFactoryImplementor sessionFactory) {
+			public void integrate(Metadata metadata, BootstrapContext bootstrapContext,
+			        SessionFactoryImplementor sessionFactory) {
 				if (enversEnabled) {
 					try {
 						Properties properties = new java.util.Properties();
@@ -139,9 +135,8 @@ class EnversAuditTableInitializerDatabaseIT extends DatabaseIT {
 			}
 
 			@Override
-			public void disintegrate(
-			        @UnknownKeyFor @NonNull @Initialized SessionFactoryImplementor sessionFactoryImplementor,
-			        @UnknownKeyFor @NonNull @Initialized SessionFactoryServiceRegistry sessionFactoryServiceRegistry) {
+			public void disintegrate(SessionFactoryImplementor sessionFactoryImplementor,
+			        SessionFactoryServiceRegistry sessionFactoryServiceRegistry) {
 				// No cleanup needed: the audit table initialization performed in integrate() is a one-time
 				// schema operation with no resources to release when the SessionFactory is closed.
 			}


### PR DESCRIPTION
## Description

Master is failing to build (see the [OWASP Dependency Check run](https://github.com/openmrs/openmrs-core/actions/runs/26543209174), which fails at the *Build project with Maven* step):

```
EnversAuditTableInitializerDatabaseIT.java: package org.checkerframework.checker.initialization.qual does not exist
EnversAuditTableInitializerDatabaseIT.java: package org.checkerframework.checker.nullness.qual does not exist
```

### Root cause
`EnversAuditTableInitializerDatabaseIT` imported `org.checkerframework.checker.*` annotations. Those classes were never declared as a dependency — they only reached the test classpath **transitively** because `postgresql:42.7.10` declared `org.checkerframework:checker-qual:3.52.0` (runtime). The recent bump to `postgresql:42.7.11` (#6136) **dropped that dependency**, so the annotations no longer resolve and test compilation fails (`mvn install -DskipTests` still compiles tests).

### Fix
The annotations (`@UnknownKeyFor @NonNull @Initialized`) were decorative parameter qualifiers on an anonymous Hibernate `Integrator` implementation — almost certainly copied from Hibernate's annotated API. Parameter annotations do not affect override matching and the test behaves identically without them. Removing them:

- fixes the build, and
- eliminates the fragile reliance on a transitive dependency — better than re-pinning postgresql (which would reintroduce CVE-2026-42198) or adding `checker-qual` purely to satisfy cosmetic annotations.

## Verification
- `mvn -pl api -am test-compile -DskipTests` → `BUILD SUCCESS` (previously failed on this file).
- `checkerframework` is used in no other file in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)