### PR TITLE
TRUNK-6674: Accept new SNOMED CT code for Minutes duration unit (2.9.x backport)

### DIFF
--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -32,6 +32,16 @@ public class Duration {
 	
 	public static final String SNOMED_CT_MINUTES_CODE = "258701004";
 	
+	/**
+	 * Active SNOMED CT code for minute. SNOMED CT inactivated the legacy code
+	 * {@link #SNOMED_CT_MINUTES_CODE} ("258701004") in its 2021-07-31 release, and dictionaries such as
+	 * CIEL now map minutes concepts to this code. The legacy code is still accepted for backward
+	 * compatibility.
+	 *
+	 * @since 2.8.8, 2.9.0, 3.0.0
+	 */
+	public static final String SNOMED_CT_MINUTES_CODE_2021 = "1156209001";
+	
 	public static final String SNOMED_CT_HOURS_CODE = "258702006";
 	
 	public static final String SNOMED_CT_DAYS_CODE = "258703001";
@@ -77,7 +87,7 @@ public class Duration {
 		if (SNOMED_CT_SECONDS_CODE.equals(code)) {
 			return addSeconds(startDate, this.duration);
 		}
-		if (SNOMED_CT_MINUTES_CODE.equals(code)) {
+		if (SNOMED_CT_MINUTES_CODE.equals(code) || SNOMED_CT_MINUTES_CODE_2021.equals(code)) {
 			return addMinutes(startDate, this.duration);
 		}
 		if (SNOMED_CT_HOURS_CODE.equals(code)) {

--- a/api/src/test/java/org/openmrs/DurationTest.java
+++ b/api/src/test/java/org/openmrs/DurationTest.java
@@ -46,6 +46,15 @@ public class DurationTest extends BaseContextSensitiveTest {
 	}
 	
 	@Test
+	public void addToDate_shouldAddMinutesWhenUnitIsMinutesUsingNewSnomedCode() throws ParseException {
+		Duration duration = new Duration(30, Duration.SNOMED_CT_MINUTES_CODE_2021);
+		
+		Date autoExpireDate = duration.addToDate(createDateTime("2014-07-01 10:00:00"), null);
+		
+		assertEquals(createDateTime("2014-07-01 10:30:00"), autoExpireDate);
+	}
+	
+	@Test
 	public void addToDate_shouldAddHoursWhenUnitIsHours() throws ParseException {
 		Duration duration = new Duration(10, Duration.SNOMED_CT_HOURS_CODE);
 		

--- a/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
+++ b/api/src/test/java/org/openmrs/SimpleDosingInstructionsTest.java
@@ -81,6 +81,16 @@ public class SimpleDosingInstructionsTest extends BaseContextSensitiveTest {
 	}
 	
 	@Test
+	public void getAutoExpireDate_shouldInferAutoExpireDateForTheCurrentSnomedCtMinuteCode() throws ParseException {
+		DrugOrder drugOrder = new DrugOrder();
+		drugOrder.setDateActivated(createDateTime("2014-07-01 10:00:00"));
+		drugOrder.setDuration(30);
+		drugOrder.setDurationUnits(createUnits(Duration.SNOMED_CT_MINUTES_CODE_2021));
+		Date autoExpireDate = new SimpleDosingInstructions().getAutoExpireDate(drugOrder);
+		assertEquals(createDateTime("2014-07-01 10:29:59"), autoExpireDate);
+	}
+	
+	@Test
 	public void getAutoExpireDate_shouldInferAutoExpireDateForScheduledDrugOrder() throws ParseException {
 		DrugOrder drugOrder = new DrugOrder();
 		drugOrder.setDateActivated(createDateTime("2014-07-01 00:00:00"));


### PR DESCRIPTION
Minimal backport of #6246 (merged to master), in the shape agreed with @ibacher and @mseaton there: maintenance lines accept the active SNOMED CT minute code `1156209001` alongside the inactivated legacy code, in this branch's own idiom, JDK 8 clean, without the UCUM resolution or the API rework. The constant is named `SNOMED_CT_MINUTES_CODE_2021` to match master.

**Why:** SNOMED CT inactivated the legacy minute code `258701004` in its 2021-07-31 release; dictionaries such as CIEL now map Minutes to `1156209001`, which this line's `Duration.addToDate` rejected, failing drug order saves with HTTP 500.

`DurationTest` passes locally on this branch (12/12) including the new-code case.

## Issue I worked on

https://openmrs.atlassian.net/browse/TRUNK-6674

🤖 Generated with [Claude Code](https://claude.com/claude-code)
