### PR TITLE
Clean up the module jar copy in ModuleClassLoader

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -228,30 +228,12 @@ public class ModuleClassLoader extends URLClassLoader {
 		if (devDir == null) {
 			File tmpModuleJar = new File(tmpModuleDir, module.getModuleId() + ".jar");
 
-			if (!tmpModuleJar.exists()) {
-				try {
-					tmpModuleJar.createNewFile();
-				} catch (IOException io) {
-					log.warn("Unable to create tmpModuleFile", io);
-				}
-			}
-
 			// copy the module jar into that temporary folder
-			FileInputStream in = null;
-			FileOutputStream out = null;
-			try {
-				in = new FileInputStream(module.getFile());
-				out = new FileOutputStream(tmpModuleJar);
+			try (FileInputStream in = new FileInputStream(module.getFile());
+			        FileOutputStream out = new FileOutputStream(tmpModuleJar)) {
 				OpenmrsUtil.copyFile(in, out);
 			} catch (IOException io) {
 				log.warn("Unable to copy tmpModuleFile", io);
-			} finally {
-				try {
-					in.close();
-				} catch (Exception e) { /* pass */}
-				try {
-					out.close();
-				} catch (Exception e) { /* pass */}
 			}
 
 			// add the module jar as a url in the classpath of the classloader


### PR DESCRIPTION
## What

Two small cleanups to the module jar copy in `ModuleClassLoader.getModuleUrls()`:

- The copy opened its `FileInputStream`/`FileOutputStream` by hand and closed them in a `finally` that calls `close()` on references still `null` when opening the input stream throws, relying on the surrounding `catch` to swallow the resulting `NullPointerException`. Converted to try-with-resources, which closes both streams (in reverse order, with proper suppressed-exception handling, and only the ones actually opened).
- Dropped the preceding `if (!tmpModuleJar.exists()) createNewFile()` block: the `FileOutputStream` that copies into it creates the file anyway, so the pre-creation is redundant.

Behaviour is unchanged: an `IOException` while copying is still caught and logged. Pure cleanup with no functional change, so no new test; the existing module-loading tests exercise this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
