### PR TITLE
Require Get Patient Programs privilege for by-uuid program lookups

### DIFF
--- a/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
+++ b/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
@@ -594,6 +594,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	@Authorized({ "Get Patient Programs" })
 	public PatientProgramAttribute getPatientProgramAttributeByUuid(String var1);
 
+	@Authorized({ PrivilegeConstants.GET_PATIENT_PROGRAMS })
 	public Map<Object, Object> getPatientProgramAttributeByAttributeName(List<Integer> patients, String attributeName);
 
 	@Transactional(readOnly = true)

--- a/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
+++ b/api/src/main/java/org/openmrs/api/ProgramWorkflowService.java
@@ -232,6 +232,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @param uuid the universally unique identifier
 	 * @return the program which matches the given uuid
 	 */
+	@Authorized({ PrivilegeConstants.GET_PATIENT_PROGRAMS })
 	public PatientState getPatientStateByUuid(String uuid);
 
 	/**
@@ -506,6 +507,7 @@ public interface ProgramWorkflowService extends OpenmrsService {
 	 * @param uuid the universally unique identifier
 	 * @return the patient program which matches the given uuid
 	 */
+	@Authorized({ PrivilegeConstants.GET_PATIENT_PROGRAMS })
 	public PatientProgram getPatientProgramByUuid(String uuid);
 
 	/**

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -468,6 +468,21 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * @see ProgramWorkflowService#getPatientProgramByUuid(String)
+	 */
+	@Test
+	public void getPatientProgramByUuid_shouldFailIfUserHasNoGetPatientProgramsPrivilege() {
+		// a valid uuid so the missing privilege is the only possible reason for failure
+		String uuid = "2edf272c-bf05-4208-9f93-2fa213ed0415";
+
+		// log out so the context no longer holds the Get Patient Programs privilege
+		Context.logout();
+
+		assertThrows(APIAuthenticationException.class,
+		    () -> Context.getProgramWorkflowService().getPatientProgramByUuid(uuid));
+	}
+
+	/**
 	 * @see ProgramWorkflowService#getPatientStateByUuid(String)
 	 */
 	@Test
@@ -483,6 +498,21 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 	@Test
 	public void getPatientStateByUuid_shouldReturnNullIfNoObjectFoundWithGivenUuid() {
 		assertNull(Context.getProgramWorkflowService().getPatientStateByUuid("some invalid uuid"));
+	}
+
+	/**
+	 * @see ProgramWorkflowService#getPatientStateByUuid(String)
+	 */
+	@Test
+	public void getPatientStateByUuid_shouldFailIfUserHasNoGetPatientProgramsPrivilege() {
+		// a valid uuid so the missing privilege is the only possible reason for failure
+		String uuid = "ea89deaa-23cc-4840-92fe-63d199c37e4c";
+
+		// log out so the context no longer holds the Get Patient Programs privilege
+		Context.logout();
+
+		assertThrows(APIAuthenticationException.class,
+		    () -> Context.getProgramWorkflowService().getPatientStateByUuid(uuid));
 	}
 
 	/**
@@ -764,6 +794,22 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 		int totalAttributeTypes = pws.getAllProgramAttributeTypes().size();
 		pws.purgeProgramAttributeType(programAttributeType);
 		assertEquals((totalAttributeTypes - 1), pws.getAllProgramAttributeTypes().size());
+	}
+
+	/**
+	 * @see ProgramWorkflowService#getPatientProgramAttributeByAttributeName(List, String)
+	 */
+	@Test
+	public void getPatientProgramAttributeByAttributeName_shouldFailIfUserHasNoGetPatientProgramsPrivilege() {
+		// valid arguments so the missing privilege is the only possible reason for failure
+		List<Integer> patients = Arrays.asList(2);
+		String attributeName = "ProgramId";
+
+		// log out so the context no longer holds the Get Patient Programs privilege
+		Context.logout();
+
+		assertThrows(APIAuthenticationException.class,
+		    () -> Context.getProgramWorkflowService().getPatientProgramAttributeByAttributeName(patients, attributeName));
 	}
 
 	@Test


### PR DESCRIPTION
### Summary
`ProgramWorkflowService.getPatientProgramByUuid(String)` and `getPatientStateByUuid(String)` carry no `@Authorized` annotation. OpenMRS enforces service authorization in `AuthorizationAdvice.before()`, which only checks when the method declares at least one privilege; a method with none falls through with no check, not even an authentication requirement. So any authenticated user (and, per the advice logic, effectively any caller reaching the service) can read patient program-enrollment data by uuid.

Every other read on the service already requires `Get Patient Programs`, including `getPatientProgram(Integer)`, `getPatientProgram(...)`, and the other lookups.

### Change
Annotate both by-uuid methods with `@Authorized({ PrivilegeConstants.GET_PATIENT_PROGRAMS })`, matching the existing reads.

### Notes
Addresses private advisory GHSA-gqf9-38mg-wgqg.