### PR TITLE
TRUNK-6675: Module is not updated when omod changes (forward-port to master)

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -438,27 +438,29 @@ public class ModuleClassLoader extends URLClassLoader {
 			long moduleLastModified = module.getFile().lastModified();
 			File moduleLastModifiedFile = new File(tmpModuleDir, ".moduleLastModified");
 
+			boolean deleted = true;
 			if (Context.isOptimizedStartup() && moduleLastModifiedFile.exists()) {
 				// Re-create tmpModuleDir if module changed
 				try {
 					String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
 					if (!Long.valueOf(savedLastModified).equals(moduleLastModified)) {
 						log.debug("Deleting {} since the module was modified", tmpModuleDir.getAbsolutePath());
-						tmpModuleDir.delete();
+						deleted = deleteLibCacheDir(tmpModuleDir, module.getModuleId());
 					}
 				} catch (IOException | NumberFormatException e) {
 					log.warn("Error while reading module last modified file: {}", moduleLastModifiedFile, e);
+					deleted = deleteLibCacheDir(tmpModuleDir, module.getModuleId());
 				}
 			} else {
 				log.debug("Optimized startup disabled or {} does not exist, deleting {}", moduleLastModifiedFile,
 				    tmpModuleDir);
-				tmpModuleDir.delete();
+				deleted = deleteLibCacheDir(tmpModuleDir, module.getModuleId());
 			}
 
 			tmpModuleDir.mkdirs();
 			libCacheFolders.put(module.getModuleId(), tmpModuleDir);
 
-			if (moduleLastModified != 0L) {
+			if (deleted && moduleLastModified != 0L) {
 				try {
 					FileUtils.writeStringToFile(moduleLastModifiedFile, moduleLastModified + "", Charset.defaultCharset());
 				} catch (IOException e) {
@@ -467,6 +469,16 @@ public class ModuleClassLoader extends URLClassLoader {
 			}
 
 			return tmpModuleDir;
+		}
+	}
+
+	private static boolean deleteLibCacheDir(File dir, String moduleId) {
+		try {
+			FileUtils.deleteDirectory(dir);
+			return true;
+		} catch (IOException e) {
+			log.warn("Failed to delete lib cache dir {} for module {}", dir, moduleId, e);
+			return false;
 		}
 	}
 

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -9,18 +9,26 @@
  */
 package org.openmrs.module;
 
+import java.io.File;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.OpenmrsClassLoader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -458,6 +466,95 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 
 		assertFalse(ModuleClassLoader.isMatchingConditionalResource(mockModuleV2_0, fileUrl, conditionalResource),
 		    "Path should not match glob pattern: " + filePath);
+	}
+
+	@Test
+	public void getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenModuleChanged() throws Exception {
+		File tempLibCache = Files.createTempDirectory("libcache-test").toFile();
+		Field libCacheFolderField = OpenmrsClassLoader.class.getDeclaredField("libCacheFolder");
+		libCacheFolderField.setAccessible(true);
+		File savedLibCacheFolder = (File) libCacheFolderField.get(null);
+		libCacheFolderField.set(null, tempLibCache);
+
+		Field libCacheFoldersField = ModuleClassLoader.class.getDeclaredField("libCacheFolders");
+		libCacheFoldersField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, File> libCacheFolders = (Map<String, File>) libCacheFoldersField.get(null);
+
+		Properties savedRuntimeProperties = Context.getRuntimeProperties();
+		File omodFile = File.createTempFile("testmodule", ".omod");
+		try {
+			Properties props = Context.getRuntimeProperties();
+			props.setProperty("optimized.startup", "true");
+			Context.setRuntimeProperties(props);
+
+			long currentTimestamp = System.currentTimeMillis();
+			omodFile.setLastModified(currentTimestamp);
+
+			Module module = new Module("testmodule", "testmodule", "org.openmrs.module.testmodule",
+				"author", "description", "1.0", "1.0");
+			module.setFile(omodFile);
+
+			File moduleDir = new File(tempLibCache, "testmodule");
+			moduleDir.mkdirs();
+			FileUtils.writeStringToFile(new File(moduleDir, ".moduleLastModified"),
+				String.valueOf(currentTimestamp - 1000), Charset.defaultCharset());
+			File staleFile = new File(moduleDir, "old-resource.txt");
+			FileUtils.writeStringToFile(staleFile, "stale content", Charset.defaultCharset());
+
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertFalse(staleFile.exists(), "Stale file should be deleted when module changes");
+			assertTrue(moduleDir.exists(), "Module dir should be recreated");
+		} finally {
+			Context.setRuntimeProperties(savedRuntimeProperties);
+			libCacheFolderField.set(null, savedLibCacheFolder);
+			libCacheFolders.remove("testmodule");
+			omodFile.delete();
+			FileUtils.deleteDirectory(tempLibCache);
+		}
+	}
+
+	@Test
+	public void getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenOptimizedStartupDisabled() throws Exception {
+		File tempLibCache = Files.createTempDirectory("libcache-test").toFile();
+		Field libCacheFolderField = OpenmrsClassLoader.class.getDeclaredField("libCacheFolder");
+		libCacheFolderField.setAccessible(true);
+		File savedLibCacheFolder = (File) libCacheFolderField.get(null);
+		libCacheFolderField.set(null, tempLibCache);
+
+		Field libCacheFoldersField = ModuleClassLoader.class.getDeclaredField("libCacheFolders");
+		libCacheFoldersField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, File> libCacheFolders = (Map<String, File>) libCacheFoldersField.get(null);
+
+		Properties savedRuntimeProperties = Context.getRuntimeProperties();
+		File omodFile = File.createTempFile("testmodule2", ".omod");
+		try {
+			Module module = new Module("testmodule2", "testmodule2", "org.openmrs.module.testmodule2",
+				"author", "description", "1.0", "1.0");
+			module.setFile(omodFile);
+
+			File moduleDir = new File(tempLibCache, "testmodule2");
+			moduleDir.mkdirs();
+			File staleFile = new File(moduleDir, "old-resource.txt");
+			FileUtils.writeStringToFile(staleFile, "stale content", Charset.defaultCharset());
+
+			Properties props = Context.getRuntimeProperties();
+			props.setProperty("optimized.startup", "false");
+			Context.setRuntimeProperties(props);
+
+			ModuleClassLoader.getLibCacheFolderForModule(module);
+
+			assertFalse(staleFile.exists(), "Stale file should be deleted when optimized startup is disabled");
+			assertTrue(moduleDir.exists(), "Module dir should be recreated");
+		} finally {
+			Context.setRuntimeProperties(savedRuntimeProperties);
+			libCacheFolderField.set(null, savedLibCacheFolder);
+			libCacheFolders.remove("testmodule2");
+			omodFile.delete();
+			FileUtils.deleteDirectory(tempLibCache);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Forward-port of #6257 to `master`. #6257 was merged into `2.9.x` only, so `master` (3.0.0-SNAPSHOT) still carries the original bug and would regress relative to 2.9.0.

The fix, in `ModuleClassLoader.getLibCacheFolderForModule`:

- Replaces `tmpModuleDir.delete()` with a new `deleteLibCacheDir(...)` helper that uses `FileUtils.deleteDirectory(...)`. `File.delete()` silently no-ops on a non-empty directory, so when a module's omod changed, its stale lib-cache directory was never recreated — the "module is not updated when the omod changes" symptom.
- Guards the `.moduleLastModified` write on a successful delete (`if (deleted && moduleLastModified != 0L)`), so a failed deletion doesn't mask the problem on the next restart.
- Logs an accurate message when directory deletion fails, rather than the misleading "Error while reading module last modified file".

## Notes

Cherry-pick of `918f05117` (the #6257 merge commit) onto master. The only conflicts were cosmetic: master wraps one `log.debug` line with tab+spaces and keeps static imports at the bottom of the test file, whereas 2.9.x used tabs and top-of-file imports. Resolved by keeping master's formatting; the fix logic is byte-for-byte identical to what merged on 2.9.x.

## Test plan

- [x] `ModuleClassLoaderTest` (41 tests, incl. the new `getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenModuleChanged` and the delete/last-modified coverage added by #6257)

## Related

Forward-port of #6257. Originally merged to `2.9.x` as `918f05117`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)