### PR TITLE
Add on-demand Claude PR review workflow (dev/3+ gated)

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,8 +23,9 @@ env:
 
 jobs:
   review:
-    # Bound cost and stop a hung run on this public repo.
-    timeout-minutes: 15
+    # Bound cost and stop a hung run on this public repo. Generous because
+    # Opus 4.8 at max effort reasons deeply and takes longer per review.
+    timeout-minutes: 20
     # Cheap pre-filter so we don't start a runner on unrelated comments:
     # a PR comment (not a plain issue), not authored by a bot (so the reviewer's
     # own comment can never re-trigger this), containing the trigger phrase.
@@ -102,5 +103,7 @@ jobs:
           # `gh pr diff`/git. `contents: read` above is what actually prevents
           # any push, so read-only Bash is safe.
           claude_args: |
-            --max-turns 4
+            --model claude-opus-4-8
+            --effort max
+            --max-turns 5
             --disallowedTools "Write,Edit"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -27,10 +27,9 @@ env:
 jobs:
   review:
     # Bound cost and stop a hung run on this public repo. Generous because
-    # Opus 4.8 at max effort plus the skill's verification steps take a while.
-    # Note: the skill builds base+PR for build-config PRs, which can exceed
-    # this on core's large build; such runs stop here and the skill reports the
-    # unverified check as a question rather than a fact.
+    # Opus 4.8 at max effort plus the skill's read-based verification take a
+    # while. The prompt forbids running PR builds, so reviews don't wait on long
+    # mvn builds (and build-only checks are reported as questions, not facts).
     timeout-minutes: 30
     # Cheap pre-filter so we don't start a runner on unrelated comments:
     # a PR comment (not a plain issue), not authored by a bot (so the reviewer's
@@ -119,6 +118,17 @@ jobs:
             submit the findings as inline review comments through the GitHub API.
             This runs in CI with no interactive user to report back to, so if the
             PR is clean with nothing to act on, post nothing.
+
+            Security constraint — this OVERRIDES the skill wherever they differ:
+            you are reviewing untrusted PR code, so never execute any code or
+            build from the repository. Do not run mvn, gradle, npm, make, the
+            test suite, or any script or binary from the tree, and do not build
+            base or PR branches in worktrees. Verify only by reading files and
+            by read-only tooling: git diff/log/grep, gh pr diff, and gh api.
+            Where the skill would build something to verify it (e.g. a
+            build-config PR), you cannot run that build here — treat it as an
+            experiment that cannot run and report the check as a question, per
+            the skill's own rule, rather than asserting it as fact.
           # Review-only: Write/Edit disabled so Claude cannot alter tracked
           # files (the skill writes its payload JSON via python in Bash, not the
           # Write tool). Bash stays enabled — the skill drives through git, gh,

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -105,5 +105,5 @@ jobs:
           claude_args: |
             --model claude-opus-4-8
             --effort max
-            --max-turns 5
+            --max-turns 10
             --disallowedTools "Write,Edit"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -16,10 +16,13 @@ concurrency:
   group: claude-pr-review-${{ github.event.issue.number }}
   cancel-in-progress: true
 
-# Edit these to change the org or which stages may invoke the reviewer.
+# Edit these to change the org, which stages may invoke the reviewer, or the
+# review methodology source. Pin SKILL_URL to a commit SHA (swap `main` for the
+# SHA in the raw path) to freeze the methodology and avoid it changing upstream.
 env:
   REVIEWER_ORG: openmrs
   REVIEWER_TEAMS: "dev-3 dev-4 dev-5"
+  SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/main/.claude/skills/pr-review/SKILL.md
 
 jobs:
   review:
@@ -70,13 +73,15 @@ jobs:
 
       # issue_comment checks out the default branch by default. Fetch the PR
       # head instead so the review sees the PR's code, not master. This ref
-      # resolves for fork PRs too.
+      # resolves for fork PRs too. fetch-depth: 0 (full history) is required by
+      # the skill's local-git verification — merge-base, diffing against the
+      # base branch, drift checks — which a shallow clone cannot support.
       - name: Check out the PR head
         if: steps.gate.outputs.allowed == 'true'
         uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
-          fetch-depth: 1
+          fetch-depth: 0
 
       # Pull the review methodology from the trusted querystore repo into a temp
       # path OUTSIDE the checked-out PR tree, so a malicious PR cannot substitute
@@ -84,8 +89,6 @@ jobs:
       # silently reviewing with no methodology.
       - name: Fetch the pr-review skill
         if: steps.gate.outputs.allowed == 'true'
-        env:
-          SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/main/.claude/skills/pr-review/SKILL.md
         run: |
           dest="$RUNNER_TEMP/pr-review-SKILL.md"
           curl -fsSL "$SKILL_URL" -o "$dest"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -39,8 +39,11 @@ jobs:
         run: |
           allowed=false
           for team in $REVIEWER_TEAMS; do
-            if gh api "/orgs/${REVIEWER_ORG}/teams/${team}/memberships/${LOGIN}" \
-                 --jq '.state' 2>/dev/null | grep -qx active; then
+            # Capture the state and compare in bash; do NOT pipe into grep for a
+            # security gate. An active membership returns state "active".
+            state="$(gh api "/orgs/${REVIEWER_ORG}/teams/${team}/memberships/${LOGIN}" \
+                       --jq '.state' 2>/dev/null || true)"
+            if [ "$state" = "active" ]; then
               allowed=true
               echo "::notice::${LOGIN} is a member of ${REVIEWER_ORG}/${team}; proceeding."
               break

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -24,8 +24,11 @@ env:
 jobs:
   review:
     # Bound cost and stop a hung run on this public repo. Generous because
-    # Opus 4.8 at max effort reasons deeply and takes longer per review.
-    timeout-minutes: 20
+    # Opus 4.8 at max effort plus the skill's verification steps take a while.
+    # Note: the skill builds base+PR for build-config PRs, which can exceed
+    # this on core's large build; such runs stop here and the skill reports the
+    # unverified check as a question rather than a fact.
+    timeout-minutes: 30
     # Cheap pre-filter so we don't start a runner on unrelated comments:
     # a PR comment (not a plain issue), not authored by a bot (so the reviewer's
     # own comment can never re-trigger this), containing the trigger phrase.
@@ -75,35 +78,51 @@ jobs:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 1
 
+      # Pull the review methodology from the trusted querystore repo into a temp
+      # path OUTSIDE the checked-out PR tree, so a malicious PR cannot substitute
+      # its own SKILL.md. Fail loudly if it's missing or unexpected rather than
+      # silently reviewing with no methodology.
+      - name: Fetch the pr-review skill
+        if: steps.gate.outputs.allowed == 'true'
+        env:
+          SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/main/.claude/skills/pr-review/SKILL.md
+        run: |
+          dest="$RUNNER_TEMP/pr-review-SKILL.md"
+          curl -fsSL "$SKILL_URL" -o "$dest"
+          test -s "$dest"
+          grep -q "name: pr-review" "$dest"
+          echo "Fetched pr-review skill ($(wc -l < "$dest") lines)."
+
       - name: Review
         if: steps.gate.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@v1
+        env:
+          # The skill posts its review through `gh api .../reviews`; give gh the
+          # workflow token so those calls are authenticated.
+          GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # No trigger_phrase: supplying `prompt` selects the action's
-          # automation mode (trigger_phrase is ignored). That is what we want —
-          # the job `if:` and the gate above already decide who and when, and
-          # this lets us drive a review tailored to openmrs-core.
+          # No trigger_phrase: supplying `prompt` selects automation mode. The
+          # methodology comes from the pr-review skill, injected as a system
+          # prompt via --append-system-prompt-file below — skills are not
+          # reliably auto-invoked in automation mode (claude-code-action #1003),
+          # so injecting the file is the documented, dependable path.
           prompt: |
-            Begin your comment with this exact line:
-            "🤖 Automated review by Claude, requested by a maintainer. A maintainer still makes the final merge decision."
-
-            Review this openmrs-core pull request. Because core is the API
-            contract that hundreds of downstream modules depend on, weight these
-            most heavily:
-            - Backward compatibility and any public-API breakage
-            - Security (this underpins a medical record system)
-            - Test coverage for the changed behavior
-            - Adherence to the OpenMRS coding conventions
-
-            Post a single PR comment with your findings. Do NOT modify code,
-            push commits, or open pull requests.
-          # Review-only: Write/Edit are disabled so Claude cannot alter files.
-          # Bash stays enabled on purpose — the action reads the diff through
-          # `gh pr diff`/git. `contents: read` above is what actually prevents
-          # any push, so read-only Bash is safe.
+            Review pull request #${{ github.event.issue.number }} in the
+            repository ${{ github.repository }}, following the PR-review
+            methodology appended to your system prompt exactly: its verification
+            requirements, its rules for every inline comment, and its posting
+            rules. Post the review to the PR the way the skill's `--post` does —
+            submit the findings as inline review comments through the GitHub API.
+            This runs in CI with no interactive user to report back to, so if the
+            PR is clean with nothing to act on, post nothing.
+          # Review-only: Write/Edit disabled so Claude cannot alter tracked
+          # files (the skill writes its payload JSON via python in Bash, not the
+          # Write tool). Bash stays enabled — the skill drives through git, gh,
+          # and python. `contents: read` guarantees no push regardless.
           claude_args: |
             --model claude-opus-4-8
             --effort max
-            --max-turns 10
+            --append-system-prompt-file ${{ runner.temp }}/pr-review-SKILL.md
+            --max-turns 40
             --disallowedTools "Write,Edit"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,10 +10,15 @@ on:
   issue_comment:
     types: [created]
 
-# One review at a time per PR; a fresh "@claude review" supersedes an
-# in-flight one instead of posting a duplicate.
+# One review at a time per PR; a fresh "@claude review" supersedes an in-flight
+# one instead of posting a duplicate. The group is keyed on the PR AND on whether
+# this comment is a review request: concurrency is evaluated per workflow run
+# BEFORE the job `if:`, and the workflow triggers on every issue comment, so a
+# PR-number-only group would let an unrelated comment (its run joins the same
+# group, then skips) cancel an in-flight review. Two review requests share the
+# `-true` group and the newer supersedes; everything else lands in `-false`.
 concurrency:
-  group: claude-pr-review-${{ github.event.issue.number }}
+  group: claude-pr-review-${{ github.event.issue.number }}-${{ contains(github.event.comment.body, '@claude review') }}
   cancel-in-progress: true
 
 # Edit these to change the org, which stages may invoke the reviewer, or the

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,16 +10,14 @@ on:
   issue_comment:
     types: [created]
 
-# One review at a time per PR; a fresh "@claude review" supersedes an in-flight
-# one instead of posting a duplicate. The group is keyed on the PR AND on whether
-# this comment is a review request: concurrency is evaluated per workflow run
-# BEFORE the job `if:`, and the workflow triggers on every issue comment, so a
-# PR-number-only group would let an unrelated comment (its run joins the same
-# group, then skips) cancel an in-flight review. Two review requests share the
-# `-true` group and the newer supersedes; everything else lands in `-false`.
-concurrency:
-  group: claude-pr-review-${{ github.event.issue.number }}-${{ contains(github.event.comment.body, '@claude review') }}
-  cancel-in-progress: true
+# No `concurrency` here on purpose. It is evaluated at run creation, upstream of
+# the membership gate below, so any cancel-in-progress group joinable by an
+# arbitrary comment is a denial-of-service vector: on this public repo anyone
+# could post "@claude review" (or quote it) to join the group and cancel a
+# legitimate in-flight review before their own run is gated out. Cancellation
+# cannot be membership-gated (that needs a runtime API call, not an `if:`), so
+# we simply don't cancel. The cost is that a dev who invokes twice gets two
+# reviews rather than a supersede — rare, visible, and preferable to the DoS.
 
 # Edit these to change the org, which stages may invoke the reviewer, or the
 # review methodology source. Pin SKILL_URL to a commit SHA (swap `main` for the

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,0 +1,80 @@
+# On-demand PR review by Claude.
+# Runs ONLY when a /dev/3-or-above developer comments "@claude review" on a PR.
+# It never runs automatically on PR open. Gating is by membership of the
+# OpenMRS developer-stage GitHub teams below, because a GitHub Action cannot
+# read OpenMRS developer stages directly. "/dev/3 and above" == membership of
+# any of dev-3, dev-4, dev-5 (the teams are flat, not nested).
+name: Claude PR Review
+
+on:
+  issue_comment:
+    types: [created]
+
+# Edit these to change the org or which stages may invoke the reviewer.
+env:
+  REVIEWER_ORG: openmrs
+  REVIEWER_TEAMS: "dev-3 dev-4 dev-5"
+
+jobs:
+  review:
+    # Cheap pre-filter so we don't start a runner on unrelated comments:
+    # only PR comments (not issue comments) that contain the trigger phrase.
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Fail-closed dev-stage gate: the commenter must be an active member of
+      # one of the reviewer teams. DEV_STAGE_READ_TOKEN needs read:org scope,
+      # because the default GITHUB_TOKEN cannot read another org's team
+      # membership (and this runs on a fork).
+      - name: Verify commenter is /dev/3 or above
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.DEV_STAGE_READ_TOKEN }}
+          LOGIN: ${{ github.event.comment.user.login }}
+        run: |
+          allowed=false
+          for team in $REVIEWER_TEAMS; do
+            if gh api "/orgs/${REVIEWER_ORG}/teams/${team}/memberships/${LOGIN}" \
+                 --jq '.state' 2>/dev/null | grep -qx active; then
+              allowed=true
+              echo "::notice::${LOGIN} is a member of ${REVIEWER_ORG}/${team}; proceeding."
+              break
+            fi
+          done
+          echo "allowed=${allowed}" >> "$GITHUB_OUTPUT"
+          if [ "$allowed" = false ]; then
+            echo "::notice::${LOGIN} is not /dev/3+ (not in: ${REVIEWER_TEAMS}); skipping."
+          fi
+
+      - name: Checkout
+        if: steps.gate.outputs.allowed == 'true'
+        uses: actions/checkout@v6
+
+      - name: Review
+        if: steps.gate.outputs.allowed == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trigger_phrase: "@claude review"
+          prompt: |
+            Begin your comment with this exact line:
+            "🤖 Automated review by Claude, requested via @claude review. A maintainer still makes the merge decision."
+
+            Review this openmrs-core pull request. Because core is the API
+            contract that hundreds of downstream modules depend on, weight these
+            most heavily:
+            - Backward compatibility and any public-API breakage
+            - Security (this underpins a medical record system)
+            - Test coverage for the changed behavior
+            - Adherence to the OpenMRS coding conventions
+
+            Post a single PR comment with your findings. Do NOT modify code,
+            push commits, or open pull requests.
+          claude_args: |
+            --max-turns 4
+            --disallowedTools Edit,Write,Bash

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -10,6 +10,12 @@ on:
   issue_comment:
     types: [created]
 
+# One review at a time per PR; a fresh "@claude review" supersedes an
+# in-flight one instead of posting a duplicate.
+concurrency:
+  group: claude-pr-review-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 # Edit these to change the org or which stages may invoke the reviewer.
 env:
   REVIEWER_ORG: openmrs
@@ -17,20 +23,24 @@ env:
 
 jobs:
   review:
+    # Bound cost and stop a hung run on this public repo.
+    timeout-minutes: 15
     # Cheap pre-filter so we don't start a runner on unrelated comments:
-    # only PR comments (not issue comments) that contain the trigger phrase.
+    # a PR comment (not a plain issue), not authored by a bot (so the reviewer's
+    # own comment can never re-trigger this), containing the trigger phrase.
     if: >
       github.event.issue.pull_request != null &&
+      github.event.comment.user.type != 'Bot' &&
       contains(github.event.comment.body, '@claude review')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read          # read-only: the hard guarantee that no code is pushed
+      pull-requests: write     # read the PR/diff and post the review
+      issues: write            # a PR conversation comment posts via the issues API
     steps:
       # Fail-closed dev-stage gate: the commenter must be an active member of
       # one of the reviewer teams. DEV_STAGE_READ_TOKEN needs read:org scope,
-      # because the default GITHUB_TOKEN cannot read another org's team
-      # membership (and this runs on a fork).
+      # because the default GITHUB_TOKEN cannot read org team membership.
       - name: Verify commenter is /dev/3 or above
         id: gate
         env:
@@ -54,19 +64,28 @@ jobs:
             echo "::notice::${LOGIN} is not /dev/3+ (not in: ${REVIEWER_TEAMS}); skipping."
           fi
 
-      - name: Checkout
+      # issue_comment checks out the default branch by default. Fetch the PR
+      # head instead so the review sees the PR's code, not master. This ref
+      # resolves for fork PRs too.
+      - name: Check out the PR head
         if: steps.gate.outputs.allowed == 'true'
         uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
 
       - name: Review
         if: steps.gate.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude review"
+          # No trigger_phrase: supplying `prompt` selects the action's
+          # automation mode (trigger_phrase is ignored). That is what we want —
+          # the job `if:` and the gate above already decide who and when, and
+          # this lets us drive a review tailored to openmrs-core.
           prompt: |
             Begin your comment with this exact line:
-            "🤖 Automated review by Claude, requested via @claude review. A maintainer still makes the merge decision."
+            "🤖 Automated review by Claude, requested by a maintainer. A maintainer still makes the final merge decision."
 
             Review this openmrs-core pull request. Because core is the API
             contract that hundreds of downstream modules depend on, weight these
@@ -78,6 +97,10 @@ jobs:
 
             Post a single PR comment with your findings. Do NOT modify code,
             push commits, or open pull requests.
+          # Review-only: Write/Edit are disabled so Claude cannot alter files.
+          # Bash stays enabled on purpose — the action reads the diff through
+          # `gh pr diff`/git. `contents: read` above is what actually prevents
+          # any push, so read-only Bash is safe.
           claude_args: |
             --max-turns 4
-            --disallowedTools Edit,Write,Bash
+            --disallowedTools "Write,Edit"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -20,12 +20,13 @@ on:
 # reviews rather than a supersede — rare, visible, and preferable to the DoS.
 
 # Edit these to change the org, which stages may invoke the reviewer, or the
-# review methodology source. Pin SKILL_URL to a commit SHA (swap `main` for the
-# SHA in the raw path) to freeze the methodology and avoid it changing upstream.
+# review methodology source. SKILL_URL is pinned to a querystore commit SHA so
+# the review methodology can't change under us without a deliberate bump here
+# (bump the SHA in a PR to pick up skill updates).
 env:
   REVIEWER_ORG: openmrs
   REVIEWER_TEAMS: "dev-3 dev-4 dev-5"
-  SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/main/.claude/skills/pr-review/SKILL.md
+  SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/a5ea7a9b4640849d31b6adf65f0e5706a3a18666/.claude/skills/pr-review/SKILL.md
 
 jobs:
   review:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -120,11 +120,13 @@ jobs:
             PR is clean with nothing to act on, post nothing.
 
             Security constraint — this OVERRIDES the skill wherever they differ:
-            you are reviewing untrusted PR code, so never execute any code or
-            build from the repository. Do not run mvn, gradle, npm, make, the
-            test suite, or any script or binary from the tree, and do not build
-            base or PR branches in worktrees. Verify only by reading files and
-            by read-only tooling: git diff/log/grep, gh pr diff, and gh api.
+            you are reviewing untrusted PR code, so never execute the
+            repository's own code. Do not run its build or tests (mvn, gradle,
+            npm, make, and the like), and do not run any script or binary from
+            the tree, including inside worktrees. This ban is on the PR's code
+            only — your own read-only tooling is expected: use git
+            (diff/log/grep), gh (pr diff, api), curl to fetch upstream
+            references, and python to assemble the review payload you post.
             Where the skill would build something to verify it (e.g. a
             build-config PR), you cannot run that build here — treat it as an
             experiment that cannot run and report the check as a question, per


### PR DESCRIPTION
## What this adds

A GitHub Actions workflow (`.github/workflows/claude-pr-review.yml`) that runs an automated Claude code review of a pull request **only when a developer explicitly asks for it**. It never runs automatically on PR open or push.

## How it works

- **Trigger:** a comment containing `@claude review` on a pull request.
- **Who may invoke it:** only members of the `/dev/3`, `/dev/4`, or `/dev/5` GitHub teams (`dev-3`, `dev-4`, `dev-5`). The gate loops over those teams and allows on the first match; everyone else — including drive-by commenters — is silently ignored, so review costs can't be triggered by arbitrary users.
- **Why a team check:** a GitHub Action can't read OpenMRS developer stages directly, so we mirror them onto the existing dev-stage teams. The teams are flat (not nested), hence "3 and above" checks all three.
- **Scope:** review only. `--disallowedTools Edit,Write,Bash` means it reads the diff and posts one clearly-labeled comment; it cannot modify code, push commits, or open PRs.
- **Fail-closed:** if the membership lookup can't run (missing/insufficient token), it denies rather than allows.

## Required before it does anything (org admin)

Two repository/organization secrets must be added to `openmrs/openmrs-core`:

1. `ANTHROPIC_API_KEY` — an org-owned Claude API key (the review engine's auth).
2. `DEV_STAGE_READ_TOKEN` — a **minimal, read-only** credential with `read:org` (org **Members: read**) so the workflow can check team membership. A fine-grained PAT scoped to only that, or a GitHub App token, is preferred over reusing any write-capable token. The default `GITHUB_TOKEN` cannot read org team membership, so a dedicated credential is required.

Until both secrets exist, the workflow is inert (fails closed). Safe rollout order: merge → add secrets → test with a real `@claude review` comment.

## Security notes

- `issue_comment` workflows always run from the workflow file on the default branch, so a malicious PR cannot alter this workflow to exfiltrate the token.
- The token is exposed only to the membership-check step, not to the review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)