### PR TITLE
TRUNK-6196: purgePatient fails with FK violations on newer clinical tables

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateConditionDAO.java
@@ -13,6 +13,7 @@ import javax.persistence.TypedQuery;
 import java.util.Arrays;
 import java.util.List;
 
+import org.hibernate.FlushMode;
 import org.hibernate.SessionFactory;
 import org.openmrs.Condition;
 import org.openmrs.Encounter;
@@ -120,6 +121,25 @@ public class HibernateConditionDAO implements ConditionDAO {
 	 */
 	@Override
 	public void deleteCondition(Condition condition) throws DAOException {
+		// A newer version that references this condition through previous_version (created when an
+		// edited condition is re-saved) would block the delete on the condition_previous_version_fk,
+		// so clear that reference first. This is done on the loaded entities, rather than a bulk HQL
+		// update, so a managed referrer cannot re-flush the stale reference at commit time. The read
+		// would otherwise trigger a session-wide auto flush that could fail on unrelated transient
+		// state, so suspend automatic flushing while it runs.
+		FlushMode previousFlushMode = sessionFactory.getCurrentSession().getHibernateFlushMode();
+		sessionFactory.getCurrentSession().setHibernateFlushMode(FlushMode.MANUAL);
+		try {
+			List<Condition> referrers = sessionFactory.getCurrentSession()
+			        .createQuery("from Condition where previousVersion = :condition", Condition.class)
+			        .setParameter("condition", condition).list();
+			for (Condition referrer : referrers) {
+				referrer.setPreviousVersion(null);
+			}
+		}
+		finally {
+			sessionFactory.getCurrentSession().setHibernateFlushMode(previousFlushMode);
+		}
 		sessionFactory.getCurrentSession().delete(condition);
 	}
 

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -24,6 +24,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.FlushMode;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
 import org.hibernate.SessionFactory;
@@ -34,7 +35,9 @@ import org.hibernate.search.engine.search.predicate.SearchPredicate;
 import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;
+import org.openmrs.Condition;
 import org.openmrs.Location;
+import org.openmrs.MedicationDispense;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
@@ -321,7 +324,59 @@ public class HibernatePatientDAO implements PatientDAO {
 	 */
         @Override
 	public void deletePatient(Patient patient) throws DAOException {
+		deletePatientClinicalData(patient);
 		HibernatePersonDAO.deletePersonAndAttributes(sessionFactory, patient);
+	}
+
+	/**
+	 * Removes rows in the patient-scoped clinical tables that were added to core after the original
+	 * patient-lifecycle logic was written (conditions, allergies and medication dispenses). Their
+	 * foreign keys to the patient would otherwise block deleting the patient/person rows during a
+	 * purge. Unlike the void-filtered service fetch methods, this removes every row including voided
+	 * ones.
+	 *
+	 * @param patient the patient whose clinical data is being purged
+	 */
+	private void deletePatientClinicalData(Patient patient) {
+		// The reads and the bulk update below would otherwise trigger a session-wide auto flush that
+		// could fail on unrelated transient state in the session, so suspend automatic flushing while
+		// purging. Rows are removed through the session (rather than a bulk HQL delete) so that any
+		// already-managed instance is marked deleted and cannot be re-flushed against the now removed
+		// row at commit time; this also lets the allergy cascade remove its allergy_reaction rows. All
+		// of these read every row including voided ones, unlike the void-filtered service fetch methods.
+		FlushMode previousFlushMode = sessionFactory.getCurrentSession().getHibernateFlushMode();
+		sessionFactory.getCurrentSession().setHibernateFlushMode(FlushMode.MANUAL);
+		try {
+			// medication dispenses reference the patient directly
+			List<MedicationDispense> dispenses = sessionFactory.getCurrentSession()
+			        .createQuery("from MedicationDispense where patient = :patient", MedicationDispense.class)
+			        .setParameter("patient", patient).list();
+			for (MedicationDispense dispense : dispenses) {
+				sessionFactory.getCurrentSession().delete(dispense);
+			}
+
+			List<Allergy> allergies = sessionFactory.getCurrentSession()
+			        .createQuery("from Allergy where patient = :patient", Allergy.class).setParameter("patient", patient)
+			        .list();
+			for (Allergy allergy : allergies) {
+				sessionFactory.getCurrentSession().delete(allergy);
+			}
+
+			// clear the previous_version self references at the database level first, so the order in
+			// which the conditions are deleted relative to each other cannot trip the self foreign key
+			sessionFactory.getCurrentSession()
+			        .createQuery("update Condition set previousVersion = null where patient = :patient")
+			        .setParameter("patient", patient).executeUpdate();
+			List<Condition> conditions = sessionFactory.getCurrentSession()
+			        .createQuery("from Condition where patient = :patient", Condition.class).setParameter("patient", patient)
+			        .list();
+			for (Condition condition : conditions) {
+				sessionFactory.getCurrentSession().delete(condition);
+			}
+		}
+		finally {
+			sessionFactory.getCurrentSession().setHibernateFlushMode(previousFlushMode);
+		}
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -51,6 +51,7 @@ import org.openmrs.Allergen;
 import org.openmrs.AllergenType;
 import org.openmrs.Allergies;
 import org.openmrs.Allergy;
+import org.openmrs.AllergyReaction;
 import org.openmrs.CodedOrFreeText;
 import org.openmrs.Concept;
 import org.openmrs.Condition;
@@ -2031,7 +2032,111 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		// return null now
 		assertNull(patientService.getPatient(2));
 	}
-	
+
+	/**
+	 * @see PatientService#purgePatient(Patient)
+	 */
+	@Test
+	public void purgePatient_shouldDeletePatientWithConditionsAllergiesAndMedicationDispenses() throws Exception {
+		// loaded for the status concept (11112) referenced by the medication dispense created below
+		executeDataSet(MEDICATION_DISPENSE_XML);
+		ConditionService conditionService = Context.getConditionService();
+		// patient 432 has no encounters or orders, so the purge can be flushed to the database to
+		// prove the cascade actually removes the clinical rows rather than just scheduling deletes
+		Patient patientToPurge = patientService.getPatient(432);
+		assertNotNull(patientToPurge);
+
+		// an active condition for the patient
+		CodedOrFreeText activeText = new CodedOrFreeText();
+		activeText.setNonCoded("Active condition");
+		Condition activeCondition = new Condition();
+		activeCondition.setCondition(activeText);
+		activeCondition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		activeCondition.setPatient(patientToPurge);
+		conditionService.saveCondition(activeCondition);
+
+		// a voided condition, to exercise the include-voided purge path
+		CodedOrFreeText voidedText = new CodedOrFreeText();
+		voidedText.setNonCoded("Voided condition");
+		Condition voidedCondition = new Condition();
+		voidedCondition.setCondition(voidedText);
+		voidedCondition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		voidedCondition.setPatient(patientToPurge);
+		conditionService.saveCondition(voidedCondition);
+		conditionService.voidCondition(voidedCondition, "test");
+
+		// editing a condition voids the original and creates a new one pointing back at it via
+		// previous_version, which the purge cascade must clear before deleting the conditions
+		activeCondition.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
+		Condition editedCondition = conditionService.saveCondition(activeCondition);
+		assertNotNull(editedCondition.getPreviousVersion());
+
+		// an allergy with a reaction, so the cascade has to remove the allergy_reaction row first
+		Allergy allergy = new Allergy(patientToPurge, new Allergen(AllergenType.DRUG, new Concept(3), null),
+		    new Concept(4), "some comment", new ArrayList<>());
+		allergy.addReaction(new AllergyReaction(allergy, new Concept(21), null));
+		patientService.saveAllergy(allergy);
+
+		// a voided allergy (different allergen), to exercise the include-voided purge path
+		Allergy voidedAllergy = new Allergy(patientToPurge, new Allergen(AllergenType.DRUG, new Concept(24), null),
+		    new Concept(4), "voided allergy", new ArrayList<>());
+		patientService.saveAllergy(voidedAllergy);
+		patientService.voidAllergy(voidedAllergy, "test");
+
+		// a medication dispense referencing the patient
+		MedicationDispense medicationDispense = new MedicationDispense();
+		medicationDispense.setPatient(patientToPurge);
+		medicationDispense.setConcept(Context.getConceptService().getConcept(792));
+		medicationDispense.setStatus(Context.getConceptService().getConcept(11112));
+		Context.getMedicationDispenseService().saveMedicationDispense(medicationDispense);
+
+		Context.flushSession();
+
+		// without the purge cascade this fails with a foreign-key violation on the clinical tables;
+		// the flush forces the deletes, and a successful patient delete proves every dependent
+		// clinical row (conditions, allergy + reaction, medication dispense) was removed first
+		patientService.purgePatient(patientToPurge);
+		Context.flushSession();
+		Context.clearSession();
+
+		assertNull(patientService.getPatient(432));
+	}
+
+	/**
+	 * @see PatientService#purgePatient(Patient)
+	 */
+	@Test
+	public void purgePatient_shouldDeletePatientWhenModifiedClinicalDataIsHeldInTheSession() throws Exception {
+		ConditionService conditionService = Context.getConditionService();
+		Patient patientToPurge = patientService.getPatient(432);
+		assertNotNull(patientToPurge);
+
+		// persist a condition, then start fresh so it comes back as a clean managed entity
+		CodedOrFreeText text = new CodedOrFreeText();
+		text.setNonCoded("Active condition");
+		Condition condition = new Condition();
+		condition.setCondition(text);
+		condition.setClinicalStatus(ConditionClinicalStatus.ACTIVE);
+		condition.setPatient(patientToPurge);
+		conditionService.saveCondition(condition);
+		Context.flushSession();
+		Context.clearSession();
+
+		// reload and leave a pending, unflushed change on the condition
+		patientToPurge = patientService.getPatient(432);
+		Condition managed = conditionService.getAllConditions(patientToPurge).get(0);
+		managed.setAdditionalDetail("pending change");
+
+		// purge without flushing the pending change first: a bulk delete would remove the row and
+		// then re-flush the dirty managed condition against it at commit (StaleStateException),
+		// whereas deleting through the session marks the managed instance deleted instead
+		patientService.purgePatient(patientToPurge);
+		Context.flushSession();
+		Context.clearSession();
+
+		assertNull(patientService.getPatient(432));
+	}
+
 	@Test
 	public void getPatients_shouldNotReturnVoidedPatients() throws Exception {
 		executeDataSet(FIND_PATIENTS_XML);

--- a/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConditionServiceImplTest.java
@@ -440,8 +440,33 @@ public class ConditionServiceImplTest extends BaseContextSensitiveTest {
 		assertNotNull(existingCondition);
 		
 		conditionService.purgeCondition(conditionService.getCondition(conditionId));
-		
+
 		Condition purgedCondition = conditionService.getCondition(conditionId);
 		assertNull(purgedCondition);
+	}
+
+	/**
+	 * @see ConditionService#purgeCondition(Condition)
+	 */
+	@Test
+	public void purgeCondition_shouldPurgeConditionReferencedByAnotherConditionsPreviousVersion() {
+		// editing a condition voids the original and saves a new one whose previous_version points
+		// back at it
+		Condition condition = conditionService.getConditionByUuid(EXISTING_CONDITION_UUID);
+		Integer previousVersionId = condition.getConditionId();
+		condition.setClinicalStatus(ConditionClinicalStatus.INACTIVE);
+		Condition newCondition = conditionService.saveCondition(condition);
+		assertEquals(previousVersionId, newCondition.getPreviousVersion().getConditionId());
+
+		// purging the older condition must not fail on the condition_previous_version_fk
+		conditionService.purgeCondition(conditionService.getCondition(previousVersionId));
+		Context.flushSession();
+		Context.clearSession();
+
+		assertNull(conditionService.getCondition(previousVersionId));
+		// the newer condition survives with its previous_version reference cleared
+		Condition survivor = conditionService.getConditionByUuid(newCondition.getUuid());
+		assertNotNull(survivor);
+		assertNull(survivor.getPreviousVersion());
 	}
 }


### PR DESCRIPTION
## Description

`purgePatient` deleted only the person/patient rows (plus names, addresses and attributes), so a patient carrying data in clinical tables added to core **after** the original lifecycle logic — **conditions, allergies and medication dispenses** — could not be hard-purged: the delete aborted with a foreign-key violation (e.g. `condition_patient_fk`). `purgeCondition` had the same gap on its `condition_previous_version_fk` self reference.

Fixes the purge half of the patient-lifecycle gap described in #6196 (the merge half was #6194 / #6198).

## Changes

- **`HibernatePatientDAO.deletePatient`** now removes the patient's medication dispenses, allergies and conditions before deleting the person/patient rows.
  - Rows are removed through the session (load + `delete`) rather than a bulk HQL delete, so any already-managed instance is marked deleted and cannot be re-flushed against the now-removed row at commit, and so the allergy cascade removes its `allergy_reaction` children.
  - The reads include **voided** rows (unlike the void-filtered service fetch methods) because a purge must remove everything.
  - Condition `previous_version` self references are cleared at the DB level first, so the order the conditions are deleted among themselves cannot trip the self foreign key.
  - All of it runs under `FlushMode.MANUAL` so it cannot auto-flush unrelated transient session state.
- **`HibernateConditionDAO.deleteCondition`** now clears any newer version's `previous_version` reference (created when an edited condition is re-saved) before deleting — on the loaded entities rather than via a bulk update, so a managed referrer cannot re-flush the stale reference.

## Out of scope

- `Diagnosis` (`encounter_diagnosis`) also carries a `patient_id` FK, but its `encounter_id` is **NOT NULL** — a diagnosis can only exist on a patient who also has an encounter, and encounters already block purge (long-standing, unchanged behaviour). So it cannot block purge for any patient that was otherwise purgeable.
- Case 3 from the issue (purging an `Order`) needs a separate reproduction and is not addressed here.

## Tests

- `PatientServiceTest.purgePatient_shouldDeletePatientWithConditionsAllergiesAndMedicationDispenses` — purges a patient with an active condition, a voided condition, an edited condition (previous_version chain), an allergy + reaction, a voided allergy, and a medication dispense; uses an encounter/order-free patient so the delete is actually flushed to the DB.
- `PatientServiceTest.purgePatient_shouldDeletePatientWhenModifiedClinicalDataIsHeldInTheSession` — regression test: a dirty managed condition held in the session across the purge (would throw `StaleStateException` under a bulk delete).
- `ConditionServiceImplTest.purgeCondition_shouldPurgeConditionReferencedByAnotherConditionsPreviousVersion`.

All green: `PatientServiceTest` (183), `ConditionServiceImplTest` (18), `HibernateConditionDAOTest` (6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)