### PR TITLE
Check Task type before instantiating scheduler task classes

### DIFF
--- a/api/src/main/java/org/openmrs/scheduler/LegacyTask.java
+++ b/api/src/main/java/org/openmrs/scheduler/LegacyTask.java
@@ -28,14 +28,12 @@ public class LegacyTask implements TaskHandler<TaskDefinition> {
 		} catch (ClassNotFoundException e) {
 			throw new TaskException("Task class " + taskData.getTaskClass() + " not found", false);
 		}
-		Object instance = taskClass.getDeclaredConstructor().newInstance();
-
-		if (instance instanceof Task) {
-			Task task = (Task) instance;
-			task.initialize(taskData);
-			task.execute();
-		} else {
+		if (!Task.class.isAssignableFrom(taskClass)) {
 			throw new TaskException("Task class " + taskData.getTaskClass() + " must implement Task", false);
 		}
+
+		Task task = (Task) taskClass.getDeclaredConstructor().newInstance();
+		task.initialize(taskData);
+		task.execute();
 	}
 }

--- a/api/src/main/java/org/openmrs/validator/SchedulerFormValidator.java
+++ b/api/src/main/java/org/openmrs/validator/SchedulerFormValidator.java
@@ -71,11 +71,12 @@ public class SchedulerFormValidator implements Validator {
 			try {
 				Class<?> taskClass = OpenmrsClassLoader.getInstance().loadClass(taskDefinition.getTaskClass());
 
-				Object o = taskClass.newInstance();
-				if (!(o instanceof Task)) {
+				if (!Task.class.isAssignableFrom(taskClass)) {
 					errors.rejectValue("taskClass", "Scheduler.taskForm.classDoesNotImplementTask",
 					    new Object[] { taskDefinition.getTaskClass(), Task.class.getName() },
 					    "Class does not implement Task interface");
+				} else {
+					taskClass.newInstance();
 				}
 
 			} catch (IllegalAccessException iae) {

--- a/api/src/test/java/org/openmrs/scheduler/LegacyTaskTest.java
+++ b/api/src/test/java/org/openmrs/scheduler/LegacyTaskTest.java
@@ -1,0 +1,54 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.scheduler;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.validator.SchedulerFormValidatorTest.ConstructorSideEffectNonTask;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link LegacyTask}.
+ */
+public class LegacyTaskTest extends BaseContextSensitiveTest {
+
+	/**
+	 * Unlike {@link org.openmrs.validator.SchedulerFormValidator}, the JobRunr scheduler service does
+	 * not validate a {@link TaskDefinition} before persisting or running it, so a definition whose task
+	 * class does not implement {@link Task} can reach {@link LegacyTask#execute} unchecked. This pins
+	 * LegacyTask's own runtime guard: such a class must be rejected before it is instantiated, so that
+	 * a constructor or static initializer with side effects never runs.
+	 *
+	 * @see LegacyTask#execute(TaskDefinition, TaskContext)
+	 */
+	@Test
+	public void execute_shouldRejectANonTaskClassBeforeInstantiatingIt() {
+		ConstructorSideEffectNonTask.instantiated = false;
+
+		TaskDefinition def = new TaskDefinition();
+		def.setName("Chores");
+		def.setRepeatInterval(3600000L);
+		def.setTaskClass(ConstructorSideEffectNonTask.class.getName());
+
+		// Catch the broad type so we can inspect the outcome ourselves: without the type check the
+		// class is instantiated first and the (Task) cast fails with a ClassCastException, whereas the
+		// guard rejects it up front with a TaskException and never constructs it.
+		Exception exception = assertThrows(Exception.class, () -> new LegacyTask().execute(def, null));
+
+		assertFalse(ConstructorSideEffectNonTask.instantiated,
+		    "a class that does not implement Task must be rejected before it is instantiated");
+		assertTrue(exception instanceof TaskException,
+		    "rejection must surface as a TaskException, not a ClassCastException after instantiation");
+		assertTrue(exception.getMessage().contains("must implement Task"));
+	}
+}

--- a/api/src/test/java/org/openmrs/validator/SchedulerFormValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/SchedulerFormValidatorTest.java
@@ -10,6 +10,7 @@
 package org.openmrs.validator;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.validation.BindException;
@@ -131,7 +132,7 @@ public class SchedulerFormValidatorTest extends BaseContextSensitiveTest {
 		TaskDefinition def = new TaskDefinition();
 		def.setName("Chores");
 		def.setRepeatInterval(3600000L);
-		def.setTaskClass("org.openmrs.BaseOpenmrsData");
+		def.setTaskClass(UninstantiableTask.class.getName());
 
 		Errors errors = new BindException(def, "def");
 		new SchedulerFormValidator().validate(def, errors);
@@ -215,4 +216,50 @@ public class SchedulerFormValidatorTest extends BaseContextSensitiveTest {
 		assertTrue(errors.hasFieldErrors("description"));
 		assertTrue(errors.hasFieldErrors("startTimePattern"));
 	}
+
+	/**
+	 * A non-Task class whose construction has an observable side effect, used to prove that a class
+	 * which does not implement {@link org.openmrs.scheduler.Task} is rejected by the type check before
+	 * it is ever instantiated.
+	 */
+	public static class ConstructorSideEffectNonTask {
+
+		static boolean instantiated = false;
+
+		public ConstructorSideEffectNonTask() {
+			instantiated = true;
+		}
+	}
+
+	/**
+	 * @see SchedulerFormValidator#validate(Object,Errors)
+	 */
+	@Test
+	public void validate_shouldRejectANonTaskClassBeforeInstantiatingIt() {
+		ConstructorSideEffectNonTask.instantiated = false;
+		TaskDefinition def = new TaskDefinition();
+		def.setName("Chores");
+		def.setRepeatInterval(3600000L);
+		def.setTaskClass(ConstructorSideEffectNonTask.class.getName());
+
+		Errors errors = new BindException(def, "def");
+		new SchedulerFormValidator().validate(def, errors);
+
+		assertTrue(errors.hasFieldErrors("taskClass"));
+		assertEquals("Scheduler.taskForm.classDoesNotImplementTask", errors.getFieldError("taskClass").getCode());
+		assertFalse(ConstructorSideEffectNonTask.instantiated,
+		    "a class that does not implement Task must be rejected before it is instantiated");
+	}
+
+	/**
+	 * An abstract class that implements Task but cannot be instantiated (public no-arg constructor, so
+	 * newInstance throws InstantiationException rather than IllegalAccessException). Used to exercise
+	 * the instantiation-failure branch, which now runs only after the Task type check passes.
+	 */
+	public abstract static class UninstantiableTask implements Task {
+
+		public UninstantiableTask() {
+		}
+	}
+
 }

--- a/api/src/test/java/org/openmrs/validator/SchedulerFormValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/SchedulerFormValidatorTest.java
@@ -224,7 +224,7 @@ public class SchedulerFormValidatorTest extends BaseContextSensitiveTest {
 	 */
 	public static class ConstructorSideEffectNonTask {
 
-		static boolean instantiated = false;
+		public static boolean instantiated = false;
 
 		public ConstructorSideEffectNonTask() {
 			instantiated = true;


### PR DESCRIPTION
### Summary
`LegacyTask.execute` and `SchedulerFormValidator.validate` load the configured `task_class_name` through `OpenmrsClassLoader` and call `newInstance()` on it **before** checking whether the result implements `Task`:

- `api/.../scheduler/LegacyTask.java` — `taskClass.getDeclaredConstructor().newInstance()` then `if (instance instanceof Task)`
- `api/.../validator/SchedulerFormValidator.java` — `taskClass.newInstance()` then `if (!(o instanceof Task))`

So configuring a scheduler task with any fully-qualified class name on the classpath runs that class's constructor and static initializer as a side effect, even when it isn't a `Task`.

### Change
Check `Task.class.isAssignableFrom(taskClass)` first, and only instantiate classes that implement `Task`. The validator still instantiates a genuine `Task` afterward so the existing instantiation/access error reporting is preserved.

### Severity
Reaching either path requires the `Manage Scheduler` privilege, and such a user can already schedule a real `Task` that runs arbitrary code, so this is defense in depth (no new privilege boundary crossed) rather than a critical bug.

### Tests
- New `validate_shouldRejectANonTaskClassBeforeInstantiatingIt` uses a sentinel non-`Task` class with a constructor side effect and asserts it is rejected without being instantiated.
- The existing `validate_shouldFailValidationIfClassCannotBeInstantiated` now points at an abstract `Task` subtype so the instantiation-failure branch is still exercised after the type check.

Addresses GHSA-6ggw-67pv-j87p.