### PR TITLE
TRUNK-6644: Fix footer hiding continue button on displays shorter than 850px

### DIFF
--- a/web/src/main/resources/org/openmrs/web/filter/footer.vm
+++ b/web/src/main/resources/org/openmrs/web/filter/footer.vm
@@ -90,7 +90,7 @@
         box-shadow: 0 2px 4px rgba(0,0,0,0.05);
         margin-bottom: 20px;
         overflow-y: auto;
-        max-height: calc(100vh - 180px);
+        max-height: calc(100vh - 200px);
     }
 
     @media (max-width: 768px) {
@@ -110,6 +110,16 @@
         .content-container {
             margin: 1rem;
             max-height: calc(100vh - 200px);
+        }
+    }
+
+    @media (max-height: 850px) {
+        body {
+            padding-bottom: 140px;
+        }
+        .content-container {
+            max-height: calc(100vh - 220px);
+            overflow-y: auto;
         }
     }
 </style>


### PR DESCRIPTION
## What was changed
Updated `footer.vm` to prevent the fixed footer from overlapping the Continue button during the initial setup wizard on displays with a viewport height smaller than 850px.

## Why this PR exists
On displays shorter than 850px in height, the fixed-position footer was rendering on top of the Continue/submit button in the setup wizard, making it impossible for users to proceed through the initial setup.

## How it was done
- Updated `max-height` on `.content-container` from `calc(100vh - 180px)` to `calc(100vh - 200px)` to create more clearance from the footer
- Added a new `@media (max-height: 850px)` query that increases `padding-bottom` on the body and further reduces the `max-height` of `.content-container` to `calc(100vh - 220px)`, ensuring the content area always remains scrollable and fully above the fixed footer.