### PR TITLE
TRUNK-6512: Add ability to fetch reference range by date

### DIFF
--- a/api/src/main/java/org/openmrs/api/ConceptService.java
+++ b/api/src/main/java/org/openmrs/api/ConceptService.java
@@ -10,6 +10,7 @@
 package org.openmrs.api;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -2193,6 +2194,9 @@ public interface ConceptService extends OpenmrsService {
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
 	ConceptReferenceRange getConceptReferenceRange(Person person, Concept concept);
+
+	@Authorized(PrivilegeConstants.GET_CONCEPTS)
+	ConceptReferenceRange getConceptReferenceRange(Person person, Concept concept, Date date);
 
 	/**
 	 * Get the appropriate concept reference range for a given context. The context specifies the

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -2068,10 +2068,16 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 
 	@Override
 	public ConceptReferenceRange getConceptReferenceRange(Person person, Concept concept) {
+		return getConceptReferenceRange(person, concept, null);
+	}
+
+	@Override
+	public ConceptReferenceRange getConceptReferenceRange(Person person, Concept concept, Date date) {
 		if (person == null || concept == null) {
 			return null;
 		}
-		return Context.getConceptService().getConceptReferenceRange(new ConceptReferenceRangeContext(person, concept, null));
+
+		return Context.getConceptService().getConceptReferenceRange(new ConceptReferenceRangeContext(person, concept, date));
 	}
 
 	@Override

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -3970,6 +3970,21 @@ public class ConceptServiceTest extends BaseContextSensitiveTest {
 		assertEquals(3, conceptReferenceRanges.get(0).getId());
 	}
 
+	@Test
+	public void getConceptReferenceRange_shouldAcceptDateParameter() {
+		executeDataSet(CONCEPT_WITH_CONCEPT_REFERENCE_RANGES_XML);
+
+		Person person = new Person();
+		person.setBirthdate(java.sql.Date.valueOf("2000-01-01"));
+
+		Concept concept = conceptService.getConcept(5497);
+		Date date = java.sql.Date.valueOf("2020-01-01");
+
+		ConceptReferenceRange range = conceptService.getConceptReferenceRange(person, concept, date);
+
+		assertNotNull(range);
+	}
+
 	/**
 	 * @see ConceptService#saveConcept(Concept)
 	 */


### PR DESCRIPTION
## Description

Added a date-based overload for 'getConceptReferenceRange'.

## Issue

TRUNK-6512

## Testing

- [x] Added test
- [x] Ran './mvnw -pl api test -Dtest=ConceptServiceTest'
