### PR TITLE
TRUNK-6429: core Events/CDC sign-off fixes (#6289)

### DIFF
--- a/api/src/main/java/org/openmrs/aop/OpenmrsServiceEventAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/OpenmrsServiceEventAdvice.java
@@ -29,8 +29,18 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
- * Publishes {@link SaveServiceEvent}, {@link VoidServiceEvent}, {@link UnvoidServiceEvent},
- * {@link RetireServiceEvent}, and {@link UnretireServiceEvent}.
+ * Publishes typed {@link SaveServiceEvent}, {@link VoidServiceEvent}, {@link UnvoidServiceEvent},
+ * {@link RetireServiceEvent}, and {@link UnretireServiceEvent} for proxied public service methods
+ * whose names match {@code save*}, {@code create*}, {@code void*}, {@code unvoid*}, {@code retire*},
+ * {@code unretire*}, or {@code purge*}.
+ * <p>
+ * Events are published <strong>before</strong> the intercepted method runs ({@code proceed()}). A
+ * synchronous listener therefore sees the entity in its pre-operation state (e.g. a newly created
+ * record may not yet have a database id). For post-persist change notifications regardless of call
+ * path, prefer the Hibernate-level {@link org.openmrs.api.db.event.SaveDbEvent} /
+ * {@link org.openmrs.api.db.event.DeleteDbEvent} stream emitted by {@link org.openmrs.api.db.hibernate.EventInterceptor}.
+ * Operations that bypass this advice (non-pattern method names, self-invocation, or direct DAO writes)
+ * must publish events explicitly — see e.g. #6195, #6197, #6199.
  * <p>
  * It is registered after transaction advice so that
  * {@link org.openmrs.event.outbox.OutboxEventListener},

--- a/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxPollingTaskHandler.java
+++ b/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxPollingTaskHandler.java
@@ -104,7 +104,7 @@ public class OutboxPollingTaskHandler implements TaskHandler<OutboxPollingTaskDa
 
 				Set<String> completedListeners = new LinkedHashSet<>();
 				try {
-					Class<?> eventClass = Class.forName(item.getEventType());
+					Class<?> eventClass = Context.loadClass(item.getEventType());
 					Object event;
 					if (EventPayload.class.isAssignableFrom(eventClass)) {
 						event = eventClass.getDeclaredConstructor().newInstance();

--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.9.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.9.x.xml
@@ -2239,7 +2239,7 @@
       <column name="event_type" type="VARCHAR(255)"> 
         <constraints nullable="false"/> 
       </column>  
-      <column name="payload" type="TEXT"> 
+      <column name="payload" type="MEDIUMTEXT"> 
         <constraints nullable="false"/> 
       </column>  
       <column defaultValue="PENDING" name="status" type="VARCHAR(50)"> 
@@ -2249,7 +2249,7 @@
         <constraints nullable="false"/> 
       </column>  
       <column name="error_message" type="VARCHAR(1024)"/>  
-      <column name="completed_listeners" type="TEXT"/>  
+      <column name="completed_listeners" type="MEDIUMTEXT"/>  
       <column defaultValueComputed="NULL" name="creator" type="INT"/>  
       <column name="date_created" type="datetime(0)"> 
         <constraints nullable="false"/> 

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
@@ -141,6 +141,15 @@
 			<column name="description" type="varchar(255)"/>
 		</addColumn>
 	</changeSet>
+
+	<changeSet id="TRUNK-6289-2026-07-11-outbox-payload-mediumtext" author="Tarekchehahde">
+		<preConditions onFail="MARK_RAN">
+			<tableExists tableName="outbox_event"/>
+		</preConditions>
+		<comment>Widen outbox_event payload columns to match @Lob intent (#6289 sign-off)</comment>
+		<modifyDataType tableName="outbox_event" columnName="payload" newDataType="MEDIUMTEXT"/>
+		<modifyDataType tableName="outbox_event" columnName="completed_listeners" newDataType="MEDIUMTEXT"/>
+	</changeSet>
 	
 </databaseChangeLog>
 


### PR DESCRIPTION
## Summary
Addresses the **openmrs-core** sign-off blockers called out in #6289:

- **Outbox payload size:** `outbox_event.payload` and `completed_listeners` widened from `TEXT` to `MEDIUMTEXT` (Liquibase + schema snapshot) so `@Lob` payloads are not capped at 64 KB on MySQL/MariaDB and large events no longer roll back the originating transaction.
- **Outbox class loading:** `OutboxPollingTaskHandler` resolves stored event types via `Context.loadClass()` so module-defined event classes are visible to the poller.
- **Integrator guidance:** `OpenmrsServiceEventAdvice` Javadoc documents pre-`proceed()` publication timing, the typed `*ServiceEvent` vs `SaveDbEvent`/`DeleteDbEvent` split, and points to #6195/#6197/#6199 for bypass cases.

Partially addresses #6289 (core only). Remaining sign-off items are in Artemis/Camel/Debezium modules and deployment docs.

Related PRs for event-coverage instances: #6293, #6294, #6295.

## Test plan
- [ ] Liquibase update on MySQL/MariaDB widens columns without data loss
- [ ] `mvn -pl api -Dtest=OutboxEventIT test`
- [ ] Fresh schema snapshot validates

**Local note:** Maven was not available in the contributor environment; CI is expected to run the test suite.

Made with [Cursor](https://cursor.com)