### PR TITLE
Use PipeParser for inbound HL7 to remove XML/XXE attack surface (2.8.x backport of #6223)

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -41,7 +41,7 @@ import ca.uhn.hl7v2.model.v25.datatype.XPN;
 import ca.uhn.hl7v2.model.v25.segment.NK1;
 import ca.uhn.hl7v2.model.v25.segment.PID;
 import ca.uhn.hl7v2.parser.EncodingNotSupportedException;
-import ca.uhn.hl7v2.parser.GenericParser;
+import ca.uhn.hl7v2.parser.Parser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.Location;
@@ -88,7 +88,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 	
 	protected HL7DAO dao;
 	
-	private GenericParser parser;
+	private Parser parser;
 	
 	private MessageTypeRouter router;
 
@@ -105,7 +105,7 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 	 *
 	 * @param parser the parser to use
 	 */
-	public void setParser(GenericParser parser) {
+	public void setParser(Parser parser) {
 		this.parser = parser;
 	}
 	

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -295,7 +295,10 @@
 	<bean id="hL7ServiceTarget" class="org.openmrs.hl7.impl.HL7ServiceImpl">
 		<property name="HL7DAO" ref="hL7DAO"/>
 		<property name="parser">
-			<bean class="ca.uhn.hl7v2.parser.GenericParser"/>
+			<!-- PipeParser (ER7 only), not GenericParser: rejects XML-encoded payloads outright
+			     rather than routing them to HAPI's XML parser, which can expose XXE (external file
+			     reads, SSRF, entity-expansion DoS) when its JAXP factory is not hardened. -->
+			<bean class="ca.uhn.hl7v2.parser.PipeParser"/>
 		</property>
 		<property name="router">
 			<bean class="ca.uhn.hl7v2.app.MessageTypeRouter"/>

--- a/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
+++ b/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
@@ -186,6 +186,28 @@ public class HL7ServiceTest extends BaseContextSensitiveTest {
 		                + "OBX|2|DT|5096^RETURN VISIT DATE^99DCT||20080229|||||||||20080212");
 		assertNotNull(message);
 	}
+
+	/**
+	 * The {@code hL7Parser} bean is a {@link ca.uhn.hl7v2.parser.PipeParser} (not a
+	 * {@code GenericParser}), so an XML-encoded payload is rejected outright with an unsupported
+	 * encoding error instead of being routed to HAPI's XML parser, which can expose XML external entity
+	 * (XXE) processing when its underlying JAXP factory is not hardened. This guards against a
+	 * regression that reintroduces XML parsing of inbound HL7. The DOCTYPE/external entity below is
+	 * never resolved because the message is refused before any XML processing occurs.
+	 *
+	 * @see HL7Service#parseHL7String(String)
+	 */
+	@Test
+	public void parseHL7String_shouldRejectXmlEncodedMessages() {
+		HL7Service hl7service = Context.getHL7Service();
+		String xmlHl7 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+		        + "<!DOCTYPE ORU_R01 [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>\n"
+		        + "<ORU_R01 xmlns=\"urn:hl7-org:v2xml\">\n" + "  <MSH><MSH.1>|</MSH.1><MSH.2>^~\\&amp;</MSH.2></MSH>\n"
+		        + "  <PID><PID.5><XPN.1>&xxe;</XPN.1></PID.5></PID>\n" + "</ORU_R01>";
+		HL7Exception thrown = assertThrows(HL7Exception.class, () -> hl7service.parseHL7String(xmlHl7));
+		assertEquals("HL7 encoding not supported", thrown.getMessage());
+	}
+
 	
 	/**
 	 * @see HL7Service#processHL7Message(Message)


### PR DESCRIPTION
Backport of #6223 to the 2.8.x maintenance line.

The `hL7Parser` bean on 2.8.x is a HAPI `GenericParser`, which routes XML-encoded payloads to HAPI's XML parser. On hapi-base 2.1 that parser builds an `LSParser` with no XXE hardening, so an XML message with a DOCTYPE/external entity yields XXE (local file reads, SSRF, entity-expansion DoS). Inbound HL7 parsing runs before the authorization check, so the surface is reachable without authentication.

master removed this in #6223; 2.7.x/2.8.x/2.9.x still ship the `GenericParser` bean.

Switches the bean to `PipeParser` (ER7 only), which rejects XML outright before any XML processing; widens `HL7ServiceImpl.parser` to the `Parser` supertype so the XML setter injection still resolves; adds a regression test.

Addresses GHSA-27xq-2wmf-6hpg and GHSA-2h4h-2mf9-836w on 2.8.x.