### PR TITLE
Harden Velocity message templating against server-side template injection

### DIFF
--- a/api/src/main/java/org/openmrs/notification/MessageService.java
+++ b/api/src/main/java/org/openmrs/notification/MessageService.java
@@ -15,6 +15,8 @@ import java.util.Map;
 
 import org.openmrs.Role;
 import org.openmrs.User;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.util.PrivilegeConstants;
 
 public interface MessageService {
 
@@ -79,8 +81,22 @@ public interface MessageService {
 	public Message createMessage(String recipients, String sender, String subject, String message, String attachment,
 	        String attachmentContentType, String attachmentFileName) throws MessageException;
 
+	/**
+	 * Prepares a message from a stored template, rendering it with the Velocity engine. Because the
+	 * template body is treated as executable Velocity source, this is gated behind
+	 * {@link PrivilegeConstants#MANAGE_ALERTS} so that untrusted callers cannot drive the template
+	 * engine.
+	 */
+	@Authorized(PrivilegeConstants.MANAGE_ALERTS)
 	public Message prepareMessage(String templateName, Map data) throws MessageException;
 
+	/**
+	 * Prepares a message from the given template, rendering it with the Velocity engine. Because the
+	 * template body is treated as executable Velocity source, this is gated behind
+	 * {@link PrivilegeConstants#MANAGE_ALERTS} so that untrusted callers cannot drive the template
+	 * engine.
+	 */
+	@Authorized(PrivilegeConstants.MANAGE_ALERTS)
 	public Message prepareMessage(Template template) throws MessageException;
 
 	// Template methods

--- a/api/src/main/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparator.java
+++ b/api/src/main/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparator.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
 import org.openmrs.notification.Message;
 import org.openmrs.notification.MessageException;
 import org.openmrs.notification.MessagePreparator;
@@ -44,6 +45,13 @@ public class VelocityMessagePreparator implements MessagePreparator {
 			Properties props = new Properties();
 			props.put("runtime.log.logsystem.log4j.category", "velocity");
 			props.put("runtime.log.logsystem.log4j.logger", "velocity");
+			// Render templates with the SecureUberspector so that a template can never reach
+			// reflection-based code execution such as
+			// $obj.class.forName('java.lang.Runtime').getRuntime().exec(...). It blocks the reflective
+			// method calls used to load arbitrary classes and obtain a Runtime/ProcessBuilder, removing
+			// the server-side template injection -> remote code execution primitive that the default
+			// UberspectImpl exposes for any object placed in the rendering context.
+			props.put(RuntimeConstants.UBERSPECT_CLASSNAME, "org.apache.velocity.util.introspection.SecureUberspector");
 			engine.init(props);
 		} catch (Exception e) {
 			log.error("Failed to create velocity engine " + e.getMessage(), e);

--- a/api/src/test/java/org/openmrs/notification/MessageServiceTest.java
+++ b/api/src/test/java/org/openmrs/notification/MessageServiceTest.java
@@ -9,12 +9,17 @@
  */
 package org.openmrs.notification;
 
+import java.util.HashMap;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -109,6 +114,28 @@ public class MessageServiceTest extends BaseContextSensitiveTest {
 				fail();
 			}
 		}
+	}
+
+	/**
+	 * Preparing a message renders the template body with the Velocity engine, so it must be gated
+	 * behind a privilege rather than being callable by any (or no) user.
+	 *
+	 * @see MessageService#prepareMessage(Template)
+	 */
+	@Test
+	public void prepareMessage_shouldOnlyBeAllowedForUsersWithTheManageAlertsPrivilege() throws MessageException {
+		Template template = new Template();
+		template.setData(new HashMap<>());
+		template.setTemplate("Hello $name!");
+
+		// the default authenticated user is a super user and may prepare messages
+		assertNotNull(ms.prepareMessage(template));
+
+		// a user without the Manage Alerts privilege may not, via either overload (the privilege
+		// check fires before the method body, so no stored template is needed for the name overload)
+		Context.becomeUser("3-4");
+		assertThrows(APIAuthenticationException.class, () -> ms.prepareMessage(template));
+		assertThrows(APIAuthenticationException.class, () -> ms.prepareMessage("anyTemplateName", new HashMap<>()));
 	}
 
 }

--- a/api/src/test/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparatorTest.java
+++ b/api/src/test/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparatorTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.openmrs.notification.Message;
+import org.openmrs.notification.MessageException;
 import org.openmrs.notification.MessagePreparator;
 import org.openmrs.notification.Template;
 
@@ -28,10 +29,9 @@ public class VelocityMessagePreparatorTest {
 
 	/**
 	 * The engine must be configured with the SecureUberspector so that a template cannot use reflection
-	 * to obtain {@link Runtime} (the classic Velocity SSTI -&gt; RCE primitive). With the default
-	 * introspector {@code $foo.class.forName('java.lang.Runtime').getRuntime()} resolves to a live
-	 * Runtime instance; the secure introspector blocks the reflective method calls so the reference
-	 * cannot resolve.
+	 * to obtain {@link Runtime} (the classic Velocity SSTI -&gt; RCE primitive). Both the
+	 * {@code $foo.class} property form and the {@code $foo.getClass()} method form must be neutralised;
+	 * with the default introspector either resolves to a live Runtime instance.
 	 *
 	 * @see VelocityMessagePreparator#prepare(Template)
 	 */
@@ -42,14 +42,12 @@ public class VelocityMessagePreparatorTest {
 		Map<String, Object> data = new HashMap<>();
 		data.put("foo", "bar");
 
-		Template template = new Template();
-		template.setData(data);
-		template.setTemplate("#set($r=$foo.class.forName('java.lang.Runtime').getRuntime())[$r]");
+		// property form: $foo.class.forName(...)
+		assertRuntimeIsNotReachable(preparator, data, "#set($r=$foo.class.forName('java.lang.Runtime').getRuntime())[$r]");
 
-		Message message = preparator.prepare(template);
-
-		assertFalse(message.getContent().contains("java.lang.Runtime"),
-		    "SecureUberspector must block reflective access to java.lang.Runtime, but rendered: " + message.getContent());
+		// method form: $foo.getClass().forName(...)
+		assertRuntimeIsNotReachable(preparator, data,
+		    "#set($r=$foo.getClass().forName('java.lang.Runtime').getRuntime())[$r]");
 	}
 
 	/**
@@ -71,5 +69,17 @@ public class VelocityMessagePreparatorTest {
 		Message message = preparator.prepare(template);
 
 		assertEquals("Hello World!", message.getContent());
+	}
+
+	private void assertRuntimeIsNotReachable(MessagePreparator preparator, Map<String, Object> data, String templateBody)
+	        throws MessageException {
+		Template template = new Template();
+		template.setData(data);
+		template.setTemplate(templateBody);
+
+		Message message = preparator.prepare(template);
+
+		assertFalse(message.getContent().contains("java.lang.Runtime"),
+		    "SecureUberspector must block reflective access to java.lang.Runtime, but rendered: " + message.getContent());
 	}
 }

--- a/api/src/test/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparatorTest.java
+++ b/api/src/test/java/org/openmrs/notification/mail/velocity/VelocityMessagePreparatorTest.java
@@ -1,0 +1,75 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.notification.mail.velocity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.notification.Message;
+import org.openmrs.notification.MessagePreparator;
+import org.openmrs.notification.Template;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@link VelocityMessagePreparator}, in particular that the underlying Velocity engine is
+ * hardened against server-side template injection.
+ */
+public class VelocityMessagePreparatorTest {
+
+	/**
+	 * The engine must be configured with the SecureUberspector so that a template cannot use reflection
+	 * to obtain {@link Runtime} (the classic Velocity SSTI -&gt; RCE primitive). With the default
+	 * introspector {@code $foo.class.forName('java.lang.Runtime').getRuntime()} resolves to a live
+	 * Runtime instance; the secure introspector blocks the reflective method calls so the reference
+	 * cannot resolve.
+	 *
+	 * @see VelocityMessagePreparator#prepare(Template)
+	 */
+	@Test
+	public void prepare_shouldNotAllowReflectiveAccessToRuntimeInTemplate() throws Exception {
+		MessagePreparator preparator = new VelocityMessagePreparator();
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("foo", "bar");
+
+		Template template = new Template();
+		template.setData(data);
+		template.setTemplate("#set($r=$foo.class.forName('java.lang.Runtime').getRuntime())[$r]");
+
+		Message message = preparator.prepare(template);
+
+		assertFalse(message.getContent().contains("java.lang.Runtime"),
+		    "SecureUberspector must block reflective access to java.lang.Runtime, but rendered: " + message.getContent());
+	}
+
+	/**
+	 * Hardening the engine must not break legitimate variable substitution.
+	 *
+	 * @see VelocityMessagePreparator#prepare(Template)
+	 */
+	@Test
+	public void prepare_shouldStillSubstituteOrdinaryVariables() throws Exception {
+		MessagePreparator preparator = new VelocityMessagePreparator();
+
+		Map<String, Object> data = new HashMap<>();
+		data.put("name", "World");
+
+		Template template = new Template();
+		template.setData(data);
+		template.setTemplate("Hello $name!");
+
+		Message message = preparator.prepare(template);
+
+		assertEquals("Hello World!", message.getContent());
+	}
+}


### PR DESCRIPTION
## Summary

`VelocityMessagePreparator` initialised its `VelocityEngine` with the default `UberspectImpl`, which lets a template reflectively navigate from any context object to arbitrary classes — the classic Velocity SSTI primitive `$obj.class.forName('java.lang.Runtime').getRuntime().exec(...)`. I verified empirically that with the default engine a template can obtain a live `java.lang.Runtime`, and that `SecureUberspector` blocks it.

This PR hardens that path as **defence in depth**. To be clear about scope: **no current OpenMRS Core entry point feeds untrusted input into `prepareMessage()`.** `prepareMessage(...)` has no callers outside the service itself, `Template#setTemplate(...)` is never called with request data, and the only real `MessageService` consumers (`UserServiceImpl#setUserActivationKey`, `AlertReminderTask`) use server-side strings. So this guards against a future regression rather than fixing a reachable vulnerability.

## Changes

1. **`VelocityMessagePreparator`** — configure the engine with `SecureUberspector` via `RuntimeConstants.UBERSPECT_CLASSNAME`. This blocks the reflective method calls used to load classes / obtain `Runtime`/`ProcessBuilder`, while leaving ordinary `$variable` substitution intact. (Using the constant rather than a string literal avoids a silently-ineffective config if the property key ever changes.)
2. **`MessageService`** — gate the two `prepareMessage(...)` overloads (the only paths that drive the template engine) behind `@Authorized(PrivilegeConstants.MANAGE_ALERTS)`, consistent with the sibling `AlertService`. `sendMessage(...)` is intentionally left unannotated because the unauthenticated password-reset flow (`UserServiceImpl#setUserActivationKey`) depends on it.
3. **`VelocityMessagePreparatorTest`** — new test asserting (a) a template cannot reflect its way to `java.lang.Runtime`, and (b) normal variable substitution still works.

## Testing

- `VelocityMessagePreparatorTest` — both tests pass. The reflection test renders `java.lang.Runtime@…` against the old (default) engine and is blocked with `SecureUberspector`, so it is a genuine regression guard, not a tautology.
- `mvn -pl api spotless:check` passes.
- The pre-existing `MessageServiceTest#sendMessage_shouldSendMessage` failure is unrelated (no SMTP server in the build environment) and reproduces on `master` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
