### PR TITLE
TRUNK-6429: Publish save event when stopping orders

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -41,6 +41,7 @@ import org.openmrs.Provider;
 import org.openmrs.ReferralOrder;
 import org.openmrs.TestOrder;
 import org.openmrs.Visit;
+import org.openmrs.aop.event.SaveServiceEvent;
 import org.openmrs.api.APIException;
 import org.openmrs.api.AmbiguousOrderException;
 import org.openmrs.api.CannotDeleteObjectInUseException;
@@ -59,6 +60,7 @@ import org.openmrs.api.UnchangeableObjectException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.db.OrderDAO;
 import org.openmrs.customdatatype.CustomDatatypeUtil;
+import org.openmrs.event.EventPublisher;
 import org.openmrs.order.OrderUtil;
 import org.openmrs.parameter.OrderSearchCriteria;
 import org.openmrs.util.ConfigUtil;
@@ -94,6 +96,9 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 
 	@Autowired
 	protected OrderDAO dao;
+
+	@Autowired
+	private EventPublisher eventPublisher;
 
 	private static OrderNumberGenerator orderNumberGenerator = null;
 
@@ -894,6 +899,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		}
 
 		setProperty(orderToStop, "dateStopped", discontinueDate);
+		eventPublisher.publishEvent(new SaveServiceEvent<>(orderToStop));
 		saveOrderInternal(orderToStop, null);
 	}
 

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -56,6 +56,7 @@ import org.openmrs.Provider;
 import org.openmrs.SimpleDosingInstructions;
 import org.openmrs.TestOrder;
 import org.openmrs.Visit;
+import org.openmrs.aop.event.SaveServiceEvent;
 import org.openmrs.api.builder.DrugOrderBuilder;
 import org.openmrs.api.builder.OrderBuilder;
 import org.openmrs.api.context.Context;
@@ -73,6 +74,8 @@ import org.openmrs.util.DateUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.PrivilegeConstants;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.PayloadApplicationEvent;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -613,6 +616,63 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 		assertEquals(discontinueOrder.getAction(), Action.DISCONTINUE);
 		assertEquals(discontinueOrder.getOrderReasonNonCoded(), discontinueReasonNonCoded);
 		assertEquals(discontinueOrder.getPreviousOrder(), order);
+	}
+
+	/**
+	 * @see OrderService#discontinueOrder(org.openmrs.Order, String, java.util.Date,
+	 *      org.openmrs.Provider, org.openmrs.Encounter)
+	 */
+	@Test
+	public void discontinueOrder_shouldPublishSaveServiceEventForTheStoppedOrder() {
+		List<Order> savedOrders = listenForSavedOrders();
+
+		Order order = orderService.getOrderByOrderNumber("111");
+		Integer orderId = order.getOrderId();
+		Encounter encounter = encounterService.getEncounter(3);
+		Provider orderer = providerService.getProvider(1);
+
+		orderService.discontinueOrder(order, "Test if I can discontinue this", new Date(), orderer, encounter);
+
+		assertTrue(savedOrders.stream()
+		        .anyMatch(savedOrder -> orderId.equals(savedOrder.getOrderId()) && savedOrder.getDateStopped() != null));
+	}
+
+	/**
+	 * @see OrderService#saveOrder(org.openmrs.Order, OrderContext)
+	 */
+	@Test
+	public void saveOrder_shouldPublishSaveServiceEventForTheStoppedPreviousOrder() {
+		List<Order> savedOrders = listenForSavedOrders();
+
+		Order previousOrder = orderService.getOrder(111);
+		Integer previousOrderId = previousOrder.getOrderId();
+		Order order = previousOrder.cloneForDiscontinuing();
+		order.setOrderReasonNonCoded("Discontinue this");
+		order.setEncounter(encounterService.getEncounter(3));
+		order.setOrderer(providerService.getProvider(1));
+		order.setDateActivated(new Date());
+
+		orderService.saveOrder(order, null);
+
+		assertTrue(savedOrders.stream().anyMatch(
+		    savedOrder -> previousOrderId.equals(savedOrder.getOrderId()) && savedOrder.getDateStopped() != null));
+	}
+
+	private List<Order> listenForSavedOrders() {
+		List<Order> savedOrders = new ArrayList<>();
+		((ConfigurableApplicationContext) applicationContext).addApplicationListener(event -> {
+			Object payload = event;
+			if (event instanceof PayloadApplicationEvent<?>) {
+				payload = ((PayloadApplicationEvent<?>) event).getPayload();
+			}
+			if (payload instanceof SaveServiceEvent<?>) {
+				Object entity = ((SaveServiceEvent<?>) payload).getEntity();
+				if (entity instanceof Order) {
+					savedOrders.add((Order) entity);
+				}
+			}
+		});
+		return savedOrders;
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed

This PR publishes a `SaveServiceEvent` for the original order when it is stopped through `OrderServiceImpl.stopOrder(...)`.

`stopOrder(...)` already centralizes the internal paths that mark an existing order as stopped, including `OrderService.discontinueOrder(...)` and saving a `DISCONTINUE` order. Since those paths persist through the private `saveOrderInternal(...)` method, they bypass the public service method advice that normally emits `SaveServiceEvent`s.

The event is published after `dateStopped` is set on the stopped order, so event-driven consumers can observe that the original order is no longer active.

I also added tests covering both entry points described in the issue:

- `discontinueOrder(...)` publishes a `SaveServiceEvent` for the stopped order.
- `saveOrder(...)` with a `DISCONTINUE` order publishes a `SaveServiceEvent` for the stopped previous order.

## Issue I worked on

Fixes https://github.com/openmrs/openmrs-core/issues/6197

## Testing

- [x] `mvn -pl api -Dtest=OrderServiceTest#discontinueOrder_shouldPublishSaveServiceEventForTheStoppedOrder,OrderServiceTest#saveOrder_shouldPublishSaveServiceEventForTheStoppedPreviousOrder test`

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes.
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [ ] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

Note: I left the full-build checklist items unchecked because I only validated this PR with the targeted tests listed above. While checking broader coverage in this environment, an existing `OrderServiceTest#discontinueOrder_shouldPopulateCorrectAttributesOnTheDiscontinueAndDiscontinuedOrders` assertion also failed on a clean `origin/master` checkout, so I am not claiming a successful full `mvn clean package` run here.

_This PR was developed by Codex under jmtdev0's supervision._
