### PR TITLE
Fix spotless formatting violation in ModuleClassLoaderTest

### DIFF
--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -491,14 +491,14 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 			long currentTimestamp = System.currentTimeMillis();
 			omodFile.setLastModified(currentTimestamp);
 
-			Module module = new Module("testmodule", "testmodule", "org.openmrs.module.testmodule",
-				"author", "description", "1.0", "1.0");
+			Module module = new Module("testmodule", "testmodule", "org.openmrs.module.testmodule", "author", "description",
+			        "1.0", "1.0");
 			module.setFile(omodFile);
 
 			File moduleDir = new File(tempLibCache, "testmodule");
 			moduleDir.mkdirs();
-			FileUtils.writeStringToFile(new File(moduleDir, ".moduleLastModified"),
-				String.valueOf(currentTimestamp - 1000), Charset.defaultCharset());
+			FileUtils.writeStringToFile(new File(moduleDir, ".moduleLastModified"), String.valueOf(currentTimestamp - 1000),
+			    Charset.defaultCharset());
 			File staleFile = new File(moduleDir, "old-resource.txt");
 			FileUtils.writeStringToFile(staleFile, "stale content", Charset.defaultCharset());
 
@@ -531,8 +531,8 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		Properties savedRuntimeProperties = Context.getRuntimeProperties();
 		File omodFile = File.createTempFile("testmodule2", ".omod");
 		try {
-			Module module = new Module("testmodule2", "testmodule2", "org.openmrs.module.testmodule2",
-				"author", "description", "1.0", "1.0");
+			Module module = new Module("testmodule2", "testmodule2", "org.openmrs.module.testmodule2", "author",
+			        "description", "1.0", "1.0");
 			module.setFile(omodFile);
 
 			File moduleDir = new File(tempLibCache, "testmodule2");


### PR DESCRIPTION
## Summary

`spotless:check` currently fails on `master` for `api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java`. Because spotless runs over the whole `openmrs-api` module during the build's `Install dependencies` step, this blocks CI for **every** pull request that touches openmrs-api (e.g. #6315), not just changes to that file.

The violation was introduced by the forward-port of #6257 (PR #6314): the merge-conflict resolution kept a line-wrapping style (broken before `"author", "description"` / before `String.valueOf(...)`) that spotless does not accept.

This reformats the affected lines in `getLibCacheFolderForModule_shouldRecreateNonEmptyDirWhenModuleChanged` and the adjacent test to spotless's canonical output. No logic changes.

## Test plan

- [x] `mvn -pl api spotless:check` passes
- [x] Change is whitespace-only (line wrapping); no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)