### PR TITLE
docs: use Maven wrapper in contribution checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ see https://issues.openmrs.org/browse/TRUNK-
 
   No? -> write tests and add them to this commit `git add . && git commit --amend`
 
-- [ ] I ran `mvn clean package` right before creating this pull request and
+- [ ] I ran `./mvnw clean package` right before creating this pull request and
   added all formatting changes to my commit.
 
   No? -> execute above command

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Regardless of whether you're reporting the bug to the OpenMRS core team or to a 
 
   Make sure all unit tests still pass:
 
-        mvn clean package
+        ./mvnw clean package
 
   Push changes to your fork:
 


### PR DESCRIPTION
﻿## Description of what I changed
Updated the contribution docs and PR checklist to use the repository Maven wrapper (`./mvnw clean package`) for the standard build command.

## Issue I worked on
N/A - small documentation consistency fix.

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the code style of this project. N/A; documentation-only change.
- [ ] I have added tests to cover my changes. N/A; documentation-only change.
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit. Not run; documentation-only change.
- [ ] All new and existing tests passed. Not run; documentation-only change.
- [x] My pull request is based on the latest changes of the master branch.

Validation run:
- git diff --check
- Test-Path mvnw
- rg CONTRIBUTING.md and .github/PULL_REQUEST_TEMPLATE.md for Maven wrapper build command
