### PR TITLE
docs: remove outdated reference to LoginServlet in WebConstants

### DIFF
--- a/web/src/main/java/org/openmrs/web/WebConstants.java
+++ b/web/src/main/java/org/openmrs/web/WebConstants.java
@@ -77,8 +77,6 @@ public class WebConstants {
 	/**
 	 * Global property name for the number of times one IP can fail at logging in before being locked
 	 * out. A value of 0 for this property means no IP lockout checks.
-	 *
-	 * @see org.openmrs.web.servlet.LoginServlet
 	 */
 	public static final String GP_ALLOWED_LOGIN_ATTEMPTS_PER_IP = "security.loginAttemptsAllowedPerIP";
 


### PR DESCRIPTION
The documentation in WebConstants.java was referencing org.openmrs.web.servlet.LoginServlet, which no longer exists in the project. This PR removes the outdated javadoc line.