### PR TITLE
docs: use Maven wrapper in deploy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,19 @@ cd openmrs-core/webapp
 To run Jetty on a custom port, use the `jetty.http.port` property:
 
 ```bash
-mvn -Djetty.http.port=8081 jetty:run
+../mvnw -Djetty.http.port=8081 jetty:run
 ```
 
 To run on Cargo, use the `cargo:run` command:
 
 ```bash
-mvn cargo:run
+../mvnw cargo:run
 ```
 
 To run Cargo on a custom port, use the `cargo.servlet.port` property:
 
 ```bash
-mvn -Dcargo.servlet.port=8081 cargo:run
+../mvnw -Dcargo.servlet.port=8081 cargo:run
 ```
 
 If all goes well (check the console output) you can access the OpenMRS application at `localhost:8080/openmrs`.


### PR DESCRIPTION
﻿## Description of what I changed
Updated the README deploy examples that are run from `webapp/` to use the repository Maven wrapper (`../mvnw`) consistently.

## Issue I worked on
N/A - small documentation consistency fix.

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the code style of this project. N/A; documentation-only change.
- [ ] I have added tests to cover my changes. N/A; documentation-only change.
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit. Not run; documentation-only change.
- [ ] All new and existing tests passed. Not run; documentation-only change.
- [x] My pull request is based on the latest changes of the master branch.

Validation run:
- git diff --check
- Test-Path mvnw
- rg README.md for Maven wrapper examples
