### PR TITLE
Revert "Recursively clear a module's lib cache when the module changes"

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -415,8 +415,7 @@ public class ModuleClassLoader extends URLClassLoader {
 	 * ease cleanup when unloading a module while openmrs is running.
 	 * <p>
 	 * The method persists lastModified of a module in .moduleLastModified file. If the value changed,
-	 * the dir will be deleted and re-created. The marker is only refreshed once the previous contents
-	 * were successfully removed, so a failed delete is retried on the next startup.
+	 * the dir will be deleted and re-created.
 	 *
 	 * @param module Module which the cache will be used for
 	 * @return File directory where the files will be placed
@@ -439,89 +438,36 @@ public class ModuleClassLoader extends URLClassLoader {
 			long moduleLastModified = module.getFile().lastModified();
 			File moduleLastModifiedFile = new File(tmpModuleDir, ".moduleLastModified");
 
-			boolean cacheCleared = true;
 			if (Context.isOptimizedStartup() && moduleLastModifiedFile.exists()) {
 				// Re-create tmpModuleDir if module changed
 				try {
 					String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						cacheCleared = deleteLibCacheFolder(tmpModuleDir);
+						tmpModuleDir.delete();
 					}
 				} catch (IOException | NumberFormatException e) {
-					log.warn("Could not read the last modified marker {}; clearing the lib cache to be safe",
-					    moduleLastModifiedFile, e);
-					cacheCleared = deleteLibCacheFolder(tmpModuleDir);
+					log.warn("Error while reading module last modified file: {}", moduleLastModifiedFile, e);
 				}
 			} else {
 				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 				    tmpModuleDir);
-				cacheCleared = deleteLibCacheFolder(tmpModuleDir);
+				tmpModuleDir.delete();
 			}
 
-			if (!tmpModuleDir.mkdirs() && !tmpModuleDir.isDirectory()) {
-				log.warn("Unable to create the module lib cache folder {}", tmpModuleDir);
-			}
+			tmpModuleDir.mkdirs();
 			libCacheFolders.put(module.getModuleId(), tmpModuleDir);
 
-			// Only refresh the marker over a fully cleared cache: stamping it over leftovers would make
-			// every later optimized startup trust the stale jars, while a stale or missing marker makes
-			// the next startup retry the delete, e.g. once the old classloader's file locks are gone.
-			if (cacheCleared && moduleLastModified != 0L) {
+			if (moduleLastModified != 0L) {
 				try {
 					FileUtils.writeStringToFile(moduleLastModifiedFile, moduleLastModified + "", Charset.defaultCharset());
 				} catch (IOException e) {
-					log.warn("Could not write the last modified marker {}", moduleLastModifiedFile, e);
+					log.warn("Error while writing module last modified file: {}", moduleLastModifiedFile, e);
 				}
 			}
 
 			return tmpModuleDir;
 		}
-	}
-
-	/**
-	 * Recursively deletes the module's lib cache folder (or a stray regular file in its place) so a
-	 * modified module is fully re-expanded. {@link java.io.File#delete()} only removes an empty
-	 * directory and silently no-ops otherwise, so jars a module dropped between versions would linger
-	 * in the cache and stay on its classpath. Only a direct child of the lib cache root is ever
-	 * deleted.
-	 * <p>
-	 * A disposed classloader still executing during an in-place reload keeps reading the jars it
-	 * already has open on POSIX (the open handle outlives the unlink, unlike the previous in-place
-	 * overwrite in getModuleUrls, which corrupted them); anything it never opened fails loudly after
-	 * the prune instead of silently serving another version's bytes.
-	 *
-	 * @param tmpModuleDir the module's lib cache folder
-	 * @return true if the folder no longer exists, false if it could not be fully removed or the delete
-	 *         was refused because the folder is not directly inside the lib cache root
-	 */
-	static boolean deleteLibCacheFolder(File tmpModuleDir) {
-		try {
-			// Guard this recursive delete on a path built from the module id: only ever remove a
-			// direct child of the lib cache root, never something a malformed id resolved to outside it.
-			if (!OpenmrsClassLoader.getLibCacheFolder().getCanonicalFile()
-			        .equals(tmpModuleDir.getCanonicalFile().getParentFile())) {
-				log.warn("Refusing to delete {}; it is not directly inside the lib cache folder", tmpModuleDir);
-				return false;
-			}
-			if (tmpModuleDir.isFile()) {
-				// A stray regular file where the cache folder should be; FileUtils.deleteDirectory
-				// would throw an unchecked IllegalArgumentException for it rather than an IOException.
-				FileUtils.forceDelete(tmpModuleDir);
-			} else {
-				FileUtils.deleteDirectory(tmpModuleDir);
-			}
-		} catch (IOException e) {
-			log.warn("Unable to delete the module lib cache folder {}", tmpModuleDir, e);
-		}
-		if (tmpModuleDir.exists()) {
-			log.warn("The module lib cache folder {} could not be fully cleared and may still hold jars from a previous "
-			        + "version of the module, which can leave stale classes on the module classpath; clearing it will "
-			        + "be retried on the next restart.",
-			    tmpModuleDir);
-			return false;
-		}
-		return true;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -9,32 +9,23 @@
  */
 package org.openmrs.module;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
-import org.openmrs.util.OpenmrsClassLoader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 
@@ -486,156 +477,5 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		final URL fileUrl = URI.create("file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
 		assertFalse(
 		    ModuleClassLoader.isMatchingConditionalResource(moduleWithNullConfigVersions, fileUrl, conditionalResource));
-	}
-
-	/**
-	 * Builds a module whose backing omod is a fresh temp file, with a module id unique to the calling
-	 * test so each test works in its own folder under the shared lib cache root.
-	 */
-	private Module moduleWithTempOmod(String moduleId) throws IOException {
-		Module module = new Module("mockmodule", moduleId, "org.openmrs.module." + moduleId, "author", "description", "2.0",
-		        "2.0");
-		File omod = File.createTempFile(moduleId, ".omod");
-		omod.deleteOnExit();
-		module.setFile(omod);
-		return module;
-	}
-
-	/**
-	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
-	 */
-	@Test
-	public void getLibCacheFolderForModule_shouldPruneJarsDroppedByAModifiedModule() throws IOException {
-		Module module = moduleWithTempOmod("libcacheprunetest");
-		File omod = module.getFile();
-
-		// Prime the cache folder to look like the previous version's expansion: a lib jar the new
-		// version no longer ships, plus a .moduleLastModified marker predating this omod so the
-		// module counts as modified.
-		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
-		File staleJar = new File(new File(cacheFolder, "lib"), "dropped-by-upgrade.jar");
-		FileUtils.writeStringToFile(staleJar, "stale", Charset.defaultCharset());
-		File marker = new File(cacheFolder, ".moduleLastModified");
-		FileUtils.writeStringToFile(marker, Long.toString(omod.lastModified() - 1000L), Charset.defaultCharset());
-		assertTrue(staleJar.exists());
-
-		try {
-			File result = ModuleClassLoader.getLibCacheFolderForModule(module);
-
-			assertThat(result, is(cacheFolder));
-			assertFalse(staleJar.exists(), "a jar dropped by the upgraded module must not linger in the lib cache");
-			assertTrue(cacheFolder.isDirectory(), "the lib cache folder should be recreated for re-expansion");
-			// The successful clear must also refresh the marker, or every later optimized startup
-			// would re-delete and re-expand the cache, silently defeating optimized startup.
-			assertThat(FileUtils.readFileToString(marker, Charset.defaultCharset()), is(Long.toString(omod.lastModified())));
-		} finally {
-			FileUtils.deleteQuietly(cacheFolder);
-		}
-	}
-
-	/**
-	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
-	 */
-	@Test
-	public void getLibCacheFolderForModule_shouldClearTheCacheWhenTheLastModifiedMarkerIsUnparseable() throws IOException {
-		Module module = moduleWithTempOmod("libcachemarkertest");
-
-		// A corrupt marker we cannot parse: we can no longer tell whether the module changed, so the
-		// cache must be cleared rather than reused with possibly stale jars.
-		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
-		File staleJar = new File(new File(cacheFolder, "lib"), "dropped-by-upgrade.jar");
-		FileUtils.writeStringToFile(staleJar, "stale", Charset.defaultCharset());
-		FileUtils.writeStringToFile(new File(cacheFolder, ".moduleLastModified"), "not-a-timestamp",
-		    Charset.defaultCharset());
-		assertTrue(staleJar.exists());
-
-		try {
-			ModuleClassLoader.getLibCacheFolderForModule(module);
-
-			assertFalse(staleJar.exists(), "an unparseable last-modified marker must clear the cache rather than reuse it");
-		} finally {
-			FileUtils.deleteQuietly(cacheFolder);
-		}
-	}
-
-	/**
-	 * @see ModuleClassLoader#deleteLibCacheFolder(File)
-	 */
-	@Test
-	public void deleteLibCacheFolder_shouldRefuseToDeleteAFolderOutsideTheLibCacheRoot() throws IOException {
-		// A folder that is a sibling of the lib cache root, i.e. not a direct child, as a malformed
-		// module id such as "../something" would resolve to.
-		File outside = new File(OpenmrsClassLoader.getLibCacheFolder().getParentFile(), "libcache-guard-test");
-		File keep = new File(outside, "keep.txt");
-		FileUtils.writeStringToFile(keep, "keep", Charset.defaultCharset());
-		assertTrue(keep.exists());
-
-		try {
-			assertFalse(ModuleClassLoader.deleteLibCacheFolder(outside),
-			    "a refused delete must not report the folder as cleared");
-
-			assertTrue(keep.exists(),
-			    "must refuse to recursively delete a folder that is not directly inside the lib cache root");
-		} finally {
-			FileUtils.deleteQuietly(outside);
-		}
-	}
-
-	/**
-	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
-	 */
-	@Test
-	@DisabledOnOs(OS.WINDOWS) // java.io.File cannot remove a directory's read permission on Windows
-	public void getLibCacheFolderForModule_shouldNotRefreshTheMarkerWhenTheCacheCannotBeCleared() throws IOException {
-		Module module = moduleWithTempOmod("libcachefailedcleartest");
-		File omod = module.getFile();
-
-		// A folder the recursive delete cannot fully remove, standing in for jars still locked by the
-		// previous classloader during a hot upgrade: commons-io restores write permissions while
-		// deleting (OVERRIDE_READ_ONLY), but it cannot walk a directory it is not allowed to read.
-		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
-		File undeletable = new File(new File(cacheFolder, "lib"), "undeletable");
-		FileUtils.writeStringToFile(new File(undeletable, "child.txt"), "x", Charset.defaultCharset());
-		File marker = new File(cacheFolder, ".moduleLastModified");
-		FileUtils.writeStringToFile(marker, Long.toString(omod.lastModified() - 1000L), Charset.defaultCharset());
-		assumeTrue(undeletable.setReadable(false, false));
-
-		try {
-			ModuleClassLoader.getLibCacheFolderForModule(module);
-
-			// If the folder was cleared anyway (e.g. running as root), the failure path was not exercised.
-			assumeTrue(undeletable.exists());
-			String stamped = marker.exists() ? FileUtils.readFileToString(marker, Charset.defaultCharset()) : null;
-			assertNotEquals(Long.toString(omod.lastModified()), stamped,
-			    "the last modified marker must not be refreshed over a cache that could not be cleared, otherwise "
-			            + "the next optimized startup trusts the stale jars instead of retrying the delete");
-		} finally {
-			undeletable.setReadable(true, false);
-			FileUtils.deleteQuietly(cacheFolder);
-		}
-	}
-
-	/**
-	 * @see ModuleClassLoader#getLibCacheFolderForModule(Module)
-	 */
-	@Test
-	public void getLibCacheFolderForModule_shouldReplaceAStrayFileAtTheCacheFolderPath() throws IOException {
-		Module module = moduleWithTempOmod("libcachestrayfiletest");
-
-		// A regular file sitting where the module's cache folder should be; FileUtils.deleteDirectory
-		// would throw an unchecked IllegalArgumentException for it and fail the module's startup.
-		File cacheFolder = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
-		FileUtils.writeStringToFile(cacheFolder, "stray", Charset.defaultCharset());
-		assertTrue(cacheFolder.isFile());
-
-		try {
-			File result = ModuleClassLoader.getLibCacheFolderForModule(module);
-
-			assertThat(result, is(cacheFolder));
-			assertTrue(cacheFolder.isDirectory(),
-			    "a stray regular file at the cache folder path must be replaced with the folder");
-		} finally {
-			FileUtils.deleteQuietly(cacheFolder);
-		}
 	}
 }


### PR DESCRIPTION
Reverts openmrs/openmrs-core#6305 because it was done here: https://github.com/openmrs/openmrs-core/pull/6257