### PR TITLE
Fix Hibernate 7.4 dropping primary key on order_type_class_map join table

### DIFF
--- a/api/src/main/java/org/openmrs/OrderType.java
+++ b/api/src/main/java/org/openmrs/OrderType.java
@@ -23,7 +23,6 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.envers.Audited;
@@ -60,10 +59,14 @@ public class OrderType extends BaseChangeableOpenmrsMetadata {
 	@JoinColumn(name = "parent")
 	private OrderType parent;
 
+	// Don't declare uniqueConstraints on this join table. As of Hibernate 7.4, an explicit unique
+	// constraint covering the join columns is emitted in place of the composite primary key, and
+	// dbUnit's REFRESH (against the integration tests' hbm2ddl-generated schema) needs that primary
+	// key to update existing rows. Leaving it off lets hbm2ddl generate the primary key; production
+	// gets its primary key from Liquibase regardless.
 	@Independent
 	@ManyToMany
-	@JoinTable(name = "order_type_class_map", joinColumns = @JoinColumn(name = "order_type_id"), inverseJoinColumns = @JoinColumn(name = "concept_class_id"), uniqueConstraints = @UniqueConstraint(columnNames = {
-	        "order_type_id", "concept_class_id" }))
+	@JoinTable(name = "order_type_class_map", joinColumns = @JoinColumn(name = "order_type_id"), inverseJoinColumns = @JoinColumn(name = "concept_class_id"))
 	private Set<ConceptClass> conceptClasses;
 
 	/**


### PR DESCRIPTION
## Summary

Prepares the codebase for the Hibernate 7.4 upgrade (#6130). On Hibernate 7.4, the integration-test job fails with `org.dbunit.dataset.NoPrimaryKeyException: ORDER_TYPE_CLASS_MAP` (97 errors across many ITs).

## Root cause

The test harness builds the in-memory H2 schema from Hibernate's hbm2ddl, and dbUnit's `REFRESH` operation needs a primary key to update existing rows. In Hibernate **7.4**, when a `@JoinTable`'s explicit `@UniqueConstraint` covers exactly the columns that would form the join table's composite primary key, Hibernate emits the *unique constraint instead of* the primary key.

`OrderType.conceptClasses` was the only `@ManyToMany` Set declaring such a redundant `@UniqueConstraint`, so its `order_type_class_map` join table lost its primary key (`user_role` and `location_tag_map`, which have no explicit unique constraint, kept theirs).

## Fix

Remove the redundant `@UniqueConstraint`. The two FK columns are the natural key of a `Set` join table, so hbm2ddl generates the composite primary key automatically again — matching the production schema, which already defines that PK via Liquibase (`liquibase-update-to-latest-2.0.x.xml`). The annotation's `uniqueConstraints` only ever affected hbm2ddl-generated DDL, so **production is unaffected** and the change is harmless on the current Hibernate 7.3.6 too.

## Testing

Locally bumped Hibernate to 7.4.0 and reran the affected tests:

- **Before:** `ConceptIT`, `ModuleUtilIT`, `SchedulerServiceIT`, `S3StorageServiceIT`, `Database1_9_7UpgradeIT` → 97 errors.
- **After:** all green, including `ValidateHibernateMappingsDatabaseIT` (mapping-vs-schema validation) and the 238 `OrderServiceTest` / `OrderTypeTest` cases.

Once this merges, Dependabot PR #6130 will rebase and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)