### PR TITLE
TRUNK-6674: Resolve drug order duration units across all known SNOMED CT and UCUM codes

### DIFF
--- a/api/src/main/java/org/openmrs/BaseDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/BaseDosingInstructions.java
@@ -26,7 +26,7 @@ public abstract class BaseDosingInstructions implements DosingInstructions {
 		if (drugOrder.getDuration() == null || drugOrder.getDurationUnits() == null) {
 			return null;
 		}
-		String durationCode = Duration.getCode(drugOrder.getDurationUnits());
+		String durationCode = Duration.getKnownCode(drugOrder.getDurationUnits());
 		if (durationCode == null) {
 			return null;
 		}

--- a/api/src/main/java/org/openmrs/BaseDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/BaseDosingInstructions.java
@@ -26,11 +26,10 @@ public abstract class BaseDosingInstructions implements DosingInstructions {
 		if (drugOrder.getDuration() == null || drugOrder.getDurationUnits() == null) {
 			return null;
 		}
-		String durationCode = Duration.getKnownCode(drugOrder.getDurationUnits());
-		if (durationCode == null) {
+		Duration duration = Duration.getDuration(drugOrder.getDuration(), drugOrder.getDurationUnits());
+		if (duration == null) {
 			return null;
 		}
-		Duration duration = new Duration(drugOrder.getDuration(), durationCode);
 		return aMomentBefore(duration.addToDate(drugOrder.getEffectiveStartDate(), drugOrder.getFrequency()));
 	}
 

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -61,6 +61,15 @@ public class Duration {
 	public static final String SNOMED_CT_CONCEPT_SOURCE_HL7_CODE = "SCT";
 
 	/**
+	 * Name identifying the SNOMED CT concept source, used as a fallback for dictionaries that register
+	 * the source by name without setting its HL7 code to {@link #SNOMED_CT_CONCEPT_SOURCE_HL7_CODE},
+	 * mirroring how {@link #UCUM_CONCEPT_SOURCE_NAME} is matched.
+	 *
+	 * @since 3.0.0
+	 */
+	public static final String SNOMED_CT_CONCEPT_SOURCE_NAME = "SNOMED CT";
+
+	/**
 	 * Name identifying the concept source for The Unified Code for Units of Measure
 	 * (<a href="https://ucum.org">ucum.org</a>), whose codes for the units of time are stable by
 	 * design. Dictionaries commonly map duration unit concepts to UCUM in addition to SNOMED CT.
@@ -204,11 +213,25 @@ public class Duration {
 
 	private final Integer duration;
 
+	private final Unit unit;
+
+	/**
+	 * The raw code this duration was constructed from, retained only so {@link #addToDate} can name the
+	 * offending code when it is not one this class recognises. Null when the duration was built from an
+	 * already-resolved {@link Unit}.
+	 */
 	private final String code;
 
 	public Duration(Integer duration, String code) {
 		this.duration = duration;
 		this.code = code;
+		this.unit = findUnit(code);
+	}
+
+	private Duration(Integer duration, Unit unit) {
+		this.duration = duration;
+		this.unit = unit;
+		this.code = null;
 	}
 
 	/**
@@ -220,14 +243,20 @@ public class Duration {
 	 * @return date which is startDate plus duration
 	 */
 	public Date addToDate(Date startDate, OrderFrequency frequency) {
-		Unit unit = SNOMED_CT_UNITS_BY_CODE.get(code);
-		if (unit == null) {
-			unit = UCUM_UNITS_BY_CODE.get(code);
-		}
 		if (unit == null) {
 			throw new APIException("Duration.unknown.code", new Object[] { code });
 		}
 		return unit.addToDate(startDate, this.duration, frequency);
+	}
+
+	/**
+	 * Resolves a bare code to a {@link Unit} the way the legacy {@link #Duration(Integer, String)}
+	 * constructor must: by trying the SNOMED CT then the UCUM code tables, since the constructor
+	 * carries no concept source. Returns null when the code is not recognised.
+	 */
+	private static Unit findUnit(String code) {
+		Unit unit = SNOMED_CT_UNITS_BY_CODE.get(code);
+		return unit != null ? unit : UCUM_UNITS_BY_CODE.get(code);
 	}
 
 	/**
@@ -278,7 +307,6 @@ public class Duration {
 	 * @since 3.0.0
 	 */
 	public static Duration getDuration(Integer duration, Concept durationUnits) {
-		String knownCode = null;
 		Unit knownUnit = null;
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
 			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
@@ -290,19 +318,18 @@ public class Duration {
 				continue;
 			}
 			if (knownUnit == null) {
-				knownCode = conceptReferenceTerm.getCode();
 				knownUnit = unit;
 			} else if (knownUnit != unit) {
 				log.warn("Not resolving duration units concept {} because its SAME-AS mappings denote different units,"
-				        + " e.g. codes {} and {}",
-				    durationUnits.getUuid(), knownCode, conceptReferenceTerm.getCode());
+				        + " e.g. {} and {}",
+				    durationUnits.getUuid(), knownUnit, unit);
 				return null;
 			}
 		}
-		if (knownCode == null) {
+		if (knownUnit == null) {
 			return null;
 		}
-		return new Duration(duration, knownCode);
+		return new Duration(duration, knownUnit);
 	}
 
 	private static Unit findUnit(ConceptSource conceptSource, String code) {
@@ -316,7 +343,8 @@ public class Duration {
 	}
 
 	private static boolean isSnomedCtSource(ConceptSource conceptSource) {
-		return SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code());
+		return SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
+		        || SNOMED_CT_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName());
 	}
 
 	private static boolean isUcumSource(ConceptSource conceptSource) {

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -271,7 +271,7 @@ public class Duration {
 	 *             concept's mappings and is not necessarily a code this class can interpret; use
 	 *             {@link #getDuration(Integer, Concept)} instead
 	 */
-	@Deprecated
+	@Deprecated(since = "3.0.0")
 	public static String getCode(Concept durationUnits) {
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
 			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
@@ -309,27 +309,30 @@ public class Duration {
 	public static Duration getDuration(Integer duration, Concept durationUnits) {
 		Unit knownUnit = null;
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
-			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
-				continue;
-			}
-			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
-			Unit unit = findUnit(conceptReferenceTerm.getConceptSource(), conceptReferenceTerm.getCode());
-			if (unit == null) {
-				continue;
-			}
-			if (knownUnit == null) {
-				knownUnit = unit;
-			} else if (knownUnit != unit) {
-				log.warn("Not resolving duration units concept {} because its SAME-AS mappings denote different units,"
-				        + " e.g. {} and {}",
-				    durationUnits.getUuid(), knownUnit, unit);
-				return null;
+			Unit unit = findUnit(conceptMapping);
+			if (unit != null) {
+				if (knownUnit == null) {
+					knownUnit = unit;
+				} else if (knownUnit != unit) {
+					log.warn("Not resolving duration units concept {} because its SAME-AS mappings denote different"
+					        + " units, e.g. {} and {}",
+					    durationUnits.getUuid(), knownUnit, unit);
+					return null;
+				}
 			}
 		}
 		if (knownUnit == null) {
 			return null;
 		}
 		return new Duration(duration, knownUnit);
+	}
+
+	private static Unit findUnit(ConceptMap conceptMapping) {
+		if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
+			return null;
+		}
+		ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
+		return findUnit(conceptReferenceTerm.getConceptSource(), conceptReferenceTerm.getCode());
 	}
 
 	private static Unit findUnit(ConceptSource conceptSource, String code) {

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -9,7 +9,10 @@
  */
 package org.openmrs;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.openmrs.api.APIException;
 
@@ -22,7 +25,7 @@ import static org.apache.commons.lang3.time.DateUtils.addWeeks;
 import static org.apache.commons.lang3.time.DateUtils.addYears;
 
 /**
- * Duration represented using SNOMED CT duration codes
+ * Duration represented using SNOMED CT or UCUM duration codes
  *
  * @since 1.10
  */
@@ -31,6 +34,15 @@ public class Duration {
 	public static final String SNOMED_CT_SECONDS_CODE = "257997001";
 
 	public static final String SNOMED_CT_MINUTES_CODE = "258701004";
+
+	/**
+	 * The SNOMED CT code for minute that is active since the 2021-07-31 release, in which the legacy
+	 * code {@link #SNOMED_CT_MINUTES_CODE} was inactivated as ambiguous. Dictionaries that track
+	 * current SNOMED CT releases, such as CIEL, map their minutes concepts to this code.
+	 *
+	 * @since 3.0.0
+	 */
+	public static final String SNOMED_CT_MINUTES_CODE_2021 = "1156209001";
 
 	public static final String SNOMED_CT_HOURS_CODE = "258702006";
 
@@ -46,6 +58,50 @@ public class Duration {
 
 	public static final String SNOMED_CT_CONCEPT_SOURCE_HL7_CODE = "SCT";
 
+	/**
+	 * Name identifying the concept source for The Unified Code for Units of Measure
+	 * (<a href="https://ucum.org">ucum.org</a>), whose codes for the units of time are stable by
+	 * design. Dictionaries commonly map duration unit concepts to UCUM in addition to SNOMED CT.
+	 *
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_CONCEPT_SOURCE_NAME = "UCUM";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_SECONDS_CODE = "s";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_MINUTES_CODE = "min";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_HOURS_CODE = "h";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_DAYS_CODE = "d";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_WEEKS_CODE = "wk";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_MONTHS_CODE = "mo";
+
+	/**
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_YEARS_CODE = "a";
+
 	private static final int SECONDS_PER_MINUTE = 60;
 
 	private static final int MINUTES_PER_HOUR = 60;
@@ -55,6 +111,105 @@ public class Duration {
 	private static final int SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
 
 	private static final int SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
+
+	/**
+	 * The units of time a duration code can denote. Several codes may denote the same unit, e.g. the
+	 * legacy SNOMED CT minute code, its active replacement and the UCUM minute code.
+	 */
+	private enum Unit {
+
+		SECONDS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addSeconds(startDate, duration);
+			}
+		},
+
+		MINUTES {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addMinutes(startDate, duration);
+			}
+		},
+
+		HOURS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addHours(startDate, duration);
+			}
+		},
+
+		DAYS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addDays(startDate, duration);
+			}
+		},
+
+		WEEKS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addWeeks(startDate, duration);
+			}
+		},
+
+		MONTHS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addMonths(startDate, duration);
+			}
+		},
+
+		YEARS {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				return addYears(startDate, duration);
+			}
+		},
+
+		RECURRING_INTERVAL {
+
+			@Override
+			Date addToDate(Date startDate, Integer duration, OrderFrequency frequency) {
+				if (frequency == null) {
+					throw new APIException("Duration.error.frequency.null", (Object[]) null);
+				}
+				return addSeconds(startDate, (int) (duration * SECONDS_PER_DAY / frequency.getFrequencyPerDay()));
+			}
+		};
+
+		abstract Date addToDate(Date startDate, Integer duration, OrderFrequency frequency);
+	}
+
+	private static final Map<String, Unit> UNITS_BY_CODE;
+
+	static {
+		Map<String, Unit> unitsByCode = new HashMap<>();
+		unitsByCode.put(SNOMED_CT_SECONDS_CODE, Unit.SECONDS);
+		unitsByCode.put(UCUM_SECONDS_CODE, Unit.SECONDS);
+		unitsByCode.put(SNOMED_CT_MINUTES_CODE, Unit.MINUTES);
+		unitsByCode.put(SNOMED_CT_MINUTES_CODE_2021, Unit.MINUTES);
+		unitsByCode.put(UCUM_MINUTES_CODE, Unit.MINUTES);
+		unitsByCode.put(SNOMED_CT_HOURS_CODE, Unit.HOURS);
+		unitsByCode.put(UCUM_HOURS_CODE, Unit.HOURS);
+		unitsByCode.put(SNOMED_CT_DAYS_CODE, Unit.DAYS);
+		unitsByCode.put(UCUM_DAYS_CODE, Unit.DAYS);
+		unitsByCode.put(SNOMED_CT_WEEKS_CODE, Unit.WEEKS);
+		unitsByCode.put(UCUM_WEEKS_CODE, Unit.WEEKS);
+		unitsByCode.put(SNOMED_CT_MONTHS_CODE, Unit.MONTHS);
+		unitsByCode.put(UCUM_MONTHS_CODE, Unit.MONTHS);
+		unitsByCode.put(SNOMED_CT_YEARS_CODE, Unit.YEARS);
+		unitsByCode.put(UCUM_YEARS_CODE, Unit.YEARS);
+		unitsByCode.put(SNOMED_CT_RECURRING_INTERVAL_CODE, Unit.RECURRING_INTERVAL);
+		UNITS_BY_CODE = Collections.unmodifiableMap(unitsByCode);
+	}
 
 	private final Integer duration;
 
@@ -74,39 +229,19 @@ public class Duration {
 	 * @return date which is startDate plus duration
 	 */
 	public Date addToDate(Date startDate, OrderFrequency frequency) {
-		if (SNOMED_CT_SECONDS_CODE.equals(code)) {
-			return addSeconds(startDate, this.duration);
-		}
-		if (SNOMED_CT_MINUTES_CODE.equals(code)) {
-			return addMinutes(startDate, this.duration);
-		}
-		if (SNOMED_CT_HOURS_CODE.equals(code)) {
-			return addHours(startDate, this.duration);
-		}
-		if (SNOMED_CT_DAYS_CODE.equals(code)) {
-			return addDays(startDate, this.duration);
-		}
-		if (SNOMED_CT_WEEKS_CODE.equals(code)) {
-			return addWeeks(startDate, this.duration);
-		}
-		if (SNOMED_CT_MONTHS_CODE.equals(code)) {
-			return addMonths(startDate, this.duration);
-		}
-		if (SNOMED_CT_YEARS_CODE.equals(code)) {
-			return addYears(startDate, this.duration);
-		}
-		if (SNOMED_CT_RECURRING_INTERVAL_CODE.equals(code)) {
-			if (frequency == null) {
-				throw new APIException("Duration.error.frequency.null", (Object[]) null);
-			}
-			return addSeconds(startDate, (int) (this.duration * SECONDS_PER_DAY / frequency.getFrequencyPerDay()));
-		} else {
+		Unit unit = UNITS_BY_CODE.get(code);
+		if (unit == null) {
 			throw new APIException("Duration.unknown.code", new Object[] { code });
 		}
+		return unit.addToDate(startDate, this.duration, frequency);
 	}
 
 	/**
 	 * Returns concept reference term code of the mapping to the SNOMED CT concept source
+	 * <p>
+	 * Note that the returned code depends on the iteration order of the concept's mappings and is not
+	 * necessarily a code this class can interpret; see {@link #getKnownCode(Concept)} for resolving a
+	 * concept to a code that is guaranteed to be accepted by {@link #addToDate(Date, OrderFrequency)}.
 	 * <p>
 	 * <strong>Should</strong> return null if the concept has no mapping to the SNOMED CT source<br/>
 	 * <strong>Should</strong> return the code for the term of the mapping to the SNOMED CT source
@@ -118,11 +253,68 @@ public class Duration {
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
 			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
 			if (ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())
-			        && Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE
-			                .equals(conceptReferenceTerm.getConceptSource().getHl7Code())) {
+			        && isSnomedCtSource(conceptReferenceTerm.getConceptSource())) {
 				return conceptReferenceTerm.getCode();
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Returns a code of the given concept that this class knows how to interpret as a duration unit,
+	 * considering all of the concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
+	 * Every code this method returns is accepted by {@link #addToDate(Date, OrderFrequency)}.
+	 * <p>
+	 * Unlike {@link #getCode(Concept)}, the result does not depend on the iteration order of the
+	 * concept's mappings. Dictionaries may map one unit concept to several codes, for example both the
+	 * legacy and the current SNOMED CT code for minute, and any of them is accepted as long as all
+	 * known codes of the concept denote the same unit. If they denote different units, null is
+	 * returned, so that a miscurated dictionary surfaces as a validation error rather than a silently
+	 * wrong expiry date.
+	 * <p>
+	 * <strong>Should</strong> return the code of a SNOMED CT SAME-AS mapping with a known code<br/>
+	 * <strong>Should</strong> return a minutes code for a concept carrying both the legacy and the
+	 * current SNOMED CT minute code<br/>
+	 * <strong>Should</strong> return a UCUM code when the concept has only a UCUM mapping<br/>
+	 * <strong>Should</strong> return null if no SAME-AS mapping carries a known code<br/>
+	 * <strong>Should</strong> return null if known codes of the concept denote different units
+	 *
+	 * @param durationUnits the duration units concept of a drug order
+	 * @return a known reference term code, or null if the concept cannot be resolved to a single unit
+	 * @since 3.0.0
+	 */
+	public static String getKnownCode(Concept durationUnits) {
+		String knownCode = null;
+		Unit knownUnit = null;
+		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
+			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
+				continue;
+			}
+			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
+			ConceptSource conceptSource = conceptReferenceTerm.getConceptSource();
+			if (!isSnomedCtSource(conceptSource) && !isUcumSource(conceptSource)) {
+				continue;
+			}
+			Unit unit = UNITS_BY_CODE.get(conceptReferenceTerm.getCode());
+			if (unit == null) {
+				continue;
+			}
+			if (knownUnit == null) {
+				knownCode = conceptReferenceTerm.getCode();
+				knownUnit = unit;
+			} else if (knownUnit != unit) {
+				return null;
+			}
+		}
+		return knownCode;
+	}
+
+	private static boolean isSnomedCtSource(ConceptSource conceptSource) {
+		return SNOMED_CT_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code());
+	}
+
+	private static boolean isUcumSource(ConceptSource conceptSource) {
+		return UCUM_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName())
+		        || UCUM_CONCEPT_SOURCE_NAME.equals(conceptSource.getHl7Code());
 	}
 }

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -35,6 +35,11 @@ public class Duration {
 
 	public static final String SNOMED_CT_SECONDS_CODE = "257997001";
 
+	/**
+	 * The legacy SNOMED CT code for minute, inactive in SNOMED CT since its 2021-07-31 release but
+	 * still accepted for backward compatibility with existing dictionaries. New mappings should use
+	 * {@link #SNOMED_CT_MINUTES_CODE_2021}.
+	 */
 	public static final String SNOMED_CT_MINUTES_CODE = "258701004";
 
 	/**
@@ -112,6 +117,15 @@ public class Duration {
 	 * @since 3.0.0
 	 */
 	public static final String UCUM_YEARS_CODE = "a";
+
+	/**
+	 * HL7 code identifying the concept source for The Unified Code for Units of Measure. It happens to
+	 * share its value with {@link #UCUM_CONCEPT_SOURCE_NAME}, but names and HL7 codes are semantically
+	 * different identifiers.
+	 *
+	 * @since 3.0.0
+	 */
+	public static final String UCUM_CONCEPT_SOURCE_HL7_CODE = "UCUM";
 
 	private static final int SECONDS_PER_MINUTE = 60;
 
@@ -351,7 +365,7 @@ public class Duration {
 	}
 
 	private static boolean isUcumSource(ConceptSource conceptSource) {
-		return UCUM_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName())
-		        || UCUM_CONCEPT_SOURCE_NAME.equals(conceptSource.getHl7Code());
+		return UCUM_CONCEPT_SOURCE_HL7_CODE.equals(conceptSource.getHl7Code())
+		        || UCUM_CONCEPT_SOURCE_NAME.equalsIgnoreCase(conceptSource.getName());
 	}
 }

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs;
 
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.openmrs.api.APIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.commons.lang3.time.DateUtils.addDays;
 import static org.apache.commons.lang3.time.DateUtils.addHours;
@@ -30,6 +30,8 @@ import static org.apache.commons.lang3.time.DateUtils.addYears;
  * @since 1.10
  */
 public class Duration {
+
+	private static final Logger log = LoggerFactory.getLogger(Duration.class);
 
 	public static final String SNOMED_CT_SECONDS_CODE = "257997001";
 
@@ -188,28 +190,17 @@ public class Duration {
 		abstract Date addToDate(Date startDate, Integer duration, OrderFrequency frequency);
 	}
 
-	private static final Map<String, Unit> UNITS_BY_CODE;
+	private static final Map<String, Unit> SNOMED_CT_UNITS_BY_CODE = Map.ofEntries(
+	    Map.entry(SNOMED_CT_SECONDS_CODE, Unit.SECONDS), Map.entry(SNOMED_CT_MINUTES_CODE, Unit.MINUTES),
+	    Map.entry(SNOMED_CT_MINUTES_CODE_2021, Unit.MINUTES), Map.entry(SNOMED_CT_HOURS_CODE, Unit.HOURS),
+	    Map.entry(SNOMED_CT_DAYS_CODE, Unit.DAYS), Map.entry(SNOMED_CT_WEEKS_CODE, Unit.WEEKS),
+	    Map.entry(SNOMED_CT_MONTHS_CODE, Unit.MONTHS), Map.entry(SNOMED_CT_YEARS_CODE, Unit.YEARS),
+	    Map.entry(SNOMED_CT_RECURRING_INTERVAL_CODE, Unit.RECURRING_INTERVAL));
 
-	static {
-		Map<String, Unit> unitsByCode = new HashMap<>();
-		unitsByCode.put(SNOMED_CT_SECONDS_CODE, Unit.SECONDS);
-		unitsByCode.put(UCUM_SECONDS_CODE, Unit.SECONDS);
-		unitsByCode.put(SNOMED_CT_MINUTES_CODE, Unit.MINUTES);
-		unitsByCode.put(SNOMED_CT_MINUTES_CODE_2021, Unit.MINUTES);
-		unitsByCode.put(UCUM_MINUTES_CODE, Unit.MINUTES);
-		unitsByCode.put(SNOMED_CT_HOURS_CODE, Unit.HOURS);
-		unitsByCode.put(UCUM_HOURS_CODE, Unit.HOURS);
-		unitsByCode.put(SNOMED_CT_DAYS_CODE, Unit.DAYS);
-		unitsByCode.put(UCUM_DAYS_CODE, Unit.DAYS);
-		unitsByCode.put(SNOMED_CT_WEEKS_CODE, Unit.WEEKS);
-		unitsByCode.put(UCUM_WEEKS_CODE, Unit.WEEKS);
-		unitsByCode.put(SNOMED_CT_MONTHS_CODE, Unit.MONTHS);
-		unitsByCode.put(UCUM_MONTHS_CODE, Unit.MONTHS);
-		unitsByCode.put(SNOMED_CT_YEARS_CODE, Unit.YEARS);
-		unitsByCode.put(UCUM_YEARS_CODE, Unit.YEARS);
-		unitsByCode.put(SNOMED_CT_RECURRING_INTERVAL_CODE, Unit.RECURRING_INTERVAL);
-		UNITS_BY_CODE = Collections.unmodifiableMap(unitsByCode);
-	}
+	private static final Map<String, Unit> UCUM_UNITS_BY_CODE = Map.ofEntries(Map.entry(UCUM_SECONDS_CODE, Unit.SECONDS),
+	    Map.entry(UCUM_MINUTES_CODE, Unit.MINUTES), Map.entry(UCUM_HOURS_CODE, Unit.HOURS),
+	    Map.entry(UCUM_DAYS_CODE, Unit.DAYS), Map.entry(UCUM_WEEKS_CODE, Unit.WEEKS),
+	    Map.entry(UCUM_MONTHS_CODE, Unit.MONTHS), Map.entry(UCUM_YEARS_CODE, Unit.YEARS));
 
 	private final Integer duration;
 
@@ -229,7 +220,10 @@ public class Duration {
 	 * @return date which is startDate plus duration
 	 */
 	public Date addToDate(Date startDate, OrderFrequency frequency) {
-		Unit unit = UNITS_BY_CODE.get(code);
+		Unit unit = SNOMED_CT_UNITS_BY_CODE.get(code);
+		if (unit == null) {
+			unit = UCUM_UNITS_BY_CODE.get(code);
+		}
 		if (unit == null) {
 			throw new APIException("Duration.unknown.code", new Object[] { code });
 		}
@@ -239,21 +233,22 @@ public class Duration {
 	/**
 	 * Returns concept reference term code of the mapping to the SNOMED CT concept source
 	 * <p>
-	 * Note that the returned code depends on the iteration order of the concept's mappings and is not
-	 * necessarily a code this class can interpret; see {@link #getKnownCode(Concept)} for resolving a
-	 * concept to a code that is guaranteed to be accepted by {@link #addToDate(Date, OrderFrequency)}.
-	 * <p>
 	 * <strong>Should</strong> return null if the concept has no mapping to the SNOMED CT source<br/>
 	 * <strong>Should</strong> return the code for the term of the mapping to the SNOMED CT source
 	 *
 	 * @param durationUnits
 	 * @return a string which is reference term code
+	 * @deprecated as of 3.0.0, because the returned code depends on the iteration order of the
+	 *             concept's mappings and is not necessarily a code this class can interpret; use
+	 *             {@link #getDuration(Integer, Concept)} instead
 	 */
+	@Deprecated
 	public static String getCode(Concept durationUnits) {
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
 			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
 			if (ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())
-			        && isSnomedCtSource(conceptReferenceTerm.getConceptSource())) {
+			        && Duration.SNOMED_CT_CONCEPT_SOURCE_HL7_CODE
+			                .equals(conceptReferenceTerm.getConceptSource().getHl7Code())) {
 				return conceptReferenceTerm.getCode();
 			}
 		}
@@ -261,29 +256,28 @@ public class Duration {
 	}
 
 	/**
-	 * Returns a code of the given concept that this class knows how to interpret as a duration unit,
-	 * considering all of the concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
-	 * Every code this method returns is accepted by {@link #addToDate(Date, OrderFrequency)}.
+	 * Resolves the given duration units concept to a {@link Duration} of the given length, considering
+	 * all of the concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
 	 * <p>
-	 * Unlike {@link #getCode(Concept)}, the unit denoted by the result does not depend on the iteration
-	 * order of the concept's mappings, though which of several equivalent codes is returned may.
-	 * Dictionaries may map one unit concept to several codes, for example both the legacy and the
-	 * current SNOMED CT code for minute, and any of them is accepted as long as all known codes of the
-	 * concept denote the same unit. If they denote different units, null is returned, so that a
-	 * miscurated dictionary surfaces as a validation error rather than a silently wrong expiry date.
+	 * The result does not depend on the iteration order of the concept's mappings. Dictionaries may map
+	 * one unit concept to several codes, for example both the legacy and the current SNOMED CT code for
+	 * minute, and the concept resolves as long as all of its known codes denote the same unit. If they
+	 * denote different units, null is returned and the conflict is logged, so that a miscurated
+	 * dictionary surfaces as a validation error rather than a silently wrong expiry date.
 	 * <p>
-	 * <strong>Should</strong> return the code of a SNOMED CT SAME-AS mapping with a known code<br/>
-	 * <strong>Should</strong> return a minutes code for a concept carrying both the legacy and the
-	 * current SNOMED CT minute code<br/>
-	 * <strong>Should</strong> return a UCUM code when the concept has only a UCUM mapping<br/>
+	 * <strong>Should</strong> resolve a SNOMED CT SAME-AS mapping with a known code<br/>
+	 * <strong>Should</strong> resolve a concept carrying both the legacy and the current SNOMED CT
+	 * minute code<br/>
+	 * <strong>Should</strong> resolve a concept with only a UCUM mapping<br/>
 	 * <strong>Should</strong> return null if no SAME-AS mapping carries a known code<br/>
 	 * <strong>Should</strong> return null if known codes of the concept denote different units
 	 *
+	 * @param duration the length of the duration, in the units the concept denotes
 	 * @param durationUnits the duration units concept of a drug order
-	 * @return a known reference term code, or null if the concept cannot be resolved to a single unit
+	 * @return a Duration, or null if the concept cannot be resolved to exactly one known unit
 	 * @since 3.0.0
 	 */
-	public static String getKnownCode(Concept durationUnits) {
+	public static Duration getDuration(Integer duration, Concept durationUnits) {
 		String knownCode = null;
 		Unit knownUnit = null;
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
@@ -291,11 +285,7 @@ public class Duration {
 				continue;
 			}
 			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
-			ConceptSource conceptSource = conceptReferenceTerm.getConceptSource();
-			if (!isSnomedCtSource(conceptSource) && !isUcumSource(conceptSource)) {
-				continue;
-			}
-			Unit unit = UNITS_BY_CODE.get(conceptReferenceTerm.getCode());
+			Unit unit = findUnit(conceptReferenceTerm.getConceptSource(), conceptReferenceTerm.getCode());
 			if (unit == null) {
 				continue;
 			}
@@ -303,10 +293,26 @@ public class Duration {
 				knownCode = conceptReferenceTerm.getCode();
 				knownUnit = unit;
 			} else if (knownUnit != unit) {
+				log.warn("Not resolving duration units concept {} because its SAME-AS mappings denote different units,"
+				        + " e.g. codes {} and {}",
+				    durationUnits.getUuid(), knownCode, conceptReferenceTerm.getCode());
 				return null;
 			}
 		}
-		return knownCode;
+		if (knownCode == null) {
+			return null;
+		}
+		return new Duration(duration, knownCode);
+	}
+
+	private static Unit findUnit(ConceptSource conceptSource, String code) {
+		if (isSnomedCtSource(conceptSource)) {
+			return SNOMED_CT_UNITS_BY_CODE.get(code);
+		}
+		if (isUcumSource(conceptSource)) {
+			return UCUM_UNITS_BY_CODE.get(code);
+		}
+		return null;
 	}
 
 	private static boolean isSnomedCtSource(ConceptSource conceptSource) {

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -24,6 +24,18 @@ import static org.apache.commons.lang3.time.DateUtils.addYears;
 
 /**
  * Duration represented using SNOMED CT or UCUM duration codes
+ * <p>
+ * The vocabulary codes this class understands are deliberately compiled in rather than configurable
+ * at runtime: what a duration code means is the semantics of the standard itself, not
+ * implementation data, and a misconfigured mapping would silently change how long medications run
+ * before they auto-expire. Runtime-configurable registries and terminology-server lookups were
+ * considered and rejected; the trade-offs are recorded on TRUNK-6674. The compiled-in design stays
+ * safe only while three invariants hold, so preserve them when touching the code registries:
+ * entries are additive across vocabulary generations and never removed or repurposed, because
+ * existing dictionaries and module binaries carry the old codes; unknown codes surface as
+ * validation errors rather than save-time failures; and UCUM, whose codes are stable by design, is
+ * recognised alongside SNOMED CT so no single SNOMED inactivation, like the 2021 minute code
+ * change, can break order saving on its own.
  *
  * @since 1.10
  */

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -265,12 +265,12 @@ public class Duration {
 	 * considering all of the concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
 	 * Every code this method returns is accepted by {@link #addToDate(Date, OrderFrequency)}.
 	 * <p>
-	 * Unlike {@link #getCode(Concept)}, the result does not depend on the iteration order of the
-	 * concept's mappings. Dictionaries may map one unit concept to several codes, for example both the
-	 * legacy and the current SNOMED CT code for minute, and any of them is accepted as long as all
-	 * known codes of the concept denote the same unit. If they denote different units, null is
-	 * returned, so that a miscurated dictionary surfaces as a validation error rather than a silently
-	 * wrong expiry date.
+	 * Unlike {@link #getCode(Concept)}, the unit denoted by the result does not depend on the iteration
+	 * order of the concept's mappings, though which of several equivalent codes is returned may.
+	 * Dictionaries may map one unit concept to several codes, for example both the legacy and the
+	 * current SNOMED CT code for minute, and any of them is accepted as long as all known codes of the
+	 * concept denote the same unit. If they denote different units, null is returned, so that a
+	 * miscurated dictionary surfaces as a validation error rather than a silently wrong expiry date.
 	 * <p>
 	 * <strong>Should</strong> return the code of a SNOMED CT SAME-AS mapping with a known code<br/>
 	 * <strong>Should</strong> return a minutes code for a concept carrying both the legacy and the

--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -13,8 +13,6 @@ import java.util.Date;
 import java.util.Map;
 
 import org.openmrs.api.APIException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.apache.commons.lang3.time.DateUtils.addDays;
 import static org.apache.commons.lang3.time.DateUtils.addHours;
@@ -30,8 +28,6 @@ import static org.apache.commons.lang3.time.DateUtils.addYears;
  * @since 1.10
  */
 public class Duration {
-
-	private static final Logger log = LoggerFactory.getLogger(Duration.class);
 
 	public static final String SNOMED_CT_SECONDS_CODE = "257997001";
 
@@ -299,64 +295,49 @@ public class Duration {
 	}
 
 	/**
-	 * Resolves the given duration units concept to a {@link Duration} of the given length, considering
-	 * all of the concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
+	 * Resolves the given duration units concept to a {@link Duration} of the given length from the
+	 * concept's SAME-AS mappings to the SNOMED CT and UCUM concept sources.
 	 * <p>
-	 * The result does not depend on the iteration order of the concept's mappings. Dictionaries may map
-	 * one unit concept to several codes, for example both the legacy and the current SNOMED CT code for
-	 * minute, and the concept resolves as long as all of its known codes denote the same unit. If they
-	 * denote different units, null is returned and the conflict is logged, so that a miscurated
-	 * dictionary surfaces as a validation error rather than a silently wrong expiry date.
+	 * SNOMED CT mappings take priority: the first SNOMED CT mapping carrying a known code resolves the
+	 * concept, and UCUM is consulted only when no SNOMED CT mapping does. Concepts that resolved while
+	 * only SNOMED CT was consulted therefore keep resolving identically however their UCUM mappings are
+	 * curated, and UCUM strictly extends resolution to concepts, such as ones mapped only to UCUM, that
+	 * previously resolved to nothing. Dictionaries may map one unit concept to several codes, for
+	 * example both the legacy and the current SNOMED CT code for minute, which denote the same unit and
+	 * resolve to it whichever is seen first.
 	 * <p>
 	 * <strong>Should</strong> resolve a SNOMED CT SAME-AS mapping with a known code<br/>
 	 * <strong>Should</strong> resolve a concept carrying both the legacy and the current SNOMED CT
 	 * minute code<br/>
 	 * <strong>Should</strong> resolve a concept with only a UCUM mapping<br/>
-	 * <strong>Should</strong> return null if no SAME-AS mapping carries a known code<br/>
-	 * <strong>Should</strong> return null if known codes of the concept denote different units
+	 * <strong>Should</strong> prefer the SNOMED CT mapping when a UCUM mapping denotes a different
+	 * unit<br/>
+	 * <strong>Should</strong> fall back to UCUM when no SNOMED CT mapping carries a known code<br/>
+	 * <strong>Should</strong> return null if no SAME-AS mapping carries a known code
 	 *
 	 * @param duration the length of the duration, in the units the concept denotes
 	 * @param durationUnits the duration units concept of a drug order
-	 * @return a Duration, or null if the concept cannot be resolved to exactly one known unit
+	 * @return a Duration, or null if no SAME-AS mapping carries a known code
 	 * @since 3.0.0
 	 */
 	public static Duration getDuration(Integer duration, Concept durationUnits) {
-		Unit knownUnit = null;
+		Unit ucumUnit = null;
 		for (ConceptMap conceptMapping : durationUnits.getConceptMappings()) {
-			Unit unit = findUnit(conceptMapping);
-			if (unit != null) {
-				if (knownUnit == null) {
-					knownUnit = unit;
-				} else if (knownUnit != unit) {
-					log.warn("Not resolving duration units concept {} because its SAME-AS mappings denote different"
-					        + " units, e.g. {} and {}",
-					    durationUnits.getUuid(), knownUnit, unit);
-					return null;
+			if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
+				continue;
+			}
+			ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
+			ConceptSource conceptSource = conceptReferenceTerm.getConceptSource();
+			if (isSnomedCtSource(conceptSource)) {
+				Unit snomedCtUnit = SNOMED_CT_UNITS_BY_CODE.get(conceptReferenceTerm.getCode());
+				if (snomedCtUnit != null) {
+					return new Duration(duration, snomedCtUnit);
 				}
+			} else if (ucumUnit == null && isUcumSource(conceptSource)) {
+				ucumUnit = UCUM_UNITS_BY_CODE.get(conceptReferenceTerm.getCode());
 			}
 		}
-		if (knownUnit == null) {
-			return null;
-		}
-		return new Duration(duration, knownUnit);
-	}
-
-	private static Unit findUnit(ConceptMap conceptMapping) {
-		if (!ConceptMapType.SAME_AS_MAP_TYPE_UUID.equals(conceptMapping.getConceptMapType().getUuid())) {
-			return null;
-		}
-		ConceptReferenceTerm conceptReferenceTerm = conceptMapping.getConceptReferenceTerm();
-		return findUnit(conceptReferenceTerm.getConceptSource(), conceptReferenceTerm.getCode());
-	}
-
-	private static Unit findUnit(ConceptSource conceptSource, String code) {
-		if (isSnomedCtSource(conceptSource)) {
-			return SNOMED_CT_UNITS_BY_CODE.get(code);
-		}
-		if (isUcumSource(conceptSource)) {
-			return UCUM_UNITS_BY_CODE.get(code);
-		}
-		return null;
+		return ucumUnit != null ? new Duration(duration, ucumUnit) : null;
 	}
 
 	private static boolean isSnomedCtSource(ConceptSource conceptSource) {

--- a/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
@@ -126,7 +126,7 @@ public class SimpleDosingInstructions extends BaseDosingInstructions {
 		ValidationUtils.rejectIfEmpty(errors, "route", "DrugOrder.error.routeIsNullForDosingTypeSimple");
 		ValidationUtils.rejectIfEmpty(errors, "frequency", "DrugOrder.error.frequencyIsNullForDosingTypeSimple");
 		if (order.getAutoExpireDate() == null && order.getDurationUnits() != null
-		        && Duration.getKnownCode(order.getDurationUnits()) == null) {
+		        && Duration.getDuration(order.getDuration(), order.getDurationUnits()) == null) {
 			errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
 		}
 	}

--- a/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
@@ -127,7 +127,7 @@ public class SimpleDosingInstructions extends BaseDosingInstructions {
 		ValidationUtils.rejectIfEmpty(errors, "frequency", "DrugOrder.error.frequencyIsNullForDosingTypeSimple");
 		if (order.getAutoExpireDate() == null && order.getDurationUnits() != null
 		        && Duration.getDuration(order.getDuration(), order.getDurationUnits()) == null) {
-			errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
+			errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToKnownDurationCode");
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
+++ b/api/src/main/java/org/openmrs/SimpleDosingInstructions.java
@@ -126,7 +126,7 @@ public class SimpleDosingInstructions extends BaseDosingInstructions {
 		ValidationUtils.rejectIfEmpty(errors, "route", "DrugOrder.error.routeIsNullForDosingTypeSimple");
 		ValidationUtils.rejectIfEmpty(errors, "frequency", "DrugOrder.error.frequencyIsNullForDosingTypeSimple");
 		if (order.getAutoExpireDate() == null && order.getDurationUnits() != null
-		        && Duration.getCode(order.getDurationUnits()) == null) {
+		        && Duration.getKnownCode(order.getDurationUnits()) == null) {
 			errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
 		}
 	}

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -190,7 +190,7 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 			if (!drugDurationUnits.contains(order.getDurationUnits())) {
 				errors.rejectValue("durationUnits", "DrugOrder.error.notAmongAllowedConcepts");
 			}
-			if (Duration.getKnownCode(order.getDurationUnits()) == null) {
+			if (Duration.getDuration(order.getDuration(), order.getDurationUnits()) == null) {
 				errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
 			}
 		}

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -191,7 +191,7 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 				errors.rejectValue("durationUnits", "DrugOrder.error.notAmongAllowedConcepts");
 			}
 			if (Duration.getDuration(order.getDuration(), order.getDurationUnits()) == null) {
-				errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
+				errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToKnownDurationCode");
 			}
 		}
 		if (order.getRoute() != null) {

--- a/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
+++ b/api/src/main/java/org/openmrs/validator/DrugOrderValidator.java
@@ -190,7 +190,7 @@ public class DrugOrderValidator extends OrderValidator implements Validator {
 			if (!drugDurationUnits.contains(order.getDurationUnits())) {
 				errors.rejectValue("durationUnits", "DrugOrder.error.notAmongAllowedConcepts");
 			}
-			if (Duration.getCode(order.getDurationUnits()) == null) {
+			if (Duration.getKnownCode(order.getDurationUnits()) == null) {
 				errors.rejectValue("durationUnits", "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode");
 			}
 		}

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1015,7 +1015,7 @@ TestOrder.error.specimenSourceNotAmongAllowedConcepts=The specimen source concep
 ServiceOrder.error.specimenSourceNotAmongAllowedConcepts=The specimen source concept must be among allowed concepts as specified by the order.testSpecimenSourcesConceptUuid global property
 
 Duration.error.frequency.null=Frequency can not be null when duration in Recurring Interval
-Duration.unknown.code=Unknown code {0} for SNOMED CT duration units
+Duration.unknown.code=Unknown code {0} for SNOMED CT or UCUM duration units
 
 Encounter.header=Encounters
 Encounter.manage=Manage Encounters

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1007,7 +1007,7 @@ DrugOrder.error.instructionIsNullForDosingTypeFreeText=Instructions is required 
 DrugOrder.error.dosingInstructionsIsNullForDosingTypeFreeText=Dosing instructions is required if dosing type is FreeText
 DrugOrder.error.routeNotAmongAllowedConcepts=The route concept must be among allowed concepts as specified by the order.drugRoutesConceptUuid global property
 DrugOrder.error.drugIsRequired=Drug is required
-DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode=Duration units must be mapped to SNOMED CT duration code with the map type set to SAME-AS
+DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode=Duration units must be mapped, with the map type set to SAME-AS, to a known SNOMED CT or UCUM duration code
 DrugOrder.error.doseZeroOrLess=Dose should be greater than 0
 
 TestOrder.error.specimenSourceNotAmongAllowedConcepts=The specimen source concept must be among allowed concepts as specified by the order.testSpecimenSourcesConceptUuid global property

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1007,7 +1007,8 @@ DrugOrder.error.instructionIsNullForDosingTypeFreeText=Instructions is required 
 DrugOrder.error.dosingInstructionsIsNullForDosingTypeFreeText=Dosing instructions is required if dosing type is FreeText
 DrugOrder.error.routeNotAmongAllowedConcepts=The route concept must be among allowed concepts as specified by the order.drugRoutesConceptUuid global property
 DrugOrder.error.drugIsRequired=Drug is required
-DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode=Duration units must be mapped, with the map type set to SAME-AS, to a known SNOMED CT or UCUM duration code
+DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode=Duration units must be mapped to SNOMED CT duration code with the map type set to SAME-AS
+DrugOrder.error.durationUnitsNotMappedToKnownDurationCode=Duration units must be mapped to a known SNOMED CT or UCUM duration code with the map type SAME-AS
 DrugOrder.error.doseZeroOrLess=Dose should be greater than 0
 
 TestOrder.error.specimenSourceNotAmongAllowedConcepts=The specimen source concept must be among allowed concepts as specified by the order.testSpecimenSourcesConceptUuid global property

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -73,6 +73,15 @@ public class DurationTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
+	public void addToDate_shouldAddWeeksWhenUnitIsWeeks() throws ParseException {
+		Duration duration = new Duration(3, Duration.SNOMED_CT_WEEKS_CODE);
+
+		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
+
+		assertEquals(createDateTime("2014-07-22 10:00:00"), autoExpireDate);
+	}
+
+	@Test
 	public void addToDate_shouldAddMonthsWhenUnitIsMonths() throws ParseException {
 		Duration duration = new Duration(3, Duration.SNOMED_CT_MONTHS_CODE);
 
@@ -206,7 +215,7 @@ public class DurationTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void getKnownCode_shouldReturnNullIfNoSameAsMappingCarriesAKnownCode() {
-		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", "999999999"));
+		Concept units = SimpleDosingInstructionsTest.createUnits("SCT", "999999999", null);
 
 		assertNull(Duration.getKnownCode(units));
 	}
@@ -230,6 +239,16 @@ public class DurationTest extends BaseContextSensitiveTest {
 		    sameAsMapping("UCUM", null, Duration.UCUM_MONTHS_CODE));
 
 		assertNull(Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldMatchTheUcumSourceNameCaseInsensitively() {
+		Concept units = unitsWithMappings(sameAsMapping("ucum", null, Duration.UCUM_MINUTES_CODE));
+
+		assertEquals(Duration.UCUM_MINUTES_CODE, Duration.getKnownCode(units));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -238,11 +238,28 @@ public class DurationTest extends BaseContextSensitiveTest {
 	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getDuration_shouldReturnNullIfKnownCodesOfTheConceptDenoteDifferentUnits() {
+	public void getDuration_shouldPreferTheSnomedCtMappingWhenAUcumMappingDenotesADifferentUnit() throws ParseException {
 		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_DAYS_CODE),
 		    sameAsMapping("UCUM", null, Duration.UCUM_MONTHS_CODE));
 
-		assertNull(Duration.getDuration(30, units));
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-31 10:00:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
+	}
+
+	/**
+	 * @see Duration#getDuration(Integer, Concept)
+	 */
+	@Test
+	public void getDuration_shouldFallBackToUcumWhenNoSnomedCtMappingCarriesAKnownCode() throws ParseException {
+		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", "999999999"),
+		    sameAsMapping("UCUM", null, Duration.UCUM_MINUTES_CODE));
+
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-01 10:30:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -175,90 +175,97 @@ public class DurationTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnTheCodeOfASnomedCtSameAsMappingWithAKnownCode() {
+	public void getDuration_shouldResolveASnomedCtSameAsMappingWithAKnownCode() throws ParseException {
 		Concept units = SimpleDosingInstructionsTest.createUnits(Duration.SNOMED_CT_DAYS_CODE);
 
-		assertEquals(Duration.SNOMED_CT_DAYS_CODE, Duration.getKnownCode(units));
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-31 10:00:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnAMinutesCodeForAConceptCarryingBothLegacyAndCurrentSnomedCtMinuteCodes()
-	        throws ParseException {
+	public void getDuration_shouldResolveAConceptCarryingBothLegacyAndCurrentSnomedCtMinuteCodes() throws ParseException {
 		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_MINUTES_CODE_2021),
 		    sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_MINUTES_CODE));
 
-		String code = Duration.getKnownCode(units);
+		Duration duration = Duration.getDuration(30, units);
 
-		assertNotNull(code);
-		Date autoExpireDate = new Duration(30, code).addToDate(createDateTime("2014-07-01 10:00:00"), null);
-		assertEquals(createDateTime("2014-07-01 10:30:00"), autoExpireDate);
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-01 10:30:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnAUcumCodeWhenTheConceptHasOnlyAUcumMapping() {
+	public void getDuration_shouldResolveAConceptWithOnlyAUcumMapping() throws ParseException {
 		Concept units = unitsWithMappings(sameAsMapping("UCUM", null, Duration.UCUM_MINUTES_CODE));
 
-		assertEquals(Duration.UCUM_MINUTES_CODE, Duration.getKnownCode(units));
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-01 10:30:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnNullIfNoSameAsMappingCarriesAKnownCode() {
+	public void getDuration_shouldReturnNullIfNoSameAsMappingCarriesAKnownCode() {
 		Concept units = SimpleDosingInstructionsTest.createUnits("SCT", "999999999", null);
 
-		assertNull(Duration.getKnownCode(units));
+		assertNull(Duration.getDuration(30, units));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnNullIfTheKnownCodeIsMappedWithANonSameAsType() {
+	public void getDuration_shouldReturnNullIfTheKnownCodeIsMappedWithANonSameAsType() {
 		Concept units = SimpleDosingInstructionsTest.createUnits("SCT", Duration.SNOMED_CT_DAYS_CODE, "some-map-type-uuid");
 
-		assertNull(Duration.getKnownCode(units));
+		assertNull(Duration.getDuration(30, units));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldReturnNullIfKnownCodesOfTheConceptDenoteDifferentUnits() {
+	public void getDuration_shouldReturnNullIfKnownCodesOfTheConceptDenoteDifferentUnits() {
 		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_DAYS_CODE),
 		    sameAsMapping("UCUM", null, Duration.UCUM_MONTHS_CODE));
 
-		assertNull(Duration.getKnownCode(units));
+		assertNull(Duration.getDuration(30, units));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldMatchTheUcumSourceNameCaseInsensitively() {
+	public void getDuration_shouldMatchTheUcumSourceNameCaseInsensitively() throws ParseException {
 		Concept units = unitsWithMappings(sameAsMapping("ucum", null, Duration.UCUM_MINUTES_CODE));
 
-		assertEquals(Duration.UCUM_MINUTES_CODE, Duration.getKnownCode(units));
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-01 10:30:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
 	}
 
 	/**
-	 * @see Duration#getKnownCode(Concept)
+	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
-	public void getKnownCode_shouldIgnoreKnownCodesMappedToOtherSources() {
+	public void getDuration_shouldIgnoreKnownCodesMappedToOtherSources() {
 		Concept units = unitsWithMappings(sameAsMapping("Some Dictionary", "L", Duration.UCUM_MINUTES_CODE));
 
-		assertNull(Duration.getKnownCode(units));
+		assertNull(Duration.getDuration(30, units));
 	}
 
 	private static Concept unitsWithMappings(ConceptMap... mappings) {

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -262,6 +262,19 @@ public class DurationTest extends BaseContextSensitiveTest {
 	 * @see Duration#getDuration(Integer, Concept)
 	 */
 	@Test
+	public void getDuration_shouldMatchTheSnomedCtSourceNameCaseInsensitivelyWhenNoHl7CodeIsSet() throws ParseException {
+		Concept units = unitsWithMappings(sameAsMapping("snomed ct", null, Duration.SNOMED_CT_DAYS_CODE));
+
+		Duration duration = Duration.getDuration(30, units);
+
+		assertNotNull(duration);
+		assertEquals(createDateTime("2014-07-31 10:00:00"), duration.addToDate(createDateTime("2014-07-01 10:00:00"), null));
+	}
+
+	/**
+	 * @see Duration#getDuration(Integer, Concept)
+	 */
+	@Test
 	public void getDuration_shouldIgnoreKnownCodesMappedToOtherSources() {
 		Concept units = unitsWithMappings(sameAsMapping("Some Dictionary", "L", Duration.UCUM_MINUTES_CODE));
 

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -20,6 +20,7 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.openmrs.test.TestUtil.createDateTime;
@@ -38,6 +39,15 @@ public class DurationTest extends BaseContextSensitiveTest {
 	@Test
 	public void addToDate_shouldAddMinutesWhenUnitIsMinutes() throws ParseException {
 		Duration duration = new Duration(30, Duration.SNOMED_CT_MINUTES_CODE);
+
+		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
+
+		assertEquals(createDateTime("2014-07-01 10:30:00"), autoExpireDate);
+	}
+
+	@Test
+	public void addToDate_shouldAddMinutesWhenUnitIsTheCurrentSnomedCtMinuteCode() throws ParseException {
+		Duration duration = new Duration(30, Duration.SNOMED_CT_MINUTES_CODE_2021);
 
 		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
 
@@ -78,6 +88,26 @@ public class DurationTest extends BaseContextSensitiveTest {
 		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
 
 		assertEquals(createDateTime("2017-07-01 10:00:00"), autoExpireDate);
+	}
+
+	@Test
+	public void addToDate_shouldAddTimeForUcumTimeCodes() throws ParseException {
+		Date startDate = createDateTime("2014-07-01 10:00:00");
+
+		assertEquals(createDateTime("2014-07-01 10:00:30"),
+		    new Duration(30, Duration.UCUM_SECONDS_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2014-07-01 10:30:00"),
+		    new Duration(30, Duration.UCUM_MINUTES_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2014-07-01 20:00:00"),
+		    new Duration(10, Duration.UCUM_HOURS_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2014-07-31 10:00:00"),
+		    new Duration(30, Duration.UCUM_DAYS_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2014-07-22 10:00:00"),
+		    new Duration(3, Duration.UCUM_WEEKS_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2014-10-01 10:00:00"),
+		    new Duration(3, Duration.UCUM_MONTHS_CODE).addToDate(startDate, null));
+		assertEquals(createDateTime("2017-07-01 10:00:00"),
+		    new Duration(3, Duration.UCUM_YEARS_CODE).addToDate(startDate, null));
 	}
 
 	@Test
@@ -133,5 +163,105 @@ public class DurationTest extends BaseContextSensitiveTest {
 		final String daysCode = Duration.SNOMED_CT_DAYS_CODE;
 		Concept concept = SimpleDosingInstructionsTest.createUnits(daysCode);
 		assertEquals(daysCode, Duration.getCode(concept));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnTheCodeOfASnomedCtSameAsMappingWithAKnownCode() {
+		Concept units = SimpleDosingInstructionsTest.createUnits(Duration.SNOMED_CT_DAYS_CODE);
+
+		assertEquals(Duration.SNOMED_CT_DAYS_CODE, Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnAMinutesCodeForAConceptCarryingBothLegacyAndCurrentSnomedCtMinuteCodes()
+	        throws ParseException {
+		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_MINUTES_CODE_2021),
+		    sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_MINUTES_CODE));
+
+		String code = Duration.getKnownCode(units);
+
+		assertNotNull(code);
+		Date autoExpireDate = new Duration(30, code).addToDate(createDateTime("2014-07-01 10:00:00"), null);
+		assertEquals(createDateTime("2014-07-01 10:30:00"), autoExpireDate);
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnAUcumCodeWhenTheConceptHasOnlyAUcumMapping() {
+		Concept units = unitsWithMappings(sameAsMapping("UCUM", null, Duration.UCUM_MINUTES_CODE));
+
+		assertEquals(Duration.UCUM_MINUTES_CODE, Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnNullIfNoSameAsMappingCarriesAKnownCode() {
+		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", "999999999"));
+
+		assertNull(Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnNullIfTheKnownCodeIsMappedWithANonSameAsType() {
+		Concept units = SimpleDosingInstructionsTest.createUnits("SCT", Duration.SNOMED_CT_DAYS_CODE, "some-map-type-uuid");
+
+		assertNull(Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldReturnNullIfKnownCodesOfTheConceptDenoteDifferentUnits() {
+		Concept units = unitsWithMappings(sameAsMapping("SNOMED CT", "SCT", Duration.SNOMED_CT_DAYS_CODE),
+		    sameAsMapping("UCUM", null, Duration.UCUM_MONTHS_CODE));
+
+		assertNull(Duration.getKnownCode(units));
+	}
+
+	/**
+	 * @see Duration#getKnownCode(Concept)
+	 */
+	@Test
+	public void getKnownCode_shouldIgnoreKnownCodesMappedToOtherSources() {
+		Concept units = unitsWithMappings(sameAsMapping("Some Dictionary", "L", Duration.UCUM_MINUTES_CODE));
+
+		assertNull(Duration.getKnownCode(units));
+	}
+
+	private static Concept unitsWithMappings(ConceptMap... mappings) {
+		Concept concept = new Concept();
+		for (ConceptMap mapping : mappings) {
+			concept.addConceptMapping(mapping);
+		}
+		return concept;
+	}
+
+	private static ConceptMap sameAsMapping(String sourceName, String sourceHl7Code, String code) {
+		ConceptSource conceptSource = new ConceptSource();
+		conceptSource.setName(sourceName);
+		conceptSource.setHl7Code(sourceHl7Code);
+		ConceptReferenceTerm conceptReferenceTerm = new ConceptReferenceTerm();
+		conceptReferenceTerm.setConceptSource(conceptSource);
+		conceptReferenceTerm.setCode(code);
+		ConceptMap conceptMapping = new ConceptMap();
+		conceptMapping.setConceptReferenceTerm(conceptReferenceTerm);
+		ConceptMapType conceptMapType = new ConceptMapType();
+		conceptMapType.setUuid(ConceptMapType.SAME_AS_MAP_TYPE_UUID);
+		conceptMapping.setConceptMapType(conceptMapType);
+		return conceptMapping;
 	}
 }

--- a/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
+++ b/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
@@ -70,6 +70,19 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
+	public void validate_shouldPassValidationIfDurationUnitsIsMappedToTheCurrentSnomedCtMinuteCode() {
+		DrugOrder drugOrder = createValidDrugOrder();
+		drugOrder.setDuration(30);
+		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_MINUTES_CODE_2021));
+		drugOrder.setAutoExpireDate(null);
+		Errors errors = new BindException(drugOrder, "drugOrder");
+
+		new SimpleDosingInstructions().validate(drugOrder, errors);
+
+		assertFalse(errors.hasErrors());
+	}
+
+	@Test
 	public void getAutoExpireDate_shouldInferAutoExpireDateForAKnownSNOMEDCTDurationUnit() throws ParseException {
 		DrugOrder drugOrder = new DrugOrder();
 		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));
@@ -77,6 +90,30 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_SECONDS_CODE));
 		Date autoExpireDate = new SimpleDosingInstructions().getAutoExpireDate(drugOrder);
 		assertEquals(createDateTime("2014-07-01 10:00:29"), autoExpireDate);
+	}
+
+	@Test
+	public void getAutoExpireDate_shouldInferAutoExpireDateForTheCurrentSnomedCtMinuteCode() throws ParseException {
+		DrugOrder drugOrder = new DrugOrder();
+		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));
+		drugOrder.setDuration(30);
+		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_MINUTES_CODE_2021));
+
+		Date autoExpireDate = new SimpleDosingInstructions().getAutoExpireDate(drugOrder);
+
+		assertEquals(createDateTime("2014-07-01 10:29:59"), autoExpireDate);
+	}
+
+	@Test
+	public void getAutoExpireDate_shouldInferAutoExpireDateForAUcumDurationUnit() throws ParseException {
+		DrugOrder drugOrder = new DrugOrder();
+		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));
+		drugOrder.setDuration(30);
+		drugOrder.setDurationUnits(createUnits("UCUM", Duration.UCUM_MINUTES_CODE, null));
+
+		Date autoExpireDate = new SimpleDosingInstructions().getAutoExpireDate(drugOrder);
+
+		assertEquals(createDateTime("2014-07-01 10:29:59"), autoExpireDate);
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
+++ b/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
@@ -83,6 +83,19 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
+	public void validate_shouldFailValidationIfDurationUnitsIsMappedOnlyToAnUnknownDurationCode() {
+		DrugOrder drugOrder = createValidDrugOrder();
+		drugOrder.setDuration(30);
+		drugOrder.setDurationUnits(createUnits("999999999"));
+		drugOrder.setAutoExpireDate(null);
+		Errors errors = new BindException(drugOrder, "drugOrder");
+
+		new SimpleDosingInstructions().validate(drugOrder, errors);
+
+		assertTrue(errors.hasFieldErrors("durationUnits"));
+	}
+
+	@Test
 	public void getAutoExpireDate_shouldInferAutoExpireDateForAKnownSNOMEDCTDurationUnit() throws ParseException {
 		DrugOrder drugOrder = new DrugOrder();
 		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));

--- a/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
+++ b/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
@@ -38,7 +38,7 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 		new SimpleDosingInstructions().validate(drugOrder, errors);
 
 		assertTrue(errors.hasFieldErrors("durationUnits"));
-		assertEquals("DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode",
+		assertEquals("DrugOrder.error.durationUnitsNotMappedToKnownDurationCode",
 		    errors.getFieldError("durationUnits").getCode());
 	}
 

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -26,6 +26,7 @@ import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Patient;
 import org.openmrs.SimpleDosingInstructions;
+import org.openmrs.SimpleDosingInstructionsTest;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
@@ -713,6 +714,36 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		new DrugOrderValidator().validate(order, errors);
 		assertEquals("DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode",
 		    errors.getFieldError("durationUnits").getCode());
+	}
+
+	/**
+	 * @see DrugOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailIfDurationUnitsIsMappedOnlyToAnUnknownDurationCode() {
+		Patient patient = Context.getPatientService().getPatient(7);
+		CareSetting careSetting = Context.getOrderService().getCareSetting(2);
+		OrderType orderType = Context.getOrderService().getOrderTypeByName("Drug order");
+
+		//place drug order
+		DrugOrder order = new DrugOrder();
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		order.setEncounter(encounter);
+		order.setConcept(Context.getConceptService().getConcept(5497));
+		order.setPatient(patient);
+		order.setCareSetting(careSetting);
+		order.setOrderer(Context.getProviderService().getProvider(1));
+		order.setDateActivated(encounter.getEncounterDatetime());
+		order.setOrderType(orderType);
+		order.setDosingType(FreeTextDosingInstructions.class);
+		order.setInstructions("None");
+		order.setDosingInstructions("Test Instruction");
+		order.setDuration(20);
+		order.setDurationUnits(SimpleDosingInstructionsTest.createUnits("SCT", "999999999", null));
+		Errors errors = new BindException(order, "order");
+		new DrugOrderValidator().validate(order, errors);
+		assertTrue(errors.getFieldErrors("durationUnits").stream()
+		        .anyMatch(e -> "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode".equals(e.getCode())));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/DrugOrderValidatorTest.java
@@ -712,7 +712,7 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		order.setDurationUnits(cs.getConcept(28));
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
-		assertEquals("DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode",
+		assertEquals("DrugOrder.error.durationUnitsNotMappedToKnownDurationCode",
 		    errors.getFieldError("durationUnits").getCode());
 	}
 
@@ -743,7 +743,7 @@ public class DrugOrderValidatorTest extends BaseContextSensitiveTest {
 		Errors errors = new BindException(order, "order");
 		new DrugOrderValidator().validate(order, errors);
 		assertTrue(errors.getFieldErrors("durationUnits").stream()
-		        .anyMatch(e -> "DrugOrder.error.durationUnitsNotMappedToSnomedCtDurationCode".equals(e.getCode())));
+		        .anyMatch(e -> "DrugOrder.error.durationUnitsNotMappedToKnownDurationCode".equals(e.getCode())));
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed

Saving a drug order whose duration units concept carries the current SNOMED CT minute code fails with HTTP 500: `Unknown code 1156209001 for SNOMED CT duration units` (`org.openmrs.Duration:104`). SNOMED CT inactivated the legacy minute code `258701004` ("min", ambiguous) in its 2021-07-31 release, and dictionaries that track SNOMED CT releases now map their minutes concepts to the active code `1156209001`. CIEL's Minutes (1733) today carries SAME-AS mappings to *both* SNOMED codes, plus UCUM `min`.

The 500 is a symptom of three related defects in how core resolves duration units:

1. **Validation and execution disagree.** `SimpleDosingInstructions.validate()` and `DrugOrderValidator` accept a units concept if it has *any* SNOMED CT SAME-AS code, while `Duration.addToDate()` requires the code to be on a hardcoded list. A concept mapped to a real-but-unrecognized code passes validation and then throws at save time, surfacing as an HTTP 500 instead of a validation error.
2. **Resolution is nondeterministic.** `Duration.getCode()` returns the first SNOMED SAME-AS code in mapping-set iteration order. With CIEL's Minutes now carrying two SNOMED SAME-AS codes, whether an order saves depends on which mapping happens to be returned first.
3. **The hardcoded code list ages.** Core only knew the pre-2021 SNOMED codes, so every vocabulary change breaks order saving platform-wide until core chases the new code.

**The fix** introduces one deterministic resolution, `Duration.getDuration(Integer duration, Concept durationUnits)`, shared by auto-expiry derivation and both validators. Callers go straight from the order fields to a `Duration`; reference term codes stay entirely under the hood.

- It considers **all** SAME-AS mappings of the concept to the SNOMED CT and UCUM sources (each matched by its HL7 code or its source name), not just whichever mapping iterates first.
- Codes resolve to a unit through source-scoped registries (one per vocabulary, so a code can never resolve through the wrong source) that also know the current SNOMED CT minute code `1156209001` and the UCUM time codes `s`, `min`, `h`, `d`, `wk`, `mo`, `a`. UCUM codes are stable by design, which makes resolution robust against future SNOMED code churn instead of chasing codes one release at a time.
- SNOMED CT mappings take priority: the first SNOMED CT mapping carrying a known code resolves the concept, and UCUM is consulted only when no SNOMED CT mapping does. Per review, refusing to resolve when SNOMED CT and UCUM mappings disagree would have imposed a consistency rule on data that was valid while UCUM was ignored; with source priority, every concept that resolves today keeps resolving identically however its UCUM mappings are curated, and UCUM strictly extends resolution to concepts that previously resolved to nothing.
- `BaseDosingInstructions.getAutoExpireDate()`, `SimpleDosingInstructions.validate()` and `DrugOrderValidator` all use it, so an unresolvable unit is rejected at validation time with the existing `durationUnits` field error, and auto-expiry derivation can no longer throw for dictionary data. `Duration.getCode()` is deprecated with behavior unchanged (fhir2 still calls it), and `addToDate(...)` keeps accepting bare codes for API compatibility.

**Behavior compatibility:**

- Concepts mapped to the legacy SNOMED codes (existing working deployments): unchanged.
- CIEL-current dictionaries (the reported failure): orders save, deterministically.
- Concepts mapped only to UCUM: previously rejected by validation, now work.
- Concepts whose SNOMED SAME-AS code is unknown to core: previously passed validation and then failed with a 500 at save; now rejected at validation with a meaningful message.

## Verification

- `258701004` inactive since 2021-07-31 and `1156209001` active, confirmed against a SNOMED terminology server (tx.fhir.org `$lookup`).
- dev3 (platform 2.8.7, current CIEL): Minutes is the only duration unit whose SNOMED mapping changed; it carries both SNOMED codes as SAME-AS plus UCUM `min`. Most units in the "Duration units" set (CIEL 1732) also carry their UCUM code; Hours (1822) carries a malformed UCUM mapping (`h57.1`, reported upstream), which resolution skips as designed, so Hours resolves through its still-active SNOMED code and has no UCUM fallback until the CIEL mapping is fixed.
- `DurationTest`, `SimpleDosingInstructionsTest` and `DrugOrderValidatorTest` pass locally, with cases for the current minute code, the UCUM codes, multi-mapping concepts, unknown codes, the SNOMED CT preference when a UCUM mapping disagrees, the UCUM fallback when the only SNOMED CT code is unknown, case-insensitive UCUM source names and source filtering.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6674

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests in the touched test classes pass locally; full suite left to CI.
- [x] My pull request is based on the latest changes of the master branch.

Opened as an independently derived fix at the maintainer's request, without consulting the other open PRs for this report, so the approaches can be compared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





## Alternatives considered

- **Runtime-configurable code registry** (global property or metadata mapping): would let admins add codes without a platform release, but it moves a semantic-correctness decision ("this code means days") from compile-time review into runtime config, where a typo silently changes when medications auto-expire. For codes that have changed once in roughly a decade, that trades a rare, loud, reviewed failure for a rare, silent, config-shaped one. The existing split is kept deliberately: implementations configure *which concepts* are orderable duration units; the platform owns *what the codes mean*.
- **Terminology-server lookup** (ask SNOMED CT whether a code denotes a unit of time): adds a runtime dependency and offline failure modes, and still would not supply the calendar arithmetic each unit needs.
- **UCUM as the only vocabulary**: closest to durable, since UCUM codes are stable by design and FHIR's `Timing.UnitsOfTime` hardcodes the same seven, but every existing dictionary carries SNOMED mappings, so SNOMED stays first-class with UCUM alongside as the stable rail.
- **Repurposing `SNOMED_CT_MINUTES_CODE` to the new value** instead of adding a constant: public String constants inline at compile time, so modules compiled against older core keep the old value until rebuilt and then silently flip behavior; fhir2's translator map is the concrete casualty.

What makes the compiled-in registry safe, and must be preserved when extending it: entries are additive and never removed or repurposed; concepts that resolve to nothing fail as validation errors, never a save-time 500; and two vocabulary rails, with SNOMED CT taking priority and UCUM filling gaps, mean no single SNOMED inactivation is load-bearing. This rationale is also summarized in the `Duration` class Javadoc.


