### PR TITLE
Use shared reusable workflow for Claude PR review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -1,154 +1,20 @@
-# On-demand PR review by Claude.
-# Runs ONLY when a /dev/3-or-above developer comments "@claude review" on a PR.
-# It never runs automatically on PR open. Gating is by membership of the
-# OpenMRS developer-stage GitHub teams below, because a GitHub Action cannot
-# read OpenMRS developer stages directly. "/dev/3 and above" == membership of
-# any of dev-3, dev-4, dev-5 (the teams are flat, not nested).
+# On-demand PR review by Claude, invoked by commenting "@claude review" on a PR.
+# The logic lives in a shared reusable workflow so every OpenMRS repo stays in
+# sync; see openmrs/openmrs-contrib-gha-workflows. Pinned to a commit SHA so
+# behaviour changes only when this line is deliberately bumped. Defaults there
+# are Opus 4.8 at max effort; override via `with:` if needed.
 name: Claude PR Review
 
 on:
   issue_comment:
     types: [created]
 
-# No `concurrency` here on purpose. It is evaluated at run creation, upstream of
-# the membership gate below, so any cancel-in-progress group joinable by an
-# arbitrary comment is a denial-of-service vector: on this public repo anyone
-# could post "@claude review" (or quote it) to join the group and cancel a
-# legitimate in-flight review before their own run is gated out. Cancellation
-# cannot be membership-gated (that needs a runtime API call, not an `if:`), so
-# we simply don't cancel. The cost is that a dev who invokes twice gets two
-# reviews rather than a supersede — rare, visible, and preferable to the DoS.
-
-# Edit these to change the org, which stages may invoke the reviewer, or the
-# review methodology source. SKILL_URL is pinned to a querystore commit SHA so
-# the review methodology can't change under us without a deliberate bump here
-# (bump the SHA in a PR to pick up skill updates).
-env:
-  REVIEWER_ORG: openmrs
-  REVIEWER_TEAMS: "dev-3 dev-4 dev-5"
-  SKILL_URL: https://raw.githubusercontent.com/openmrs/openmrs-module-querystore/a5ea7a9b4640849d31b6adf65f0e5706a3a18666/.claude/skills/pr-review/SKILL.md
-
 jobs:
   review:
-    # Bound cost and stop a hung run on this public repo. Generous because
-    # Opus 4.8 at max effort plus the skill's read-based verification take a
-    # while. The prompt forbids running PR builds, so reviews don't wait on long
-    # mvn builds (and build-only checks are reported as questions, not facts).
-    timeout-minutes: 30
-    # Cheap pre-filter so we don't start a runner on unrelated comments:
-    # a PR comment (not a plain issue), not authored by a bot (so the reviewer's
-    # own comment can never re-trigger this), containing the trigger phrase.
-    if: >
-      github.event.issue.pull_request != null &&
-      github.event.comment.user.type != 'Bot' &&
-      contains(github.event.comment.body, '@claude review')
-    runs-on: ubuntu-latest
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@558dd1a135e03acd83557bcbb9bed1e2e60c4ed3
+    secrets: inherit
     permissions:
-      contents: read          # read-only: the hard guarantee that no code is pushed
-      pull-requests: write     # read the PR/diff and post the review
-      issues: write            # a PR conversation comment posts via the issues API
-      id-token: write          # claude-code-action fetches an OIDC token on startup even with an API key
-    steps:
-      # Fail-closed dev-stage gate: the commenter must be an active member of
-      # one of the reviewer teams. DEV_STAGE_READ_TOKEN needs read:org scope,
-      # because the default GITHUB_TOKEN cannot read org team membership.
-      - name: Verify commenter is /dev/3 or above
-        id: gate
-        env:
-          GH_TOKEN: ${{ secrets.DEV_STAGE_READ_TOKEN }}
-          LOGIN: ${{ github.event.comment.user.login }}
-        run: |
-          allowed=false
-          for team in $REVIEWER_TEAMS; do
-            # Capture the state and compare in bash; do NOT pipe into grep for a
-            # security gate. An active membership returns state "active".
-            state="$(gh api "/orgs/${REVIEWER_ORG}/teams/${team}/memberships/${LOGIN}" \
-                       --jq '.state' 2>/dev/null || true)"
-            if [ "$state" = "active" ]; then
-              allowed=true
-              echo "::notice::${LOGIN} is a member of ${REVIEWER_ORG}/${team}; proceeding."
-              break
-            fi
-          done
-          echo "allowed=${allowed}" >> "$GITHUB_OUTPUT"
-          if [ "$allowed" = false ]; then
-            echo "::notice::${LOGIN} is not /dev/3+ (not in: ${REVIEWER_TEAMS}); skipping."
-          fi
-
-      # issue_comment checks out the default branch by default. Fetch the PR
-      # head instead so the review sees the PR's code, not master. This ref
-      # resolves for fork PRs too. fetch-depth: 0 (full history) is required by
-      # the skill's local-git verification — merge-base, diffing against the
-      # base branch, drift checks — which a shallow clone cannot support.
-      - name: Check out the PR head
-        if: steps.gate.outputs.allowed == 'true'
-        uses: actions/checkout@v6
-        with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
-          fetch-depth: 0
-
-      # Pull the review methodology from the trusted querystore repo into a temp
-      # path OUTSIDE the checked-out PR tree, so a malicious PR cannot substitute
-      # its own SKILL.md. Fail loudly if it's missing or unexpected rather than
-      # silently reviewing with no methodology.
-      - name: Fetch the pr-review skill
-        if: steps.gate.outputs.allowed == 'true'
-        run: |
-          dest="$RUNNER_TEMP/pr-review-SKILL.md"
-          curl -fsSL "$SKILL_URL" -o "$dest"
-          test -s "$dest"
-          grep -q "name: pr-review" "$dest"
-          echo "Fetched pr-review skill ($(wc -l < "$dest") lines)."
-
-      - name: Review
-        if: steps.gate.outputs.allowed == 'true'
-        uses: anthropics/claude-code-action@v1
-        env:
-          # The skill posts its review through `gh api .../reviews`; give gh the
-          # workflow token so those calls are authenticated.
-          GH_TOKEN: ${{ github.token }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # No trigger_phrase: supplying `prompt` selects automation mode. The
-          # methodology comes from the pr-review skill, injected as a system
-          # prompt via --append-system-prompt-file below — skills are not
-          # reliably auto-invoked in automation mode (claude-code-action #1003),
-          # so injecting the file is the documented, dependable path.
-          prompt: |
-            Review pull request #${{ github.event.issue.number }} in the
-            repository ${{ github.repository }}, following the PR-review
-            methodology appended to your system prompt exactly: its verification
-            requirements, its rules for every inline comment, and its posting
-            rules. Post the review to the PR the way the skill's `--post` does —
-            submit the findings as inline review comments through the GitHub API.
-            This runs in CI with no interactive user to report back to, so if the
-            PR is clean with nothing to act on, post nothing.
-
-            Security constraint — this OVERRIDES the skill wherever they differ:
-            you are reviewing untrusted PR code, so never execute the
-            repository's own code. Do not run its build or tests (mvn, gradle,
-            npm, make, and the like), and do not run any script or binary from
-            the tree, including inside worktrees. This ban is on the PR's code
-            only — your own read-only tooling is expected: use git
-            (diff/log/grep), gh (pr diff, api), curl to fetch upstream
-            references, and python to assemble the review payload you post.
-            Where the skill would build something to verify it (e.g. a
-            build-config PR), you cannot run that build here — treat it as an
-            experiment that cannot run and report the check as a question, per
-            the skill's own rule, rather than asserting it as fact.
-          # Tool permissions: claude-code-action DENIES all tools by default in
-          # automation mode, so the skill's gh/git/python Bash calls were all
-          # denied and it could never post (the cause of the empty first runs).
-          # --allowedTools is a positive allow-list; anything not listed
-          # (including Write/Edit and build tools like mvn) is denied, which also
-          # enforces the no-untrusted-build rule at the permission layer. The
-          # native inline-comment tool is allowed as an alternative posting path
-          # (the skill posts via `gh api .../reviews`, which works under Bash).
-          # --disallowedTools kept as belt-and-suspenders on Write/Edit.
-          claude_args: |
-            --model claude-opus-4-8
-            --effort max
-            --append-system-prompt-file ${{ runner.temp }}/pr-review-SKILL.md
-            --max-turns 40
-            --allowedTools "Bash,Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment"
-            --disallowedTools "Write,Edit"
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write


### PR DESCRIPTION
Replaces the standalone Claude PR review workflow with a thin caller of the shared reusable workflow in [openmrs/openmrs-contrib-gha-workflows](https://github.com/openmrs/openmrs-contrib-gha-workflows/blob/main/.github/workflows/claude-pr-review.yml), pinned to commit `558dd1a`.

**Behaviour is unchanged** — the reusable defaults to Opus 4.8 / max effort, the same `--allowedTools`, the same dev/3+ gate, the same skill. This just makes the shared workflow the single source of truth so fixes and improvements land in one place instead of being copied per repo.

- Secrets (`ANTHROPIC_API_KEY`, `DEV_STAGE_READ_TOKEN`) pass through via `secrets: inherit` (already org-level).
- Pinned to a SHA so the reviewer's behaviour on core changes only when this line is deliberately bumped.

Follows the full working chain: #6254 → #6258 → #6259 → #6260, now consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)