### PR TITLE
Use PipeParser for inbound HL7 to remove XML/XXE attack surface

### DIFF
--- a/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
+++ b/api/src/main/java/org/openmrs/api/OpenmrsApplicationContextConfig.java
@@ -43,7 +43,7 @@ import org.springframework.transaction.TransactionManager;
 
 import ca.uhn.hl7v2.app.Application;
 import ca.uhn.hl7v2.app.MessageTypeRouter;
-import ca.uhn.hl7v2.parser.GenericParser;
+import ca.uhn.hl7v2.parser.PipeParser;
 
 /**
  * Provides OpenMRS Application Context Spring Configuration. It's a replacement for
@@ -129,9 +129,16 @@ public class OpenmrsApplicationContextConfig {
 		return configurer;
 	}
 
+	/**
+	 * OpenMRS only ever produces and consumes pipe-delimited (ER7) HL7v2 messages. A {@link PipeParser}
+	 * is used here instead of a {@code GenericParser} so that XML-encoded payloads are rejected
+	 * outright rather than being routed to HAPI's XML parser, which can expose XML external entity
+	 * (XXE) processing - external file reads, SSRF and entity-expansion DoS - when its underlying JAXP
+	 * factory is not hardened. See HL7Service#parseHL7String.
+	 */
 	@Bean
-	public GenericParser hL7Parser() {
-		return new GenericParser();
+	public PipeParser hL7Parser() {
+		return new PipeParser();
 	}
 
 	@Bean

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -79,7 +79,7 @@ import ca.uhn.hl7v2.model.v25.datatype.XPN;
 import ca.uhn.hl7v2.model.v25.segment.NK1;
 import ca.uhn.hl7v2.model.v25.segment.PID;
 import ca.uhn.hl7v2.parser.EncodingNotSupportedException;
-import ca.uhn.hl7v2.parser.GenericParser;
+import ca.uhn.hl7v2.parser.Parser;
 
 /**
  * OpenMRS HL7 API default methods This class shouldn't be instantiated by itself. Use the
@@ -98,7 +98,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service, Re
 
 	@Autowired
 	@Qualifier("hL7Parser")
-	private GenericParser parser;
+	private Parser parser;
 
 	@Autowired
 	@Qualifier("hL7Router")
@@ -122,7 +122,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service, Re
 	 *
 	 * @param parser the parser to use
 	 */
-	public void setParser(GenericParser parser) {
+	public void setParser(Parser parser) {
 		this.parser = parser;
 	}
 

--- a/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
+++ b/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
@@ -188,6 +188,27 @@ public class HL7ServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * The {@code hL7Parser} bean is a {@link ca.uhn.hl7v2.parser.PipeParser} (not a
+	 * {@code GenericParser}), so an XML-encoded payload is rejected outright with an unsupported
+	 * encoding error instead of being routed to HAPI's XML parser, which can expose XML external entity
+	 * (XXE) processing when its underlying JAXP factory is not hardened. This guards against a
+	 * regression that reintroduces XML parsing of inbound HL7. The DOCTYPE/external entity below is
+	 * never resolved because the message is refused before any XML processing occurs.
+	 *
+	 * @see HL7Service#parseHL7String(String)
+	 */
+	@Test
+	public void parseHL7String_shouldRejectXmlEncodedMessages() {
+		HL7Service hl7service = Context.getHL7Service();
+		String xmlHl7 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		        + "<!DOCTYPE ORU_R01 [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>\n"
+		        + "<ORU_R01 xmlns=\"urn:hl7-org:v2xml\">\n" + "  <MSH><MSH.1>|</MSH.1><MSH.2>^~\\&amp;</MSH.2></MSH>\n"
+		        + "  <PID><PID.5><XPN.1>&xxe;</XPN.1></PID.5></PID>\n" + "</ORU_R01>";
+		HL7Exception thrown = assertThrows(HL7Exception.class, () -> hl7service.parseHL7String(xmlHl7));
+		assertEquals("HL7 encoding not supported", thrown.getMessage());
+	}
+
+	/**
 	 * @see HL7Service#processHL7Message(Message)
 	 */
 	@Test


### PR DESCRIPTION
## Summary

The `hL7Parser` Spring bean was a HAPI `GenericParser`, which auto-detects message encoding from the first non-whitespace character and routes XML-encoded payloads (`<...`) to HAPI's XML parser. That XML parser can expose **XML external entity (XXE)** processing — external file reads, SSRF, and entity-expansion DoS — when its underlying JAXP factory is not hardened.

OpenMRS only ever produces and consumes pipe-delimited (ER7) HL7v2 messages (e.g. `ORUR01Handler` encodes via `PipeParser.encode`), so the XML branch is **unused attack surface**.

## Changes

- **`OpenmrsApplicationContextConfig.hL7Parser()`** now returns a `PipeParser` instead of a `GenericParser`. A `PipeParser` rejects XML payloads outright with an unsupported-encoding error, so they never reach the XML parser.
- **`HL7ServiceImpl`** parser field and `setParser(...)` are widened from `GenericParser` to the common `Parser` supertype, so injection still resolves and any existing `setParser` caller remains source-compatible (`setParser` is impl-only, not on the `HL7Service` interface).
- **Regression test** `HL7ServiceTest.parseHL7String_shouldRejectXmlEncodedMessages` feeds an XML/`DOCTYPE`/external-entity payload and asserts it is refused (`HL7Exception: "HL7 encoding not supported"`) before any XML processing occurs. This fails on the old `GenericParser` bean and passes on the new `PipeParser` bean.

## Reachability / scope

This is defense-in-depth on a largely-latent gap, not an unauthenticated network hole. The parser is reached via the HL7 in-queue drain (`ProcessHL7InQueueTask`, which is not a default-enabled scheduled task) after an authenticated, privileged caller writes to `hl7_in_queue`, or via direct `parseHL7String` calls. Behavior degrades gracefully: an XML message now lands in `hl7_in_error` rather than being parsed.

## Testing

- `mvn -pl api test -Dtest=HL7ServiceTest` → 30 tests, 0 failures (2 pre-existing skips).
- Full Spring context wiring exercised by the context-sensitive test, confirming the rewired bean injects cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)