### PR TITLE
TRUNK-6558 Return null from getTaskByName when the task does not exist

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/jobrunr/JobRunrSchedulerService.java
+++ b/api/src/main/java/org/openmrs/scheduler/jobrunr/JobRunrSchedulerService.java
@@ -54,6 +54,7 @@ import org.openmrs.scheduler.db.SchedulerDAO;
 import org.openmrs.util.PrivilegeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.orm.ObjectRetrievalFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -236,7 +237,12 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public TaskDefinition getTaskByName(String name) {
-		return schedulerDAO.getTaskByName(name);
+		try {
+			return schedulerDAO.getTaskByName(name);
+		} catch (ObjectRetrievalFailureException e) {
+			log.warn("getTaskByName({}) failed, because: {}", name, e.toString());
+			return null;
+		}
 	}
 
 	@Override

--- a/api/src/test/java/org/openmrs/scheduler/SchedulerServiceIT.java
+++ b/api/src/test/java/org/openmrs/scheduler/SchedulerServiceIT.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -183,6 +184,11 @@ public class SchedulerServiceIT extends BaseContextSensitiveNonTransactionalTest
 		schedulerService.deleteTask(id);
 
 		assertThrows(ObjectRetrievalFailureException.class, () -> schedulerService.getTask(id));
+	}
+
+	@Test
+	void getTaskByName_shouldReturnNullWhenTaskDoesNotExist() {
+		assertNull(schedulerService.getTaskByName("Task That Was Never Registered"));
 	}
 
 	@Test


### PR DESCRIPTION
## Description

`JobRunrSchedulerService.getTaskByName` propagates the DAO's `ObjectRetrievalFailureException` when no task matches the given name, breaking the long-standing `SchedulerService` contract: the pre-JobRunr `TimerSchedulerServiceImpl` caught the exception and returned `null`.

Modules that probe for their task before registering it — the common activator pattern:

```java
TaskDefinition existing = schedulerService.getTaskByName(TASK_NAME);
if (existing == null) {
    // register the task
}
```

now fail to start on any fresh database, because the exception thrown during `Activator.started()` cancels the Spring context refresh and unloads all modules.

This restores the historical behavior: catch `ObjectRetrievalFailureException`, log a warning, and return `null` — matching the removed `TimerSchedulerServiceImpl` implementation.

Master equivalent of #6162 (same fix against the 2.9.x branch).

## Testing

- Added `SchedulerServiceIT.getTaskByName_shouldReturnNullWhenTaskDoesNotExist` (fails with `ObjectRetrievalFailureException` before the fix, passes after).
- Full `SchedulerServiceIT` suite passes (22 tests).
- Verified end-to-end on a Reference Application 3.7.0-SNAPSHOT standalone with a fresh demo database: module activators that call `getTaskByName` for a not-yet-registered task now start cleanly.

## Related Issue

Follow-up to TRUNK-6558 (SchedulerService JobRunr upgrade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)