### PR TITLE
Bound the OWASP dependency-check job to 60 minutes

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   dependencycheck:
     runs-on: ubuntu-latest
+    # a stalled NVD feed download otherwise runs until the 6 hour GitHub default; normal runs
+    # take 3-8 minutes with occasional NVD-update tails up to ~35, so 60 clears the worst observed
+    timeout-minutes: 60
     name: dependencycheck_test
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description of what I changed

The OWASP dependency-check workflow has no job-level timeout, so a stalled NVD feed download runs until the 6 hour GitHub Actions default and burns a runner for the duration. This adds `timeout-minutes: 60`; across five months of runs, healthy executions take 3-8 minutes with occasional NVD-update tails up to about 35, so 60 clears the worst observed case while capping a wedge at one sixth of the default. Same treatment as the bound added to the main build workflow in #6275.

## Issue I worked on

CI hardening follow-up to #6275 (TRUNK-6465); no separate ticket.

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. (Workflow config only; validated by this PR's own dependency-check run using the changed file.)
- [ ] I ran `mvn clean package` right before creating this pull request. (No code touched.)
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQKxQruWri68zismbxhxW3

