### PR TITLE
Suppress false-positive httpcore CVE-2026-54399/54428 in dependency-check

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -54,4 +54,21 @@
 	   <cve>CVE-2014-8073</cve>
 	   <cve>CVE-2025-25927</cve>
 	</suppress>
+	<suppress>
+	   <notes><![CDATA[
+	   False positive. Per the Apache advisory (GHSA-hf6x-8p5f-cgmf and the
+	   oss-security announcement) both CVEs affect the 5.x artifact
+	   org.apache.httpcomponents.core5:httpcore5 only (5.4.2 / 5.5-beta1 and
+	   earlier); CVE-2026-54428 targets the HTTP/2 HPACK decoder, which the 4.x
+	   line does not implement. We pull org.apache.httpcomponents:httpcore 4.4.16
+	   transitively (hibernate-search elasticsearch rest4 client -> httpclient
+	   4.5.14); 4.4.16 is the final 4.4.x release, so there is no 4.x upstream fix.
+	   Dependency-Check matches it via the shared apache:httpcomponents_core CPE.
+	   The regex is scoped to 4.4.x so a future move onto the affected 5.x line
+	   would correctly resurface these CVEs rather than stay suppressed.
+	   ]]></notes>
+	   <packageUrl regex="true">^pkg:maven/org\.apache\.httpcomponents/httpcore(-nio)?@4\.4\..*$</packageUrl>
+	   <cve>CVE-2026-54399</cve>
+	   <cve>CVE-2026-54428</cve>
+	</suppress>
 </suppressions>


### PR DESCRIPTION
## Summary

The OWASP Dependency-Check workflow is currently **failing on master** ([run](https://github.com/openmrs/openmrs-core/actions/runs/29048370628/job/86222554550)) because `httpcore-4.4.16.jar` is flagged for two newly-published CVEs, both CVSS 7.5, above the `--failOnCVSS 6.2` threshold:

- **CVE-2026-54399** — HTTP/1.1 message parser resource consumption
- **CVE-2026-54428** — HTTP/2 HPACK decoder resource consumption

## Why this is a false positive

Per the Apache advisory ([GHSA-hf6x-8p5f-cgmf](https://github.com/advisories/GHSA-hf6x-8p5f-cgmf) and the [oss-security announcement](http://www.openwall.com/lists/oss-security/2026/07/01/4)), both CVEs affect the **5.x** artifact `org.apache.httpcomponents.core5:httpcore5` only (5.4.2 / 5.5-beta1 and earlier). CVE-2026-54428 specifically targets the **HTTP/2 HPACK decoder**, which the 4.x line does not implement at all.

We use `org.apache.httpcomponents:httpcore` **4.4.16** — a different Maven coordinate on the 4.x line — pulled transitively:

```
hibernate-search-backend-elasticsearch
  -> hibernate-search-backend-elasticsearch-client-rest4
    -> httpclient 4.5.14
      -> httpcore 4.4.16
```

4.4.16 is the final 4.4.x release, so there is no 4.x upstream version to bump to. Dependency-Check matches it only via the shared `apache:httpcomponents_core` CPE, which spans the 4.x/5.x split.

## Fix

A scoped suppression in `dependency-check-suppressions.xml`, following the existing pattern in that file. It is limited to httpcore 4.4.x and these two CVE ids, so:

- A new/different CVE on this artifact still surfaces.
- The regex does **not** match the 5.x `httpcore5` line, so if the project ever upgrades into the actually-affected codebase, these CVEs correctly resurface rather than staying silently suppressed.

Verified by running the real Dependency-Check tool locally: it parses and loads the rule and completes the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)