### PR TITLE
TRUNK-6516: Fix outbox/broker issues found in events/CDC sign-off (2.9.x)

### DIFF
--- a/api/src/main/java/org/openmrs/aop/OpenmrsServiceEventAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/OpenmrsServiceEventAdvice.java
@@ -33,10 +33,17 @@ import java.util.function.Function;
  * {@link RetireServiceEvent}, and {@link UnretireServiceEvent}.
  * <p>
  * It is registered after transaction advice so that {@link org.openmrs.event.outbox.OutboxEventListener},
- * {@link org.springframework.transaction.event.TransactionalEventListener} and 
+ * {@link org.springframework.transaction.event.TransactionalEventListener} and
  * {@link org.springframework.context.event.EventListener}
  * can run in the same transaction.
- * 
+ * <p>
+ * Events are published synchronously before the service method executes. Any exception thrown by a
+ * synchronous {@link org.springframework.context.event.EventListener} will propagate out of the
+ * advice and abort the service call — this is intentional, as it allows listeners to act as
+ * precondition guards. Listeners that must not block the service call should use
+ * {@link org.springframework.transaction.event.TransactionalEventListener} (runs after commit) or
+ * {@link org.openmrs.event.outbox.OutboxEventListener} (persisted and delivered asynchronously).
+ *
  * @since 2.9.0
  */
 @Aspect

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -696,7 +696,7 @@ public class Context {
 	/**
 	 * Used by {@link org.openmrs.aop.AuthorizationAdvice} to give access for unauthenticated users when
 	 * running initialization code with proxy privileges. See e.g.
-	 * {@link org.openmrs.event.outbox.tasks.OutboxTaskSchedulerInitializer#afterSingletonsInstantiated()}.
+	 * {@link org.openmrs.event.outbox.tasks.OutboxTaskSchedulerInitializer#schedule()}.
 	 *
 	 * @return true if there are any proxy privileges
 	 * @since 2.9.0

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
@@ -233,7 +233,14 @@ public class HibernateAdministrationDAO implements AdministrationDAO, Applicatio
 		} else {
 			int fieldLength;
 			try {
-				fieldLength = ((Column) persistentClass.getProperty(fieldName).getColumnIterator().next()).getLength();
+				Column column = (Column) persistentClass.getProperty(fieldName).getColumnIterator().next();
+				String columnDefinition = column.getSqlType();
+				if (columnDefinition != null && (columnDefinition.equalsIgnoreCase("LONGTEXT")
+				        || columnDefinition.equalsIgnoreCase("MEDIUMTEXT"))) {
+					fieldLength = Integer.MAX_VALUE;
+				} else {
+					fieldLength = column.getLength();
+				}
 			}
 			catch (Exception e) {
 				log.debug("Could not determine maximum length", e);

--- a/api/src/main/java/org/openmrs/event/broker/BrokerEventListenerFactory.java
+++ b/api/src/main/java/org/openmrs/event/broker/BrokerEventListenerFactory.java
@@ -55,10 +55,12 @@ public class BrokerEventListenerFactory implements EventListenerFactory, Ordered
 				// If the parameter is wrapped in a generic BrokerIncomingEvent<?>, extract the inner generic type
 				if (payloadType != null && BrokerIncomingEvent.class.isAssignableFrom(payloadType)) {
 					Class<?> genericType = resolvableType.getGeneric(0).resolve();
-					if (genericType == null) {
-						genericType = Object.class;
+					if (genericType == null || genericType == Object.class) {
+						throw new IllegalArgumentException(
+						        "BrokerEventListener on " + method + " must use a concrete type parameter, not <?> or raw. "
+						                + "Use BrokerIncomingEvent<YourDto> instead of BrokerIncomingEvent<?>");
 					}
-					
+
 					payloadType = genericType;
 					listeners.addIfAbsent(new Listener(annotation.value(), annotation.broker(), payloadType));
 					return new BrokerApplicationListenerMethodAdapter(beanName, type, method);

--- a/api/src/main/java/org/openmrs/event/outbox/OutboxEvent.java
+++ b/api/src/main/java/org/openmrs/event/outbox/OutboxEvent.java
@@ -45,7 +45,7 @@ public class OutboxEvent extends BaseOpenmrsObject implements Auditable {
 	private String eventType;
 
 	@Lob
-	@Column(name = "payload", nullable = false)
+	@Column(name = "payload", nullable = false, columnDefinition = "MEDIUMTEXT")
 	private String payload;
 
 	@Column(name = "date_created", nullable = false)
@@ -67,7 +67,7 @@ public class OutboxEvent extends BaseOpenmrsObject implements Auditable {
 	private String errorMessage;
 	
 	@Lob
-	@Column(name = "completed_listeners")
+	@Column(name = "completed_listeners", columnDefinition = "MEDIUMTEXT")
 	private String completedListeners;
 
 	@ManyToOne

--- a/api/src/main/java/org/openmrs/event/outbox/OutboxEventRegistry.java
+++ b/api/src/main/java/org/openmrs/event/outbox/OutboxEventRegistry.java
@@ -11,7 +11,7 @@ package org.openmrs.event.outbox;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.MapMaker;
+import org.openmrs.event.outbox.tasks.OutboxTaskSchedulerInitializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.SmartInitializingSingleton;
@@ -31,13 +31,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
 /**
  * It is used to discover any {@link OutboxEventListener} listeners and
  * dispatch events to them.
- * 
+ * <p>
+ * After scanning for listeners at startup it drives the outbox scheduler lifecycle, triggering
+ * {@link OutboxTaskSchedulerInitializer#schedule()} when at least one listener is present and
+ * {@link OutboxTaskSchedulerInitializer#deleteScheduledTasks()} when there are none or the feature
+ * is disabled.
+ *
  * @since 2.9.0
  */
 @Component
@@ -49,20 +53,24 @@ public class OutboxEventRegistry implements SmartInitializingSingleton {
 	private final List<ListenerMethod> registry;
 	private final Cache<ResolvableType, Boolean> hasOutboxListenersCache;
 	private final boolean enabled;
-	
-	public OutboxEventRegistry(ApplicationContext applicationContext, @Value("${outboxevent.enabled:true}") boolean enabled) {
+	private final OutboxTaskSchedulerInitializer schedulerInitializer;
+
+	public OutboxEventRegistry(ApplicationContext applicationContext, @Value("${outboxevent.enabled:true}") boolean enabled,
+	    OutboxTaskSchedulerInitializer schedulerInitializer) {
 		this.applicationContext = applicationContext;
 		this.registry = new ArrayList<>();
 		this.hasOutboxListenersCache = CacheBuilder.newBuilder().expireAfterWrite(Duration.ofMinutes(10)).build();
 		this.enabled = enabled;
+		this.schedulerInitializer = schedulerInitializer;
 	}
 
 	@Override
 	public void afterSingletonsInstantiated() {
 		if (!enabled) {
+			schedulerInitializer.deleteScheduledTasks();
 			return;
 		}
-		
+
 		for (String beanName : applicationContext.getBeanDefinitionNames()) {
 			Class<?> type = applicationContext.getType(beanName);
 			if (type != null) {
@@ -84,6 +92,14 @@ public class OutboxEventRegistry implements SmartInitializingSingleton {
 
 		// Sort all listeners once at application startup
 		Collections.sort(registry);
+
+		// Trigger scheduling only after scanning is complete, so the poller starts when at least
+		// one listener is present and is removed when none remain.
+		if (hasOutboxListeners()) {
+			schedulerInitializer.schedule();
+		} else {
+			schedulerInitializer.deleteScheduledTasks();
+		}
 	}
 	
 	public boolean hasOutboxListeners() {

--- a/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxPollingTaskHandler.java
+++ b/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxPollingTaskHandler.java
@@ -98,7 +98,7 @@ public class OutboxPollingTaskHandler implements TaskHandler<OutboxPollingTaskDa
 
 				Set<String> completedListeners = new LinkedHashSet<>();
 				try {
-					Class<?> eventClass = Class.forName(item.getEventType());
+					Class<?> eventClass = Context.loadClass(item.getEventType());
 					Object event;
 					if (EventPayload.class.isAssignableFrom(eventClass)) {
 						event = eventClass.getDeclaredConstructor().newInstance();

--- a/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxTaskSchedulerInitializer.java
+++ b/api/src/main/java/org/openmrs/event/outbox/tasks/OutboxTaskSchedulerInitializer.java
@@ -10,63 +10,70 @@
 package org.openmrs.event.outbox.tasks;
 
 import org.openmrs.api.context.Context;
-import org.openmrs.event.outbox.OutboxEventRegistry;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.util.PrivilegeConstants;
-import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 
 /**
+ * Owns the lifecycle of the outbox scheduler tasks. Scheduling is triggered by
+ * {@link org.openmrs.event.outbox.OutboxEventRegistry} once it has scanned for
+ * {@link org.openmrs.event.outbox.OutboxEventListener} beans, so that the poller only starts when
+ * at least one listener is present.
+ *
  * @since 2.9.0
  */
 @Component
-public class OutboxTaskSchedulerInitializer implements SmartInitializingSingleton {
-	
+public class OutboxTaskSchedulerInitializer {
+
 	public static final String OUTBOX_POLLER_TASK_NAME = "Transactional Outbox Poller";
 	public static final String OUTBOX_POLLER_TASK_UUID = "bc2739ac-5bf3-4ecd-8e11-d383d53695bb";
 	public static final String OUTBOX_CLEANUP_TASK_NAME = "Transactional Outbox Cleanup";
 	public static final String OUTBOX_CLEANUP_TASK_UUID = "a0c11918-0aba-46bf-a7c6-7b0cc47e7323";
 
 	private final SchedulerService schedulerService;
-	
-	private final OutboxEventRegistry outboxEventRegistry;
 
-	public OutboxTaskSchedulerInitializer(SchedulerService schedulerService, OutboxEventRegistry outboxEventRegistry) {
+	public OutboxTaskSchedulerInitializer(SchedulerService schedulerService) {
 		this.schedulerService = schedulerService;
-		this.outboxEventRegistry = outboxEventRegistry;
 	}
 
-	@Override
-	public void afterSingletonsInstantiated() {
+	public void schedule() {
 		try {
 			if (!Context.isSessionOpen()) {
 				Context.openSession();
 			}
 			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_SCHEDULER);
-			
-			if (outboxEventRegistry.hasOutboxListeners()) {
-				// Schedule the outbox polling task to run recurrently in the background
-				schedulerService.scheduleRecurrently(
-					OUTBOX_POLLER_TASK_UUID,
-					new OutboxPollingTaskData(),
-					Duration.ofSeconds(15),
-					OUTBOX_POLLER_TASK_NAME
-				);
 
-				// Schedule the outbox cleanup task to run recurrently (e.g., every day)
-				schedulerService.scheduleRecurrently(
-					OUTBOX_CLEANUP_TASK_UUID,
-					new OutboxCleanupTaskData(),
-					Duration.ofDays(1),
-					OUTBOX_CLEANUP_TASK_NAME
-				);
-			} else {
-				schedulerService.deleteRecurringTask(OUTBOX_POLLER_TASK_UUID);
-				schedulerService.deleteRecurringTask(OUTBOX_CLEANUP_TASK_UUID);
-				
+			// Schedule the outbox polling task to run recurrently in the background
+			schedulerService.scheduleRecurrently(
+				OUTBOX_POLLER_TASK_UUID,
+				new OutboxPollingTaskData(),
+				Duration.ofSeconds(15),
+				OUTBOX_POLLER_TASK_NAME
+			);
+
+			// Schedule the outbox cleanup task to run recurrently (e.g., every day)
+			schedulerService.scheduleRecurrently(
+				OUTBOX_CLEANUP_TASK_UUID,
+				new OutboxCleanupTaskData(),
+				Duration.ofDays(1),
+				OUTBOX_CLEANUP_TASK_NAME
+			);
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_SCHEDULER);
+		}
+	}
+
+	public void deleteScheduledTasks() {
+		try {
+			if (!Context.isSessionOpen()) {
+				Context.openSession();
 			}
+			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_SCHEDULER);
+
+			schedulerService.deleteRecurringTask(OUTBOX_POLLER_TASK_UUID);
+			schedulerService.deleteRecurringTask(OUTBOX_CLEANUP_TASK_UUID);
 		} finally {
 			Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_SCHEDULER);
 		}

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
@@ -57,7 +57,7 @@
 			<column name="event_type" type="VARCHAR(255)">
 				<constraints nullable="false"/>
 			</column>
-			<column name="payload" type="TEXT">
+			<column name="payload" type="MEDIUMTEXT">
 				<constraints nullable="false"/>
 			</column>
 			<column defaultValue="PENDING" name="status" type="VARCHAR(50)">
@@ -67,7 +67,7 @@
 				<constraints nullable="false"/>
 			</column>
 			<column name="error_message" type="VARCHAR(1024)"/>
-			<column name="completed_listeners" type="TEXT"/>
+			<column name="completed_listeners" type="MEDIUMTEXT"/>
 			<column name="creator" type="INT"/>
 			<column name="date_created" type="DATETIME(3)">
 				<constraints nullable="false"/>

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Location;
 import org.openmrs.Role;
+import org.openmrs.event.outbox.OutboxEvent;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindException;
@@ -147,5 +149,22 @@ public class HibernateAdministrationDAOTest extends BaseContextSensitiveTest {
 		Errors errors = new BindException(role, "type");
 		dao.validate(role, errors);
 		assertFalse(errors.hasFieldErrors("role"));
+	}
+
+	/**
+	 * @see HibernateAdministrationDAO#getMaximumPropertyLength(Class, String)
+	 */
+	@Test
+	public void getMaximumPropertyLength_shouldTreatMediumtextColumnsAsUnbounded() {
+		assertEquals(Integer.MAX_VALUE, dao.getMaximumPropertyLength(OutboxEvent.class, "payload"));
+		assertEquals(Integer.MAX_VALUE, dao.getMaximumPropertyLength(OutboxEvent.class, "completedListeners"));
+	}
+
+	/**
+	 * @see HibernateAdministrationDAO#getMaximumPropertyLength(Class, String)
+	 */
+	@Test
+	public void getMaximumPropertyLength_shouldReturnActualLengthForBoundedColumns() {
+		assertEquals(1024, dao.getMaximumPropertyLength(OutboxEvent.class, "errorMessage"));
 	}
 }

--- a/api/src/test/java/org/openmrs/event/broker/BrokerEventListenerFactoryTest.java
+++ b/api/src/test/java/org/openmrs/event/broker/BrokerEventListenerFactoryTest.java
@@ -99,13 +99,25 @@ public class BrokerEventListenerFactoryTest {
 	}
 
 	@Test
-	public void createApplicationListener_shouldNotThrowExceptionIfRawBrokerIncomingEvent() {
+	public void createApplicationListener_shouldThrowExceptionIfRawBrokerIncomingEvent() {
 		Method method = ReflectionUtils.findMethod(TestBean.class, "rawListener", BrokerIncomingEvent.class);
-		
-		factory.createApplicationListener("testBean", TestBean.class, method);
 
-		List<BrokerEventListenerFactory.Listener> registeredListeners = factory.getListeners();
-		assertEquals(1, registeredListeners.size());
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			factory.createApplicationListener("testBean", TestBean.class, method);
+		});
+
+		assertTrue(exception.getMessage().contains("must use a concrete type parameter, not <?> or raw"));
+	}
+
+	@Test
+	public void createApplicationListener_shouldThrowExceptionIfWildcardBrokerIncomingEvent() {
+		Method method = ReflectionUtils.findMethod(TestBean.class, "wildcardListener", BrokerIncomingEvent.class);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+			factory.createApplicationListener("testBean", TestBean.class, method);
+		});
+
+		assertTrue(exception.getMessage().contains("must use a concrete type parameter, not <?> or raw"));
 	}
 
 	@Test
@@ -139,6 +151,9 @@ public class BrokerEventListenerFactoryTest {
 		@SuppressWarnings("rawtypes")
 		@BrokerEventListener("my-source")
 		public void rawListener(BrokerIncomingEvent event) {}
+
+		@BrokerEventListener("my-source")
+		public void wildcardListener(BrokerIncomingEvent<?> event) {}
 
 		public void notAListener() {}
 	}

--- a/api/src/test/java/org/openmrs/event/broker/BrokerEventListenerTest.java
+++ b/api/src/test/java/org/openmrs/event/broker/BrokerEventListenerTest.java
@@ -53,43 +53,37 @@ public class BrokerEventListenerTest extends BaseContextSensitiveTest {
 	
 	@Test
 	public void shouldReceiveEventWhenSourceAndBrokerMatch() {
-		BrokerIncomingEvent event = new BrokerIncomingEvent();
-		event.setSource("test-source");
-		event.setBroker("test-broker");
-		
+		BrokerIncomingEvent<String> event = new BrokerIncomingEvent<>("payload", "test-source", "test-broker");
+
 		eventPublisher.publishEvent(event);
-		
+
 		assertThat(testListener.getReceivedEvents(), hasItem(event));
 	}
-	
+
 	@Test
 	public void shouldFilterOutEventWhenSourceDoesNotMatch() {
-		BrokerIncomingEvent event = new BrokerIncomingEvent();
-		event.setSource("wrong-source");
-		event.setBroker("test-broker");
-		
+		BrokerIncomingEvent<String> event = new BrokerIncomingEvent<>("payload", "wrong-source", "test-broker");
+
 		eventPublisher.publishEvent(event);
-		
+
 		assertThat(testListener.getReceivedEvents(), is(empty()));
 	}
-	
+
 	@Test
 	public void shouldFilterOutEventWhenBrokerDoesNotMatch() {
-		BrokerIncomingEvent event = new BrokerIncomingEvent();
-		event.setSource("test-source");
-		event.setBroker("wrong-broker");
-		
+		BrokerIncomingEvent<String> event = new BrokerIncomingEvent<>("payload", "test-source", "wrong-broker");
+
 		eventPublisher.publishEvent(event);
-		
+
 		assertThat(testListener.getReceivedEvents(), is(empty()));
 	}
-	
+
 	@Component
 	public static class TestListener {
 		private final List<BrokerIncomingEvent> receivedEvents = new ArrayList<>();
-		
+
 		@BrokerEventListener(value = "test-source", broker = "test-broker")
-		public void handleEvent(BrokerIncomingEvent event) {
+		public void handleEvent(BrokerIncomingEvent<String> event) {
 			receivedEvents.add(event);
 		}
 		

--- a/api/src/test/java/org/openmrs/event/outbox/OutboxEventIT.java
+++ b/api/src/test/java/org/openmrs/event/outbox/OutboxEventIT.java
@@ -58,7 +58,7 @@ public class OutboxEventIT extends BaseContextSensitiveNonTransactionalTest {
 		adminService.saveGlobalProperty(new GlobalProperty("eventPublished", "false"));
 		testEventPublisherService.clearOutbox();
 		testOutboxEventListener.clearCapturedEvents();
-		outboxTaskSchedulerInitializer.afterSingletonsInstantiated();
+		outboxTaskSchedulerInitializer.schedule();
 	}
 	
 	@Test


### PR DESCRIPTION
## Summary

Backport of #6298 to the 2.9.x branch, adapted to the 2.9.x platform (`javax.persistence` / Hibernate 5 / Spring 5, unlike master's jakarta / Hibernate 6 / Spring 6). Addresses findings 1, 2, 4, 5, and 7 from the events/CDC sign-off issue #6289.

Because master and 2.9.x have diverged on these files, this is not a clean cherry-pick — each finding's intent was reapplied on top of 2.9.x's actual code.

- **Finding 1 — Outbox poller never starts for module listeners:** `OutboxEventRegistry` now owns the scheduler lifecycle. After scanning listener beans it calls `OutboxTaskSchedulerInitializer.schedule()`/`deleteScheduledTasks()`, guaranteeing the poller only starts once listeners are known. `OutboxTaskSchedulerInitializer` no longer implements `SmartInitializingSingleton` and no longer references `OutboxEventRegistry`. This fixes the real bug on 2.9.x, where both beans were `SmartInitializingSingleton` with undefined ordering.

- **Finding 2 — `ClassNotFoundException` for module-defined event types:** `Class.forName(...)` → `Context.loadClass(...)` in `OutboxPollingTaskHandler` so the `OpenmrsClassLoader` resolves module classes.

- **Finding 4 — `outbox_event.payload` overflows at 64 KB:** `payload` and `completed_listeners` changed from `TEXT` to `MEDIUMTEXT` in `liquibase-update-to-latest-2.9.x.xml` and the `OutboxEvent` entity `columnDefinition`. `HibernateAdministrationDAO.getMaximumPropertyLength` now treats `LONGTEXT`/`MEDIUMTEXT` columns as unbounded so `ValidateUtil` accepts large payloads (adapted to Hibernate 5's `getColumnIterator()` + `int` return; 2.9.x previously had no `LONGTEXT` handling at all).

- **Finding 5 — `BrokerIncomingEvent<?>` dead-letters every message:** `BrokerEventListenerFactory` now throws `IllegalArgumentException` at registration time when a `@BrokerEventListener` uses a wildcard or raw `BrokerIncomingEvent`.

- **Finding 7 — Listener exception aborts service call (documented as intentional):** Javadoc on `OpenmrsServiceEventAdvice` clarifying that a synchronous `@EventListener` exception propagating out and aborting the service call is by design.

## Differences from the master PR

- **Skipped `liquibase-schema-only-2.9.x.xml`** — that generated snapshot does not exist on 2.9.x yet (latest is 2.8.x); it's a release-time artifact.
- **Skipped the incidental `BrokerIncomingEvent`/`BrokerOutgoingEvent` javadoc tweaks** — 2.9.x already has richer, accurate `JacksonConfig` docs there.
- **Added a fix master missed:** updated a now-broken `{@link ...#afterSingletonsInstantiated()}` javadoc in `Context.java` to `#schedule()`.
- **Added test coverage** for the DAO MEDIUMTEXT-unbounded branch (`HibernateAdministrationDAOTest`), which also verifies Hibernate 5's `Column.getSqlType()` returns the `columnDefinition` string.

## Test plan

- [x] `HibernateAdministrationDAOTest` (incl. new MEDIUMTEXT-unbounded + bounded-column tests)
- [x] `BaseAttributeTypeValidatorTest` (regression: 64 KB `TEXT` limit still enforced)
- [x] `BrokerEventListenerFactoryTest` (incl. raw + wildcard fail-fast)
- [x] `BrokerEventListenerTest`
- [x] `OutboxEventIT` (full integration of Findings 1 & 2)

## Related

Backport of #6298. Partially addresses #6289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)