### PR TITLE
mergePatients does not reassign Conditions, Allergies, or MedicationDispenses to the surviving patient

### DIFF
--- a/api/src/main/java/org/openmrs/api/PatientService.java
+++ b/api/src/main/java/org/openmrs/api/PatientService.java
@@ -525,6 +525,15 @@ public interface PatientService extends OpenmrsService {
 	 * <strong>Should</strong> merge non voided person attributes from non preferred to preferred patient
 	 * <strong>Should</strong> merge other non voided observations from non preferred to preferred patient
 	 * <strong>Should</strong> merge other non voided orders from non preferred to preferred patient
+	 * <strong>Should</strong> move conditions from non preferred to preferred patient
+	 * <strong>Should</strong> move encounter linked condition from non preferred to preferred patient
+	 * <strong>Should</strong> not move voided conditions
+	 * <strong>Should</strong> move allergies from non preferred to preferred patient
+	 * <strong>Should</strong> not move allergy if preferred patient already has same allergen
+	 * <strong>Should</strong> move only allergens not already on preferred patient
+	 * <strong>Should</strong> not move voided allergies
+	 * <strong>Should</strong> move medication dispenses from non preferred to preferred patient
+	 * <strong>Should</strong> not move voided medication dispense
 	 * <strong>Should</strong> merge non preferred death date when preferred death date is not null or empty
 	 * <strong>Should</strong> merge non preferred death cause when preferred death cause is not null or empty
 	 * <strong>Should</strong> void non preferred person object

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -27,8 +27,10 @@ import org.openmrs.Allergies;
 import org.openmrs.Allergy;
 import org.openmrs.BaseOpenmrsMetadata;
 import org.openmrs.Concept;
+import org.openmrs.Condition;
 import org.openmrs.Encounter;
 import org.openmrs.Location;
+import org.openmrs.MedicationDispense;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
@@ -44,9 +46,11 @@ import org.openmrs.User;
 import org.openmrs.Visit;
 import org.openmrs.api.APIException;
 import org.openmrs.api.BlankIdentifierException;
+import org.openmrs.api.ConditionService;
 import org.openmrs.api.DuplicateIdentifierException;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.InsufficientIdentifiersException;
+import org.openmrs.api.MedicationDispenseService;
 import org.openmrs.api.MissingRequiredIdentifierException;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.PatientIdentifierException;
@@ -61,6 +65,8 @@ import org.openmrs.api.db.PatientDAO;
 import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.parameter.EncounterSearchCriteria;
 import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
+import org.openmrs.parameter.MedicationDispenseCriteria;
+import org.openmrs.parameter.MedicationDispenseCriteriaBuilder;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.person.PersonMergeLog;
@@ -569,6 +575,9 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		mergeProgramEnrolments(preferred, notPreferred, mergedData);
 		mergeRelationships(preferred, notPreferred, mergedData);
 		mergeObservationsNotContainedInEncounters(preferred, notPreferred, mergedData);
+		mergeConditions(preferred, notPreferred, mergedData);
+		mergeAllergies(preferred, notPreferred, mergedData);
+		mergeMedicationDispenses(preferred, notPreferred, mergedData);
 		mergeIdentifiers(preferred, notPreferred, mergedData);
 		
 		mergeNames(preferred, notPreferred, mergedData);
@@ -722,6 +731,54 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		}
 	}
 	
+	private void mergeConditions(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
+		// move all non-voided conditions (both patient-level and encounter-linked, since moving an
+		// encounter does not reassign the patient on its conditions)
+		// TODO: this should be a copy, not a move
+		ConditionService conditionService = Context.getConditionService();
+		for (Condition condition : conditionService.getAllConditions(notPreferred)) {
+			condition.setPatient(preferred);
+			log.debug("Merging condition {} to {}", condition.getConditionId(), preferred.getPatientId());
+			Condition persisted = conditionService.saveCondition(condition);
+			mergedData.addMovedCondition(persisted.getUuid());
+		}
+	}
+
+	private void mergeAllergies(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
+		// move all non-voided allergies, skipping any whose allergen the preferred patient already
+		// records: a patient cannot hold two allergies for the same allergen (Allergies enforces this),
+		// so moving a duplicate would make the survivor's allergy list fail to load afterwards
+		// TODO: this should be a copy, not a move
+		PatientService patientService = Context.getPatientService();
+		Allergies preferredAllergies = patientService.getAllergies(preferred);
+		for (Allergy allergy : patientService.getAllergies(notPreferred)) {
+			if (preferredAllergies.containsAllergen(allergy)) {
+				log.debug("Skipping allergy {}; preferred patient {} already has the same allergen",
+				    allergy.getAllergyId(), preferred.getPatientId());
+				continue;
+			}
+			allergy.setPatient(preferred);
+			log.debug("Merging allergy {} to {}", allergy.getAllergyId(), preferred.getPatientId());
+			patientService.saveAllergy(allergy);
+			mergedData.addMovedAllergy(allergy.getUuid());
+		}
+	}
+
+	private void mergeMedicationDispenses(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
+		// move all non-voided medication dispenses (encounter-linked ones are not reassigned when their
+		// encounter is moved, so they must be handled here)
+		// TODO: this should be a copy, not a move
+		MedicationDispenseService medicationDispenseService = Context.getMedicationDispenseService();
+		MedicationDispenseCriteria criteria = new MedicationDispenseCriteriaBuilder().setPatient(notPreferred).build();
+		for (MedicationDispense medicationDispense : medicationDispenseService.getMedicationDispenseByCriteria(criteria)) {
+			medicationDispense.setPatient(preferred);
+			log.debug("Merging medication dispense {} to {}", medicationDispense.getMedicationDispenseId(),
+			    preferred.getPatientId());
+			MedicationDispense persisted = medicationDispenseService.saveMedicationDispense(medicationDispense);
+			mergedData.addMovedMedicationDispense(persisted.getUuid());
+		}
+	}
+
 	private void mergeIdentifiers(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
 		// move all identifiers
 		// (must be done after all calls to services above so hbm doesn't try to save things prematurely (hacky)

--- a/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
+++ b/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
@@ -64,7 +64,28 @@ public class PersonMergeLogData {
 	 * preferred
 	 */
 	private List<String> movedIndependentObservations;
-	
+
+	/**
+	 * List of UUIDs of conditions moved from non-preferred to preferred
+	 *
+	 * @since 2.9.0
+	 */
+	private List<String> movedConditions;
+
+	/**
+	 * List of UUIDs of allergies moved from non-preferred to preferred
+	 *
+	 * @since 2.9.0
+	 */
+	private List<String> movedAllergies;
+
+	/**
+	 * List of UUIDs of medication dispenses moved from non-preferred to preferred
+	 *
+	 * @since 2.9.0
+	 */
+	private List<String> movedMedicationDispenses;
+
 	/**
 	 * List of UUIDs of orders copied from non-preferred to preferred
 	 */
@@ -206,7 +227,58 @@ public class PersonMergeLogData {
 		}
 		movedIndependentObservations.add(uuid);
 	}
-	
+
+	/**
+	 * @since 2.9.0
+	 */
+	public List<String> getMovedConditions() {
+		return movedConditions;
+	}
+
+	/**
+	 * @since 2.9.0
+	 */
+	public void addMovedCondition(String uuid) {
+		if (movedConditions == null) {
+			movedConditions = new ArrayList<>();
+		}
+		movedConditions.add(uuid);
+	}
+
+	/**
+	 * @since 2.9.0
+	 */
+	public List<String> getMovedAllergies() {
+		return movedAllergies;
+	}
+
+	/**
+	 * @since 2.9.0
+	 */
+	public void addMovedAllergy(String uuid) {
+		if (movedAllergies == null) {
+			movedAllergies = new ArrayList<>();
+		}
+		movedAllergies.add(uuid);
+	}
+
+	/**
+	 * @since 2.9.0
+	 */
+	public List<String> getMovedMedicationDispenses() {
+		return movedMedicationDispenses;
+	}
+
+	/**
+	 * @since 2.9.0
+	 */
+	public void addMovedMedicationDispense(String uuid) {
+		if (movedMedicationDispenses == null) {
+			movedMedicationDispenses = new ArrayList<>();
+		}
+		movedMedicationDispenses.add(uuid);
+	}
+
 	public List<String> getCreatedOrders() {
 		return createdOrders;
 	}
@@ -363,6 +435,15 @@ public class PersonMergeLogData {
 		}
 		if (getMovedIndependentObservations() != null) {
 			str += getMovedIndependentObservations().toString();
+		}
+		if (getMovedConditions() != null) {
+			str += getMovedConditions().toString();
+		}
+		if (getMovedAllergies() != null) {
+			str += getMovedAllergies().toString();
+		}
+		if (getMovedMedicationDispenses() != null) {
+			str += getMovedMedicationDispenses().toString();
 		}
 		if (getMovedUsers() != null) {
 			str += getMovedUsers().toString();

--- a/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
+++ b/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
@@ -67,22 +67,16 @@ public class PersonMergeLogData {
 
 	/**
 	 * List of UUIDs of conditions moved from non-preferred to preferred
-	 *
-	 * @since 2.9.0
 	 */
 	private List<String> movedConditions;
 
 	/**
 	 * List of UUIDs of allergies moved from non-preferred to preferred
-	 *
-	 * @since 2.9.0
 	 */
 	private List<String> movedAllergies;
 
 	/**
 	 * List of UUIDs of medication dispenses moved from non-preferred to preferred
-	 *
-	 * @since 2.9.0
 	 */
 	private List<String> movedMedicationDispenses;
 

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -47,10 +47,18 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.Allergen;
+import org.openmrs.AllergenType;
+import org.openmrs.Allergies;
+import org.openmrs.Allergy;
+import org.openmrs.CodedOrFreeText;
 import org.openmrs.Concept;
+import org.openmrs.Condition;
+import org.openmrs.ConditionClinicalStatus;
 import org.openmrs.Encounter;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Location;
+import org.openmrs.MedicationDispense;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
@@ -71,6 +79,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.PatientServiceImpl;
 import org.openmrs.api.impl.PatientServiceImplTest;
 import org.openmrs.comparator.PatientIdentifierTypeDefaultComparator;
+import org.openmrs.parameter.MedicationDispenseCriteria;
+import org.openmrs.parameter.MedicationDispenseCriteriaBuilder;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.impl.LuhnIdentifierValidator;
 import org.openmrs.person.PersonMergeLog;
@@ -113,6 +123,8 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 	private static final String PATIENT_MERGE_XML = "org/openmrs/api/include/PatientServiceTest-mergePatients.xml";
 
 	private static final String PATIENT_MERGE_OBS_WITH_GROUP_MEMBER = "org/openmrs/api/include/PatientServiceTest-mergePatientWithExistingObsHavingGroupMember.xml";
+
+	private static final String MEDICATION_DISPENSE_XML = "org/openmrs/api/include/MedicationDispenseServiceTest-initialData.xml";
 	
 	// Services
 	protected static PatientService patientService = null;
@@ -2499,7 +2511,288 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		}
 		assertTrue(isValueInList(uuid, audit.getPersonMergeLogData().getMovedIndependentObservations()), "moving of independent observation was not audited");
 	}
-	
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldMoveConditionsFromNonPreferredToPreferredPatient() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+		ConditionService conditionService = Context.getConditionService();
+
+		// give the non-preferred patient a condition
+		CodedOrFreeText codedOrFreeText = new CodedOrFreeText();
+		codedOrFreeText.setNonCoded("Severe headache");
+		Condition condition = new Condition();
+		condition.setCondition(codedOrFreeText);
+		condition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		condition.setPatient(notPreferred);
+		conditionService.saveCondition(condition);
+		assertThat(conditionService.getAllConditions(notPreferred).size(), is(1));
+		assertThat(conditionService.getAllConditions(preferred).size(), is(0));
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// the condition should now belong to the preferred patient and the move should be audited
+		List<Condition> preferredConditions = conditionService.getAllConditions(preferred);
+		assertThat(preferredConditions.size(), is(1));
+		assertThat(preferredConditions.get(0).getCondition().getNonCoded(), is("Severe headache"));
+		assertTrue(isValueInList(preferredConditions.get(0).getUuid(), audit.getPersonMergeLogData().getMovedConditions()),
+		    "moving of condition was not audited");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldMoveEncounterLinkedConditionFromNonPreferredToPreferredPatient() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+		ConditionService conditionService = Context.getConditionService();
+
+		// give the non-preferred patient a condition linked to one of its encounters: moving the encounter
+		// does not reassign the condition's patient, so mergeConditions must move it (and keep the link)
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		assertThat(encounter.getPatient(), is(notPreferred));
+		CodedOrFreeText codedOrFreeText = new CodedOrFreeText();
+		codedOrFreeText.setNonCoded("Encounter linked condition");
+		Condition condition = new Condition();
+		condition.setCondition(codedOrFreeText);
+		condition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		condition.setPatient(notPreferred);
+		condition.setEncounter(encounter);
+		conditionService.saveCondition(condition);
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// the condition (and the encounter it rides on) now belong to the preferred patient, and the move is audited
+		List<Condition> preferredConditions = conditionService.getAllConditions(preferred);
+		assertThat(preferredConditions.size(), is(1));
+		Condition moved = preferredConditions.get(0);
+		assertThat(moved.getCondition().getNonCoded(), is("Encounter linked condition"));
+		assertThat(moved.getEncounter().getEncounterId(), is(3));
+		assertThat(moved.getEncounter().getPatient(), is(preferred));
+		assertTrue(isValueInList(moved.getUuid(), audit.getPersonMergeLogData().getMovedConditions()),
+		    "moving of encounter-linked condition was not audited");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldNotMoveVoidedConditions() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+		ConditionService conditionService = Context.getConditionService();
+
+		// notPreferred has one live condition and one voided condition
+		CodedOrFreeText liveText = new CodedOrFreeText();
+		liveText.setNonCoded("Live condition");
+		Condition live = new Condition();
+		live.setCondition(liveText);
+		live.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		live.setPatient(notPreferred);
+		conditionService.saveCondition(live);
+		CodedOrFreeText voidedText = new CodedOrFreeText();
+		voidedText.setNonCoded("Voided condition");
+		Condition voided = new Condition();
+		voided.setCondition(voidedText);
+		voided.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		voided.setPatient(notPreferred);
+		conditionService.saveCondition(voided);
+		String voidedUuid = voided.getUuid();
+		conditionService.voidCondition(voided, "test");
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// only the live condition moves; the voided one stays behind on the loser and is not audited
+		List<Condition> preferredConditions = conditionService.getAllConditions(preferred);
+		assertThat(preferredConditions.size(), is(1));
+		assertThat(preferredConditions.get(0).getCondition().getNonCoded(), is("Live condition"));
+		assertFalse(isValueInList(voidedUuid, audit.getPersonMergeLogData().getMovedConditions()),
+		    "voided condition should not have been moved");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldMoveAllergiesFromNonPreferredToPreferredPatient() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// give the non-preferred patient an allergy
+		Allergen allergen = new Allergen(AllergenType.DRUG, new Concept(3), null);
+		Allergy allergy = new Allergy(notPreferred, allergen, new Concept(4), "some comment", new ArrayList<>());
+		patientService.saveAllergy(allergy);
+		String allergyUuid = allergy.getUuid();
+		assertThat(patientService.getAllergies(notPreferred).size(), is(1));
+		assertThat(patientService.getAllergies(preferred).size(), is(0));
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// the allergy should now belong to the preferred patient and the move should be audited
+		Allergies preferredAllergies = patientService.getAllergies(preferred);
+		assertThat(preferredAllergies.size(), is(1));
+		assertThat(preferredAllergies.get(0).getUuid(), is(allergyUuid));
+		assertTrue(isValueInList(allergyUuid, audit.getPersonMergeLogData().getMovedAllergies()),
+		    "moving of allergy was not audited");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldNotMoveAllergyIfPreferredPatientAlreadyHasSameAllergen() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// both patients are allergic to the same coded allergen (the same canonical concept, so the
+		// allergens compare equal by uuid the way two separately-loaded allergies would in production)
+		Concept allergen = Context.getConceptService().getConcept(3);
+		Allergy preferredAllergy = new Allergy(preferred, new Allergen(AllergenType.DRUG, allergen, null),
+		    new Concept(4), "preferred comment", new ArrayList<>());
+		patientService.saveAllergy(preferredAllergy);
+		String preferredAllergyUuid = preferredAllergy.getUuid();
+		Allergy notPreferredAllergy = new Allergy(notPreferred, new Allergen(AllergenType.DRUG, allergen, null),
+		    new Concept(4), "non-preferred comment", new ArrayList<>());
+		patientService.saveAllergy(notPreferredAllergy);
+		String notPreferredAllergyUuid = notPreferredAllergy.getUuid();
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// the duplicate allergen must not be moved, otherwise getAllergies(preferred) would fail to load
+		Allergies preferredAllergies = patientService.getAllergies(preferred);
+		assertThat(preferredAllergies.size(), is(1));
+		assertThat(preferredAllergies.get(0).getUuid(), is(preferredAllergyUuid));
+		assertFalse(isValueInList(notPreferredAllergyUuid, audit.getPersonMergeLogData().getMovedAllergies()),
+		    "duplicate allergen should not have been moved");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldMoveOnlyAllergensNotAlreadyOnPreferredPatient() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// preferred and notPreferred share one allergen; notPreferred also has a second, unique one.
+		// The shared allergen must be skipped and the unique one moved, both in the same merge.
+		Concept sharedAllergen = Context.getConceptService().getConcept(3);
+		patientService.saveAllergy(new Allergy(preferred, new Allergen(AllergenType.DRUG, sharedAllergen, null),
+		    new Concept(4), "shared - preferred", new ArrayList<>()));
+		Allergy sharedNotPreferred = new Allergy(notPreferred, new Allergen(AllergenType.DRUG, sharedAllergen, null),
+		    new Concept(4), "shared - non-preferred", new ArrayList<>());
+		patientService.saveAllergy(sharedNotPreferred);
+		Allergy uniqueNotPreferred = new Allergy(notPreferred, new Allergen(AllergenType.DRUG, new Concept(24), null),
+		    new Concept(4), "unique - non-preferred", new ArrayList<>());
+		patientService.saveAllergy(uniqueNotPreferred);
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// preferred keeps its shared allergen and gains only the unique one (no duplicate that would break loading)
+		Allergies preferredAllergies = patientService.getAllergies(preferred);
+		assertThat(preferredAllergies.size(), is(2));
+		List<String> movedAllergies = audit.getPersonMergeLogData().getMovedAllergies();
+		assertTrue(isValueInList(uniqueNotPreferred.getUuid(), movedAllergies), "unique allergen should have been moved");
+		assertFalse(isValueInList(sharedNotPreferred.getUuid(), movedAllergies),
+		    "duplicate allergen should not have been moved");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldNotMoveVoidedAllergies() throws Exception {
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// notPreferred has one live allergy and one voided allergy (different allergens)
+		Allergy live = new Allergy(notPreferred, new Allergen(AllergenType.DRUG, new Concept(3), null),
+		    new Concept(4), "live allergy", new ArrayList<>());
+		patientService.saveAllergy(live);
+		String liveUuid = live.getUuid();
+		Allergy voided = new Allergy(notPreferred, new Allergen(AllergenType.DRUG, new Concept(24), null),
+		    new Concept(4), "voided allergy", new ArrayList<>());
+		patientService.saveAllergy(voided);
+		String voidedUuid = voided.getUuid();
+		patientService.voidAllergy(voided, "test");
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// only the live allergy moves; the voided one stays behind on the loser and is not audited
+		Allergies preferredAllergies = patientService.getAllergies(preferred);
+		assertThat(preferredAllergies.size(), is(1));
+		assertThat(preferredAllergies.get(0).getUuid(), is(liveUuid));
+		assertFalse(isValueInList(voidedUuid, audit.getPersonMergeLogData().getMovedAllergies()),
+		    "voided allergy should not have been moved");
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldMoveMedicationDispensesFromNonPreferredToPreferredPatient() throws Exception {
+		executeDataSet(MEDICATION_DISPENSE_XML);
+		MedicationDispenseService medicationDispenseService = Context.getMedicationDispenseService();
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// the non-preferred patient has two medication dispenses, the preferred patient has none
+		List<MedicationDispense> notPreferredDispenses = medicationDispenseService.getMedicationDispenseByCriteria(
+		    new MedicationDispenseCriteriaBuilder().setPatient(notPreferred).build());
+		assertThat(notPreferredDispenses.size(), is(2));
+		List<String> movedUuids = notPreferredDispenses.stream().map(MedicationDispense::getUuid)
+		    .collect(Collectors.toList());
+		MedicationDispenseCriteria preferredCriteria = new MedicationDispenseCriteriaBuilder().setPatient(preferred).build();
+		assertThat(medicationDispenseService.getMedicationDispenseByCriteria(preferredCriteria).size(), is(0));
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// the medication dispenses should now belong to the preferred patient and the moves should be audited
+		assertThat(medicationDispenseService.getMedicationDispenseByCriteria(preferredCriteria).size(), is(2));
+		assertThat(audit.getPersonMergeLogData().getMovedMedicationDispenses(), containsInAnyOrder(movedUuids.toArray()));
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldNotMoveVoidedMedicationDispense() throws Exception {
+		executeDataSet(MEDICATION_DISPENSE_XML);
+		MedicationDispenseService medicationDispenseService = Context.getMedicationDispenseService();
+		Patient preferred = patientService.getPatient(999);
+		Patient notPreferred = patientService.getPatient(7);
+		voidOrders(Collections.singleton(notPreferred));
+
+		// void one of the non-preferred patient's two dispenses
+		List<MedicationDispense> notPreferredDispenses = medicationDispenseService.getMedicationDispenseByCriteria(
+		    new MedicationDispenseCriteriaBuilder().setPatient(notPreferred).build());
+		assertThat(notPreferredDispenses.size(), is(2));
+		String voidedUuid = medicationDispenseService.voidMedicationDispense(notPreferredDispenses.get(0), "test").getUuid();
+		String liveUuid = notPreferredDispenses.get(1).getUuid();
+
+		PersonMergeLog audit = mergeAndRetrieveAudit(preferred, notPreferred);
+
+		// only the non-voided dispense is moved and audited; the voided one stays behind on the loser
+		MedicationDispenseCriteria preferredCriteria = new MedicationDispenseCriteriaBuilder().setPatient(preferred).build();
+		List<MedicationDispense> preferredDispenses = medicationDispenseService.getMedicationDispenseByCriteria(preferredCriteria);
+		assertThat(preferredDispenses.size(), is(1));
+		assertThat(preferredDispenses.get(0).getUuid(), is(liveUuid));
+		assertFalse(isValueInList(voidedUuid, audit.getPersonMergeLogData().getMovedMedicationDispenses()),
+		    "voided medication dispense should not have been moved");
+	}
+
 	/**
 	 * @see PatientService#mergePatients(Patient,Patient)
 	 */


### PR DESCRIPTION
## Description

`PatientService.mergePatients(preferred, notPreferred)` did **not** reassign **Conditions**, **Allergies**, or **MedicationDispenses** from the non-preferred (loser) patient to the preferred (winner) patient. After a merge these patient-scoped clinical records stayed attached to the now-voided loser and silently disappeared from the surviving patient's active record — a clinical-data-loss / patient-safety concern (e.g. a hidden penicillin allergy or active condition).

These three tables were added to core *after* the merge logic was written, and unlike encounter-linked clinical data (Diagnoses, Orders, encounter-contained Obs) they do **not** ride along when an encounter is moved — `EncounterServiceImpl.saveEncounter` propagates the patient to Obs/Orders/Diagnoses, but not to MedicationDispenses, and it saves encounter-linked Conditions/Allergies without changing their patient.

## Changes

- Add `mergeConditions`, `mergeAllergies` and `mergeMedicationDispenses` helpers to `PatientServiceImpl.mergePatients`. Each moves every **non-voided** record from the non-preferred to the preferred patient via the corresponding service (`ConditionService.saveCondition`, `PatientService.saveAllergy`, `MedicationDispenseService.saveMedicationDispense`), mirroring the existing `mergeObservationsNotContainedInEncounters` pattern. Saving through the services keeps the changes audited and emits the normal save events.
- **Allergies are deduplicated by allergen.** A patient cannot hold two allergies for the same allergen (`Allergies` enforces this on load), so an allergy whose allergen the preferred patient already records is left behind rather than moved — otherwise the survivor's allergy list would throw `APIException("Duplicate allergens not allowed")` on every subsequent load. (`AllergyValidator`'s duplicate check only runs for *new* allergies, so a moved allergy bypasses it — the explicit dedup guard is what protects the survivor.) This mirrors the dedup the existing merge already does for identifiers/names/addresses/relationships. Conditions and MedicationDispenses have no such uniqueness constraint and are moved unconditionally.
- Add `movedConditions`, `movedAllergies` and `movedMedicationDispenses` collections (plus accessors) to `PersonMergeLogData`, and include them in `computeHashValue`, so the moves are recorded in the `PersonMergeLog`.
- Document the new behaviors as `<strong>Should</strong>` doclet tags on the `PatientService.mergePatients` javadoc.

## Result after merge

| Type | Before | After |
|---|---|---|
| Condition | stranded on voided loser ❌ | reassigned to winner ✅ |
| Allergy | stranded on voided loser ❌ | reassigned to winner (deduped by allergen) ✅ |
| MedicationDispense | stranded on voided loser ❌ | reassigned to winner ✅ |

(Obs, Encounter/Visit/Program, Diagnosis and Order were already handled correctly and are unchanged.)

## Testing

Nine new `PatientServiceTest` cases. Each creates the record(s) on the non-preferred patient, merges, and asserts the runtime effect on the survivor **and** the `PersonMergeLog` audit:

Conditions:
- `mergePatients_shouldMoveConditionsFromNonPreferredToPreferredPatient`
- `mergePatients_shouldMoveEncounterLinkedConditionFromNonPreferredToPreferredPatient` — verifies the condition and its encounter both end up on the winner (encounter move + condition copy-on-write composition).
- `mergePatients_shouldNotMoveVoidedConditions`

Allergies:
- `mergePatients_shouldMoveAllergiesFromNonPreferredToPreferredPatient`
- `mergePatients_shouldNotMoveAllergyIfPreferredPatientAlreadyHasSameAllergen` — regression for the duplicate-allergen crash; fails (throws) without the dedup.
- `mergePatients_shouldMoveOnlyAllergensNotAlreadyOnPreferredPatient` — loser shares one allergen with the winner and has a second unique one; the unique one moves and the shared one is skipped in the same merge.
- `mergePatients_shouldNotMoveVoidedAllergies`

MedicationDispenses:
- `mergePatients_shouldMoveMedicationDispensesFromNonPreferredToPreferredPatient`
- `mergePatients_shouldNotMoveVoidedMedicationDispense`

The voided-record tests give the loser both a live and a voided record and assert only the live one moves, so they cannot pass vacuously. All `mergePatients_*` tests (46 total, including the 9 new) plus the `PersonMergeLogData` serialization round-trip test (`PersonServiceTest`) pass.

Fixes #6194

🤖 Generated with [Claude Code](https://claude.com/claude-code)