### PR TITLE
Fix loading runtime properties in tests

### DIFF
--- a/api/src/test/java/org/openmrs/test/TestUtil.java
+++ b/api/src/test/java/org/openmrs/test/TestUtil.java
@@ -9,8 +9,6 @@
  */
 package org.openmrs.test;
 
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.sql.Connection;
 import java.text.ParseException;
 import java.util.Collection;
@@ -53,56 +51,14 @@ public class TestUtil {
 	}
 
 	/**
-	 * Mimics org.openmrs.web.Listener.getRuntimeProperties()
+	 * Loads runtime properties using the same lookup rules as the application.
 	 *
 	 * @param webappName name to use when looking up the runtime properties env var or filename
 	 * @return Properties runtime
 	 */
 	public static Properties getRuntimeProperties(String webappName) {
-
-		Properties props = new Properties();
-
-		try {
-			FileInputStream propertyStream = null;
-
-			// Look for environment variable
-			// {WEBAPP.NAME}_RUNTIME_PROPERTIES_FILE
-			String env = webappName.toUpperCase() + "_RUNTIME_PROPERTIES_FILE";
-
-			String filepath = System.getenv(env);
-
-			if (filepath != null) {
-				try {
-					propertyStream = new FileInputStream(filepath);
-				} catch (IOException e) {}
-			}
-
-			// env is the name of the file to look for in the directories
-			String filename = webappName + "-runtime.properties";
-
-			if (propertyStream == null) {
-				filepath = OpenmrsUtil.getApplicationDataDirectory() + filename;
-				try {
-					propertyStream = new FileInputStream(filepath);
-				} catch (IOException e) {}
-			}
-
-			// look in current directory last
-			if (propertyStream == null) {
-				filepath = filename;
-				try {
-					propertyStream = new FileInputStream(filepath);
-				} catch (IOException e) {}
-			}
-
-			if (propertyStream == null)
-				throw new IOException("Could not open '" + filename + "' in user or local directory.");
-			OpenmrsUtil.loadProperties(props, propertyStream);
-			propertyStream.close();
-
-		} catch (IOException e) {}
-
-		return props;
+		Properties properties = OpenmrsUtil.getRuntimeProperties(webappName);
+		return properties == null ? new Properties() : properties;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/test/TestUtilTest.java
+++ b/api/src/test/java/org/openmrs/test/TestUtilTest.java
@@ -1,4 +1,13 @@
-
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.test;
 package org.openmrs.test;
 
 import java.util.Properties;

--- a/api/src/test/java/org/openmrs/test/TestUtilTest.java
+++ b/api/src/test/java/org/openmrs/test/TestUtilTest.java
@@ -1,0 +1,43 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.test;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.openmrs.util.OpenmrsUtil;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
+
+class TestUtilTest {
+
+	@Test
+	void getRuntimeProperties_shouldUseApplicationRuntimePropertiesLoader() {
+		Properties expected = new Properties();
+
+		try (MockedStatic<OpenmrsUtil> openmrsUtilMock = mockStatic(OpenmrsUtil.class)) {
+			openmrsUtilMock.when(() -> OpenmrsUtil.getRuntimeProperties("testapp")).thenReturn(expected);
+
+			assertSame(expected, TestUtil.getRuntimeProperties("testapp"));
+		}
+	}
+
+	@Test
+	void getRuntimeProperties_shouldReturnEmptyPropertiesWhenNoneAreFound() {
+		try (MockedStatic<OpenmrsUtil> openmrsUtilMock = mockStatic(OpenmrsUtil.class)) {
+			openmrsUtilMock.when(() -> OpenmrsUtil.getRuntimeProperties("testapp")).thenReturn(null);
+
+			assertTrue(TestUtil.getRuntimeProperties("testapp").isEmpty());
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/test/TestUtilTest.java
+++ b/api/src/test/java/org/openmrs/test/TestUtilTest.java
@@ -1,12 +1,4 @@
-/**
- * This Source Code Form is subject to the terms of the Mozilla Public License,
- * v. 2.0. If a copy of the MPL was not distributed with this file, You can
- * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
- * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
- *
- * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
- * graphic logo is a trademark of OpenMRS Inc.
- */
+
 package org.openmrs.test;
 
 import java.util.Properties;


### PR DESCRIPTION

This change removes the duplicated runtime-properties lookup logic from **TestUtil**.
Tests now delegate to **OpenmrsUtil.getRuntimeProperties(...)**, ensuring they follow the same lookup order and functional-test-mode behavior as the application. When no runtime properties file is found, tests continue to receive an empty Properties object to preserve existing behavior.
Added unit tests to verify delegation and the empty-properties fallback.


**Testing:**
• Added TestUtilTest


JIRA TICKET :-> https://openmrs.atlassian.net/browse/TRUNK-6677