### PR TITLE
TRUNK-6675: Module is not updated when omod changes

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -479,15 +479,19 @@ public class ModuleClassLoader extends URLClassLoader {
 						Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						tmpModuleDir.delete();
+						FileUtils.deleteDirectory(tmpModuleDir);
 					}
 				} catch (IOException | NumberFormatException e) {
 					log.warn("Error while reading module last modified file: {}", moduleLastModifiedFile, e);
 				}
 			} else {
-				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile, 
+				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 					tmpModuleDir);
-				tmpModuleDir.delete();
+				try {
+					FileUtils.deleteDirectory(tmpModuleDir);
+				} catch (IOException e) {
+					log.warn("Failed to delete lib cache dir for module {}", module.getModuleId(), e);
+				}
 			}
 
 			tmpModuleDir.mkdirs();

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -14,18 +14,25 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.OpenmrsClassLoader;
 
 public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	
@@ -473,6 +480,86 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 
 		assertFalse(ModuleClassLoader.isMatchingConditionalResource(mockModuleV2_0, fileUrl, conditionalResource),
 			"Path should not match glob pattern: " + filePath);
+	}
+
+	@Test
+	public void getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenModuleChanged() throws Exception {
+		File tempLibCache = Files.createTempDirectory("libcache-test").toFile();
+		Field libCacheFolderField = OpenmrsClassLoader.class.getDeclaredField("libCacheFolder");
+		libCacheFolderField.setAccessible(true);
+		File savedLibCacheFolder = (File) libCacheFolderField.get(null);
+		libCacheFolderField.set(null, tempLibCache);
+
+		Field libCacheFoldersField = ModuleClassLoader.class.getDeclaredField("libCacheFolders");
+		libCacheFoldersField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, File> libCacheFolders = (Map<String, File>) libCacheFoldersField.get(null);
+
+		File omodFile = File.createTempFile("testmodule", ".omod");
+		try {
+			long currentTimestamp = System.currentTimeMillis();
+			omodFile.setLastModified(currentTimestamp);
+
+			Module module = new Module("testmodule", "testmodule", "org.openmrs.module.testmodule",
+				"author", "description", "1.0", "1.0");
+			module.setFile(omodFile);
+
+			File moduleDir = new File(tempLibCache, "testmodule");
+			moduleDir.mkdirs();
+			FileUtils.writeStringToFile(new File(moduleDir, ".moduleLastModified"),
+				String.valueOf(currentTimestamp - 1000), Charset.defaultCharset());
+			File staleFile = new File(moduleDir, "old-resource.txt");
+			FileUtils.writeStringToFile(staleFile, "stale content", Charset.defaultCharset());
+
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertFalse(staleFile.exists(), "Stale file should be deleted when module changes");
+			assertTrue(moduleDir.exists(), "Module dir should be recreated");
+		} finally {
+			libCacheFolderField.set(null, savedLibCacheFolder);
+			libCacheFolders.remove("testmodule");
+			omodFile.delete();
+			FileUtils.deleteDirectory(tempLibCache);
+		}
+	}
+
+	@Test
+	public void getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenOptimizedStartupDisabled() throws Exception {
+		File tempLibCache = Files.createTempDirectory("libcache-test").toFile();
+		Field libCacheFolderField = OpenmrsClassLoader.class.getDeclaredField("libCacheFolder");
+		libCacheFolderField.setAccessible(true);
+		File savedLibCacheFolder = (File) libCacheFolderField.get(null);
+		libCacheFolderField.set(null, tempLibCache);
+
+		Field libCacheFoldersField = ModuleClassLoader.class.getDeclaredField("libCacheFolders");
+		libCacheFoldersField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, File> libCacheFolders = (Map<String, File>) libCacheFoldersField.get(null);
+
+		File omodFile = File.createTempFile("testmodule2", ".omod");
+		try {
+			Module module = new Module("testmodule2", "testmodule2", "org.openmrs.module.testmodule2",
+				"author", "description", "1.0", "1.0");
+			module.setFile(omodFile);
+
+			File moduleDir = new File(tempLibCache, "testmodule2");
+			moduleDir.mkdirs();
+			File staleFile = new File(moduleDir, "old-resource.txt");
+			FileUtils.writeStringToFile(staleFile, "stale content", Charset.defaultCharset());
+
+			Context.getRuntimeProperties().setProperty("optimized.startup", "false");
+
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertFalse(staleFile.exists(), "Stale file should be deleted when optimized startup is disabled");
+			assertTrue(moduleDir.exists(), "Module dir should be recreated");
+		} finally {
+			Context.getRuntimeProperties().remove("optimized.startup");
+			libCacheFolderField.set(null, savedLibCacheFolder);
+			libCacheFolders.remove("testmodule2");
+			omodFile.delete();
+			FileUtils.deleteDirectory(tempLibCache);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- `File.delete()` only removes empty directories, so when a SNAPSHOT omod was rebuilt between restarts the lib cache directory (e.g. `legacyui/`) could not be deleted and its stale expanded resources persisted.
- `OpenmrsClassLoader.expandURL` has a `file.exists()` short-circuit that returns the cached (stale) resource without re-expanding, so any resource loaded through the lazy-expansion path would remain stale indefinitely after the first failed delete.
- The new timestamp was still written to `.moduleLastModified` after the failed delete, causing every subsequent restart to see matching timestamps and skip the deletion entirely.

Both `tmpModuleDir.delete()` calls in `getLibCacheFolderForModule` are replaced with `FileUtils.deleteDirectory()`, which recursively removes the directory tree. Two regression tests are added to `ModuleClassLoaderTest` covering the module-changed and optimized-startup-disabled paths.

Fixes https://issues.openmrs.org/browse/TRUNK-6675
Related to https://issues.openmrs.org/browse/TRUNK-6509

## Test plan

- [x] `ModuleClassLoaderTest#getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenModuleChanged`
- [x] `ModuleClassLoaderTest#getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenOptimizedStartupDisabled`
- [ ] Manual: rebuild a SNAPSHOT omod, restart the server, and verify the updated code is picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)