### PR TITLE
Require Get Alerts privilege to read all users' alerts

### DIFF
--- a/api/src/main/java/org/openmrs/notification/AlertService.java
+++ b/api/src/main/java/org/openmrs/notification/AlertService.java
@@ -51,11 +51,14 @@ public interface AlertService extends OpenmrsService {
 	public Alert saveAlert(Alert alert) throws APIException;
 
 	/**
-	 * Get alert by internal identifier
+	 * Get alert by internal identifier. Callers may only read an alert addressed to themselves; reading
+	 * an alert addressed to another user requires the {@link PrivilegeConstants#GET_ALERTS} privilege.
 	 *
 	 * @param alertId internal alert identifier
 	 * @return alert with given internal identifier
 	 * @throws APIException
+	 * @throws org.openmrs.api.APIAuthenticationException if the alert is addressed to another user and
+	 *             the caller lacks the {@link PrivilegeConstants#GET_ALERTS} privilege
 	 */
 	@Authorized
 	public Alert getAlert(Integer alertId) throws APIException;
@@ -70,12 +73,15 @@ public interface AlertService extends OpenmrsService {
 	public void purgeAlert(Alert alert) throws APIException;
 
 	/**
-	 * Find all alerts for a user that have not expired
+	 * Find all alerts for a user that have not expired. Callers may only read their own alerts; reading
+	 * another user's alerts requires the {@link PrivilegeConstants#GET_ALERTS} privilege.
 	 *
 	 * @param user
 	 * @return alerts that are unread _or_ read that have not expired
 	 * @see #getAlerts(User, boolean, boolean)
 	 * @throws APIException
+	 * @throws org.openmrs.api.APIAuthenticationException if <code>user</code> is another user and the
+	 *             caller lacks the {@link PrivilegeConstants#GET_ALERTS} privilege
 	 */
 	@Authorized
 	public List<Alert> getAllActiveAlerts(User user) throws APIException;
@@ -84,23 +90,29 @@ public interface AlertService extends OpenmrsService {
 	 * Find the alerts that are not read and have not expired for a user This will probably be the most
 	 * commonly called method If null is passed in for <code>user</code>, find alerts for the currently
 	 * authenticated user. If no user is authenticated, search on "new User()" (for "Anonymous" role
-	 * alert possibilities)
+	 * alert possibilities). Callers may only read their own alerts; reading another user's alerts
+	 * requires the {@link PrivilegeConstants#GET_ALERTS} privilege.
 	 *
 	 * @param user the user that is assigned to the returned alerts
 	 * @return alerts that are unread and not expired
 	 * @throws APIException
+	 * @throws org.openmrs.api.APIAuthenticationException if <code>user</code> is another user and the
+	 *             caller lacks the {@link PrivilegeConstants#GET_ALERTS} privilege
 	 */
 	@Authorized
 	public List<Alert> getAlertsByUser(User user) throws APIException;
 
 	/**
-	 * Finds alerts for the given user with the given status
+	 * Finds alerts for the given user with the given status. Callers may only read their own alerts;
+	 * reading another user's alerts requires the {@link PrivilegeConstants#GET_ALERTS} privilege.
 	 *
 	 * @param user to restrict to
 	 * @param includeRead
 	 * @param includeExpired
 	 * @return alerts for this user with these options
 	 * @throws APIException
+	 * @throws org.openmrs.api.APIAuthenticationException if <code>user</code> is another user and the
+	 *             caller lacks the {@link PrivilegeConstants#GET_ALERTS} privilege
 	 */
 	@Authorized
 	public List<Alert> getAlerts(User user, boolean includeRead, boolean includeExpired) throws APIException;

--- a/api/src/main/java/org/openmrs/notification/AlertService.java
+++ b/api/src/main/java/org/openmrs/notification/AlertService.java
@@ -111,7 +111,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return list of unexpired alerts
 	 * @throws APIException
 	 */
-	@Authorized
+	@Authorized(PrivilegeConstants.GET_ALERTS)
 	public List<Alert> getAllAlerts() throws APIException;
 
 	/**
@@ -121,7 +121,7 @@ public interface AlertService extends OpenmrsService {
 	 * @return list of alerts
 	 * @throws APIException
 	 */
-	@Authorized
+	@Authorized(PrivilegeConstants.GET_ALERTS)
 	public List<Alert> getAllAlerts(boolean includeExpired) throws APIException;
 
 	/**

--- a/api/src/main/java/org/openmrs/notification/AlertService.java
+++ b/api/src/main/java/org/openmrs/notification/AlertService.java
@@ -51,14 +51,19 @@ public interface AlertService extends OpenmrsService {
 	public Alert saveAlert(Alert alert) throws APIException;
 
 	/**
-	 * Get alert by internal identifier. Callers may only read an alert addressed to themselves; reading
-	 * an alert addressed to another user requires the {@link PrivilegeConstants#GET_ALERTS} privilege.
+	 * Get alert by internal identifier. Callers may only read an alert addressed to themselves; an
+	 * alert addressed to another user is returned only to a caller holding the
+	 * {@link PrivilegeConstants#GET_ALERTS} privilege. Unlike the user-scoped reads such as
+	 * {@link #getAlerts(User, boolean, boolean)} - which throw
+	 * {@link org.openmrs.api.APIAuthenticationException} for another user's alerts - this id-based
+	 * lookup instead returns <code>null</code> in that case, the same as for an unknown identifier, so
+	 * it cannot be used to probe which alert ids exist.
 	 *
 	 * @param alertId internal alert identifier
-	 * @return alert with given internal identifier
+	 * @return the alert with the given internal identifier, or <code>null</code> if no such alert
+	 *         exists, or it is addressed to another user and the caller lacks the
+	 *         {@link PrivilegeConstants#GET_ALERTS} privilege
 	 * @throws APIException
-	 * @throws org.openmrs.api.APIAuthenticationException if the alert is addressed to another user and
-	 *             the caller lacks the {@link PrivilegeConstants#GET_ALERTS} privilege
 	 */
 	@Authorized
 	public Alert getAlert(Integer alertId) throws APIException;

--- a/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
+++ b/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.openmrs.Role;
 import org.openmrs.User;
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.Daemon;
@@ -23,6 +24,7 @@ import org.openmrs.notification.Alert;
 import org.openmrs.notification.AlertRecipient;
 import org.openmrs.notification.AlertService;
 import org.openmrs.notification.db.AlertDAO;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.util.RoleConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +99,22 @@ public class AlertServiceImpl extends BaseOpenmrsService implements Serializable
 	@Override
 	@Transactional(readOnly = true)
 	public Alert getAlert(Integer alertId) throws APIException {
-		return dao.getAlert(alertId);
+		Alert alert = dao.getAlert(alertId);
+
+		// Alerts are personal notifications, so a caller may only read an alert addressed to them,
+		// unless they hold the Get Alerts privilege and may therefore read every user's alerts.
+		if (alert != null && !canViewAllAlerts() && alert.getRecipient(Context.getAuthenticatedUser()) == null) {
+			throw new APIAuthenticationException("Privilege required: " + PrivilegeConstants.GET_ALERTS);
+		}
+
+		return alert;
+	}
+
+	/**
+	 * @return true if the authenticated user may read alerts addressed to any user
+	 */
+	private boolean canViewAllAlerts() {
+		return Context.hasPrivilege(PrivilegeConstants.GET_ALERTS);
 	}
 
 	/**
@@ -144,6 +161,18 @@ public class AlertServiceImpl extends BaseOpenmrsService implements Serializable
 	@Transactional(readOnly = true)
 	public List<Alert> getAlerts(User user, boolean includeRead, boolean includeExpired) throws APIException {
 		log.debug("Getting alerts for user " + user + " read? " + includeRead + " expired? " + includeExpired);
+
+		// Alerts are personal notifications, so a caller may only list alerts addressed to
+		// themselves, unless they hold the Get Alerts privilege and may therefore read every user's
+		// alerts. A null/blank user resolves to the anonymous recipient set, which discloses nothing.
+		// Compare on userId, the same key the query filters on, so the check matches what is returned.
+		User authenticatedUser = Context.getAuthenticatedUser();
+		boolean targetsAnotherUser = user != null && user.getUserId() != null
+		        && (authenticatedUser == null || !user.getUserId().equals(authenticatedUser.getUserId()));
+		if (targetsAnotherUser && !canViewAllAlerts()) {
+			throw new APIAuthenticationException("Privilege required: " + PrivilegeConstants.GET_ALERTS);
+		}
+
 		return dao.getAlerts(user, includeRead, includeExpired);
 	}
 

--- a/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
+++ b/api/src/main/java/org/openmrs/notification/impl/AlertServiceImpl.java
@@ -103,8 +103,10 @@ public class AlertServiceImpl extends BaseOpenmrsService implements Serializable
 
 		// Alerts are personal notifications, so a caller may only read an alert addressed to them,
 		// unless they hold the Get Alerts privilege and may therefore read every user's alerts.
+		// Return null - the same as for an unknown id - rather than throwing, so this lookup cannot be
+		// used to probe which alert ids exist (an existence oracle over sequential identifiers).
 		if (alert != null && !canViewAllAlerts() && alert.getRecipient(Context.getAuthenticatedUser()) == null) {
-			throw new APIAuthenticationException("Privilege required: " + PrivilegeConstants.GET_ALERTS);
+			return null;
 		}
 
 		return alert;

--- a/api/src/main/java/org/openmrs/scheduler/tasks/AlertReminderTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/tasks/AlertReminderTask.java
@@ -18,6 +18,7 @@ import org.openmrs.notification.Alert;
 import org.openmrs.notification.AlertRecipient;
 import org.openmrs.notification.Message;
 import org.openmrs.notification.MessageException;
+import org.openmrs.util.PrivilegeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,15 @@ public class AlertReminderTask extends AbstractTask {
 		try {
 			// Get all unread alerts
 			// TODO Change to getAllAlerts(Boolean includeRead, Boolean includeExpired);
-			Collection<Alert> alerts = Context.getAlertService().getAllAlerts(false);
+			// getAllAlerts requires the Get Alerts privilege; this system task reads every
+			// user's alerts to notify them, so grant the privilege for the duration of the read.
+			Collection<Alert> alerts;
+			Context.addProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+			try {
+				alerts = Context.getAlertService().getAllAlerts(false);
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+			}
 
 			// Send alert notifications to users who have unread alerts
 			sendAlertNotifications(alerts);

--- a/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
+++ b/api/src/main/java/org/openmrs/util/PrivilegeConstants.java
@@ -25,6 +25,9 @@ public class PrivilegeConstants {
 	private PrivilegeConstants() {
 	}
 
+	@AddOnStartup(description = "Able to get alerts")
+	public static final String GET_ALERTS = "Get Alerts";
+
 	@AddOnStartup(description = "Able to get concept entries")
 	public static final String GET_CONCEPTS = "Get Concepts";
 

--- a/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
+++ b/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
@@ -19,6 +19,7 @@ import org.openmrs.util.PrivilegeConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,7 +96,7 @@ public class AlertServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void getAlert_shouldReadOwnAlertButNotAnotherUsersAlertWithoutTheGetAlertsPrivilege() {
+	public void getAlert_shouldReadOwnAlertButReturnNullForAnotherUsersAlertWithoutTheGetAlertsPrivilege() {
 		AlertService as = Context.getAlertService();
 		User superUser = Context.getAuthenticatedUser();
 		User butch = Context.getUserService().getUserByUsername("butch");
@@ -108,8 +109,10 @@ public class AlertServiceTest extends BaseContextSensitiveTest {
 
 		// butch is a recipient of his own alert, so he may still read it
 		assertNotNull(as.getAlert(butchAlertId));
-		// but he must not be able to read an alert addressed to someone else
-		assertThrows(APIAuthenticationException.class, () -> as.getAlert(superUsersAlertId));
+		// an alert addressed to someone else reads back as null - identical to a non-existent id - so the
+		// method cannot be used to probe which alert ids exist (no existence oracle over sequential ids)
+		assertNull(as.getAlert(superUsersAlertId));
+		assertNull(as.getAlert(112233445));
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
+++ b/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
@@ -10,11 +10,15 @@
 package org.openmrs.notification;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.impl.AlertServiceImpl;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.PrivilegeConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AlertServiceTest extends BaseContextSensitiveTest {
@@ -62,5 +66,30 @@ public class AlertServiceTest extends BaseContextSensitiveTest {
 		//Test that alert contains the expected content
 		assertTrue(alertOne.getText().equals(Context.getMessageSourceService()
 		        .getMessage("Module.startupError.notification.message", new Object[] { "test" }, null)));
+	}
+
+	@Test
+	public void getAllAlerts_shouldOnlyBeAllowedForUsersWithTheGetAlertsPrivilege() {
+		// the default authenticated user is a super user and may read every user's alerts
+		assertNotNull(Context.getAlertService().getAllAlerts());
+		assertNotNull(Context.getAlertService().getAllAlerts(true));
+
+		// "butch" is a Provider with no privileges, so he must not be able to read all alerts
+		Context.becomeUser("3-4");
+		assertThrows(APIAuthenticationException.class, () -> Context.getAlertService().getAllAlerts());
+		assertThrows(APIAuthenticationException.class, () -> Context.getAlertService().getAllAlerts(true));
+	}
+
+	@Test
+	public void getAllAlerts_shouldBeAllowedForAnUnprivilegedCallerHoldingAProxyGetAlertsPrivilege() {
+		// mirrors how the AlertReminderTask scheduled job reads every user's alerts: it runs as its
+		// configured (possibly unprivileged) user and grants itself a proxy Get Alerts privilege
+		Context.becomeUser("3-4");
+		Context.addProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		try {
+			assertNotNull(Context.getAlertService().getAllAlerts(false));
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		}
 	}
 }

--- a/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
+++ b/api/src/test/java/org/openmrs/notification/AlertServiceTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.notification;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.impl.AlertServiceImpl;
@@ -88,6 +89,71 @@ public class AlertServiceTest extends BaseContextSensitiveTest {
 		Context.addProxyPrivilege(PrivilegeConstants.GET_ALERTS);
 		try {
 			assertNotNull(Context.getAlertService().getAllAlerts(false));
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		}
+	}
+
+	@Test
+	public void getAlert_shouldReadOwnAlertButNotAnotherUsersAlertWithoutTheGetAlertsPrivilege() {
+		AlertService as = Context.getAlertService();
+		User superUser = Context.getAuthenticatedUser();
+		User butch = Context.getUserService().getUserByUsername("butch");
+
+		// create one alert addressed to butch and one addressed only to the super user
+		Integer butchAlertId = as.saveAlert(new Alert("butch's alert", butch)).getAlertId();
+		Integer superUsersAlertId = as.saveAlert(new Alert("super user's alert", superUser)).getAlertId();
+
+		Context.becomeUser("3-4");
+
+		// butch is a recipient of his own alert, so he may still read it
+		assertNotNull(as.getAlert(butchAlertId));
+		// but he must not be able to read an alert addressed to someone else
+		assertThrows(APIAuthenticationException.class, () -> as.getAlert(superUsersAlertId));
+	}
+
+	@Test
+	public void getAlert_shouldReadAnotherUsersAlertForACallerHoldingAProxyGetAlertsPrivilege() {
+		AlertService as = Context.getAlertService();
+		Integer superUsersAlertId = as.saveAlert(new Alert("super user's alert", Context.getAuthenticatedUser()))
+		        .getAlertId();
+
+		Context.becomeUser("3-4");
+		Context.addProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		try {
+			assertNotNull(as.getAlert(superUsersAlertId));
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		}
+	}
+
+	@Test
+	public void getAlerts_shouldReadOwnAlertsButNotAnotherUsersAlertsWithoutTheGetAlertsPrivilege() {
+		AlertService as = Context.getAlertService();
+		User superUser = Context.getAuthenticatedUser();
+
+		Context.becomeUser("3-4");
+		User butch = Context.getAuthenticatedUser();
+
+		// butch may list his own alerts through any of the user-scoped overloads...
+		assertNotNull(as.getAlerts(butch, true, true));
+		assertNotNull(as.getAlertsByUser(butch));
+		assertNotNull(as.getAllActiveAlerts(butch));
+		// ...but not another user's
+		assertThrows(APIAuthenticationException.class, () -> as.getAlerts(superUser, true, true));
+		assertThrows(APIAuthenticationException.class, () -> as.getAlertsByUser(superUser));
+		assertThrows(APIAuthenticationException.class, () -> as.getAllActiveAlerts(superUser));
+	}
+
+	@Test
+	public void getAlerts_shouldReadAnotherUsersAlertsForACallerHoldingAProxyGetAlertsPrivilege() {
+		AlertService as = Context.getAlertService();
+		User superUser = Context.getAuthenticatedUser();
+
+		Context.becomeUser("3-4");
+		Context.addProxyPrivilege(PrivilegeConstants.GET_ALERTS);
+		try {
+			assertNotNull(as.getAlerts(superUser, true, true));
 		} finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.GET_ALERTS);
 		}


### PR DESCRIPTION
## What

`AlertService.getAllAlerts()` and `getAllAlerts(boolean)` return **every user's** alerts, but were guarded only by `@Authorized` (authentication) — so any authenticated user could read alerts addressed to others through any consumer (REST, legacy UI, modules, direct API).

This introduces a dedicated **`Get Alerts`** privilege (following the `GET_*` read-privilege convention) and gates both methods with it. The per-user reads (`getAlert`, `getAlerts`, `getAlertsByUser`, `getAllActiveAlerts`) stay open for a caller reading **their own** alerts; reading **another user's** alerts through them now also requires `Get Alerts`, closing the same cross-user disclosure at the by-id and per-user paths rather than only at `getAllAlerts`.

## Why a dedicated privilege (not Manage Alerts)

Reads should use a `GET_*` privilege rather than the write-oriented `MANAGE_ALERTS`, and a dedicated privilege allows granting read-all access without write. The privilege is registered via `@AddOnStartup` and created at startup by `checkCoreDataset()`; it is **not** auto-assigned to any role, so it does not reintroduce the leak — only super users and explicitly-granted roles receive it.

## AlertReminderTask

The scheduled `AlertReminderTask` reads all alerts as its configured job user (the JobRunr path clears the daemon-thread flag before invoking the task, so `@Authorized` is enforced). It now grants itself a proxy `Get Alerts` privilege around that read.

## Upgrade note

A new `Get Alerts` privilege is created at startup (via `@AddOnStartup` / `checkCoreDataset()`) and is **not** assigned to any role. After upgrade, grant `Get Alerts` to any role that must read **other users'** alerts:

- Roles that relied on `Manage Alerts` to list every user's alerts (e.g. the legacy "Manage Alerts" page, or any code calling `getAllAlerts()` / `getAllAlerts(boolean)`).
- Roles or integrations that read another user's alerts via `getAlert(Integer)`, `getAlerts(User, …)`, `getAlertsByUser(User)` or `getAllActiveAlerts(User)`.

Reading one's **own** alerts is unaffected and needs no new privilege. Super users are unaffected (they bypass privilege checks). Via REST, `GET /ws/rest/v1/alert` now returns only the caller's own alerts unless they hold `Get Alerts` (paired with openmrs/openmrs-module-webservices.rest#749).

## Tests

`AlertServiceTest`: callers without `Get Alerts` get `APIAuthenticationException` when reading another user's alerts through `getAllAlerts`, `getAlerts`, `getAlertsByUser` and `getAllActiveAlerts`, while `getAlert(Integer)` returns `null` for another user's alert — the same as for a non-existent id, so it cannot be used as an existence oracle; reading their own succeeds; and an unprivileged caller holding a proxy `Get Alerts` privilege succeeds (mirrors the task). `mvn -pl api test -Dtest=AlertServiceTest` → 9/9.

## Notes
- Please link the corresponding `TRUNK-` ticket.
- Core-side fix for cross-user alert disclosure; the REST module's presentation-layer change is openmrs/openmrs-module-webservices.rest#749.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

