### PR TITLE
Add provider role name lookup

### DIFF
--- a/api/src/main/java/org/openmrs/api/ProviderService.java
+++ b/api/src/main/java/org/openmrs/api/ProviderService.java
@@ -405,6 +405,19 @@ public interface ProviderService extends OpenmrsService {
 	ProviderRole getProviderRoleByUuid(String uuid);
 
 	/**
+	 * Get a {@link ProviderRole} by its exact name.
+	 * <p>
+	 * <strong>Should</strong> find provider role by name<br/>
+	 * <strong>Should</strong> return null if provider role is not found
+	 *
+	 * @param name The ProviderRole name
+	 * @return {@link ProviderRole}
+	 * @since 3.0.0
+	 */
+	@Authorized({ PrivilegeConstants.GET_PROVIDER_ROLES })
+	ProviderRole getProviderRoleByName(String name);
+
+	/**
 	 * Get providers for given roles
 	 *
 	 * @param roles The list of {@link ProviderRole}

--- a/api/src/main/java/org/openmrs/api/db/ProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/ProviderDAO.java
@@ -143,6 +143,11 @@ public interface ProviderDAO {
 	ProviderRole getProviderRoleByUuid(String uuid);
 
 	/**
+	 * @see ProviderService#getProviderRoleByName(String)
+	 */
+	ProviderRole getProviderRoleByName(String name);
+
+	/**
 	 * @see ProviderService#getProvidersByRoles(List)
 	 */
 	List<Provider> getProvidersByRoles(List<ProviderRole> roles, boolean includeRetired);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -412,6 +412,21 @@ public class HibernateProviderDAO implements ProviderDAO {
 	}
 
 	/**
+	 * @see org.openmrs.api.db.ProviderDAO#getProviderRoleByName(String)
+	 */
+	@Override
+	public ProviderRole getProviderRoleByName(String name) {
+		Session session = sessionFactory.getCurrentSession();
+		CriteriaBuilder cb = session.getCriteriaBuilder();
+		CriteriaQuery<ProviderRole> cq = cb.createQuery(ProviderRole.class);
+		Root<ProviderRole> root = cq.from(ProviderRole.class);
+
+		cq.where(cb.equal(root.get("name"), name));
+
+		return session.createQuery(cq).uniqueResult();
+	}
+
+	/**
 	 * @see ProviderDAO#getProvidersByRoles(List, boolean)
 	 */
 	@Override

--- a/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ProviderServiceImpl.java
@@ -330,6 +330,15 @@ public class ProviderServiceImpl extends BaseOpenmrsService implements ProviderS
 	}
 
 	/**
+	 * @see ProviderService#getProviderRoleByName(String)
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public ProviderRole getProviderRoleByName(String name) {
+		return dao.getProviderRoleByName(name);
+	}
+
+	/**
 	 * @see ProviderService#getProvidersByRoles(List)
 	 */
 	@Override

--- a/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProviderServiceTest.java
@@ -568,6 +568,24 @@ public class ProviderServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see ProviderService#getProviderRoleByName(String)
+	 */
+	@Test
+	public void getProviderRoleByName_shouldReturnTheProviderRoleIfExists() {
+		ProviderRole providerRole = service.getProviderRoleByName("Cell supervisor");
+		assertNotNull(providerRole);
+		assertEquals(Integer.valueOf(1003), providerRole.getProviderRoleId());
+	}
+
+	/**
+	 * @see ProviderService#getProviderRoleByName(String)
+	 */
+	@Test
+	public void getProviderRoleByName_shouldReturnNullIfNotExists() {
+		assertNull(service.getProviderRoleByName("Unknown role"));
+	}
+
+	/**
 	 * @see ProviderService#getProvidersByRoles(List)
 	 */
 	@Test

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ProviderDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ProviderDAOTest.java
@@ -110,6 +110,24 @@ public class ProviderDAOTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see ProviderDAO#getProviderRoleByName(String)
+	 */
+	@Test
+	public void getProviderRoleByName_shouldReturnTheProviderRoleIfExists() {
+		ProviderRole providerRole = providerDao.getProviderRoleByName("Cell supervisor");
+		assertNotNull(providerRole);
+		assertEquals(Integer.valueOf(1003), providerRole.getProviderRoleId());
+	}
+
+	/**
+	 * @see ProviderDAO#getProviderRoleByName(String)
+	 */
+	@Test
+	public void getProviderRoleByName_shouldReturnNullIfNotExists() {
+		assertNull(providerDao.getProviderRoleByName("Unknown role"));
+	}
+
+	/**
 	 * @see ProviderDAO#getProvidersByRoles(List, boolean)
 	 */
 	@Test

--- a/docs/provider-role-name-lookup/README.md
+++ b/docs/provider-role-name-lookup/README.md
@@ -1,0 +1,53 @@
+# Provider Role Name Lookup
+
+## Summary
+
+This feature adds `ProviderService#getProviderRoleByName(String name)` so platform code and modules can resolve a `ProviderRole` by its configured name, not only by numeric ID or UUID.
+
+Provider roles are already first-class metadata in OpenMRS. They are attached to `Provider` records and are commonly configured by administrators using human-readable names such as `Cell supervisor` or `Health center supervisor`. A name lookup method keeps provider role access consistent with similar metadata APIs, including `EncounterService#getEncounterRoleByName(String name)`.
+
+## API Contract
+
+```java
+ProviderRole role = Context.getProviderService().getProviderRoleByName("Cell supervisor");
+```
+
+The method uses exact name matching. It returns the matching `ProviderRole`, or `null` when no role has the requested name. Retired roles are still returned because metadata name resolution may be needed for historical configuration and migration workflows.
+
+## Entity Relationship
+
+```mermaid
+erDiagram
+    PROVIDER_ROLE ||--o{ PROVIDER : "classifies"
+    PROVIDER_ROLE {
+        int provider_role_id PK
+        string name
+        string description
+        boolean retired
+        string uuid
+    }
+    PROVIDER {
+        int provider_id PK
+        int provider_role_id FK
+        string identifier
+        string name
+        boolean retired
+        string uuid
+    }
+```
+
+## Implementation Notes
+
+- `ProviderService` exposes the public authorized API.
+- `ProviderServiceImpl` delegates the lookup to `ProviderDAO`.
+- `ProviderDAO` defines the persistence boundary.
+- `HibernateProviderDAO` performs the exact name query using JPA Criteria.
+- Service and DAO tests cover both the successful lookup and missing-role behavior.
+
+## Verification
+
+Run the focused provider tests:
+
+```bash
+./mvnw -pl api -Dtest=ProviderServiceTest,ProviderDAOTest test
+```


### PR DESCRIPTION
## Summary
- add ProviderService#getProviderRoleByName for resolving ProviderRole metadata by exact name
- implement DAO/Hibernate lookup and focused service/DAO tests
- add a short README with API contract and ER diagram

## Testing
- ./mvnw -pl api -Dtest=ProviderServiceTest,ProviderDAOTest test