### PR TITLE
Fail module load when its classpath cannot be built

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -233,7 +233,8 @@ public class ModuleClassLoader extends URLClassLoader {
 			        FileOutputStream out = new FileOutputStream(tmpModuleJar)) {
 				OpenmrsUtil.copyFile(in, out);
 			} catch (IOException io) {
-				log.warn("Unable to copy tmpModuleFile", io);
+				throw new ModuleException(
+				        "Unable to copy the module jar for " + module.getModuleId() + " into the lib cache", io);
 			}
 
 			// add the module jar as a url in the classpath of the classloader
@@ -299,7 +300,7 @@ public class ModuleClassLoader extends URLClassLoader {
 		} catch (MalformedURLException e) {
 			log.warn("Error while adding module 'lib' folder to URL result list");
 		} catch (IOException io) {
-			log.warn("Error while expanding lib folder", io);
+			throw new ModuleException("Unable to expand the lib folder for " + module.getModuleId(), io);
 		}
 
 		// add each xml document to the url list

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.module;
 
 import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -33,6 +34,7 @@ import org.openmrs.util.OpenmrsClassLoader;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
@@ -574,5 +576,42 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		final URL fileUrl = URI.create("file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
 		assertFalse(
 		    ModuleClassLoader.isMatchingConditionalResource(moduleWithNullConfigVersions, fileUrl, conditionalResource));
+	}
+
+	/**
+	 * @see ModuleClassLoader#ModuleClassLoader(Module, ClassLoader)
+	 */
+	@Test
+	public void moduleClassLoader_shouldFailToLoadWhenTheModuleJarCannotBeCopied() {
+		Module module = new Module("mockmodule", "libcachecopyfailtest", "org.openmrs.module.libcachecopyfailtest", "author",
+		        "description", "2.0", "2.0");
+		// Point the module at a file that does not exist so copying its jar into the lib cache fails.
+		module.setFile(new File(OpenmrsClassLoader.getLibCacheFolder(), "does-not-exist.omod"));
+
+		try {
+			assertThrows(ModuleException.class, () -> new ModuleClassLoader(module, ClassLoader.getSystemClassLoader()));
+		} finally {
+			FileUtils.deleteQuietly(new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId()));
+		}
+	}
+
+	/**
+	 * @see ModuleClassLoader#ModuleClassLoader(Module, ClassLoader)
+	 */
+	@Test
+	public void moduleClassLoader_shouldFailToLoadWhenTheLibFolderCannotBeExpanded() throws IOException {
+		Module module = new Module("mockmodule", "libcacheexpandfailtest", "org.openmrs.module.libcacheexpandfailtest",
+		        "author", "description", "2.0", "2.0");
+		// A real file that is not a valid jar: copying it succeeds, but expanding its lib folder fails.
+		File notAJar = File.createTempFile("libcacheexpandfailtest", ".omod");
+		notAJar.deleteOnExit();
+		FileUtils.writeStringToFile(notAJar, "not a jar", Charset.defaultCharset());
+		module.setFile(notAJar);
+
+		try {
+			assertThrows(ModuleException.class, () -> new ModuleClassLoader(module, ClassLoader.getSystemClassLoader()));
+		} finally {
+			FileUtils.deleteQuietly(new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId()));
+		}
 	}
 }


### PR DESCRIPTION
## What

When a module loads, `ModuleClassLoader.getModuleUrls()` copies the module's own jar into the lib cache and expands its `lib` folder. On an `IOException` in either step it only logged a warning, then built the classloader anyway (missing main jar, or an incompletely expanded lib folder). The module was then marked started but had missing classes and failed later with cryptic `ClassNotFound` errors that don't point at the real cause.

This throws a `ModuleException` in both cases instead. `ModuleFactory.startModuleInternal()` already wraps `new ModuleClassLoader(...)` in a try/catch that records the startup error, notifies admins, and rolls the module back via `stopModule`, without aborting the other modules' startup. So a module whose classpath can't be built (unreadable or corrupt omod, disk full) is now reported as failed to start with the real cause, instead of appearing started but broken.

The per-file `MalformedURLException` while adding an individual lib jar to the classpath stays a warning, since it is not a whole-module failure.

## Tests

- `moduleClassLoader_shouldFailToLoadWhenTheModuleJarCannotBeCopied`: points a module at a nonexistent file and asserts construction throws `ModuleException`.
- `moduleClassLoader_shouldFailToLoadWhenTheLibFolderCannotBeExpanded`: points a module at a real file that is not a valid jar (copy succeeds, expand fails) and asserts construction throws `ModuleException`.
- `ModuleFactoryTest` (real module loading) stays green at 9/9, confirming valid modules are unaffected.

## Note

Touches the same jar-copy block as #6307 (the try-with-resources cleanup); whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
