### PR TITLE
TRUNK-6650: Verify database authentication in startup.sh before starting Tomcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN mvn $MVN_SETTINGS $MVN_ARGS
 ### Development Stage
 FROM maven:3.9-$DEV_JDK AS dev
 
-RUN apt-get update && apt-get install -y tar gzip git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y tar gzip git curl mariadb-client && rm -rf /var/lib/apt/lists/*
 
 # Setup Tini
 ARG TARGETARCH
@@ -112,7 +112,7 @@ CMD ["/openmrs/startup-dev.sh"]
 ### Production Stage
 FROM tomcat:11-$RUNTIME_JDK
 
-RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/* && rm -rf /usr/local/tomcat/webapps/*
+RUN apt-get update && apt-get install -y curl mariadb-client && rm -rf /var/lib/apt/lists/* && rm -rf /usr/local/tomcat/webapps/*
 
 # Setup Tini
 ARG TARGETARCH

--- a/startup.sh
+++ b/startup.sh
@@ -13,6 +13,27 @@ echo "Waiting for database to initialize..."
 
 /openmrs/wait-for-it.sh -t 3600 -h "${OMRS_DB_HOSTNAME}" -p "${OMRS_DB_PORT}"
 
+echo "Verifying database authentication..."
+if [ "${OMRS_DB}" = "mysql" ] || [ "${OMRS_DB}" = "mariadb" ]; then
+  DB_READY=false
+  for i in $(seq 1 30); do
+    if mariadb -h "${OMRS_DB_HOSTNAME}" -P "${OMRS_DB_PORT}" \
+        -u "${OMRS_DB_USERNAME}" -p"${OMRS_DB_PASSWORD}" \
+        --ssl=0 -e "SELECT 1" > /dev/null 2>&1; then
+      DB_READY=true
+      echo "Database authentication successful."
+      break
+    fi
+    echo "  Database not accepting credentials yet (attempt ${i}/30) — retrying in 2s..."
+    sleep 2
+  done
+
+  if [ "$DB_READY" = false ]; then
+    echo "ERROR: Database did not accept credentials after 30 attempts."
+    exit 1
+  fi
+fi
+
 wait_for_es()
 {
 	IFS=',' read -a es_uris <<< "${OMRS_SEARCH_ES_URIS}"


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
The `startup.sh` script currently waits for the database TCP port to be available via `wait-for-it.sh`, but does not verify that MariaDB is actually ready to accept authenticated connections. On Galera clusters and container orchestrators, the TCP port can open before InnoDB recovery completes, causing OpenMRS to start against a not-yet-ready database.

This adds a credential-verified check (`mariadb -e "SELECT 1"` with retry) after the TCP port check and before Tomcat starts. The
`mariadb-client` package is installed in the Docker image so the `mariadb` command is available at runtime.

30 retries at 2-second intervals (60s total) are sufficient since `wait-for-it.sh` already confirms the port is open, only the brief InnoDB recovery window (~12s on Galera) needs to pass.

This PR is as a result of this PR https://github.com/openmrs/openmrs-contrib-cluster/pull/14

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/TRUNK-6650

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

