### PR TITLE
TRUNK-6429: publish MergePatientsServiceEvent after patient merge (#6195)

### DIFF
--- a/api/src/main/java/org/openmrs/aop/event/MergePatientsServiceEvent.java
+++ b/api/src/main/java/org/openmrs/aop/event/MergePatientsServiceEvent.java
@@ -15,8 +15,6 @@ import java.util.Set;
 import org.openmrs.Patient;
 import org.openmrs.event.BaseSessionEvent;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 /**
  * Published when {@link org.openmrs.api.PatientService#mergePatients(Patient, Patient)} completes.
  *
@@ -26,10 +24,8 @@ public class MergePatientsServiceEvent extends BaseSessionEvent {
 
 	private static final long serialVersionUID = 1L;
 
-	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 	private Patient preferred;
 
-	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 	private Patient notPreferred;
 
 	public MergePatientsServiceEvent() {

--- a/api/src/main/java/org/openmrs/aop/event/MergePatientsServiceEvent.java
+++ b/api/src/main/java/org/openmrs/aop/event/MergePatientsServiceEvent.java
@@ -1,0 +1,65 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.openmrs.Patient;
+import org.openmrs.event.BaseSessionEvent;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Published when {@link org.openmrs.api.PatientService#mergePatients(Patient, Patient)} completes.
+ *
+ * @since 2.9.0
+ */
+public class MergePatientsServiceEvent extends BaseSessionEvent {
+
+	private static final long serialVersionUID = 1L;
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+	private Patient preferred;
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
+	private Patient notPreferred;
+
+	public MergePatientsServiceEvent() {
+	}
+
+	public MergePatientsServiceEvent(Patient preferred, Patient notPreferred) {
+		super(new HashSet<>());
+		this.preferred = preferred;
+		this.notPreferred = notPreferred;
+	}
+
+	public MergePatientsServiceEvent(Patient preferred, Patient notPreferred, Set<String> tags) {
+		super(tags);
+		this.preferred = preferred;
+		this.notPreferred = notPreferred;
+	}
+
+	public Patient getPreferred() {
+		return preferred;
+	}
+
+	public void setPreferred(Patient preferred) {
+		this.preferred = preferred;
+	}
+
+	public Patient getNotPreferred() {
+		return notPreferred;
+	}
+
+	public void setNotPreferred(Patient notPreferred) {
+		this.notPreferred = notPreferred;
+	}
+}

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -57,7 +57,9 @@ import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.RefByUuid;
 import org.openmrs.api.UserService;
 import org.openmrs.api.VisitService;
+import org.openmrs.aop.event.MergePatientsServiceEvent;
 import org.openmrs.api.context.Context;
+import org.openmrs.event.EventPublisher;
 import org.openmrs.api.db.PatientDAO;
 import org.openmrs.api.db.hibernate.HibernateUtil;
 import org.openmrs.parameter.EncounterSearchCriteria;
@@ -95,6 +97,9 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 
 	@Autowired
 	private PatientDAO dao;
+
+	@Autowired
+	private EventPublisher eventPublisher;
 
 	/**
 	 * PatientIdentifierValidators registered through spring's applicationContext-service.xml
@@ -599,6 +604,8 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		personMergeLog.setLoser(notPreferred);
 		personMergeLog.setPersonMergeLogData(mergedData);
 		Context.getPersonService().savePersonMergeLog(personMergeLog);
+
+		eventPublisher.publishEvent(new MergePatientsServiceEvent(preferred, notPreferred));
 	}
 
 	private void requireNoActiveOrderOfSameType(Patient patient1, Patient patient2) {

--- a/api/src/test/java/org/openmrs/aop/event/MergePatientsServiceEventIT.java
+++ b/api/src/test/java/org/openmrs/aop/event/MergePatientsServiceEventIT.java
@@ -1,0 +1,53 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MergePatientsServiceEventIT extends BaseContextSensitiveTest {
+
+	private static final String PATIENT_MERGE_XML = "org/openmrs/api/include/PatientServiceTest-mergePatients.xml";
+
+	@Autowired
+	private ServiceEventTestListener serviceEventTestListener;
+
+	private PatientService patientService;
+
+	@BeforeEach
+	public void setUp() {
+		patientService = Context.getPatientService();
+		serviceEventTestListener.clearMergePatientsEvents();
+	}
+
+	@Test
+	public void mergePatients_shouldPublishMergePatientsServiceEvent() throws Exception {
+		executeDataSet(PATIENT_MERGE_XML);
+
+		Patient preferred = patientService.getPatient(6);
+		Patient notPreferred = patientService.getPatient(7);
+
+		patientService.mergePatients(preferred, notPreferred);
+
+		assertEquals(1, serviceEventTestListener.getMergePatientsEvents().size());
+		MergePatientsServiceEvent event = serviceEventTestListener.getMergePatientsEvents().get(0);
+		assertEquals(preferred.getPatientId(), event.getPreferred().getPatientId());
+		assertEquals(notPreferred.getPatientId(), event.getNotPreferred().getPatientId());
+		assertTrue(notPreferred.getVoided());
+	}
+}

--- a/api/src/test/java/org/openmrs/aop/event/ServiceEventTestListener.java
+++ b/api/src/test/java/org/openmrs/aop/event/ServiceEventTestListener.java
@@ -1,0 +1,51 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop.event;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.openmrs.Order;
+import org.openmrs.Visit;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ServiceEventTestListener {
+
+	private final List<SaveServiceEvent<Order>> orderSaveEvents = new CopyOnWriteArrayList<>();
+
+	private final List<SaveServiceEvent<Visit>> visitSaveEvents = new CopyOnWriteArrayList<>();
+
+	private final List<MergePatientsServiceEvent> mergePatientsEvents = new CopyOnWriteArrayList<>();
+
+	@EventListener
+	public void onOrderSave(SaveServiceEvent<Order> event) {
+		orderSaveEvents.add(event);
+	}
+
+	@EventListener
+	public void onVisitSave(SaveServiceEvent<Visit> event) {
+		visitSaveEvents.add(event);
+	}
+
+	@EventListener
+	public void onMergePatients(MergePatientsServiceEvent event) {
+		mergePatientsEvents.add(event);
+	}
+
+	public List<MergePatientsServiceEvent> getMergePatientsEvents() {
+		return mergePatientsEvents;
+	}
+
+	public void clearMergePatientsEvents() {
+		mergePatientsEvents.clear();
+	}
+}


### PR DESCRIPTION
## Summary
- Add `MergePatientsServiceEvent` carrying the preferred (winner) and not-preferred (loser) patients.
- Publish the event at the end of `PatientServiceImpl.mergePatients()` after the merge log is saved.

Fixes #6195.

## Test plan
- [ ] `mvn -pl api -Dtest=MergePatientsServiceEventIT test`
- [ ] Existing `PatientServiceTest` merge scenarios still pass

**Local note:** Maven was not available in the contributor environment; CI is expected to run the test suite.

Made with [Cursor](https://cursor.com)