### PR TITLE
Require privileges for unprotected CohortService methods

### DIFF
--- a/api/src/main/java/org/openmrs/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/api/CohortService.java
@@ -150,6 +150,7 @@ public interface CohortService extends OpenmrsService {
 	 * @return list of cohorts matching the name fragment
 	 * @throws APIException
 	 */
+	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
 	public List<Cohort> getCohorts(String nameFragment) throws APIException;
 
 	/**

--- a/api/src/main/java/org/openmrs/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/api/CohortService.java
@@ -78,6 +78,7 @@ public interface CohortService extends OpenmrsService {
 	 * @param cohort the Cohort to completely remove from the database
 	 * @throws APIException
 	 */
+	@Authorized({ PrivilegeConstants.PURGE_COHORTS })
 	public Cohort purgeCohort(Cohort cohort) throws APIException;
 
 	/**

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -123,6 +123,17 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 	 * @see CohortService#purgeCohort(Cohort)
 	 */
 	@Test
+	public void purgeCohort_shouldFailIfUserDoesNotHaveThePurgeCohortsPrivilege() {
+		executeDataSet(COHORT_XML);
+		Cohort cohort = service.getAllCohorts(true).get(0);
+		Context.logout();
+		assertThrows(APIAuthenticationException.class, () -> service.purgeCohort(cohort));
+	}
+
+	/**
+	 * @see CohortService#purgeCohort(Cohort)
+	 */
+	@Test
 	public void purgeCohort_shouldDeleteCohortFromDatabase() {
 		executeDataSet(COHORT_XML);
 		List<Cohort> allCohorts = service.getAllCohorts(true);

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -28,6 +28,7 @@ import org.openmrs.util.PrivilegeConstants;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -130,7 +131,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		Context.logout();
 		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
 		    () -> service.purgeCohort(cohort));
-		assertTrue(exception.getMessage().contains(PrivilegeConstants.PURGE_COHORTS));
+		assertThat(exception.getMessage(), containsString(PrivilegeConstants.PURGE_COHORTS));
 	}
 
 	/**
@@ -171,7 +172,7 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		Context.logout();
 		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
 		    () -> service.getCohorts("Example"));
-		assertTrue(exception.getMessage().contains(PrivilegeConstants.GET_PATIENT_COHORTS));
+		assertThat(exception.getMessage(), containsString(PrivilegeConstants.GET_PATIENT_COHORTS));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -163,6 +163,16 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 	 * @see CohortService#getCohorts(String)
 	 */
 	@Test
+	public void getCohorts_shouldFailIfUserDoesNotHaveTheGetPatientCohortsPrivilege() {
+		executeDataSet(COHORT_XML);
+		Context.logout();
+		assertThrows(APIAuthenticationException.class, () -> service.getCohorts("Example"));
+	}
+
+	/**
+	 * @see CohortService#getCohorts(String)
+	 */
+	@Test
 	public void getCohorts_shouldBeCaseInsensitive() {
 		executeDataSet(COHORT_XML);
 

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -24,6 +24,7 @@ import org.openmrs.Patient;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.PrivilegeConstants;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -127,7 +128,9 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		executeDataSet(COHORT_XML);
 		Cohort cohort = service.getAllCohorts(true).get(0);
 		Context.logout();
-		assertThrows(APIAuthenticationException.class, () -> service.purgeCohort(cohort));
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> service.purgeCohort(cohort));
+		assertTrue(exception.getMessage().contains(PrivilegeConstants.PURGE_COHORTS));
 	}
 
 	/**
@@ -166,7 +169,9 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 	public void getCohorts_shouldFailIfUserDoesNotHaveTheGetPatientCohortsPrivilege() {
 		executeDataSet(COHORT_XML);
 		Context.logout();
-		assertThrows(APIAuthenticationException.class, () -> service.getCohorts("Example"));
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> service.getCohorts("Example"));
+		assertTrue(exception.getMessage().contains(PrivilegeConstants.GET_PATIENT_COHORTS));
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Two methods on `CohortService` were missing the `@Authorized` annotation that guards the rest of the service.

**`purgeCohort(Cohort)`** permanently removes a cohort from the database (not reversible), but unlike every other mutating method on the service it had no `@Authorized` annotation. `voidCohort` (the reversible delete) requires `Delete Cohorts` and `purgeCohortMembership` requires `Edit Cohorts`, yet `purgeCohort` required nothing. A user holding only `Get Patient Cohorts` could therefore permanently delete any cohort through the REST purge path, `DELETE /ws/rest/v1/cohort/{uuid}?purge=true`. A dedicated `Purge Cohorts` privilege already exists in `PrivilegeConstants` but was never applied to this method.

**`getCohorts(String)`** was the only read on the service with no `@Authorized`, reading straight from the DAO while every sibling getter (`getCohort`, `getCohortByName`, `getAllCohorts`, `getCohortByUuid`, and so on) requires `Get Patient Cohorts`. A direct service-layer caller could therefore list cohorts (names, descriptions, member patient ids) with no authorization. The REST search path `GET /ws/rest/v1/cohort?q=` was only covered incidentally, by the resource's required-get privilege being enforced at representation-conversion time, not by the service itself.

### Change
- Annotate `purgeCohort` with `@Authorized({ PrivilegeConstants.PURGE_COHORTS })`.
- Annotate `getCohorts(String)` with `@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })`.
- Add regression tests asserting each method throws `APIAuthenticationException` for a caller without the privilege, so dropping either annotation fails the build instead of silently reopening the gap.

### Notes
The REST layer in `openmrs-module-webservices.rest` adds no authorization of its own for the purge path, so the check belongs here at the service layer. Addresses private advisory GHSA-4w59-mg6c-76ch.
