### PR TITLE
Publish MergePatientServiceEvent after patient merge

### DIFF
--- a/api/src/main/java/org/openmrs/aop/event/MergePatientServiceEvent.java
+++ b/api/src/main/java/org/openmrs/aop/event/MergePatientServiceEvent.java
@@ -1,0 +1,60 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import org.openmrs.Patient;
+import org.openmrs.event.BaseSessionEvent;
+
+import java.util.Set;
+
+/**
+ * Published manually by {@link org.openmrs.api.impl.PatientServiceImpl#mergePatients(Patient, Patient)}
+ * after a patient merge completes, since {@code mergePatients} does not match the
+ * save/create/void/unvoid/retire/unretire/purge naming convention recognised by
+ * {@link org.openmrs.aop.OpenmrsServiceEventAdvice}.
+ *
+ * @since 2.9.0
+ */
+public class MergePatientServiceEvent extends BaseSessionEvent {
+	private static final long serialVersionUID = 1L;
+
+	private Patient winner;
+
+	private Patient loser;
+
+	public MergePatientServiceEvent() {
+	}
+
+	public MergePatientServiceEvent(Patient winner, Patient loser) {
+		this(winner, loser, Set.of());
+	}
+
+	public MergePatientServiceEvent(Patient winner, Patient loser, Set<String> tags) {
+		super(tags);
+		this.winner = winner;
+		this.loser = loser;
+	}
+
+	public Patient getWinner() {
+		return winner;
+	}
+
+	public void setWinner(Patient winner) {
+		this.winner = winner;
+	}
+
+	public Patient getLoser() {
+		return loser;
+	}
+
+	public void setLoser(Patient loser) {
+		this.loser = loser;
+	}
+}

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -44,6 +44,7 @@ import org.openmrs.PersonName;
 import org.openmrs.Relationship;
 import org.openmrs.User;
 import org.openmrs.Visit;
+import org.openmrs.aop.event.MergePatientServiceEvent;
 import org.openmrs.api.APIException;
 import org.openmrs.api.BlankIdentifierException;
 import org.openmrs.api.ConditionService;
@@ -63,6 +64,7 @@ import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.PatientDAO;
 import org.openmrs.api.db.hibernate.HibernateUtil;
+import org.openmrs.event.EventPublisher;
 import org.openmrs.parameter.EncounterSearchCriteria;
 import org.openmrs.parameter.EncounterSearchCriteriaBuilder;
 import org.openmrs.parameter.MedicationDispenseCriteria;
@@ -95,18 +97,27 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	private static final Logger log = LoggerFactory.getLogger(PatientServiceImpl.class);
 	
 	private PatientDAO dao;
-	
+
+	private EventPublisher eventPublisher;
+
 	/**
 	 * PatientIdentifierValidators registered through spring's applicationContext-service.xml
 	 */
 	private static Map<Class<? extends IdentifierValidator>, IdentifierValidator> identifierValidators = null;
-	
+
 	/**
 	 * @see org.openmrs.api.PatientService#setPatientDAO(org.openmrs.api.db.PatientDAO)
 	 */
 	@Override
 	public void setPatientDAO(PatientDAO dao) {
 		this.dao = dao;
+	}
+
+	/**
+	 * Registered through spring's applicationContext-service.xml
+	 */
+	public void setEventPublisher(EventPublisher eventPublisher) {
+		this.eventPublisher = eventPublisher;
 	}
 	
 	/**
@@ -608,8 +619,12 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		personMergeLog.setLoser(notPreferred);
 		personMergeLog.setPersonMergeLogData(mergedData);
 		Context.getPersonService().savePersonMergeLog(personMergeLog);
+
+		if (eventPublisher != null) {
+			eventPublisher.publishEvent(new MergePatientServiceEvent(preferred, notPreferred));
+		}
 	}
-	
+
 	private void requireNoActiveOrderOfSameType(Patient patient1, Patient patient2) {
 		String messageKey = "Patient.merge.cannotHaveSameTypeActiveOrders";
 		List<Order> ordersByPatient1 = Context.getOrderService().getAllOrdersByPatient(patient1);

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -195,6 +195,7 @@
 	-->
 	<bean id="patientServiceTarget" class="org.openmrs.api.impl.PatientServiceImpl">
 		<property name="patientDAO" ref="patientDAO"/>
+		<property name="eventPublisher" ref="eventPublisher"/>
 		<property name="identifierValidators">
 			<map>
 				<entry key="org.openmrs.patient.impl.LuhnIdentifierValidator">

--- a/api/src/test/java/org/openmrs/aop/event/TestMergePatientServiceEventListener.java
+++ b/api/src/test/java/org/openmrs/aop/event/TestMergePatientServiceEventListener.java
@@ -1,0 +1,38 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test listener used to assert that {@link MergePatientServiceEvent} is published.
+ */
+@Component
+public class TestMergePatientServiceEventListener {
+
+	private final List<MergePatientServiceEvent> events = new ArrayList<>();
+
+	@EventListener
+	public void onMergePatientServiceEvent(MergePatientServiceEvent event) {
+		events.add(event);
+	}
+
+	public List<MergePatientServiceEvent> getEvents() {
+		return events;
+	}
+
+	public void clear() {
+		events.clear();
+	}
+}

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -75,6 +75,8 @@ import org.openmrs.Relationship;
 import org.openmrs.RelationshipType;
 import org.openmrs.User;
 import org.openmrs.Visit;
+import org.openmrs.aop.event.MergePatientServiceEvent;
+import org.openmrs.aop.event.TestMergePatientServiceEventListener;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.PatientServiceImpl;
 import org.openmrs.api.impl.PatientServiceImplTest;
@@ -761,6 +763,27 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		voidOrders(Collections.singleton(notPreferred));
 		Context.getPatientService().mergePatients(patientService.getPatient(6), notPreferred);
 		assertTrue(Context.getPersonService().getPerson(2).getVoided());
+	}
+
+	/**
+	 * @see PatientService#mergePatients(Patient,Patient)
+	 */
+	@Test
+	public void mergePatients_shouldPublishMergePatientServiceEvent() throws Exception {
+		TestMergePatientServiceEventListener listener = Context.getRegisteredComponent(
+		    "testMergePatientServiceEventListener", TestMergePatientServiceEventListener.class);
+		listener.clear();
+
+		Patient preferred = patientService.getPatient(6);
+		Patient notPreferred = patientService.getPatient(2);
+		voidOrders(Collections.singleton(notPreferred));
+
+		Context.getPatientService().mergePatients(preferred, notPreferred);
+
+		assertEquals(1, listener.getEvents().size());
+		MergePatientServiceEvent event = listener.getEvents().get(0);
+		assertEquals(preferred.getPatientId(), event.getWinner().getPatientId());
+		assertEquals(notPreferred.getPatientId(), event.getLoser().getPatientId());
 	}
 	
 	/**


### PR DESCRIPTION
This PR was written primarily by Claude Code; I reviewed the change and ran the mergePatients test suite before submitting.

## Problem

`PatientService.mergePatients` doesn't match the `save*/create*/void*/unvoid*/retire*/unretire*/purge*` method-name patterns recognised by `OpenmrsServiceEventAdvice` (added in #6084 / #6190), so no domain event is published for a patient merge. Consumers have to key off the incidental `SaveServiceEvent<PersonMergeLog>` from the final `savePersonMergeLog` call instead of a documented, stable signal - a future refactor of how the merge log is persisted would silently break those consumers.

## Fix

As suggested in the issue and confirmed by @rkorytkowski ("For methods that do not follow our save/create/void/... convention we should not extend our AOP rather publish events directly from such methods. The suggested MergePatientServiceEvent sounds right"):

- Added `MergePatientServiceEvent` (in `org.openmrs.aop.event`, alongside the existing `SaveServiceEvent`/`VoidServiceEvent`/etc.), carrying the winner and loser `Patient`.
- `PatientServiceImpl` now has an `EventPublisher` property (wired in `applicationContext-service.xml`, matching the existing `patientDAO` wiring) and publishes the event manually at the end of `mergePatients`, after `savePersonMergeLog` - i.e. after the transaction's work is complete, as suggested in the issue.
- The list-based `mergePatients(Patient, List<Patient>)` overload already delegates to the single-pair method in a loop, so it gets the event for free.

## Testing

Added `mergePatients_shouldPublishMergePatientServiceEvent` to `PatientServiceTest`, using a small test `@Component`/`@EventListener` (`TestMergePatientServiceEventListener`) to capture and assert the published event's winner/loser, following the existing `TestTransactionalEventAggregator` pattern for test-scoped listener beans.

Ran the full `mergePatients_*` test suite in `PatientServiceTest` - all pass, no regressions.

Fixes #6195