### PR TITLE
Require allergy privileges for getAllergies and setAllergies

### DIFF
--- a/api/src/main/java/org/openmrs/api/PatientService.java
+++ b/api/src/main/java/org/openmrs/api/PatientService.java
@@ -788,6 +788,7 @@ public interface PatientService extends OpenmrsService {
 	 * @param patient the patient
 	 * @return the allergies object
 	 */
+	@Authorized({ PrivilegeConstants.GET_ALLERGIES })
 	Allergies getAllergies(Patient patient);
 
 	/**
@@ -815,6 +816,7 @@ public interface PatientService extends OpenmrsService {
 	 * @param allergies the allergies
 	 * @return the saved allergies
 	 */
+	@Authorized({ PrivilegeConstants.ADD_ALLERGIES, PrivilegeConstants.EDIT_ALLERGIES })
 	Allergies setAllergies(Patient patient, Allergies allergies);
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/CohortServiceImpl.java
@@ -242,8 +242,15 @@ public class CohortServiceImpl extends BaseOpenmrsService implements CohortServi
 	 */
 	@Override
 	public void notifyPatientVoided(Patient patient) throws APIException {
-		List<CohortMembership> memberships = Context.getCohortService().getCohortMemberships(patient.getPatientId(), null,
-		    false);
+		// this membership read is internal bookkeeping done while a patient is being voided; acquire
+		// the read privilege on the voiding user's behalf rather than requiring them to hold it
+		List<CohortMembership> memberships;
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.GET_PATIENT_COHORTS);
+			memberships = Context.getCohortService().getCohortMemberships(patient.getPatientId(), null, false);
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_PATIENT_COHORTS);
+		}
 		memberships.forEach(m -> {
 			m.setVoided(patient.getVoided());
 			m.setDateVoided(patient.getDateVoided());

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -747,8 +747,18 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		// so moving a duplicate would make the survivor's allergy list fail to load afterwards
 		// TODO: this should be a copy, not a move
 		PatientService patientService = Context.getPatientService();
-		Allergies preferredAllergies = patientService.getAllergies(preferred);
-		for (Allergy allergy : patientService.getAllergies(notPreferred)) {
+		// these are internal reads made on behalf of the merge; mergePatients is authorized with
+		// Edit Patients, so acquire Get Allergies here rather than forcing the merging user to hold it
+		Allergies preferredAllergies;
+		Allergies notPreferredAllergies;
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.GET_ALLERGIES);
+			preferredAllergies = patientService.getAllergies(preferred);
+			notPreferredAllergies = patientService.getAllergies(notPreferred);
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_ALLERGIES);
+		}
+		for (Allergy allergy : notPreferredAllergies) {
 			if (preferredAllergies.containsAllergen(allergy)) {
 				log.debug("Skipping allergy {}; preferred patient {} already has the same allergen", allergy.getAllergyId(),
 				    preferred.getPatientId());

--- a/api/src/main/java/org/openmrs/validator/AllergyValidator.java
+++ b/api/src/main/java/org/openmrs/validator/AllergyValidator.java
@@ -16,7 +16,9 @@ import org.openmrs.Allergies;
 import org.openmrs.Allergy;
 import org.openmrs.annotation.Handler;
 import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.util.PrivilegeConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
@@ -87,7 +89,16 @@ public class AllergyValidator implements Validator {
 			}
 
 			if (allergy.getAllergyId() == null && allergy.getPatient() != null) {
-				Allergies existingAllergies = patientService.getAllergies(allergy.getPatient());
+				// this duplicate-allergen check is an internal read done while saving the allergy; a
+				// user with an allergy write privilege should not additionally need Get Allergies for
+				// it, so acquire the read privilege on their behalf
+				Allergies existingAllergies;
+				try {
+					Context.addProxyPrivilege(PrivilegeConstants.GET_ALLERGIES);
+					existingAllergies = patientService.getAllergies(allergy.getPatient());
+				} finally {
+					Context.removeProxyPrivilege(PrivilegeConstants.GET_ALLERGIES);
+				}
 				if (existingAllergies.containsAllergen(allergy)) {
 					String key = "ui.i18n.Concept.name." + allergen.getCodedAllergen().getUuid();
 					String name = messageSourceService.getMessage(key);

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -3702,4 +3702,35 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertThrows(APIAuthenticationException.class, () -> patientService.setAllergies(patient, allergies));
 	}
 
+	/**
+	 * Now that {@code getAllergies} requires the Get Allergies privilege,
+	 * {@link org.openmrs.validator.AllergyValidator} must not force that privilege onto every allergy
+	 * write. While a new allergy is being saved the validator reads the patient's existing allergies to
+	 * reject duplicates; that internal read is wrapped in a Get Allergies proxy privilege so a caller
+	 * holding only an allergy write privilege can still save a new allergy without also holding Get
+	 * Allergies.
+	 *
+	 * @see PatientService#saveAllergy(Allergy)
+	 * @see org.openmrs.validator.AllergyValidator
+	 */
+	@Test
+	public void saveAllergy_shouldNotRequireTheGetAllergiesPrivilegeForTheDuplicateCheck() {
+		Patient patient = patientService.getPatient(2);
+		Allergen allergen = new Allergen(AllergenType.DRUG, new Concept(3), null);
+		Allergy allergy = new Allergy(patient, allergen, new Concept(4), "some comment", new ArrayList<>());
+
+		// become a user whose role grants no privileges, then grant only Add Allergies; the caller
+		// deliberately lacks Get Allergies, so a regression in the validator's duplicate check surfaces
+		User user = Context.getUserService().getUserByUsername("butch");
+		assertNotNull(user);
+		Context.becomeUser(user.getSystemId());
+		Context.addProxyPrivilege(PrivilegeConstants.ADD_ALLERGIES);
+		try {
+			assertDoesNotThrow(() -> patientService.saveAllergy(allergy));
+		} finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.ADD_ALLERGIES);
+		}
+		assertNotNull(allergy.getAllergyId());
+	}
+
 }

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -71,6 +71,7 @@ import org.openmrs.test.TestUtil;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.PrivilegeConstants;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
@@ -3669,6 +3670,36 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		    () -> patientService.getIdentifierValidator("com.example.InvalidIdentifierValidator"));
 		assertEquals("Could not find patient identifier validator com.example.InvalidIdentifierValidator",
 		    patientIdentifierException.getMessage());
+	}
+
+	/**
+	 * Before this fix {@code getAllergies} carried no {@code @Authorized} annotation, so the
+	 * authorization advice performed no privilege check at all and any caller could read a patient's
+	 * allergy list. It now requires the Get Allergies privilege.
+	 *
+	 * @see PatientService#getAllergies(Patient)
+	 */
+	@Test
+	public void getAllergies_shouldRequireTheGetAllergiesPrivilege() {
+		Patient patient = patientService.getPatient(2);
+		Context.logout();
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> patientService.getAllergies(patient));
+		assertTrue(exception.getMessage().contains(PrivilegeConstants.GET_ALLERGIES));
+	}
+
+	/**
+	 * Before this fix {@code setAllergies} carried no {@code @Authorized} annotation, so any caller
+	 * could modify a patient's allergy list. It now requires an allergy add/edit privilege.
+	 *
+	 * @see PatientService#setAllergies(Patient, Allergies)
+	 */
+	@Test
+	public void setAllergies_shouldRequireAnAllergyWritePrivilege() {
+		Patient patient = patientService.getPatient(2);
+		Allergies allergies = new Allergies();
+		Context.logout();
+		assertThrows(APIAuthenticationException.class, () -> patientService.setAllergies(patient, allergies));
 	}
 
 }

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -3001,11 +3001,55 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertEquals(notPreferred.getIdentifiers().size() - 1, audit.getPersonMergeLogData().getCreatedIdentifiers().size());
 	}
 
+	/**
+	 * The privileges the merge workflow legitimately requires of the merging user for the data handled
+	 * by these tests. Deliberately absent are Get Allergies and Get Patient Cohorts:
+	 * {@code mergePatients} reads both patients' allergies on the merging user's behalf (under a proxy
+	 * privilege in {@code mergeAllergies}), and voiding the losing patient reads its cohort memberships
+	 * the same way ({@code CohortServiceImpl.notifyPatientVoided}), so neither internal read may demand
+	 * its privilege from the merging user. Running every merge with this privilege set keeps both
+	 * covered. (The metadata read privileges - visit attribute types, global properties, concepts,
+	 * locations, patients - are here because saving the moved data triggers validators and change
+	 * checks that read that metadata through the service proxies.)
+	 */
+	private static final String[] MERGE_PRIVILEGES = { PrivilegeConstants.EDIT_PATIENTS, PrivilegeConstants.DELETE_PATIENTS,
+	        PrivilegeConstants.EDIT_PERSONS, PrivilegeConstants.GET_PATIENTS, PrivilegeConstants.GET_CONCEPTS,
+	        PrivilegeConstants.GET_GLOBAL_PROPERTIES, PrivilegeConstants.GET_LOCATIONS, PrivilegeConstants.GET_ORDERS,
+	        PrivilegeConstants.GET_VISITS, PrivilegeConstants.EDIT_VISITS, PrivilegeConstants.GET_VISIT_ATTRIBUTE_TYPES,
+	        PrivilegeConstants.GET_ENCOUNTERS, PrivilegeConstants.EDIT_ENCOUNTERS, PrivilegeConstants.GET_PATIENT_PROGRAMS,
+	        PrivilegeConstants.EDIT_PATIENT_PROGRAMS, PrivilegeConstants.GET_RELATIONSHIPS,
+	        PrivilegeConstants.EDIT_RELATIONSHIPS, PrivilegeConstants.DELETE_RELATIONSHIPS, PrivilegeConstants.GET_OBS,
+	        PrivilegeConstants.EDIT_OBS, PrivilegeConstants.GET_CONDITIONS, PrivilegeConstants.EDIT_CONDITIONS,
+	        PrivilegeConstants.EDIT_ALLERGIES, PrivilegeConstants.GET_MEDICATION_DISPENSE,
+	        PrivilegeConstants.EDIT_MEDICATION_DISPENSE, PrivilegeConstants.GET_USERS, PrivilegeConstants.EDIT_USERS };
+
 	private PersonMergeLog mergeAndRetrieveAudit(Patient preferred, Patient notPreferred) throws SerializationException {
-		patientService.mergePatients(preferred, notPreferred);
+		mergePatientsAsNonSuperUser(preferred, notPreferred);
 		List<PersonMergeLog> result = personService.getAllPersonMergeLogs(true);
 		assertTrue(result.size() > 0, "person merge was not audited");
 		return result.get(0);
+	}
+
+	/**
+	 * Runs the merge as a user who holds only {@link #MERGE_PRIVILEGES}, so the merge workflow tests
+	 * fail if any internal step starts demanding a privilege a merging user should not need.
+	 */
+	private void mergePatientsAsNonSuperUser(Patient preferred, Patient notPreferred) throws SerializationException {
+		User user = Context.getUserService().getUserByUsername("butch");
+		assertNotNull(user);
+		Context.becomeUser(user.getSystemId());
+		for (String privilege : MERGE_PRIVILEGES) {
+			Context.addProxyPrivilege(privilege);
+		}
+		try {
+			patientService.mergePatients(preferred, notPreferred);
+		} finally {
+			for (String privilege : MERGE_PRIVILEGES) {
+				Context.removeProxyPrivilege(privilege);
+			}
+			// restore the super user; the tests run their setup and verification with full privileges
+			authenticate();
+		}
 	}
 
 	private boolean isValueInList(String value, List<String> list) {


### PR DESCRIPTION
### Summary
`PatientService.getAllergies(Patient)` and `setAllergies(Patient, Allergies)` have no `@Authorized` annotation. Authorization is enforced in `AuthorizationAdvice.before()` only when a method declares at least one privilege; a method with none falls through with no check, not even authentication. So any authenticated caller who can reach these entry points can read another patient's allergy list and persist allergy changes for a patient, even though the dedicated per-item methods are guarded (`getAllergy`/`getAllergyByUuid` require `Get Allergies`; `saveAllergy` requires `Add`/`Edit Allergies`).

### Change
- `getAllergies` → `@Authorized({ GET_ALLERGIES })`
- `setAllergies` → `@Authorized({ ADD_ALLERGIES, EDIT_ALLERGIES })`
- Internal reads that would otherwise transitively demand `Get Allergies` from callers acquire it as a proxy privilege instead: the duplicate-allergen check in `AllergyValidator`, and the allergy reads `mergePatients` makes while reconciling the two patients' allergy lists.
- Regression tests asserting each method now requires its privilege, and that a caller holding only an allergy write privilege can still save a new allergy.
- The merge workflow tests now run `mergePatients` as a non-super user holding only the privileges the merge legitimately requires, with `Get Allergies` and `Get Patient Cohorts` deliberately absent, so the internal-read proxying is guarded by all 27 audit-based merge tests (suggested by @ibacher in review).
- Running the merge as a non-super user surfaced one more leaked internal read: `CohortServiceImpl.notifyPatientVoided` reads cohort memberships through the service proxy, so voiding any patient demanded `Get Patient Cohorts` from the voiding user even though `PatientDataVoidHandler` already proxies `Edit Cohorts` for it (the annotation predates #6317). That read now acquires its own proxy privilege, matching the allergy reads.

### Scope note
The advisory also raises that `setAllergies` does not bind each submitted `Allergy` to the outer `patient` argument (the DAO `persist`s each allergy as-is). That is a separate data-integrity hardening that interacts with the void/recreate reconciliation logic in `setAllergies`, so I'm handling it in a follow-up with its own tests rather than bundling it here. This PR closes the missing-authorization half.

Addresses GHSA-jxvr-3qjq-vfqg.