### PR TITLE
TRUNK-6674: Accept new SNOMED CT code for Minutes duration unit (2.9.x backport)

### DIFF
--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -32,6 +32,16 @@ public class Duration {
 	
 	public static final String SNOMED_CT_MINUTES_CODE = "258701004";
 	
+	/**
+	 * Active SNOMED CT code for minute. SNOMED CT inactivated the legacy code
+	 * {@link #SNOMED_CT_MINUTES_CODE} ("258701004") in its 2021-07-31 release, and dictionaries such as
+	 * CIEL now map minutes concepts to this code. The legacy code is still accepted for backward
+	 * compatibility.
+	 *
+	 * @since 2.8.8, 2.9.0, 3.0.0
+	 */
+	public static final String SNOMED_CT_MINUTES_CODE_2 = "1156209001";
+	
 	public static final String SNOMED_CT_HOURS_CODE = "258702006";
 	
 	public static final String SNOMED_CT_DAYS_CODE = "258703001";
@@ -77,7 +87,7 @@ public class Duration {
 		if (SNOMED_CT_SECONDS_CODE.equals(code)) {
 			return addSeconds(startDate, this.duration);
 		}
-		if (SNOMED_CT_MINUTES_CODE.equals(code)) {
+		if (SNOMED_CT_MINUTES_CODE.equals(code) || SNOMED_CT_MINUTES_CODE_2.equals(code)) {
 			return addMinutes(startDate, this.duration);
 		}
 		if (SNOMED_CT_HOURS_CODE.equals(code)) {

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -46,6 +46,15 @@ public class DurationTest extends BaseContextSensitiveTest {
 	}
 	
 	@Test
+	public void addToDate_shouldAddMinutesWhenUnitIsMinutesUsingNewSnomedCode() throws ParseException {
+		Duration duration = new Duration(30, Duration.SNOMED_CT_MINUTES_CODE_2);
+		
+		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
+		
+		assertEquals(createDateTime("2014-07-01 10:30:00"), autoExpireDate);
+	}
+	
+	@Test
 	public void addToDate_shouldAddHoursWhenUnitIsHours() throws ParseException {
 		Duration duration = new Duration(10, Duration.SNOMED_CT_HOURS_CODE);
 		


### PR DESCRIPTION
Backport of #6242 to the 2.9.x branch, shipping in 2.9.0, so the fix is not lost in the upcoming release.

## Description of what I changed

**Before:** Saving a drug order with duration unit "Minutes" returned HTTP 500 (`Unknown code 1156209001 for SNOMED CT duration units`) because core only recognized the legacy SNOMED CT code `258701004`.

**After:** Core also recognizes `1156209001`, the active SNOMED CT minute concept. SNOMED CT inactivated the legacy code `258701004` in its 2021-07-31 release, and dictionaries such as CIEL now map Minutes concepts (CIEL 1733) to the new code, which is why current dictionaries trigger the failure. The legacy code is still accepted for backward compatibility.

Same change as #6242, applied to this branch's formatting conventions (this branch predates the Spotless migration).

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6674

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing `DurationTest` tests pass locally (`mvn -pl api -am test -Dtest=DurationTest`); full suite left to CI.
- [x] My pull request is based on the latest changes of the 2.9.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
