### PR TITLE
TRUNK-6674: List backport releases in the minutes code @since tag

### DIFF
--- a/api/src/main/java/org/openmrs/Duration.java
+++ b/api/src/main/java/org/openmrs/Duration.java
@@ -55,7 +55,7 @@ public class Duration {
 	 * code {@link #SNOMED_CT_MINUTES_CODE} was inactivated as ambiguous. Dictionaries that track
 	 * current SNOMED CT releases, such as CIEL, map their minutes concepts to this code.
 	 *
-	 * @since 3.0.0
+	 * @since 2.8.8, 2.9.0, 3.0.0
 	 */
 	public static final String SNOMED_CT_MINUTES_CODE_2021 = "1156209001";
 


### PR DESCRIPTION
One-line documentation follow-up now that the TRUNK-6674 backports have landed: #6267 merged to 2.9.x and its cherry-pick ed353be0b landed on 2.8.x, so `SNOMED_CT_MINUTES_CODE_2021` will ship in 2.8.8 and 2.9.0 as well as 3.0.0, and the `@since` tag now says so, in the style of the existing multi-release tags in `OpenmrsConstants`. The other constants introduced by TRUNK-6674 stay `3.0.0` only, since the UCUM resolution was deliberately not backported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)