### PR TITLE
TRUNK-6465: Prevent OrderServiceTest from deadlocking the connection pool (2.8.x)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,8 +39,9 @@ jobs:
           #- platform: windows-latest
           #  java-version: 24
     runs-on: ${{ matrix.platform }}
-    # a wedged test otherwise runs until the 6 hour GitHub default; normal jobs finish in 9-21 minutes
-    timeout-minutes: 40
+    # a wedged test otherwise runs until the 6 hour GitHub default; normal jobs finish in
+    # 9-21 minutes, so this leaves roughly 3x headroom for degraded runners
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,8 @@ jobs:
           #- platform: windows-latest
           #  java-version: 24
     runs-on: ${{ matrix.platform }}
+    # a wedged test otherwise runs until the 6 hour GitHub default; normal jobs finish in 9-21 minutes
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -107,6 +107,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -264,39 +268,41 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @throws InterruptedException
+	 * @throws Exception
 	 * @see OrderNumberGenerator#getNewOrderNumber(OrderContext)
 	 */
 	@Test
 	public void getNewOrderNumber_shouldAlwaysReturnUniqueOrderNumbersWhenCalledMultipleTimesWithoutSavingOrders()
-		throws InterruptedException {
+		throws Exception {
 
-		String javaVersion = System.getProperty("java.version");
-		if (javaVersion.startsWith("1.8") || javaVersion.startsWith("8")) {
-			System.out.println("Ignoring test on Java 1.8 due to hanging.  See TRUNK-6465");
-			return;
-		}
-		
 		int N = 50;
+		// Each call transiently holds two pooled connections: one for the getNewOrderNumber
+		// transaction and one for the REQUIRES_NEW transaction that increments the seed.
+		// Concurrency must therefore stay below half the c3p0 max_size of 50, otherwise
+		// every thread can end up holding one connection while waiting forever for a
+		// second one, deadlocking the pool. See TRUNK-6465.
+		int threadCount = 20;
 		final Set<String> uniqueOrderNumbers = Collections.synchronizedSet(new HashSet<String>(50));
-		List<Thread> threads = new ArrayList<>();
-		for (int i = 0; i < N; i++) {
-			threads.add(new Thread(() -> {
-				try {
-					Context.openSession();
-					Context.addProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
-					uniqueOrderNumbers.add(((OrderNumberGenerator) orderService).getNewOrderNumber(null));
-				} finally {
-					Context.removeProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
-					Context.closeSession();
-				}
-			}));
-		}
-		for (int i = 0; i < N; ++i) {
-			threads.get(i).start();
-		}
-		for (int i = 0; i < N; ++i) {
-			threads.get(i).join();
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+			for (int i = 0; i < N; i++) {
+				futures.add(executor.submit(() -> {
+					try {
+						Context.openSession();
+						Context.addProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
+						uniqueOrderNumbers.add(((OrderNumberGenerator) orderService).getNewOrderNumber(null));
+					} finally {
+						Context.removeProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
+						Context.closeSession();
+					}
+				}));
+			}
+			for (Future<?> future : futures) {
+				future.get(30, TimeUnit.SECONDS);
+			}
+		} finally {
+			executor.shutdownNow();
 		}
 		//since we used a set we should have the size as N indicating that there were no duplicates
 		assertEquals(N, uniqueOrderNumbers.size());

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -277,18 +277,18 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	public void getNewOrderNumber_shouldAlwaysReturnUniqueOrderNumbersWhenCalledMultipleTimesWithoutSavingOrders()
 		throws Exception {
 
-		int N = 50;
+		int taskCount = 50;
 		// Each call transiently holds two pooled connections: one for the getNewOrderNumber
 		// transaction and one for the REQUIRES_NEW transaction that increments the seed.
 		// Concurrency must therefore stay below half the c3p0 max_size of 50, otherwise
 		// every thread can end up holding one connection while waiting forever for a
 		// second one, deadlocking the pool. See TRUNK-6465.
 		int threadCount = 20;
-		final Set<String> uniqueOrderNumbers = Collections.synchronizedSet(new HashSet<String>(50));
+		final Set<String> uniqueOrderNumbers = Collections.synchronizedSet(new HashSet<String>(taskCount));
 		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
 		try {
 			List<Future<?>> futures = new ArrayList<>();
-			for (int i = 0; i < N; i++) {
+			for (int i = 0; i < taskCount; i++) {
 				futures.add(executor.submit(() -> {
 					try {
 						Context.openSession();
@@ -304,16 +304,15 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 				try {
 					future.get(30, TimeUnit.SECONDS);
 				} catch (TimeoutException e) {
-					fail("getNewOrderNumber did not complete within 30 seconds, most likely because the "
-					        + "connection pool deadlocked, see TRUNK-6465", e);
+					fail("getNewOrderNumber timed out, likely a connection pool deadlock; see TRUNK-6465", e);
 				}
 			}
 		} finally {
 			executor.shutdownNow();
 			executor.awaitTermination(10, TimeUnit.SECONDS);
 		}
-		//since we used a set we should have the size as N indicating that there were no duplicates
-		assertEquals(N, uniqueOrderNumbers.size());
+		//since we used a set we should have the size as taskCount indicating that there were no duplicates
+		assertEquals(taskCount, uniqueOrderNumbers.size());
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -111,6 +111,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -128,6 +129,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.openmrs.Order.Action.DISCONTINUE;
 import static org.openmrs.Order.FulfillerStatus.COMPLETED;
 import static org.openmrs.test.OpenmrsMatchers.hasId;
@@ -299,10 +301,16 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 				}));
 			}
 			for (Future<?> future : futures) {
-				future.get(30, TimeUnit.SECONDS);
+				try {
+					future.get(30, TimeUnit.SECONDS);
+				} catch (TimeoutException e) {
+					fail("getNewOrderNumber did not complete within 30 seconds, most likely because the "
+					        + "connection pool deadlocked, see TRUNK-6465", e);
+				}
 			}
 		} finally {
 			executor.shutdownNow();
+			executor.awaitTermination(10, TimeUnit.SECONDS);
 		}
 		//since we used a set we should have the size as N indicating that there were no duplicates
 		assertEquals(N, uniqueOrderNumbers.size());


### PR DESCRIPTION
## Description of what I changed

`OrderServiceTest.getNewOrderNumber_shouldAlwaysReturnUniqueOrderNumbersWhenCalledMultipleTimesWithoutSavingOrders` starts 50 raw threads. Each call transiently holds two pooled connections: one for the `getNewOrderNumber` transaction (class level `@Transactional` on `OrderServiceImpl`) and a second for the `@Transactional(REQUIRES_NEW)` transaction that increments the order number seed. With `hibernate.c3p0.max_size=50` and c3p0's default `checkoutTimeout` of 0 (wait forever), 50 concurrent outer transactions can drain the pool so that every thread holds one connection while waiting eternally for a second one that nobody can ever release. The surefire fork then hangs silently until GitHub Actions kills the job at the 6 hour limit.

This is the deadlock TRUNK-6465 reported on Java 8, which 2.8.x works around by skipping the test on that JDK. It is a race, so slower JVM startups hit it more often: on 2026-07-08/09 it wedged four consecutive-ish Java 11 jobs on the 2.8.x branch (one ran the full 6 hours, two sat hung for hours until cancelled), while the identical JDK passed the same test in 10 seconds in another run the same day.

Changes:
- Run the same 50 calls on a bounded pool of 20 threads, so peak connection demand (40 plus the test's own connection) stays below the c3p0 cap of 50 and the deadlock becomes structurally impossible on every JDK.
- `future.get(30, SECONDS)` makes any future wedge fail in seconds with a stack trace instead of hanging the fork; it also surfaces worker exceptions that the raw threads used to swallow.
- Add `timeout-minutes: 60` to the build workflow as a backstop, so a wedged job can never again cost a runner 6 hours (normal jobs finish in 9 to 21 minutes, so this leaves roughly 3x headroom for degraded runners).

This is the 2.8.x backport of #6275. On this branch it also removes the Java 8 skip that TRUNK-6571 added as a workaround, since the deadlock is now structurally impossible. Verified locally by running the full `OrderServiceTest` class on this branch under JDK 11 (232 tests, 0 failures, three runs) and under JDK 8 with the skip removed (232 tests, 0 failures), the two JDKs where the hang was observed. Draft until #6275 is agreed and merged.

A note for the ticket: the same double-checkout pattern exists at runtime, so a burst of more than ~25 concurrent order creations can wedge a production connection pool the same way. A c3p0 `checkoutTimeout` and/or rethinking the `REQUIRES_NEW` there may be worth a follow-up discussion.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6465

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (This change is itself a test fix.)
- [ ] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit. (Ran `mvn -pl api -am test-compile` and the full `OrderServiceTest` class instead; no main code is touched.)
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.8.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQKxQruWri68zismbxhxW3

