### PR TITLE
Stabilize flaky HibernateAdministrationDAOTest OutboxEvent metadata lookup

### DIFF
--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
@@ -21,10 +21,17 @@ import org.openmrs.Role;
 import org.openmrs.event.outbox.OutboxEvent;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
+// HibernateAdministrationDAO captures the boot-time Hibernate Metadata once when its context is
+// created. A prior test that rebuilds the shared context can leave that cached Metadata without the
+// annotation-scanned OutboxEvent entity, making getMaximumPropertyLength(OutboxEvent.class, ...)
+// below intermittently throw "Couldn't find a class in the hibernate configuration". Forcing a fresh
+// context for this class rebuilds the session factory so the DAO's Metadata reflects the full mapping.
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class HibernateAdministrationDAOTest extends BaseContextSensitiveTest {
 	
 	@Autowired


### PR DESCRIPTION
### Problem
`HibernateAdministrationDAOTest.getMaximumPropertyLength_*` fails intermittently in CI with:

```
org.openmrs.api.APIException: Couldn't find a class in the hibernate configuration named: org.openmrs.event.outbox.OutboxEvent
	at org.openmrs.api.db.hibernate.HibernateAdministrationDAO.getMaximumPropertyLength(HibernateAdministrationDAO.java:232)
```

### Root cause
`HibernateAdministrationDAO` captures the boot-time Hibernate `Metadata` once, in `setApplicationContext`, from `HibernateSessionFactoryBean.getMetadata()`. `OutboxEvent` is a `@Entity` with no hbm.xml, so it is registered only via the `packagesToScan = org.openmrs` annotation scan. When an earlier test in the same fork rebuilds the shared Spring context, the DAO can end up holding a `Metadata` that omits `OutboxEvent`, and `metadata.getEntityBinding(...)` returns null. The class passes in isolation and only fails in some full-suite orderings, i.e. order-dependent context pollution, not a code regression.

### Fix
Force a fresh context for this test class with `@DirtiesContext(classMode = BEFORE_CLASS)`, so the DAO's `Metadata` is rebuilt from a full `org.openmrs` scan that includes `OutboxEvent`.

### Verification and caveat
The class passes in isolation (6/6) both before and after the change, confirming a fresh context has `OutboxEvent` and that the annotation is honored (the base test's `@TestExecutionListeners` use `MERGE_WITH_DEFAULTS`, so the `DirtiesContext` listeners are registered). I could not reproduce the order-dependent failure locally to prove elimination against a live repro, so this is a mechanism-sound, verified-non-breaking mitigation rather than a repro-verified one.

### Scope
Only the 2.9.x line has these `getMaximumPropertyLength`/`OutboxEvent` tests, so this targets 2.9.x directly. master has the DAO method but not these tests; 2.8.x has no `OutboxEvent`. This is the first use of `@DirtiesContext` in the repo.
