### PR TITLE
Fix typo: passowrd -> password in Scheduler Dashboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Grafana will be available at http://localhost:3000. Use admin as username and se
 
 ### Scheduler Dashboard
 
-The scheduler dashboard can be accessed at http://localhost:9000 by default (user: admin / passowrd: Admin123). It is enabled by default when running `docker compose up` command. It is configured in `docker-compose.override.yml`.
+The scheduler dashboard can be accessed at http://localhost:9000 by default (user: admin / password: Admin123). It is enabled by default when running `docker compose up` command. It is configured in `docker-compose.override.yml`.
 
 If you want to enable it in other environments, you need to set the following properties in `openmrs-runtime.properties`:
 


### PR DESCRIPTION
Fixed spelling mistake in README.md

Corrected "passowrd" to "password" in the 
Scheduler Dashboard section.

Documentation only, no code changes.
JIRA ticket will be linked once account access is confirmed.