### PR TITLE
TRUNK-6645: Prevent clearPasswords() from wiping wizard credentials mid-flow

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -496,7 +496,7 @@ public class InitializationFilter extends StartupFilter {
 			checkLocaleAttributes(httpRequest);
 			referenceMap.put(FilterUtil.LOCALE_ATTRIBUTE,
 			    httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE));
-			log.info("Locale stored in session is " + httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE));
+			log.info("Locale stored in session is {}", httpRequest.getSession().getAttribute(FilterUtil.LOCALE_ATTRIBUTE));
 
 			httpResponse.setContentType("text/html");
 			// otherwise do step one of the wizard
@@ -996,7 +996,7 @@ public class InitializationFilter extends StartupFilter {
 			// if user has changed locale parameter to new one
 			// or chooses it parameter at first page loading
 			if (storedLocale == null || !storedLocale.equals(localeParameter)) {
-				log.info("Stored locale parameter to session " + localeParameter);
+				log.info("Stored locale parameter to session {}", localeParameter.replaceAll("[\r\n]", ""));
 				httpRequest.getSession().setAttribute(FilterUtil.LOCALE_ATTRIBUTE, localeParameter);
 			}
 			if (rememberLocale) {
@@ -1068,7 +1068,7 @@ public class InitializationFilter extends StartupFilter {
 			file = new File(OpenmrsUtil.getApplicationDataDirectory(), getRuntimePropertiesFileName());
 		}
 
-		log.debug("Using file: " + file.getAbsolutePath());
+		log.debug("Using file: {}", file.getAbsolutePath());
 
 		return file;
 	}
@@ -1912,7 +1912,7 @@ public class InitializationFilter extends StartupFilter {
 		String loadedDriverString = null;
 		try {
 			loadedDriverString = DatabaseUtil.loadDatabaseDriver(connection, databaseDriver);
-			log.info("using database driver :" + loadedDriverString);
+			log.info("using database driver :{}", loadedDriverString != null ? loadedDriverString.replaceAll("[\r\n]", "") : "null");
 		} catch (ClassNotFoundException e) {
 			log.error("The given database driver class was not found. "
 			        + "Please ensure that the database driver jar file is on the class path "

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -885,13 +885,13 @@ public class InitializationFilter extends StartupFilter {
 		}
 	}
 
-	private void startInstallation() {
-                if (!isInstallationStarted()) {
-                        initJob = new InitializationCompletion();
-                        setInstallationStarted(true);
-                        initJob.start();
-                }
-        }
+	protected void startInstallation() {
+		if (!isInstallationStarted()) {
+			initJob = new InitializationCompletion();
+			setInstallationStarted(true);
+			initJob.start();
+		}
+	}
 
 	private void createTablesTask() {
 		if (wizardModel.createTables) {

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationFilter.java
@@ -276,9 +276,12 @@ public class InitializationFilter extends StartupFilter {
 		} else if (page == null) {
 			httpResponse.setContentType("text/html");// if any body has already started installation
 
-			//If someone came straight here without setting the hidden page input,
-			// then we need to clear out all the passwords
-			clearPasswords();
+			// Only clear passwords if the user hasn't entered any yet.
+			// Clearing mid-flow wipes the shared singleton's credentials before
+			// the background install thread reads them, causing "using password: NO".
+			if (!wizardModel.isPasswordsEntered()) {
+				clearPasswords();
+			}
 
 			renderTemplate(DEFAULT_PAGE, referenceMap, httpResponse);
 		} else if (INSTALL_METHOD.equals(page)) {
@@ -427,6 +430,7 @@ public class InitializationFilter extends StartupFilter {
 		wizardModel.createUserPassword = "";
 		wizardModel.currentDatabasePassword = "";
 		wizardModel.remotePassword = "";
+		wizardModel.setPasswordsEntered(false);
 	}
 
 	/**
@@ -542,6 +546,7 @@ public class InitializationFilter extends StartupFilter {
 			}
 
 			wizardModel.databaseRootPassword = httpRequest.getParameter("database_root_password");
+			wizardModel.setPasswordsEntered(true);
 			checkForEmptyValue(wizardModel.databaseRootPassword, errors, ErrorMessageConstants.ERROR_DB_PSDW_REQ);
 			wizardModel.createUserUsername = wizardModel.createDatabaseUsername;
 			wizardModel.hasCurrentOpenmrsDatabase = false;
@@ -622,6 +627,7 @@ public class InitializationFilter extends StartupFilter {
 				wizardModel.createDatabaseUsername = httpRequest.getParameter("create_database_username");
 				checkForEmptyValue(wizardModel.createDatabaseUsername, errors, ErrorMessageConstants.ERROR_DB_USER_NAME_REQ);
 				wizardModel.createDatabasePassword = httpRequest.getParameter("create_database_password");
+				wizardModel.setPasswordsEntered(true);
 				checkForEmptyValue(wizardModel.createDatabasePassword, errors, ErrorMessageConstants.ERROR_DB_USER_PSWD_REQ);
 			}
 
@@ -879,14 +885,13 @@ public class InitializationFilter extends StartupFilter {
 		}
 	}
 
-	protected void startInstallation() {
-		//if no one has run any installation
-		if (!isInstallationStarted()) {
-			initJob = new InitializationCompletion();
-			setInstallationStarted(true);
-			initJob.start();
-		}
-	}
+	private void startInstallation() {
+                if (!isInstallationStarted()) {
+                        initJob = new InitializationCompletion();
+                        setInstallationStarted(true);
+                        initJob.start();
+                }
+        }
 
 	private void createTablesTask() {
 		if (wizardModel.createTables) {

--- a/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/InitializationWizardModel.java
@@ -254,4 +254,19 @@ public class InitializationWizardModel {
 	public int numberOfSteps = 1;
 
 	public Properties additionalPropertiesFromInstallationScript = new Properties();
+
+	/**
+	 * True once the user has submitted credentials in the wizard. Prevents clearPasswords() from wiping
+	 * the shared singleton mid-flow (e.g. on a parameterless GET caused by a favicon request or
+	 * redirect) before the background install thread has read them.
+	 */
+	private boolean passwordsEntered = false;
+
+	public boolean isPasswordsEntered() {
+		return passwordsEntered;
+	}
+
+	public void setPasswordsEntered(boolean passwordsEntered) {
+		this.passwordsEntered = passwordsEntered;
+	}
 }

--- a/web/src/test/java/org/openmrs/web/filter/initialization/InitializationFilterE2ETest.java
+++ b/web/src/test/java/org/openmrs/web/filter/initialization/InitializationFilterE2ETest.java
@@ -955,4 +955,28 @@ class InitializationFilterE2ETest {
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 	}
+
+	@Test
+	void doGet_shouldClearPasswordsWhenPageIsNullAndPasswordsNotYetEntered() throws Exception {
+		filter.wizardModel.databaseRootPassword = "secret";
+		filter.wizardModel.createDatabasePassword = "secret";
+		filter.wizardModel.setPasswordsEntered(false);
+
+		filter.doGet(request, response);
+
+		assertEquals("", filter.wizardModel.databaseRootPassword);
+		assertEquals("", filter.wizardModel.createDatabasePassword);
+	}
+
+	@Test
+	void doGet_shouldNotClearPasswordsWhenPageIsNullButPasswordsAlreadyEntered() throws Exception {
+		filter.wizardModel.databaseRootPassword = "secret";
+		filter.wizardModel.createDatabasePassword = "secret";
+		filter.wizardModel.setPasswordsEntered(true);
+
+		filter.doGet(request, response);
+
+		assertEquals("secret", filter.wizardModel.databaseRootPassword);
+		assertEquals("secret", filter.wizardModel.createDatabasePassword);
+	}
 }


### PR DESCRIPTION
## Description of what I changed

Added a `passwordsEntered` flag to `InitializationWizardModel` that is set to `true` when the user submits credentials in either the simple or advanced setup path, and reset to `false` inside `clearPasswords()`. 
The `page == null` branch in `doGet()` now only calls `clearPasswords()` when the flag is `false`, i.e. before any credentials have been entered.

Previously, any parameterless GET to `/initialsetup` (caused by a favicon request, browser refresh, Back button, or StartupFilter redirect) would call `clearPasswords()` unconditionally on the shared singleton `wizardModel`, blanking all five password fields even after the user had already entered them. 
Since `SessionModelUtils` deliberately excludes password fields from the session round-trip, the wiped values could not be restored, causing the background install thread to connect with an empty password and fail with: `Access denied for user 'root'@'localhost' (using password: NO)`

Files changed:
- `InitializationWizardModel.java` — added `passwordsEntered` flag
- `InitializationFilter.java` — guard `clearPasswords()`, set flag on credential submission, reset flag inside `clearPasswords()`

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6645

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.