### PR TITLE
Require privileges for unprotected CohortService methods (backport to 2.9.x)

### DIFF
--- a/api/src/main/java/org/openmrs/api/CohortService.java
+++ b/api/src/main/java/org/openmrs/api/CohortService.java
@@ -75,6 +75,7 @@ public interface CohortService extends OpenmrsService {
 	 * @throws APIException
 	 * <strong>Should</strong> delete cohort from database
 	 */
+	@Authorized({ PrivilegeConstants.PURGE_COHORTS })
 	public Cohort purgeCohort(Cohort cohort) throws APIException;
 	
 	/**
@@ -141,6 +142,7 @@ public interface CohortService extends OpenmrsService {
 	 * <strong>Should</strong> never return null
 	 * <strong>Should</strong> match cohorts by partial name
 	 */
+	@Authorized({ PrivilegeConstants.GET_PATIENT_COHORTS })
 	public List<Cohort> getCohorts(String nameFragment) throws APIException;
 	
 	/**

--- a/api/src/test/java/org/openmrs/api/CohortServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/CohortServiceTest.java
@@ -11,6 +11,7 @@ package org.openmrs.api;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -34,6 +35,7 @@ import org.openmrs.Patient;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Tests methods in the CohortService class TODO add all the rest of the tests
@@ -122,6 +124,19 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 	 * @see CohortService#purgeCohort(Cohort)
 	 */
 	@Test
+	public void purgeCohort_shouldFailIfUserDoesNotHaveThePurgeCohortsPrivilege() {
+		executeDataSet(COHORT_XML);
+		Cohort cohort = service.getAllCohorts(true).get(0);
+		Context.logout();
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> service.purgeCohort(cohort));
+		assertThat(exception.getMessage(), containsString(PrivilegeConstants.PURGE_COHORTS));
+	}
+
+	/**
+	 * @see CohortService#purgeCohort(Cohort)
+	 */
+	@Test
 	public void purgeCohort_shouldDeleteCohortFromDatabase() {
 		executeDataSet(COHORT_XML);
 		List<Cohort> allCohorts = service.getAllCohorts(true);
@@ -145,6 +160,18 @@ public class CohortServiceTest extends BaseContextSensitiveTest {
 		assertEquals(2, matchedCohorts.size());
 		matchedCohorts = service.getCohorts("Examples");
 		assertEquals(0, matchedCohorts.size());
+	}
+
+	/**
+	 * @see CohortService#getCohorts(String)
+	 */
+	@Test
+	public void getCohorts_shouldFailIfUserDoesNotHaveTheGetPatientCohortsPrivilege() {
+		executeDataSet(COHORT_XML);
+		Context.logout();
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> service.getCohorts("Example"));
+		assertThat(exception.getMessage(), containsString(PrivilegeConstants.GET_PATIENT_COHORTS));
 	}
 
 	/**


### PR DESCRIPTION
Backport of #6317 to the 2.9.x release line.

`CohortService.purgeCohort` (permanent, irreversible cohort deletion) and `CohortService.getCohorts(String)` (cohort search) both lacked the `@Authorized` annotation that guards every other mutating and read method on the service, so they were reachable with no privilege check: `purgeCohort` via `DELETE /ws/rest/v1/cohort/{uuid}?purge=true`, and `getCohorts` via `GET /ws/rest/v1/cohort?q=`. This applies the `Purge Cohorts` and `Get Patient Cohorts` privileges respectively, matching the rest of the service, and adds regression tests asserting each gate. Addresses private advisory GHSA-4w59-mg6c-76ch.

Cherry-picked from d8fe1365fbce0b4d3fc43045dff3b69ce58ca2f4 on master; the only backport adjustment was reconciling the test file's import block with the 2.9.x import ordering.
