### PR TITLE
TRUNK-6429: publish SaveServiceEvent when an order is stopped (#6197)

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -56,7 +56,9 @@ import org.openmrs.api.OrderNumberGenerator;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.RefByUuid;
 import org.openmrs.api.UnchangeableObjectException;
+import org.openmrs.aop.event.SaveServiceEvent;
 import org.openmrs.api.context.Context;
+import org.openmrs.event.EventPublisher;
 import org.openmrs.api.db.OrderDAO;
 import org.openmrs.customdatatype.CustomDatatypeUtil;
 import org.openmrs.order.OrderUtil;
@@ -94,6 +96,9 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 
 	@Autowired
 	protected OrderDAO dao;
+
+	@Autowired
+	private EventPublisher eventPublisher;
 
 	private static OrderNumberGenerator orderNumberGenerator = null;
 
@@ -894,7 +899,8 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		}
 
 		setProperty(orderToStop, "dateStopped", discontinueDate);
-		saveOrderInternal(orderToStop, null);
+		Order stoppedOrder = saveOrderInternal(orderToStop, null);
+		eventPublisher.publishEvent(new SaveServiceEvent<>(stoppedOrder));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/aop/event/OrderStopServiceEventIT.java
+++ b/api/src/test/java/org/openmrs/aop/event/OrderStopServiceEventIT.java
@@ -1,0 +1,55 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class OrderStopServiceEventIT extends BaseContextSensitiveTest {
+
+	@Autowired
+	private ServiceEventTestListener serviceEventTestListener;
+
+	private OrderService orderService;
+
+	@BeforeEach
+	public void setUp() {
+		orderService = Context.getOrderService();
+		serviceEventTestListener.clearOrderSaveEvents();
+	}
+
+	@Test
+	public void discontinueOrder_shouldPublishSaveServiceEventForStoppedOrder() {
+		executeDataSet("org/openmrs/api/include/OrderServiceTest-discontinueReason.xml");
+
+		Order order = orderService.getOrder(111);
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		Date discontinueDate = new Date();
+
+		serviceEventTestListener.clearOrderSaveEvents();
+		orderService.discontinueOrder(order, "no longer needed", discontinueDate, order.getOrderer(), encounter);
+
+		assertEquals(1, serviceEventTestListener.getOrderSaveEvents().size());
+		Order stoppedOrder = serviceEventTestListener.getOrderSaveEvents().get(0).getEntity();
+		assertEquals(order.getOrderId(), stoppedOrder.getOrderId());
+		assertNotNull(stoppedOrder.getDateStopped());
+	}
+}

--- a/api/src/test/java/org/openmrs/aop/event/ServiceEventTestListener.java
+++ b/api/src/test/java/org/openmrs/aop/event/ServiceEventTestListener.java
@@ -1,0 +1,36 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.openmrs.Order;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceEventTestListener {
+
+	private final List<SaveServiceEvent<Order>> orderSaveEvents = new CopyOnWriteArrayList<>();
+
+	@EventListener
+	public void onOrderSave(SaveServiceEvent<Order> event) {
+		orderSaveEvents.add(event);
+	}
+
+	public List<SaveServiceEvent<Order>> getOrderSaveEvents() {
+		return orderSaveEvents;
+	}
+
+	public void clearOrderSaveEvents() {
+		orderSaveEvents.clear();
+	}
+}


### PR DESCRIPTION
## Summary
- Publish `SaveServiceEvent<Order>` from `OrderServiceImpl.stopOrder()` after persisting `dateStopped`, since the private `saveOrderInternal` path bypasses `OpenmrsServiceEventAdvice`.
- Add `OrderStopServiceEventIT` asserting a stop event is emitted when `discontinueOrder` is called.

Fixes #6197.

## Test plan
- [ ] `mvn -pl api -Dtest=OrderStopServiceEventIT test`
- [ ] Existing `OrderServiceTest` discontinue/stop scenarios still pass

**Local note:** Maven was not available in the contributor environment; CI is expected to run the test suite.

Made with [Cursor](https://cursor.com)