### PR TITLE
Recursively clear a module's lib cache when the module changes

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -433,7 +433,8 @@ public class ModuleClassLoader extends URLClassLoader {
 	 * ease cleanup when unloading a module while openmrs is running.
 	 * <p>
 	 * The method persists lastModified of a module in .moduleLastModified file. If the value changed,
-	 * the dir will be deleted and re-created.
+	 * the dir will be deleted and re-created. The marker is only refreshed once the previous contents
+	 * were successfully removed, so a failed delete is retried on the next startup.
 	 *
 	 * @param module Module which the cache will be used for
 	 * @return File directory where the files will be placed
@@ -456,23 +457,24 @@ public class ModuleClassLoader extends URLClassLoader {
 			long moduleLastModified = module.getFile().lastModified();
 			File moduleLastModifiedFile = new File(tmpModuleDir, ".moduleLastModified");
 
+			boolean cacheCleared = true;
 			if (Context.isOptimizedStartup() && moduleLastModifiedFile.exists()) {
 				// Re-create tmpModuleDir if module changed
 				try {
 					String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						deleteLibCacheFolder(tmpModuleDir);
+						cacheCleared = deleteLibCacheFolder(tmpModuleDir);
 					}
 				} catch (IOException | NumberFormatException e) {
 					log.warn("Could not read the last modified marker {}; clearing the lib cache to be safe",
 					    moduleLastModifiedFile, e);
-					deleteLibCacheFolder(tmpModuleDir);
+					cacheCleared = deleteLibCacheFolder(tmpModuleDir);
 				}
 			} else {
 				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 				    tmpModuleDir);
-				deleteLibCacheFolder(tmpModuleDir);
+				cacheCleared = deleteLibCacheFolder(tmpModuleDir);
 			}
 
 			if (!tmpModuleDir.mkdirs() && !tmpModuleDir.isDirectory()) {
@@ -480,7 +482,10 @@ public class ModuleClassLoader extends URLClassLoader {
 			}
 			libCacheFolders.put(module.getModuleId(), tmpModuleDir);
 
-			if (moduleLastModified != 0L) {
+			// Only refresh the marker over a fully cleared cache: stamping it over leftovers would make
+			// every later optimized startup trust the stale jars, while a stale or missing marker makes
+			// the next startup retry the delete, e.g. once the old classloader's file locks are gone.
+			if (cacheCleared && moduleLastModified != 0L) {
 				try {
 					FileUtils.writeStringToFile(moduleLastModifiedFile, moduleLastModified + "", Charset.defaultCharset());
 				} catch (IOException e) {
@@ -499,26 +504,36 @@ public class ModuleClassLoader extends URLClassLoader {
 	 * a direct child of the lib cache root is ever deleted.
 	 *
 	 * @param tmpModuleDir the module's lib cache folder
+	 * @return true if the folder no longer exists, false if it or part of its contents could not be
+	 *         removed
 	 */
-	static void deleteLibCacheFolder(File tmpModuleDir) {
+	static boolean deleteLibCacheFolder(File tmpModuleDir) {
 		try {
 			// Guard this recursive delete on a path built from the module id: only ever remove a
 			// direct child of the lib cache root, never something a malformed id resolved to outside it.
 			if (!OpenmrsClassLoader.getLibCacheFolder().getCanonicalFile()
 			        .equals(tmpModuleDir.getCanonicalFile().getParentFile())) {
 				log.warn("Refusing to delete {}; it is not directly inside the lib cache folder", tmpModuleDir);
-				return;
+				return false;
 			}
-			FileUtils.deleteDirectory(tmpModuleDir);
+			if (tmpModuleDir.isFile()) {
+				// A stray regular file where the cache folder should be; FileUtils.deleteDirectory
+				// would throw an unchecked IllegalArgumentException for it rather than an IOException.
+				FileUtils.forceDelete(tmpModuleDir);
+			} else {
+				FileUtils.deleteDirectory(tmpModuleDir);
+			}
 		} catch (IOException e) {
 			log.warn("Unable to delete the module lib cache folder {}", tmpModuleDir, e);
 		}
 		if (tmpModuleDir.exists()) {
 			log.warn("The module lib cache folder {} could not be fully cleared and may still hold jars from a previous "
-			        + "version of the module, which can leave stale classes on the module classpath; delete it and "
-			        + "restart if the module misbehaves after an upgrade.",
+			        + "version of the module, which can leave stale classes on the module classpath; clearing it will "
+			        + "be retried on the next restart.",
 			    tmpModuleDir);
+			return false;
 		}
+		return true;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -462,18 +462,22 @@ public class ModuleClassLoader extends URLClassLoader {
 					String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						tmpModuleDir.delete();
+						deleteLibCacheFolder(tmpModuleDir);
 					}
 				} catch (IOException | NumberFormatException e) {
-					log.warn("Error while reading module last modified file: {}", moduleLastModifiedFile, e);
+					log.warn("Could not read the last modified marker {}; clearing the lib cache to be safe",
+					    moduleLastModifiedFile, e);
+					deleteLibCacheFolder(tmpModuleDir);
 				}
 			} else {
 				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 				    tmpModuleDir);
-				tmpModuleDir.delete();
+				deleteLibCacheFolder(tmpModuleDir);
 			}
 
-			tmpModuleDir.mkdirs();
+			if (!tmpModuleDir.mkdirs() && !tmpModuleDir.isDirectory()) {
+				log.warn("Unable to create the module lib cache folder {}", tmpModuleDir);
+			}
 			libCacheFolders.put(module.getModuleId(), tmpModuleDir);
 
 			if (moduleLastModified != 0L) {
@@ -485,6 +489,35 @@ public class ModuleClassLoader extends URLClassLoader {
 			}
 
 			return tmpModuleDir;
+		}
+	}
+
+	/**
+	 * Recursively deletes the module's lib cache folder so a modified module is fully re-expanded.
+	 * {@link java.io.File#delete()} only removes an empty directory and silently no-ops otherwise, so
+	 * jars a module dropped between versions would linger in the cache and stay on its classpath. Only
+	 * a direct child of the lib cache root is ever deleted.
+	 *
+	 * @param tmpModuleDir the module's lib cache folder
+	 */
+	static void deleteLibCacheFolder(File tmpModuleDir) {
+		try {
+			// Guard this recursive delete on a path built from the module id: only ever remove a
+			// direct child of the lib cache root, never something a malformed id resolved to outside it.
+			if (!OpenmrsClassLoader.getLibCacheFolder().getCanonicalFile()
+			        .equals(tmpModuleDir.getCanonicalFile().getParentFile())) {
+				log.warn("Refusing to delete {}; it is not directly inside the lib cache folder", tmpModuleDir);
+				return;
+			}
+			FileUtils.deleteDirectory(tmpModuleDir);
+		} catch (IOException e) {
+			log.warn("Unable to delete the module lib cache folder {}", tmpModuleDir, e);
+		}
+		if (tmpModuleDir.exists()) {
+			log.warn("The module lib cache folder {} could not be fully cleared and may still hold jars from a previous "
+			        + "version of the module, which can leave stale classes on the module classpath; delete it and "
+			        + "restart if the module misbehaves after an upgrade.",
+			    tmpModuleDir);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -489,7 +489,7 @@ public class ModuleClassLoader extends URLClassLoader {
 				try {
 					FileUtils.writeStringToFile(moduleLastModifiedFile, moduleLastModified + "", Charset.defaultCharset());
 				} catch (IOException e) {
-					log.warn("Error while writing module last modified file: {}", moduleLastModifiedFile, e);
+					log.warn("Could not write the last modified marker {}", moduleLastModifiedFile, e);
 				}
 			}
 
@@ -498,14 +498,20 @@ public class ModuleClassLoader extends URLClassLoader {
 	}
 
 	/**
-	 * Recursively deletes the module's lib cache folder so a modified module is fully re-expanded.
-	 * {@link java.io.File#delete()} only removes an empty directory and silently no-ops otherwise, so
-	 * jars a module dropped between versions would linger in the cache and stay on its classpath. Only
-	 * a direct child of the lib cache root is ever deleted.
+	 * Recursively deletes the module's lib cache folder (or a stray regular file in its place) so a
+	 * modified module is fully re-expanded. {@link java.io.File#delete()} only removes an empty
+	 * directory and silently no-ops otherwise, so jars a module dropped between versions would linger
+	 * in the cache and stay on its classpath. Only a direct child of the lib cache root is ever
+	 * deleted.
+	 * <p>
+	 * A disposed classloader still executing during an in-place reload keeps reading the jars it
+	 * already has open on POSIX (the open handle outlives the unlink, unlike the previous in-place
+	 * overwrite in getModuleUrls, which corrupted them); anything it never opened fails loudly after
+	 * the prune instead of silently serving another version's bytes.
 	 *
 	 * @param tmpModuleDir the module's lib cache folder
-	 * @return true if the folder no longer exists, false if it or part of its contents could not be
-	 *         removed
+	 * @return true if the folder no longer exists, false if it could not be fully removed or the delete
+	 *         was refused because the folder is not directly inside the lib cache root
 	 */
 	static boolean deleteLibCacheFolder(File tmpModuleDir) {
 		try {

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -489,15 +489,25 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * Builds a module whose backing omod is a fresh temp file, with a module id unique to the calling
+	 * test so each test works in its own folder under the shared lib cache root.
+	 */
+	private Module moduleWithTempOmod(String moduleId) throws IOException {
+		Module module = new Module("mockmodule", moduleId, "org.openmrs.module." + moduleId, "author", "description", "2.0",
+		        "2.0");
+		File omod = File.createTempFile(moduleId, ".omod");
+		omod.deleteOnExit();
+		module.setFile(omod);
+		return module;
+	}
+
+	/**
 	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
 	 */
 	@Test
 	public void getLibCacheFolderForModule_shouldPruneJarsDroppedByAModifiedModule() throws IOException {
-		Module module = new Module("mockmodule", "libcacheprunetest", "org.openmrs.module.libcacheprunetest", "author",
-		        "description", "2.0", "2.0");
-		File omod = File.createTempFile("libcacheprunetest", ".omod");
-		omod.deleteOnExit();
-		module.setFile(omod);
+		Module module = moduleWithTempOmod("libcacheprunetest");
+		File omod = module.getFile();
 
 		// Prime the cache folder to look like the previous version's expansion: a lib jar the new
 		// version no longer ships, plus a .moduleLastModified marker predating this omod so the
@@ -505,8 +515,8 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
 		File staleJar = new File(new File(cacheFolder, "lib"), "dropped-by-upgrade.jar");
 		FileUtils.writeStringToFile(staleJar, "stale", Charset.defaultCharset());
-		FileUtils.writeStringToFile(new File(cacheFolder, ".moduleLastModified"), Long.toString(omod.lastModified() - 1000L),
-		    Charset.defaultCharset());
+		File marker = new File(cacheFolder, ".moduleLastModified");
+		FileUtils.writeStringToFile(marker, Long.toString(omod.lastModified() - 1000L), Charset.defaultCharset());
 		assertTrue(staleJar.exists());
 
 		try {
@@ -515,6 +525,9 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 			assertThat(result, is(cacheFolder));
 			assertFalse(staleJar.exists(), "a jar dropped by the upgraded module must not linger in the lib cache");
 			assertTrue(cacheFolder.isDirectory(), "the lib cache folder should be recreated for re-expansion");
+			// The successful clear must also refresh the marker, or every later optimized startup
+			// would re-delete and re-expand the cache, silently defeating optimized startup.
+			assertThat(FileUtils.readFileToString(marker, Charset.defaultCharset()), is(Long.toString(omod.lastModified())));
 		} finally {
 			FileUtils.deleteQuietly(cacheFolder);
 		}
@@ -524,12 +537,8 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
 	 */
 	@Test
-	public void getLibCacheFolderForModule_shouldClearTheCacheWhenTheLastModifiedMarkerIsUnreadable() throws IOException {
-		Module module = new Module("mockmodule", "libcachemarkertest", "org.openmrs.module.libcachemarkertest", "author",
-		        "description", "2.0", "2.0");
-		File omod = File.createTempFile("libcachemarkertest", ".omod");
-		omod.deleteOnExit();
-		module.setFile(omod);
+	public void getLibCacheFolderForModule_shouldClearTheCacheWhenTheLastModifiedMarkerIsUnparseable() throws IOException {
+		Module module = moduleWithTempOmod("libcachemarkertest");
 
 		// A corrupt marker we cannot parse: we can no longer tell whether the module changed, so the
 		// cache must be cleared rather than reused with possibly stale jars.
@@ -543,7 +552,7 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		try {
 			ModuleClassLoader.getLibCacheFolderForModule(module);
 
-			assertFalse(staleJar.exists(), "an unreadable last-modified marker must clear the cache rather than reuse it");
+			assertFalse(staleJar.exists(), "an unparseable last-modified marker must clear the cache rather than reuse it");
 		} finally {
 			FileUtils.deleteQuietly(cacheFolder);
 		}
@@ -578,11 +587,8 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	@Test
 	@DisabledOnOs(OS.WINDOWS) // java.io.File cannot remove a directory's read permission on Windows
 	public void getLibCacheFolderForModule_shouldNotRefreshTheMarkerWhenTheCacheCannotBeCleared() throws IOException {
-		Module module = new Module("mockmodule", "libcachefailedcleartest", "org.openmrs.module.libcachefailedcleartest",
-		        "author", "description", "2.0", "2.0");
-		File omod = File.createTempFile("libcachefailedcleartest", ".omod");
-		omod.deleteOnExit();
-		module.setFile(omod);
+		Module module = moduleWithTempOmod("libcachefailedcleartest");
+		File omod = module.getFile();
 
 		// A folder the recursive delete cannot fully remove, standing in for jars still locked by the
 		// previous classloader during a hot upgrade: commons-io restores write permissions while
@@ -614,11 +620,7 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void getLibCacheFolderForModule_shouldReplaceAStrayFileAtTheCacheFolderPath() throws IOException {
-		Module module = new Module("mockmodule", "libcachestrayfiletest", "org.openmrs.module.libcachestrayfiletest",
-		        "author", "description", "2.0", "2.0");
-		File omod = File.createTempFile("libcachestrayfiletest", ".omod");
-		omod.deleteOnExit();
-		module.setFile(omod);
+		Module module = moduleWithTempOmod("libcachestrayfiletest");
 
 		// A regular file sitting where the module's cache folder should be; FileUtils.deleteDirectory
 		// would throw an unchecked IllegalArgumentException for it and fail the module's startup.

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
@@ -30,7 +32,9 @@ import org.openmrs.util.OpenmrsClassLoader;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 
@@ -558,12 +562,78 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		assertTrue(keep.exists());
 
 		try {
-			ModuleClassLoader.deleteLibCacheFolder(outside);
+			assertFalse(ModuleClassLoader.deleteLibCacheFolder(outside),
+			    "a refused delete must not report the folder as cleared");
 
 			assertTrue(keep.exists(),
 			    "must refuse to recursively delete a folder that is not directly inside the lib cache root");
 		} finally {
 			FileUtils.deleteQuietly(outside);
+		}
+	}
+
+	/**
+	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
+	 */
+	@Test
+	@DisabledOnOs(OS.WINDOWS) // java.io.File cannot remove a directory's read permission on Windows
+	public void getLibCacheFolderForModule_shouldNotRefreshTheMarkerWhenTheCacheCannotBeCleared() throws IOException {
+		Module module = new Module("mockmodule", "libcachefailedcleartest", "org.openmrs.module.libcachefailedcleartest",
+		        "author", "description", "2.0", "2.0");
+		File omod = File.createTempFile("libcachefailedcleartest", ".omod");
+		omod.deleteOnExit();
+		module.setFile(omod);
+
+		// A folder the recursive delete cannot fully remove, standing in for jars still locked by the
+		// previous classloader during a hot upgrade: commons-io restores write permissions while
+		// deleting (OVERRIDE_READ_ONLY), but it cannot walk a directory it is not allowed to read.
+		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
+		File undeletable = new File(new File(cacheFolder, "lib"), "undeletable");
+		FileUtils.writeStringToFile(new File(undeletable, "child.txt"), "x", Charset.defaultCharset());
+		File marker = new File(cacheFolder, ".moduleLastModified");
+		FileUtils.writeStringToFile(marker, Long.toString(omod.lastModified() - 1000L), Charset.defaultCharset());
+		assumeTrue(undeletable.setReadable(false, false));
+
+		try {
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			// If the folder was cleared anyway (e.g. running as root), the failure path was not exercised.
+			assumeTrue(undeletable.exists());
+			String stamped = marker.exists() ? FileUtils.readFileToString(marker, Charset.defaultCharset()) : null;
+			assertNotEquals(Long.toString(omod.lastModified()), stamped,
+			    "the last modified marker must not be refreshed over a cache that could not be cleared, otherwise "
+			            + "the next optimized startup trusts the stale jars instead of retrying the delete");
+		} finally {
+			undeletable.setReadable(true, false);
+			FileUtils.deleteQuietly(cacheFolder);
+		}
+	}
+
+	/**
+	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
+	 */
+	@Test
+	public void getLibCacheFolderForModule_shouldReplaceAStrayFileAtTheCacheFolderPath() throws IOException {
+		Module module = new Module("mockmodule", "libcachestrayfiletest", "org.openmrs.module.libcachestrayfiletest",
+		        "author", "description", "2.0", "2.0");
+		File omod = File.createTempFile("libcachestrayfiletest", ".omod");
+		omod.deleteOnExit();
+		module.setFile(omod);
+
+		// A regular file sitting where the module's cache folder should be; FileUtils.deleteDirectory
+		// would throw an unchecked IllegalArgumentException for it and fail the module's startup.
+		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
+		FileUtils.writeStringToFile(cacheFolder, "stray", Charset.defaultCharset());
+		assertTrue(cacheFolder.isFile());
+
+		try {
+			File result = ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertThat(result, is(cacheFolder));
+			assertTrue(cacheFolder.isDirectory(),
+			    "a stray regular file at the cache folder path must be replaced with the folder");
+		} finally {
+			FileUtils.deleteQuietly(cacheFolder);
 		}
 	}
 }

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -9,18 +9,23 @@
  */
 package org.openmrs.module;
 
+import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.OpenmrsClassLoader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -477,5 +482,88 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		final URL fileUrl = URI.create("file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
 		assertFalse(
 		    ModuleClassLoader.isMatchingConditionalResource(moduleWithNullConfigVersions, fileUrl, conditionalResource));
+	}
+
+	/**
+	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
+	 */
+	@Test
+	public void getLibCacheFolderForModule_shouldPruneJarsDroppedByAModifiedModule() throws IOException {
+		Module module = new Module("mockmodule", "libcacheprunetest", "org.openmrs.module.libcacheprunetest", "author",
+		        "description", "2.0", "2.0");
+		File omod = File.createTempFile("libcacheprunetest", ".omod");
+		omod.deleteOnExit();
+		module.setFile(omod);
+
+		// Prime the cache folder to look like the previous version's expansion: a lib jar the new
+		// version no longer ships, plus a .moduleLastModified marker predating this omod so the
+		// module counts as modified.
+		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
+		File staleJar = new File(new File(cacheFolder, "lib"), "dropped-by-upgrade.jar");
+		FileUtils.writeStringToFile(staleJar, "stale", Charset.defaultCharset());
+		FileUtils.writeStringToFile(new File(cacheFolder, ".moduleLastModified"), Long.toString(omod.lastModified() - 1000L),
+		    Charset.defaultCharset());
+		assertTrue(staleJar.exists());
+
+		try {
+			File result = ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertThat(result, is(cacheFolder));
+			assertFalse(staleJar.exists(), "a jar dropped by the upgraded module must not linger in the lib cache");
+			assertTrue(cacheFolder.isDirectory(), "the lib cache folder should be recreated for re-expansion");
+		} finally {
+			FileUtils.deleteQuietly(cacheFolder);
+		}
+	}
+
+	/**
+	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
+	 */
+	@Test
+	public void getLibCacheFolderForModule_shouldClearTheCacheWhenTheLastModifiedMarkerIsUnreadable() throws IOException {
+		Module module = new Module("mockmodule", "libcachemarkertest", "org.openmrs.module.libcachemarkertest", "author",
+		        "description", "2.0", "2.0");
+		File omod = File.createTempFile("libcachemarkertest", ".omod");
+		omod.deleteOnExit();
+		module.setFile(omod);
+
+		// A corrupt marker we cannot parse: we can no longer tell whether the module changed, so the
+		// cache must be cleared rather than reused with possibly stale jars.
+		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
+		File staleJar = new File(new File(cacheFolder, "lib"), "dropped-by-upgrade.jar");
+		FileUtils.writeStringToFile(staleJar, "stale", Charset.defaultCharset());
+		FileUtils.writeStringToFile(new File(cacheFolder, ".moduleLastModified"), "not-a-timestamp",
+		    Charset.defaultCharset());
+		assertTrue(staleJar.exists());
+
+		try {
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertFalse(staleJar.exists(), "an unreadable last-modified marker must clear the cache rather than reuse it");
+		} finally {
+			FileUtils.deleteQuietly(cacheFolder);
+		}
+	}
+
+	/**
+	 * @see ModuleClassLoader#deleteLibCacheFolder(File)
+	 */
+	@Test
+	public void deleteLibCacheFolder_shouldRefuseToDeleteAFolderOutsideTheLibCacheRoot() throws IOException {
+		// A folder that is a sibling of the lib cache root, i.e. not a direct child, as a malformed
+		// module id such as "../something" would resolve to.
+		File outside = new File(OpenmrsClassLoader.getLibCacheFolder().getParentFile(), "libcache-guard-test");
+		File keep = new File(outside, "keep.txt");
+		FileUtils.writeStringToFile(keep, "keep", Charset.defaultCharset());
+		assertTrue(keep.exists());
+
+		try {
+			ModuleClassLoader.deleteLibCacheFolder(outside);
+
+			assertTrue(keep.exists(),
+			    "must refuse to recursively delete a folder that is not directly inside the lib cache root");
+		} finally {
+			FileUtils.deleteQuietly(outside);
+		}
 	}
 }


### PR DESCRIPTION
## What

`ModuleClassLoader.getLibCacheFolderForModule()` is meant to wipe a module's lib cache folder when the module file changed (or on non-optimized startup) so a modified module is fully re-expanded. It used `File.delete()`, which only removes an empty directory and silently returns `false` on a populated one, and the return value was ignored. The cache folder always holds the module jar, `lib/*.jar` and the `.moduleLastModified` marker, so the delete never ran.

The effect: any jar a module dropped between versions stays in the cache and on that module's classpath after an in-place upgrade, leaving stale classes and version or class-identity conflicts that are hard to trace because the omod on disk looks correct. Fresh installs are unaffected (empty cache), and `dispose()` on unload only clears the in-memory map rather than the folder, so the normal upgrade path does not clear it either.

## Fix

Replace both `tmpModuleDir.delete()` calls with a recursive `FileUtils.deleteDirectory()` helper that warns if deletion fails.

## Test

`ModuleClassLoaderTest#getLibCacheFolderForModule_shouldPruneJarsDroppedByAModifiedModule` primes a cache folder with a lib jar and an older `.moduleLastModified` marker, calls `getLibCacheFolderForModule` for a module whose file is newer, and asserts the jar is gone. It fails on the old `File.delete()` (`expected: <false> but was: <true>`) and passes with the recursive delete.

## How this turned up

While reviewing a module that removed a bundled `javax.jms` jar in a new version: after an in-place upgrade the old jar was still on the classpath, so the change looked like it had no effect until the module's lib cache was cleared by hand.

The same code is on the 2.x branches; I can backport once this is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
