### PR TITLE
TRUNK-6465: Fail connection checkouts after 30 seconds instead of waiting forever

### DIFF
--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -19,6 +19,9 @@ hibernate.c3p0.timeout=100
 hibernate.c3p0.max_statements=0
 hibernate.c3p0.idle_test_period=3000
 hibernate.c3p0.acquire_increment=1
+# fail a connection checkout after 30s instead of waiting forever (the c3p0 default);
+# an exhausted pool otherwise freezes every waiting thread permanently, see TRUNK-6465
+hibernate.c3p0.checkoutTimeout=30000
 
 # Hibernate debugging options
 hibernate.generate_statistics=true

--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -20,7 +20,9 @@ hibernate.c3p0.max_statements=0
 hibernate.c3p0.idle_test_period=3000
 hibernate.c3p0.acquire_increment=1
 # fail a connection checkout after 30s instead of waiting forever (the c3p0 default);
-# an exhausted pool otherwise freezes every waiting thread permanently, see TRUNK-6465
+# an exhausted pool otherwise freezes every waiting thread permanently, see TRUNK-6465.
+# to override in runtime properties the key must stay camelCase (checkoutTimeout);
+# an underscore form like checkout_timeout is silently ignored by hibernate-c3p0
 hibernate.c3p0.checkoutTimeout=30000
 
 # Hibernate debugging options

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -29,6 +29,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * of 0 an exhausted pool blocks every waiting thread forever, so if a change to the property
  * loading in {@link HibernateSessionFactoryBean} silently dropped the value, pool exhaustion would
  * once again freeze the server instead of failing recoverably.
+ * <p>
+ * The max pool size is deliberately pinned as well: the bounded concurrency in
+ * {@code OrderServiceTest.getNewOrderNumber_shouldAlwaysReturnUniqueOrderNumbersWhenCalledMultipleTimesWithoutSavingOrders}
+ * is derived from it (two connections per call must stay below the pool cap), so anyone changing
+ * hibernate.c3p0.max_size needs to revisit that test's threadCount before simply updating the
+ * expected value here.
  */
 public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
 

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
@@ -22,6 +23,7 @@ import com.mchange.v2.c3p0.PoolBackedDataSource;
 import com.mchange.v2.c3p0.WrapperConnectionPoolDataSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Verifies that the connection pool limits configured in hibernate.default.properties actually
@@ -42,7 +44,14 @@ public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
 	private SessionFactory sessionFactory;
 
 	@Test
-	public void shouldBoundConnectionCheckoutWaitsAsConfigured() {
+	public void shouldApplyConfiguredConnectionPoolLimits() {
+		// a machine-local openmrs-runtime.properties may legitimately tune the pool and would
+		// win over hibernate.default.properties; only pin the shipped defaults when it does not
+		assumeTrue(
+		    Stream.of("hibernate.c3p0.checkoutTimeout", "c3p0.checkoutTimeout", "hibernate.c3p0.max_size", "c3p0.max_size")
+		            .noneMatch(runtimeProperties::containsKey),
+		    "skipped because local runtime properties override the c3p0 pool defaults");
+
 		ConnectionProvider connectionProvider = ((SessionFactoryImplementor) sessionFactory).getServiceRegistry()
 		        .getService(ConnectionProvider.class);
 		DataSource dataSource = connectionProvider.unwrap(DataSource.class);

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -1,0 +1,49 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.db.hibernate;
+
+import javax.sql.DataSource;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.junit.jupiter.api.Test;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.mchange.v2.c3p0.PoolBackedDataSource;
+import com.mchange.v2.c3p0.WrapperConnectionPoolDataSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that the connection pool limits configured in hibernate.default.properties actually
+ * reach the live c3p0 pool. Guards the checkout timeout added for TRUNK-6465: with c3p0's default
+ * of 0 an exhausted pool blocks every waiting thread forever, so if a change to the property
+ * loading in {@link HibernateSessionFactoryBean} silently dropped the value, pool exhaustion would
+ * once again freeze the server instead of failing recoverably.
+ */
+public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
+
+	@Autowired
+	private SessionFactory sessionFactory;
+
+	@Test
+	public void shouldBoundConnectionCheckoutWaitsAsConfigured() {
+		ConnectionProvider connectionProvider = ((SessionFactoryImplementor) sessionFactory).getServiceRegistry()
+		        .getService(ConnectionProvider.class);
+		DataSource dataSource = connectionProvider.unwrap(DataSource.class);
+		WrapperConnectionPoolDataSource pool = (WrapperConnectionPoolDataSource) ((PoolBackedDataSource) dataSource)
+		        .getConnectionPoolDataSource();
+
+		assertEquals(30000, pool.getCheckoutTimeout());
+		assertEquals(50, pool.getMaxPoolSize());
+	}
+}


### PR DESCRIPTION
## Description of what I changed

c3p0's default `checkoutTimeout` is 0, meaning a thread that asks the pool for a connection when none is free waits forever. Once the pool is exhausted, every waiting thread is frozen permanently and the server needs a restart. This is the production-side twin of the CI deadlock fixed in #6275: every order save transiently holds two pooled connections (the outer service transaction plus the `REQUIRES_NEW` transaction that increments the order number seed in `OrderServiceImpl.getNextOrderNumberSeedSequenceValue`), so a burst of more than about 25 concurrent order creations can drain the default 50-connection pool the same way the old test did.

This sets `hibernate.c3p0.checkoutTimeout=30000` in `hibernate.default.properties`, so pool exhaustion surfaces as a catchable `SQLException` after 30 seconds and the server recovers when the burst passes. Implementers can still override the value through runtime properties (the key must stay camelCase: hibernate-c3p0 maps only the six historical underscore keys like `max_size`, and silently ignores `checkout_timeout`; the properties file comment now says so). Note this bounds connection *checkout* only, not usage: a long-running query that already holds its connection is unaffected.

**This is a deliberate behavior change for every deployment and needs maintainer eyes before merging:** threads that today queue indefinitely for a connection will instead fail after 30 seconds. My argument for it: a request that has already waited 30 seconds on an exhausted pool is effectively dead (upstream HTTP clients have long since timed out), and a bounded failure that self-heals beats an unbounded wait that freezes the whole server. Happy to adjust the value or move this behind a documented runtime property default if reviewers prefer.

Empirical verification that the property actually reaches the pool through Hibernate's c3p0 passthrough:
- With `checkoutTimeout=1` (millisecond), the pool-starved concurrency test fails in 18 seconds with c3p0's `com.mchange.v2.resourcepool.TimeoutException: ... timeout at awaitAvailable()` instead of hanging. `awaitAvailable()` is the exact method the wedged CI jobs sat in for 6 hours.
- With `checkoutTimeout=30000`, the full `OrderServiceTest` class (235 tests) passes unchanged.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6465

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (`ConnectionPoolConfigTest` asserts the live pool's checkoutTimeout and maxPoolSize through Hibernate's ConnectionProvider; it fails with `expected 30000 but was 0` when the property is removed, pinning both the value and the property-loading path.)
- [ ] I ran `mvn clean package` right before creating this pull request. (Ran `mvn -pl api test-compile` plus the full `OrderServiceTest` class.)
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQKxQruWri68zismbxhxW3


