### PR TITLE
TRUNK-6516: Fix CDCEvent @JsonIgnore import to use FasterXML on 2.9.x

### DIFF
--- a/api/src/main/java/org/openmrs/event/CDCEvent.java
+++ b/api/src/main/java/org/openmrs/event/CDCEvent.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.event;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.ResolvableTypeProvider;

--- a/api/src/test/java/org/openmrs/serialization/JacksonConfigTest.java
+++ b/api/src/test/java/org/openmrs/serialization/JacksonConfigTest.java
@@ -15,10 +15,12 @@ import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
+import org.openmrs.event.CDCEvent;
 
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,5 +78,25 @@ public class JacksonConfigTest {
 		// Verify bidirectional relationship is maintained without infinite recursion
 		assertNotNull(deserializedIdentifier.getPatient());
 		assertEquals(patient.getUuid(), deserializedIdentifier.getPatient().getUuid());
+	}
+
+	@Test
+	public void objectMapper_shouldSerializeCDCEventWithoutSelfReferentialCycle() throws Exception {
+		// CDCEvent.getResolvableType() must be ignored by Jackson; using the Codehaus
+		// @JsonIgnore import instead of FasterXML caused InvalidDefinitionException:
+		// "Direct self-reference leading to cycle (CDCEvent["resolvableType"] -> ResolvableType[...])"
+		CDCEvent<Patient> event = new CDCEvent<>(Patient.class);
+		event.setTableName("patient");
+		event.setOperation(CDCEvent.Operation.CREATE);
+
+		String json = objectMapper.writeValueAsString(event);
+
+		assertNotNull(json);
+		assertFalse(json.contains("resolvableType"), "resolvableType must be excluded from serialized JSON");
+		assertTrue(json.contains("patient"));
+
+		CDCEvent deserialized = objectMapper.readValue(json, CDCEvent.class);
+		assertEquals("patient", deserialized.getTableName());
+		assertEquals(CDCEvent.Operation.CREATE, deserialized.getOperation());
 	}
 }


### PR DESCRIPTION
## Summary

- `CDCEvent.getResolvableType()` was annotated with `org.codehaus.jackson.annotate.JsonIgnore` (Codehaus/Jackson 1.x). FasterXML (Jackson 2.x) does not honour that annotation, so the serializer follows the getter and hits a self-referential cycle: `CDCEvent["resolvableType"] -> ResolvableType["componentType"] -> ...`, throwing `InvalidDefinitionException`.
- Fix: replace with `com.fasterxml.jackson.annotation.JsonIgnore` (already correct on master).

This is finding #3 from the events/CDC sign-off issue #6289.

## Test plan

- [x] Serialize a `CDCEvent` instance with `JacksonConfig.objectMapper()` — no `InvalidDefinitionException`
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)