### PR TITLE
TRUNK-6465: Prevent OrderServiceTest from deadlocking the connection pool (2.9.x)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,9 @@ jobs:
           - test-profile: '-Pperformance-test -Pskip-default-test'
             java-version: 11
     runs-on: ${{ matrix.platform }}
+    # a wedged test otherwise runs until the 6 hour GitHub default; normal jobs finish in
+    # 9-21 minutes, so this leaves roughly 3x headroom for degraded runners
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - name: Setup JDK

--- a/api/src/test/java/org/openmrs/api/OrderServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OrderServiceTest.java
@@ -107,6 +107,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -124,6 +129,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.openmrs.Order.Action.DISCONTINUE;
 import static org.openmrs.Order.FulfillerStatus.COMPLETED;
 import static org.openmrs.test.OpenmrsMatchers.hasId;
@@ -264,42 +270,49 @@ public class OrderServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * @throws InterruptedException
+	 * @throws Exception
 	 * @see OrderNumberGenerator#getNewOrderNumber(OrderContext)
 	 */
 	@Test
 	public void getNewOrderNumber_shouldAlwaysReturnUniqueOrderNumbersWhenCalledMultipleTimesWithoutSavingOrders()
-		throws InterruptedException {
+		throws Exception {
 
-		String javaVersion = System.getProperty("java.version");
-		if (javaVersion.startsWith("1.8") || javaVersion.startsWith("8")) {
-			System.out.println("Ignoring test on Java 1.8 due to hanging.  See TRUNK-6465");
-			return;
-		}
-		
-		int N = 50;
-		final Set<String> uniqueOrderNumbers = Collections.synchronizedSet(new HashSet<String>(50));
-		List<Thread> threads = new ArrayList<>();
-		for (int i = 0; i < N; i++) {
-			threads.add(new Thread(() -> {
+		int taskCount = 50;
+		// Each call transiently holds two pooled connections: one for the getNewOrderNumber
+		// transaction and one for the REQUIRES_NEW transaction that increments the seed.
+		// Concurrency must therefore stay below half the c3p0 max_size of 50, otherwise
+		// every thread can end up holding one connection while waiting forever for a
+		// second one, deadlocking the pool. See TRUNK-6465.
+		int threadCount = 20;
+		final Set<String> uniqueOrderNumbers = Collections.synchronizedSet(new HashSet<String>(taskCount));
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		try {
+			List<Future<?>> futures = new ArrayList<>();
+			for (int i = 0; i < taskCount; i++) {
+				futures.add(executor.submit(() -> {
+					try {
+						Context.openSession();
+						Context.addProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
+						uniqueOrderNumbers.add(((OrderNumberGenerator) orderService).getNewOrderNumber(null));
+					} finally {
+						Context.removeProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
+						Context.closeSession();
+					}
+				}));
+			}
+			for (Future<?> future : futures) {
 				try {
-					Context.openSession();
-					Context.addProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
-					uniqueOrderNumbers.add(((OrderNumberGenerator) orderService).getNewOrderNumber(null));
-				} finally {
-					Context.removeProxyPrivilege(PrivilegeConstants.ADD_ORDERS);
-					Context.closeSession();
+					future.get(30, TimeUnit.SECONDS);
+				} catch (TimeoutException e) {
+					fail("getNewOrderNumber timed out, likely a connection pool deadlock; see TRUNK-6465", e);
 				}
-			}));
+			}
+		} finally {
+			executor.shutdownNow();
+			executor.awaitTermination(10, TimeUnit.SECONDS);
 		}
-		for (int i = 0; i < N; ++i) {
-			threads.get(i).start();
-		}
-		for (int i = 0; i < N; ++i) {
-			threads.get(i).join();
-		}
-		//since we used a set we should have the size as N indicating that there were no duplicates
-		assertEquals(N, uniqueOrderNumbers.size());
+		//since we used a set we should have the size as taskCount indicating that there were no duplicates
+		assertEquals(taskCount, uniqueOrderNumbers.size());
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed

2.9.x backport of #6275 (merged to master as d82cfa7d0) and identical to the 2.8.x backport #6276 (merged as ecf705eaf). This branch carries the same connection pool deadlock: `getNewOrderNumber` holds one pooled connection for its outer transaction while the `REQUIRES_NEW` seed increment demands a second, so the test's 50 raw threads against `hibernate.c3p0.max_size=50` with c3p0's infinite checkout wait can drain the pool and hang the surefire fork until the GitHub Actions 6 hour limit. The 2.9.x run history shows the same cancelled-after-hours fingerprint (e.g. runs on 2026-06-29 and 2026-07-01).

Changes, byte-identical to the merged backport: run the 50 calls on a bounded 20-thread executor (peak demand 41 connections, below the pool cap, so the deadlock is structurally impossible on every JDK), fail fast with a diagnostic message instead of hanging, remove the TRUNK-6571 Java 8 skip that worked around this same deadlock, and add `timeout-minutes: 60` to the build workflow so any future wedge costs minutes, not 6 hours.

Verified locally on this branch by running the full `OrderServiceTest` class under JDK 11 and JDK 8 (232 tests each, 0 failures; the Java 8 leg runs the previously skipped test for the first time on this branch).

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6465

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (This change is itself a test fix.)
- [ ] I ran `mvn clean package` right before creating this pull request. (Ran `mvn -pl api -am test-compile` plus the full `OrderServiceTest` class under both affected JDKs.)
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.9.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQKxQruWri68zismbxhxW3
