### PR TITLE
TRUNK-6651: Make @OpenmrsProfile self-enforcing via @Component + @Conditional

### DIFF
--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
@@ -15,21 +15,40 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
 /**
  * Place it on classes which you want to be beans created conditionally based on OpenMRS version
  * and/or started modules.
+ * <p>
+ * This annotation is self-enforcing: it meta-annotates {@link Component} so that the class is
+ * picked up by any default-filter component-scan, and {@link Conditional} so that the bean is only
+ * registered when the profile actually matches — regardless of which component-scan discovers it.
  *
  * @since 1.10, 1.9.8, 1.8.5, 1.7.5
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Component // makes bare @OpenmrsProfile a scan stereotype
+@Conditional(OpenmrsProfileCondition.class) // gates registration in every scan / @Bean / @Import
 public @interface OpenmrsProfile {
+
+	/**
+	 * Optional bean name, equivalent to {@link Component#value()}. Use this when
+	 * {@code @OpenmrsProfile} is the only stereotype on the class. If the class also carries another
+	 * stereotype annotation with a non-empty value, the two names must agree; a conflict will cause a
+	 * Spring startup exception.
+	 *
+	 * @since 2.8
+	 */
+	String value() default "";
 
 	/**
 	 * @since 1.11.3, 1.10.2, 1.9.9
 	 */
-	public String openmrsPlatformVersion() default "";
+	String openmrsPlatformVersion() default "";
 
-	public String[] modules() default {};
+	String[] modules() default {};
 }

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java
@@ -41,7 +41,7 @@ public @interface OpenmrsProfile {
 	 * stereotype annotation with a non-empty value, the two names must agree; a conflict will cause a
 	 * Spring startup exception.
 	 *
-	 * @since 2.8
+	 * @since 3.0.0
 	 */
 	String value() default "";
 

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Spring {@link Condition} that gates bean registration on whether the current runtime matches the
+ * OpenMRS platform version and/or module requirements declared in {@link OpenmrsProfile}.
+ * <p>
+ * The matching logic is intentionally delegated to
+ * {@link OpenmrsProfileExcludeFilter#matchOpenmrsProfileAttributes(Map)} so that version/module
+ * semantics remain centralised and are not duplicated here.
+ *
+ * @since 2.8
+ * @see OpenmrsProfile
+ * @see OpenmrsProfileExcludeFilter
+ */
+public class OpenmrsProfileCondition implements Condition {
+
+	/**
+	 * Returns {@code true} (allow registration) when the runtime profile satisfies all constraints
+	 * declared on {@link OpenmrsProfile}, and {@code false} otherwise.
+	 * <p>
+	 * If the annotation attributes cannot be read for any reason the condition defaults to {@code true}
+	 * so as not to block beans that carry no meaningful constraint.
+	 */
+	@Override
+	public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+		Map<String, Object> annotationAttributes = metadata.getAnnotationAttributes(OpenmrsProfile.class.getName());
+
+		if (annotationAttributes == null) {
+			// @OpenmrsProfile not present on this metadata; don't block registration
+			return true;
+		}
+
+		// Build the attribute map in the exact shape that matchOpenmrsProfileAttributes() expects:
+		// "openmrsPlatformVersion" -> String, "modules" -> String[]
+		Map<String, Object> profile = new HashMap<>();
+		profile.put("openmrsPlatformVersion", annotationAttributes.getOrDefault("openmrsPlatformVersion", ""));
+		profile.put("modules", annotationAttributes.getOrDefault("modules", new String[0]));
+
+		return new OpenmrsProfileExcludeFilter().matchOpenmrsProfileAttributes(profile);
+	}
+}

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
@@ -24,7 +24,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  * {@link OpenmrsProfileExcludeFilter#matchOpenmrsProfileAttributes(Map)} so that version/module
  * semantics remain centralised and are not duplicated here.
  *
- * @since 2.8
+ * @since 3.0
  * @see OpenmrsProfile
  * @see OpenmrsProfileExcludeFilter
  */

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java
@@ -52,6 +52,6 @@ public class OpenmrsProfileCondition implements Condition {
 		profile.put("openmrsPlatformVersion", annotationAttributes.getOrDefault("openmrsPlatformVersion", ""));
 		profile.put("modules", annotationAttributes.getOrDefault("modules", new String[0]));
 
-		return new OpenmrsProfileExcludeFilter().matchOpenmrsProfileAttributes(profile);
+		return OpenmrsProfileExcludeFilter.matchOpenmrsProfileAttributes(profile);
 	}
 }

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileExcludeFilter.java
@@ -51,7 +51,7 @@ public class OpenmrsProfileExcludeFilter implements TypeFilter {
 		}
 	}
 
-	public boolean matchOpenmrsProfileAttributes(Map<String, Object> openmrsProfile) {
+	public static boolean matchOpenmrsProfileAttributes(Map<String, Object> openmrsProfile) {
 		Object openmrsPlatformVersion = openmrsProfile.get("openmrsPlatformVersion");
 		if (StringUtils.isBlank((String) openmrsPlatformVersion)) {
 			//Left for backwards compatibility

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -207,11 +207,11 @@
 
 	<context:component-scan base-package="org.openmrs">
 		<context:include-filter type="annotation" expression="org.openmrs.annotation.Handler"/>
-		<context:include-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileIncludeFilter"/>
-		<!-- Excludes classes with unit test super classes -->
-		<context:exclude-filter type="custom"
-								expression="org.openmrs.util.TestTypeFilter"/>
-		<context:exclude-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileExcludeFilter"/>
+		<!-- OpenmrsProfileIncludeFilter and OpenmrsProfileExcludeFilter removed:
+			@OpenmrsProfile now meta-annotates @Component (for inclusion) and
+			@Conditional(OpenmrsProfileCondition.class) (for exclusion), making both
+			TypeFilters redundant across all component-scans, including module scans. -->
+		<context:exclude-filter type="custom" expression="org.openmrs.util.TestTypeFilter"/>
 	</context:component-scan>
 
 </beans>

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileConditionTest.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileConditionTest.java
@@ -1,0 +1,71 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that {@link OpenmrsProfile} is self-enforcing via {@link OpenmrsProfileCondition}:
+ * profile gating must work even inside a component-scan that does NOT register the OpenMRS
+ * TypeFilters (OpenmrsProfileIncludeFilter / OpenmrsProfileExcludeFilter) — i.e. the module-scan
+ * escape scenario from mekomsolutions/openmrs-module-initializer#325.
+ *
+ * @since 3.0.0
+ */
+public class OpenmrsProfileConditionTest {
+
+	private AnnotationConfigApplicationContext ctx;
+
+	@BeforeEach
+	public void setUp() {
+		ctx = new AnnotationConfigApplicationContext();
+		// Simulate a module's own component-scan: default filters only,
+		// no OpenmrsProfileIncludeFilter / OpenmrsProfileExcludeFilter registered
+		ctx.scan("org.openmrs.annotation");
+		ctx.refresh();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		if (ctx != null) {
+			ctx.close();
+		}
+	}
+
+	/**
+	 * Regression test for mekomsolutions/openmrs-module-initializer#325. A bean with a
+	 * non-matching @OpenmrsProfile must NOT be registered even when discovered by a scan that does not
+	 * have the OpenMRS TypeFilters.
+	 */
+	@Test
+	public void moduleScan_shouldNotRegisterBeanWhenProfileDoesNotMatch() {
+		assertThrows(NoSuchBeanDefinitionException.class, () -> ctx.getBean(OpenmrsProfileModuleScanNonMatchingBean.class));
+	}
+
+	/**
+	 * A bare @OpenmrsProfile bean (no version/module constraint) must be registered when discovered by
+	 * a scan that does not have the OpenMRS TypeFilters.
+	 */
+	@Test
+	public void moduleScan_shouldRegisterBeanWhenProfileMatches() {
+		OpenmrsProfileModuleScanMatchingBean bean = ctx.getBean(OpenmrsProfileModuleScanMatchingBean.class);
+
+		assertThat(bean, is(notNullValue()));
+	}
+}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileModuleScanMatchingBean.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileModuleScanMatchingBean.java
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+/**
+ * Test bean with a matching (unconstrained) @OpenmrsProfile, used to verify self-enforcing behavior
+ * under a module-style scan without OpenMRS TypeFilters.
+ */
+@OpenmrsProfile
+public class OpenmrsProfileModuleScanMatchingBean {}

--- a/api/src/test/java/org/openmrs/annotation/OpenmrsProfileModuleScanNonMatchingBean.java
+++ b/api/src/test/java/org/openmrs/annotation/OpenmrsProfileModuleScanNonMatchingBean.java
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.annotation;
+
+/**
+ * Test bean with a non-matching @OpenmrsProfile, used to verify self-enforcing behavior under a
+ * module-style scan without OpenMRS TypeFilters.
+ */
+@OpenmrsProfile(openmrsPlatformVersion = "999.*")
+public class OpenmrsProfileModuleScanNonMatchingBean {}


### PR DESCRIPTION
TRUNK-6651: Make @OpenmrsProfile self-enforcing via @Component + @Conditional

## Description of what I changed

`@OpenmrsProfile` was previously enforced only by two `TypeFilter`s (`OpenmrsProfileIncludeFilter` / `OpenmrsProfileExcludeFilter`) wired into core's `<context:component-scan base-package="org.openmrs">`. Because `TypeFilter`s are scan-local, a module declaring its own `<context:component-scan>` over `org.openmrs.module.*` (with default filters and no OpenMRS-specific filters) would register a `@Component @OpenmrsProfile(...)` bean even when its profile did not
match — the scan sees `@Component` and has nothing to exclude it.

To fix this, `@OpenmrsProfile` is now meta-annotated with:

- `@Component` — makes any `@OpenmrsProfile`-annotated class a scan candidate under default filters, replacing the role of `OpenmrsProfileIncludeFilter`.
- `@Conditional(OpenmrsProfileCondition.class)` — gates bean registration on profile match in every component-scan, `@Bean` method, and `@Import`, replacing the role of `OpenmrsProfileExcludeFilter`.

Specific changes:

- `api/src/main/java/org/openmrs/annotation/OpenmrsProfile.java`
  - Added `@Component` and `@Conditional(OpenmrsProfileCondition.class)`
    meta-annotations
  - Added a `value()` attribute (default `""`) so callers can name the bean as
    they would with `@Component("name")`
- `api/src/main/java/org/openmrs/annotation/OpenmrsProfileCondition.java` (new)
  - New `Condition` implementation that reuses
    `OpenmrsProfileExcludeFilter.matchOpenmrsProfileAttributes(...)` so
    platform-version / required-module matching logic stays centralized and
    unchanged
- `api/src/main/resources/applicationContext-service.xml`
  - Removed the now-redundant `OpenmrsProfileIncludeFilter` and
    `OpenmrsProfileExcludeFilter` entries from the `org.openmrs` component-scan

**Behavioral changes (release-note worthy):**
- A `@Component @OpenmrsProfile` bean whose profile does not match will no longer load via any component-scan, including module scans that previously lacked the OpenMRS TypeFilters.
- A class using `@OpenmrsProfile` purely as a non-bean marker will now be registered as a bean when its profile matches, since `@OpenmrsProfile` is now a stereotype annotation itself.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6651

## Checklist: I completed these to help reviewers :)

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.