### PR TITLE
Fix Claude PR review: add id-token: write permission

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -47,6 +47,7 @@ jobs:
       contents: read          # read-only: the hard guarantee that no code is pushed
       pull-requests: write     # read the PR/diff and post the review
       issues: write            # a PR conversation comment posts via the issues API
+      id-token: write          # claude-code-action fetches an OIDC token on startup even with an API key
     steps:
       # Fail-closed dev-stage gate: the commenter must be an active member of
       # one of the reviewer teams. DEV_STAGE_READ_TOKEN needs read:org scope,


### PR DESCRIPTION
The Claude PR review workflow (added in #6254) failed on its first live invocations: the Review step aborted before doing any work with

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
Operation failed after 3 attempts
```

`anthropics/claude-code-action@v1` fetches an OIDC token on startup **even when authenticating with an API key**, so `id-token: write` is required in the job permissions regardless of auth method. It was omitted originally on least-privilege grounds; the first run showed it's mandatory.

This adds the single missing permission. The gate, PR-head checkout, and skill-fetch steps all succeeded on the failed runs, so this is the only blocker to the review step running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)