### PR TITLE
Fix SonarCloud reliability bugs on new code

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -96,7 +96,7 @@ public final class Daemon {
 		try {
 			return moduleStartFuture.get();
 		} catch (InterruptedException e) {
-			// ignore
+			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {
 			if (e.getCause() instanceof ModuleException) {
 				throw (ModuleException) e.getCause();
@@ -156,7 +156,7 @@ public final class Daemon {
 		try {
 			return userFuture.get();
 		} catch (InterruptedException e) {
-			// ignore
+			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {
 			if (e.getCause() instanceof Exception) {
 				throw (Exception) e.getCause();
@@ -217,7 +217,9 @@ public final class Daemon {
 		// do not return until the thread is actually started to emulate the previous behaviour
 		try {
 			countDownLatch.await();
-		} catch (InterruptedException ignored) {}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
 
 		return thread;
 	}
@@ -309,7 +311,7 @@ public final class Daemon {
 		try {
 			future.get();
 		} catch (InterruptedException e) {
-			// ignore
+			Thread.currentThread().interrupt();
 		} catch (ExecutionException e) {
 			if (e.getCause() instanceof ModuleException) {
 				throw (ModuleException) e.getCause();
@@ -409,7 +411,9 @@ public final class Daemon {
 
 		try {
 			daemonThread.get();
-		} catch (InterruptedException | ExecutionException e) {
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
 			// Ignored
 		}
 	}
@@ -455,7 +459,9 @@ public final class Daemon {
 
 		try {
 			countDownLatch.await();
-		} catch (InterruptedException ignored) {}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
 
 		return result;
 	}

--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -682,6 +682,7 @@ public class ServiceContext implements ApplicationContextAware {
 				}
 
 			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 				log.warn("Refresh lock was interrupted", e);
 			}
 		}
@@ -952,6 +953,7 @@ public class ServiceContext implements ApplicationContextAware {
 
 				Daemon.runStartupForService(openmrsService);
 			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 				log.warn("Refresh lock was interrupted while waiting to run OpenmrsService.onStartup() for " + classString,
 				    e);
 			}

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Hibernate;
 import org.openmrs.Location;
 import org.openmrs.PrivilegeListener;
 import org.openmrs.Role;
@@ -171,18 +172,10 @@ public class UserContext implements Serializable {
 			throw new ContextAuthenticationException("User not found with systemId: " + systemId);
 		}
 
-		// hydrate the user object
-		if (userToBecome.getAllRoles() != null) {
-			userToBecome.getAllRoles().size();
-		}
-
-		if (userToBecome.getUserProperties() != null) {
-			userToBecome.getUserProperties().size();
-		}
-
-		if (userToBecome.getPrivileges() != null) {
-			userToBecome.getPrivileges().size();
-		}
+		// hydrate the user object by initializing its lazy collections within the session
+		Hibernate.initialize(userToBecome.getAllRoles());
+		Hibernate.initialize(userToBecome.getUserProperties());
+		Hibernate.initialize(userToBecome.getPrivileges());
 
 		this.user = userToBecome;
 

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateContextDAO.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
+import org.hibernate.Hibernate;
 import org.hibernate.HibernateException;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
@@ -157,10 +158,10 @@ public class HibernateContextDAO implements ContextDAO {
 
 			// if the username and password match, hydrate the user and return it
 			if (passwordOnRecord != null && Security.hashMatches(passwordOnRecord, password + saltOnRecord)) {
-				// hydrate the user object
-				candidateUser.getAllRoles().size();
-				candidateUser.getUserProperties().size();
-				candidateUser.getPrivileges().size();
+				// hydrate the user object by initializing its lazy collections within the session
+				Hibernate.initialize(candidateUser.getAllRoles());
+				Hibernate.initialize(candidateUser.getUserProperties());
+				Hibernate.initialize(candidateUser.getPrivileges());
 
 				// only clean up if the were some login failures, otherwise all should be clean
 				int attempts = getUsersLoginAttempts(candidateUser);
@@ -559,6 +560,7 @@ public class HibernateContextDAO implements ContextDAO {
 		try {
 			searchSessionFactory.getSearchSession().massIndexer(types).startAndWait();
 		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new RuntimeException(e);
 		}
 	}

--- a/api/src/main/java/org/openmrs/api/storage/S3StorageService.java
+++ b/api/src/main/java/org/openmrs/api/storage/S3StorageService.java
@@ -137,6 +137,7 @@ public class S3StorageService extends BaseStorageService implements StorageServi
 		try {
 			result = object.get();
 		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new InterruptedIOException(e.getMessage());
 		} catch (ExecutionException e) {
 			throw new IOException(e);
@@ -190,6 +191,7 @@ public class S3StorageService extends BaseStorageService implements StorageServi
 			request.get();
 			return true;
 		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new InterruptedIOException(e.getMessage());
 		} catch (ExecutionException e) {
 			if (e.getCause() instanceof S3Exception) {

--- a/api/src/main/java/org/openmrs/hl7/Hl7InArchivesMigrateThread.java
+++ b/api/src/main/java/org/openmrs/hl7/Hl7InArchivesMigrateThread.java
@@ -139,6 +139,7 @@ public class Hl7InArchivesMigrateThread extends Thread {
 				try {
 					Thread.sleep(HL7Constants.THREAD_SLEEP_PERIOD);
 				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
 					log.warn("Hl7 in archive migration thread has been abnormally interrupted", e);
 				}
 

--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -339,22 +339,22 @@ public class ORUR01Handler implements Application {
 					if (!StringUtils.isEmpty(value)) {
 						conceptProposals.add(createConceptProposal(encounter, questionConcept, value));
 					} else {
+						//stop any further processing of current message by recording the error below
 						errorInHL7Queue = new HL7Exception(
 						        Context.getMessageSourceService().getMessage("Hl7.proposed.concept.name.empty"),
 						        proposingException);
-						break;//stop any further processing of current message
 					}
 
 				} catch (HL7Exception e) {
 					errorInHL7Queue = e;
-				} finally {
-					// Handle obs-level exceptions
-					if (errorInHL7Queue != null) {
-						throw new HL7Exception(
-						        Context.getMessageSourceService().getMessage("ORUR01.error.improperlyFormattedOBX",
-						            new Object[] { PipeParser.encode(obx, new EncodingCharacters('|', "^~\\&")) }, null),
-						        HL7Exception.DATA_TYPE_ERROR, errorInHL7Queue);
-					}
+				}
+
+				// Handle obs-level exceptions
+				if (errorInHL7Queue != null) {
+					throw new HL7Exception(
+					        Context.getMessageSourceService().getMessage("ORUR01.error.improperlyFormattedOBX",
+					            new Object[] { PipeParser.encode(obx, new EncodingCharacters('|', "^~\\&")) }, null),
+					        HL7Exception.DATA_TYPE_ERROR, errorInHL7Queue);
 				}
 			}
 

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -1113,7 +1113,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service, Re
 			}
 
 			//resolve the appropriate month folder
-			File monthDir = new File(yearDir, df.format(calendar.get(Calendar.MONTH) + 1));
+			File monthDir = new File(yearDir, df.format((long) calendar.get(Calendar.MONTH) + 1));
 			if (!monthDir.isDirectory()) {
 				monthDir.mkdirs();
 			}

--- a/api/src/main/java/org/openmrs/layout/name/NameSupport.java
+++ b/api/src/main/java/org/openmrs/layout/name/NameSupport.java
@@ -11,6 +11,7 @@ package org.openmrs.layout.name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -80,7 +81,7 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 		List<NameTemplate> list = new ArrayList<>();
 		// filter out unaffected templates to keep
 		list.addAll(getLayoutTemplates().stream()
-		        .filter(existingTemplate -> existingTemplate.getCodeName() != nameTemplate.getCodeName())
+		        .filter(existingTemplate -> !Objects.equals(existingTemplate.getCodeName(), nameTemplate.getCodeName()))
 		        .collect(Collectors.toList()));
 		list.add(nameTemplate);
 		setLayoutTemplates(list);

--- a/api/src/main/java/org/openmrs/logic/result/Result.java
+++ b/api/src/main/java/org/openmrs/logic/result/Result.java
@@ -83,7 +83,15 @@ public class Result extends ArrayList<Result> {
 
 	private Object resultObject;
 
-	private static final Result emptyResult = new EmptyResult();
+	/**
+	 * Lazily-initialized holder for the shared empty result. Using a holder class avoids the parent
+	 * {@link Result} class referencing its {@link EmptyResult} subclass during its own static
+	 * initialization.
+	 */
+	private static final class EmptyResultHolder {
+
+		private static final Result INSTANCE = new EmptyResult();
+	}
 
 	public Result() {
 	}
@@ -300,7 +308,7 @@ public class Result extends ArrayList<Result> {
 	 * @return null/empty result
 	 */
 	public static final Result emptyResult() {
-		return emptyResult;
+		return EmptyResultHolder.INSTANCE;
 	}
 
 	/**
@@ -589,7 +597,7 @@ public class Result extends ArrayList<Result> {
 				case CODED:
 					return 0D;
 				case DATETIME:
-					return (valueDatetime == null ? 0 : Long.valueOf(valueDatetime.getTime()).doubleValue());
+					return (valueDatetime == null ? 0D : (double) valueDatetime.getTime());
 				case NUMERIC:
 					return (valueNumeric == null ? 0D : valueNumeric);
 				case TEXT:
@@ -696,7 +704,7 @@ public class Result extends ArrayList<Result> {
 	public Result gt(Integer value) {
 		if (isSingleResult()) {
 			if (valueNumeric == null || valueNumeric <= value) {
-				return emptyResult;
+				return emptyResult();
 			}
 			return this;
 		}
@@ -707,7 +715,7 @@ public class Result extends ArrayList<Result> {
 			}
 		}
 		if (matches.size() < 1) {
-			return emptyResult;
+			return emptyResult();
 		}
 		return new Result(matches);
 	}
@@ -838,11 +846,11 @@ public class Result extends ArrayList<Result> {
 	@Override
 	public Result get(int index) {
 		if (isSingleResult()) {
-			return (index == 0 ? this : emptyResult);
+			return (index == 0 ? this : emptyResult());
 		}
 
 		if (index >= this.size()) {
-			return emptyResult;
+			return emptyResult();
 		}
 		return super.get(index);
 	}

--- a/api/src/main/java/org/openmrs/migration/MigrationHelper.java
+++ b/api/src/main/java/org/openmrs/migration/MigrationHelper.java
@@ -11,6 +11,7 @@ package org.openmrs.migration;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.security.SecureRandom;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -74,6 +75,8 @@ public class MigrationHelper {
 
 	private static final Logger log = LoggerFactory.getLogger(MigrationHelper.class);
 
+	private static final SecureRandom RANDOM = new SecureRandom();
+
 	static DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 
 	/**
@@ -126,7 +129,7 @@ public class MigrationHelper {
 	@Deprecated
 	public static int importUsers(Document document) throws ParseException {
 		int ret = 0;
-		Random rand = new Random();
+		Random rand = RANDOM;
 		UserService us = Context.getUserService();
 
 		List<Node> toAdd = new ArrayList<>();
@@ -213,7 +216,7 @@ public class MigrationHelper {
 		UserService us = Context.getUserService();
 		PersonService personService = Context.getPersonService();
 		List<Relationship> relsToAdd = new ArrayList<>();
-		Random rand = new Random();
+		Random rand = RANDOM;
 		for (String s : relationships) {
 			if (s.contains(":")) {
 				s = s.substring(s.indexOf(":") + 1);

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -230,7 +230,9 @@ public class ModuleClassLoader extends URLClassLoader {
 
 			if (!tmpModuleJar.exists()) {
 				try {
-					tmpModuleJar.createNewFile();
+					if (!tmpModuleJar.createNewFile()) {
+						log.warn("Unable to create tmpModuleFile at {}", tmpModuleJar.getAbsolutePath());
+					}
 				} catch (IOException io) {
 					log.warn("Unable to create tmpModuleFile", io);
 				}
@@ -462,7 +464,9 @@ public class ModuleClassLoader extends URLClassLoader {
 					String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						tmpModuleDir.delete();
+						if (!tmpModuleDir.delete()) {
+							log.warn("Unable to delete module cache directory {}", tmpModuleDir.getAbsolutePath());
+						}
 					}
 				} catch (IOException | NumberFormatException e) {
 					log.warn("Error while reading module last modified file: {}", moduleLastModifiedFile, e);
@@ -470,7 +474,9 @@ public class ModuleClassLoader extends URLClassLoader {
 			} else {
 				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 				    tmpModuleDir);
-				tmpModuleDir.delete();
+				if (!tmpModuleDir.delete()) {
+					log.warn("Unable to delete module cache directory {}", tmpModuleDir.getAbsolutePath());
+				}
 			}
 
 			tmpModuleDir.mkdirs();

--- a/api/src/main/java/org/openmrs/module/ModuleFactory.java
+++ b/api/src/main/java/org/openmrs/module/ModuleFactory.java
@@ -1444,7 +1444,9 @@ public class ModuleFactory {
 			return newModule;
 		} catch (Exception e) {
 			log.warn("Error while unloading old module and loading in new module");
-			moduleFile.delete();
+			if (!moduleFile.delete()) {
+				log.warn("Unable to delete module file at {}", moduleFile.getAbsolutePath());
+			}
 			return mod;
 		}
 

--- a/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsUtil.java
@@ -30,6 +30,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -123,6 +124,8 @@ public class OpenmrsUtil {
 	private static volatile MimetypesFileTypeMap mimetypesFileTypeMap = null;
 
 	private static org.slf4j.Logger log = LoggerFactory.getLogger(OpenmrsUtil.class);
+
+	private static final Random RANDOM = new Random();
 
 	private static Map<Locale, SimpleDateFormat> dateFormatCache = new HashMap<>();
 
@@ -238,22 +241,10 @@ public class OpenmrsUtil {
 	 * @throws IOException
 	 */
 	public static byte[] getFileAsBytes(File file) throws IOException {
-		FileInputStream fileInputStream = null;
 		try {
-			fileInputStream = new FileInputStream(file);
-			byte[] b = new byte[fileInputStream.available()];
-			fileInputStream.read(b);
-			return b;
-		} catch (Exception e) {
+			return Files.readAllBytes(file.toPath());
+		} catch (IOException e) {
 			log.error("Unable to get file as byte array", e);
-		} finally {
-			if (fileInputStream != null) {
-				try {
-					fileInputStream.close();
-				} catch (IOException io) {
-					log.warn("Couldn't close fileInputStream: " + io);
-				}
-			}
 		}
 
 		return null;
@@ -1484,7 +1475,7 @@ public class OpenmrsUtil {
 	 * @return file new file that is able to be written to
 	 */
 	public static File getOutFile(File dir, Date date, User user) {
-		Random gen = new Random();
+		Random gen = RANDOM;
 		File outFile;
 		do {
 			// format to print date in filename
@@ -1527,7 +1518,7 @@ public class OpenmrsUtil {
 	 * @return unique string
 	 */
 	public static String generateUid(Integer size) {
-		Random gen = new Random();
+		Random gen = RANDOM;
 		StringBuilder sb = new StringBuilder(size);
 		for (int i = 0; i < size; i++) {
 			int ch = gen.nextInt() * 62;

--- a/api/src/main/java/org/openmrs/util/ThreadSafeCircularFifoQueue.java
+++ b/api/src/main/java/org/openmrs/util/ThreadSafeCircularFifoQueue.java
@@ -852,7 +852,7 @@ public class ThreadSafeCircularFifoQueue<E> extends AbstractQueue<E> implements 
 		private void updateIndices() {
 			final int cycles = ThreadSafeCircularFifoQueue.this.iterators.cycles;
 			if (cycles != prevCycles || read != prevRead) {
-				long dequeues = (cycles - prevCycles) * maxElements + (read - prevRead);
+				long dequeues = (long) (cycles - prevCycles) * maxElements + (read - prevRead);
 
 				if (indexInvalidated(prevIndex, dequeues)) {
 					prevIndex = NONE;

--- a/liquibase/src/main/java/org/openmrs/liquibase/AbstractSnapshotTuner.java
+++ b/liquibase/src/main/java/org/openmrs/liquibase/AbstractSnapshotTuner.java
@@ -112,7 +112,9 @@ public abstract class AbstractSnapshotTuner {
 		File file = Paths.get(path).toFile();
 		if (file.exists() && file.isFile()) {
 			log.info("Deleting updated file from previous run: '{}'...", path);
-			file.delete();
+			if (!file.delete()) {
+				log.warn("Unable to delete file from previous run: '{}'", path);
+			}
 		}
 	}
 

--- a/web/src/main/java/org/openmrs/module/web/ModuleResourcesServlet.java
+++ b/web/src/main/java/org/openmrs/module/web/ModuleResourcesServlet.java
@@ -61,7 +61,7 @@ public class ModuleResourcesServlet extends HttpServlet {
 		}
 
 		response.setDateHeader("Last-Modified", f.lastModified());
-		response.setContentLength(Long.valueOf(f.length()).intValue());
+		response.setContentLength((int) f.length());
 		String mimeType = getServletContext().getMimeType(f.getName());
 		response.setContentType(mimeType);
 

--- a/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
+++ b/web/src/main/java/org/openmrs/module/web/ModuleServlet.java
@@ -48,7 +48,7 @@ public class ModuleServlet extends HttpServlet {
 
 		// where in the path to start trimming
 		int start = 1;
-		if (mod != null) {
+		if (mod != null && moduleId != null) {
 			log.debug("Module with id " + moduleId + " found.  Looking for servlet name after " + moduleId + " in url path");
 			start = moduleId.length() + 2;
 			// this skips over the moduleId that is in the path

--- a/web/src/main/java/org/openmrs/web/Listener.java
+++ b/web/src/main/java/org/openmrs/web/Listener.java
@@ -430,7 +430,9 @@ public final class Listener extends ContextLoader implements ServletContextListe
 			// got here because the dwr-modules.xml file is empty for some reason.  This might
 			// happen because the servlet container (i.e. tomcat) crashes when first loading this file
 			log.debug("Error clearing dwr-modules.xml", e);
-			dwrFile.delete();
+			if (!dwrFile.delete()) {
+				log.warn("Unable to delete dwr-modules.xml at {}", dwrFile.getAbsolutePath());
+			}
 
 			OutputStreamWriter writer = null;
 			try {

--- a/web/src/main/java/org/openmrs/web/WebDaemon.java
+++ b/web/src/main/java/org/openmrs/web/WebDaemon.java
@@ -45,7 +45,9 @@ public final class WebDaemon {
 					throw new ModuleException("Unable to start OpenMRS. Error thrown was: " + e.getMessage(), e);
 				}
 			}).get();
-		} catch (InterruptedException ignored) {} catch (ExecutionException e) {
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		} catch (ExecutionException e) {
 			Throwable cause = e.getCause();
 			if (cause instanceof DatabaseUpdateException) {
 				throw (DatabaseUpdateException) cause;

--- a/web/src/main/java/org/openmrs/web/WebUtil.java
+++ b/web/src/main/java/org/openmrs/web/WebUtil.java
@@ -408,7 +408,7 @@ public class WebUtil implements GlobalPropertyListener {
 				dateFormat = new OpenmrsDateFormat(new SimpleDateFormat(formatValue), locale);
 			}
 		}
-		return date == null ? "" : dateFormat.format(date);
+		return (date == null || dateFormat == null) ? "" : dateFormat.format(date);
 	}
 
 	/**

--- a/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
@@ -76,8 +76,7 @@ public class DatabaseDetective {
 					connection.close();
 				}
 			} catch (Exception e) {
-				// consider the database to be empty
-				return true;
+				// ignore failure to close the connection
 			}
 		}
 	}

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -95,6 +95,8 @@ import static org.openmrs.web.filter.initialization.InitializationWizardModel.DE
 public class InitializationFilter extends StartupFilter {
 
 	private static final org.slf4j.Logger log = LoggerFactory.getLogger(InitializationFilter.class);
+
+	private static final SecureRandom RANDOM = new SecureRandom();
 
 	private static final String DATABASE_POSTGRESQL = "postgresql";
 
@@ -285,7 +287,9 @@ public class InitializationFilter extends StartupFilter {
 
 			if (!runtimeProperties.exists()) {
 				try {
-					runtimeProperties.createNewFile();
+					if (!runtimeProperties.createNewFile()) {
+						log.warn("Unable to create runtime properties file at {}", runtimeProperties.getAbsolutePath());
+					}
 					// reset the error objects in case of refresh
 					wizardModel.canCreate = true;
 					wizardModel.cannotCreateErrorMessage = "";
@@ -300,7 +304,10 @@ public class InitializationFilter extends StartupFilter {
 				// delete the file again after testing the create/write
 				// so that if the user stops the webapp before finishing
 				// this wizard, they can still get back into it
-				runtimeProperties.delete();
+				if (!runtimeProperties.delete()) {
+					log.warn("Unable to delete temporary runtime properties file at {}",
+					    runtimeProperties.getAbsolutePath());
+				}
 
 			} else {
 				wizardModel.canWrite = runtimeProperties.canWrite();
@@ -448,7 +455,9 @@ public class InitializationFilter extends StartupFilter {
 			File runtimeProperties = getRuntimePropertiesFile();
 			if (!runtimeProperties.exists()) {
 				try {
-					runtimeProperties.createNewFile();
+					if (!runtimeProperties.createNewFile()) {
+						log.warn("Unable to create runtime properties file at {}", runtimeProperties.getAbsolutePath());
+					}
 					// reset the error objects in case of refresh
 					wizardModel.canCreate = true;
 					wizardModel.cannotCreateErrorMessage = "";
@@ -462,7 +471,10 @@ public class InitializationFilter extends StartupFilter {
 				// delete the file again after testing the create/write
 				// so that if the user stops the webapp before finishing
 				// this wizard, they can still get back into it
-				runtimeProperties.delete();
+				if (!runtimeProperties.delete()) {
+					log.warn("Unable to delete temporary runtime properties file at {}",
+					    runtimeProperties.getAbsolutePath());
+				}
 			} else {
 				wizardModel.canWrite = runtimeProperties.canWrite();
 
@@ -1107,7 +1119,7 @@ public class InitializationFilter extends StartupFilter {
 	/**
 	 * @return true if installation has been started
 	 */
-	public static boolean isInstallationStarted() {
+	public static synchronized boolean isInstallationStarted() {
 		return isInstallationStarted;
 	}
 
@@ -1160,8 +1172,8 @@ public class InitializationFilter extends StartupFilter {
 			IOUtils.closeQuietly(in);
 			IOUtils.closeQuietly(fileOut);
 
-			if (tempFile != null) {
-				tempFile.delete();
+			if (tempFile != null && !tempFile.delete()) {
+				log.warn("Unable to delete temporary test data file at {}", tempFile.getAbsolutePath());
 			}
 		}
 	}
@@ -1324,7 +1336,10 @@ public class InitializationFilter extends StartupFilter {
 		public void waitForCompletion() {
 			try {
 				future.get();
-			} catch (InterruptedException | ExecutionException e) {
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new RuntimeException(e);
+			} catch (ExecutionException e) {
 				throw new RuntimeException(e);
 			}
 		}
@@ -1455,10 +1470,9 @@ public class InitializationFilter extends StartupFilter {
 							// generate random password from this subset of alphabet
 							// intentionally left out these characters: ufsb$() to prevent certain words forming randomly
 							String chars = "acdeghijklmnopqrtvwxyzACDEGHIJKLMNOPQRTVWXYZ0123456789.|~@#^&";
-							Random r = new Random();
 							StringBuilder randomStr = new StringBuilder("");
 							for (int x = 0; x < 12; x++) {
-								randomStr.append(chars.charAt(r.nextInt(chars.length())));
+								randomStr.append(chars.charAt(RANDOM.nextInt(chars.length())));
 							}
 							connectionPassword.append(randomStr);
 

--- a/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/TestInstallUtil.java
@@ -118,6 +118,7 @@ public class TestInstallUtil {
 		} catch (IOException e) {
 			log.error("Failed to create the sql dump", e);
 		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			log.error("The back up was interrupted while adding test data", e);
 		}
 
@@ -207,8 +208,8 @@ public class TestInstallUtil {
 					log.error("Failed to close zip file: ", e);
 				}
 			}
-			if (tempFile != null) {
-				tempFile.delete();
+			if (tempFile != null && !tempFile.delete()) {
+				log.warn("Unable to delete temporary file at {}", tempFile.getAbsolutePath());
 			}
 		}
 

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -201,6 +201,7 @@ public class UpdateFilter extends StartupFilter {
 					log.debug("Sleeping for 3 seconds because of a bad username/password");
 					Thread.sleep(3000);
 				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
 					log.error("Unable to sleep", e);
 					throw new ServletException("Got interrupted while trying to sleep thread", e);
 				}
@@ -553,7 +554,7 @@ public class UpdateFilter extends StartupFilter {
 	 * liquibasechangeloglock table by another user, when he also tries to run database update when
 	 * another user is currently running it
 	 */
-	public static Boolean isLockReleased() {
+	public static synchronized Boolean isLockReleased() {
 		return lockReleased;
 	}
 


### PR DESCRIPTION
## Description

The SonarCloud quality gate on `master` is failing with a **Reliability Rating of D on new code** (required ≥ A). This PR fixes the legitimate Java reliability issues driving that rating.

### Fixed

| Rule | Count | Fix |
|------|-------|-----|
| `S2142` | 16 | Re-interrupt the thread (`Thread.currentThread().interrupt()`) when catching `InterruptedException` |
| `S899` | 12 | Act on (log) the boolean returned by `File.delete()` / `createNewFile()` |
| `S2119` | 5 | Reuse a single `Random`/`SecureRandom`; use `SecureRandom` for password generation |
| `S2201` | 6 | Replace the unused `Collection.size()` lazy-init trick with `Hibernate.initialize(...)` |
| `S1143` | 2 | Remove `throw`/`return` from `finally` blocks (`ORUR01Handler`, `DatabaseDetective`) |
| `S2390` | 1 | Break the `Result` → `EmptyResult` static-init cycle with a lazy holder |
| `S2153` `S2184` `S4973` `S2674` `S2886` `S2259` | 9 | Assorted boxing / int-overflow / String comparison / unchecked-read / synchronization / possible-NPE fixes |

The `DatabaseDetective` change is a genuine behavioural fix: a `return` inside a `finally` could report a **populated** database as empty when closing the connection threw.

### Intentionally not changed (need SonarCloud "won't fix")

- **`S1872` (7):** all compare `Class` objects or test-class **names** that are not on the production classpath (e.g. `"org.openmrs.api.db.UserDAOTest"`), so `instanceof` cannot be used without weakening security caller-checks.
- **`S2276` (`UpdateFilter`):** the `Thread.sleep` in a `synchronized` method is a deliberate anti-brute-force delay.
- **plsql BLOCKER:** lives in the historical `update-to-1.4.2.01-db.mysqldiff.sql` migration, which must not be edited.

> Note: many flagged files are old (docs `package.html`, legacy SQL/CSS/JS), which suggests the SonarCloud **new-code-period baseline** was reset and is scoring pre-existing code as "new". That baseline (and the won't-fix items above) likely needs an admin adjustment in SonarCloud for the gate to fully go green.

## Testing

`mvn -pl liquibase,api,web -am compile` → BUILD SUCCESS.
Targeted tests pass: `ResultTest`, `OpenmrsUtilTest`, `ORUR01HandlerTest`, `UserContextTest`, `ContextTest`, `ContextDAOTest` (177 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)