### PR TITLE
TRUNK-6678: Fix JUnit test assertions and improve disabled test documentation

### DIFF
--- a/api/src/test/java/org/openmrs/EncounterTest.java
+++ b/api/src/test/java/org/openmrs/EncounterTest.java
@@ -133,7 +133,7 @@ public class EncounterTest extends BaseContextMockTest {
 		Encounter encounter = new Encounter();
 
 		assertNotNull(encounter.getObs());
-		assertEquals(encounter.getObs().size(), 0);
+		assertEquals(0, encounter.getObs().size());
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
@@ -40,7 +40,7 @@ public class OpenmrsServiceTest extends BaseContextSensitiveTest {
 	 * @throws SerializationException
 	 */
 	@Test
-	@Disabled
+	@Disabled("Temporarily disabled because it fails when executed with other tests")
 	public void shouldCheckThatAMethodIsNotRolledBackInCaseOfAnErrorInAnotherInvokedInsideIt()
 	        throws SerializationException {
 		//TODO FIx why this test fails when run with other tests


### PR DESCRIPTION
Updated JUnit test assertions to follow the correct assertEquals(expected, actual) convention and added a descriptive reason to the @Disabled annotation. These changes improve test readability, follow JUnit best practices, and make disabled tests easier to understand.

JIRA TICKET : https://openmrs.atlassian.net/browse/TRUNK-6678