### PR TITLE
Restore Opus 4.8 / max effort for Claude PR review; drop debug output

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -109,11 +109,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # TEMPORARY (remove after posting is validated): surface Claude's full
-          # output, including per-tool permission denials, so a run that fails to
-          # post is diagnosable. Exposes the transcript in this public repo's
-          # logs (secrets stay masked) — do not leave enabled.
-          show_full_output: true
           # No trigger_phrase: supplying `prompt` selects automation mode. The
           # methodology comes from the pr-review skill, injected as a system
           # prompt via --append-system-prompt-file below — skills are not
@@ -147,14 +142,12 @@ jobs:
           # --allowedTools is a positive allow-list; anything not listed
           # (including Write/Edit and build tools like mvn) is denied, which also
           # enforces the no-untrusted-build rule at the permission layer. The
-          # native inline-comment tool is allowed as the reliable posting path.
+          # native inline-comment tool is allowed as an alternative posting path
+          # (the skill posts via `gh api .../reviews`, which works under Bash).
           # --disallowedTools kept as belt-and-suspenders on Write/Edit.
-          # TEMPORARY debug: Sonnet 5 + medium effort keeps iteration cheap while
-          # we confirm posting works; restore --model claude-opus-4-8 / --effort
-          # max once validated.
           claude_args: |
-            --model claude-sonnet-5
-            --effort medium
+            --model claude-opus-4-8
+            --effort max
             --append-system-prompt-file ${{ runner.temp }}/pr-review-SKILL.md
             --max-turns 40
             --allowedTools "Bash,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
Posting is now validated end-to-end: with the tool allow-list from #6259, `claude[bot]` posted review [#4644899156](https://github.com/openmrs/openmrs-core/pull/6189) on #6189 with two genuine findings, correctly stayed silent on a clean test-refactor (#6228), and did not re-comment on already-resolved threads.

This reverts the temporary debug settings added in #6259:
- `--model claude-opus-4-8` and `--effort max` (was Sonnet 5 / medium for cheap iteration)
- removes `show_full_output: true`

The real fix — `--allowedTools` granting the tools the review needs — stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)