### PR TITLE
Restrict concept reference range criteria SpEL to a safe surface

### DIFF
--- a/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
+++ b/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
@@ -43,6 +43,7 @@ import org.springframework.expression.spel.ast.BeanReference;
 import org.springframework.expression.spel.ast.ConstructorReference;
 import org.springframework.expression.spel.ast.Indexer;
 import org.springframework.expression.spel.ast.MethodReference;
+import org.springframework.expression.spel.ast.OperatorMatches;
 import org.springframework.expression.spel.ast.TypeReference;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -112,14 +113,15 @@ public class ConceptReferenceRangeUtility {
 	/**
 	 * Rejects expression constructs that let a stored criteria escape the intended "read a few values
 	 * and compare them" surface: constructor calls, type references, bean references, indexing
-	 * (including into strings, e.g. {@code $patient.uuid[0]}) and any method outside
-	 * {@link #ALLOWED_METHODS}.
+	 * (including into strings, e.g. {@code $patient.uuid[0]}), the {@code matches} regex operator (a
+	 * string-inspection primitive equivalent to the blocked String methods, and also a ReDoS vector)
+	 * and any method outside {@link #ALLOWED_METHODS}.
 	 */
 	private static void validateNode(SpelNode node) {
 		if (node instanceof ConstructorReference || node instanceof TypeReference || node instanceof BeanReference
-		        || node instanceof Indexer) {
+		        || node instanceof Indexer || node instanceof OperatorMatches) {
 			throw new IllegalArgumentException(
-			        "Criteria may not use constructors, type references, bean references or indexing");
+			        "Criteria may not use constructors, type references, bean references, indexing or regex matching");
 		}
 		if (node instanceof MethodReference && !ALLOWED_METHODS.contains(((MethodReference) node).getName())) {
 			throw new IllegalArgumentException("Criteria may not call method: " + ((MethodReference) node).getName());

--- a/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
+++ b/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
@@ -37,6 +38,13 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelMessage;
+import org.springframework.expression.spel.SpelNode;
+import org.springframework.expression.spel.ast.BeanReference;
+import org.springframework.expression.spel.ast.ConstructorReference;
+import org.springframework.expression.spel.ast.Indexer;
+import org.springframework.expression.spel.ast.MethodReference;
+import org.springframework.expression.spel.ast.TypeReference;
+import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.DataBindingMethodResolver;
 import org.springframework.expression.spel.support.DataBindingPropertyAccessor;
@@ -75,9 +83,50 @@ public class ConceptReferenceRangeUtility {
 	        .forPropertyAccessors(new MapAccessor(), DataBindingPropertyAccessor.forReadOnlyAccess())
 	        .withMethodResolvers(DataBindingMethodResolver.forInstanceMethodInvocation()).build();
 
+	/**
+	 * Method names a criteria expression is permitted to invoke. Allow-list of the {@code $fn} helper
+	 * API ({@link CriteriaFunctions}), a curated set of scalar/value accessors on the bound domain
+	 * objects, and String equality only. It deliberately excludes String inspection methods
+	 * (startsWith, charAt, substring, length, compareTo, getBytes, ...) and arbitrary getters, which
+	 * together with the node checks in {@link #validateNode} stop a stored criteria from being used as
+	 * a blind data-exfiltration oracle over the bound patient graph.
+	 */
+	private static final Set<String> ALLOWED_METHODS = Set.of("getLatestObs", "getCurrentHour", "getCurrentObs",
+	    "getLatestObsDate", "isObsValueCodedAnswer", "getObsDays", "getObsWeeks", "getObsMonths", "getObsYears",
+	    "getDaysBetween", "getWeeksBetween", "getMonthsBetween", "getYearsBetween", "getDays", "getWeeks", "getMonths",
+	    "getYears", "isEnrolledInProgram", "isInProgramState", "getAge", "getAgeInMonths", "getAgeInWeeks", "getAgeInDays",
+	    "getGender", "getAttribute", "getValue", "getValueNumeric", "getValueBoolean", "getValueText", "getValueDate",
+	    "getValueDatetime", "getValueCoded", "getValueAsString", "equals", "equalsIgnoreCase");
+
 	private final CriteriaFunctions functions = new CriteriaFunctions();
 
 	public ConceptReferenceRangeUtility() {
+	}
+
+	private static Expression parseAndValidate(String criteria) {
+		SpelExpression expression = (SpelExpression) PARSER.parseExpression(criteria);
+		validateNode(expression.getAST());
+		return expression;
+	}
+
+	/**
+	 * Rejects expression constructs that let a stored criteria escape the intended "read a few values
+	 * and compare them" surface: constructor calls, type references, bean references, indexing
+	 * (including into strings, e.g. {@code $patient.uuid[0]}) and any method outside
+	 * {@link #ALLOWED_METHODS}.
+	 */
+	private static void validateNode(SpelNode node) {
+		if (node instanceof ConstructorReference || node instanceof TypeReference || node instanceof BeanReference
+		        || node instanceof Indexer) {
+			throw new IllegalArgumentException(
+			        "Criteria may not use constructors, type references, bean references or indexing");
+		}
+		if (node instanceof MethodReference && !ALLOWED_METHODS.contains(((MethodReference) node).getName())) {
+			throw new IllegalArgumentException("Criteria may not call method: " + ((MethodReference) node).getName());
+		}
+		for (int i = 0; i < node.getChildCount(); i++) {
+			validateNode(node.getChild(i));
+		}
 	}
 
 	/**
@@ -137,7 +186,7 @@ public class ConceptReferenceRangeUtility {
 		root.put("$date", context.getDate());
 
 		try {
-			Expression expression = EXPRESSION_CACHE.get(criteria, PARSER::parseExpression);
+			Expression expression = EXPRESSION_CACHE.get(criteria, ConceptReferenceRangeUtility::parseAndValidate);
 			Boolean result = expression.getValue(EVAL_CONTEXT, root, Boolean.class);
 			return result != null && result;
 		} catch (SpelEvaluationException e) {

--- a/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
+++ b/api/src/main/java/org/openmrs/util/ConceptReferenceRangeUtility.java
@@ -44,6 +44,7 @@ import org.springframework.expression.spel.ast.ConstructorReference;
 import org.springframework.expression.spel.ast.Indexer;
 import org.springframework.expression.spel.ast.MethodReference;
 import org.springframework.expression.spel.ast.OperatorMatches;
+import org.springframework.expression.spel.ast.PropertyOrFieldReference;
 import org.springframework.expression.spel.ast.TypeReference;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -99,6 +100,18 @@ public class ConceptReferenceRangeUtility {
 	    "getGender", "getAttribute", "getValue", "getValueNumeric", "getValueBoolean", "getValueText", "getValueDate",
 	    "getValueDatetime", "getValueCoded", "getValueAsString", "equals", "equalsIgnoreCase");
 
+	/**
+	 * Property names that must not be reachable even through property syntax, because they expose a
+	 * non-value capability rather than a bound value. Read-only property access invokes JavaBean
+	 * getters directly and so is not covered by {@link #ALLOWED_METHODS}: {@code class} is the
+	 * reflection gateway (also blocked at evaluation), while {@code bytes} and {@code length} recover a
+	 * String's raw bytes and its length, circumventing the deliberate {@code getBytes}/{@code length}
+	 * exclusions from the allowed methods (e.g. {@code $patient.uuid.bytes.length} would otherwise leak
+	 * a value's length). Matched case-insensitively because SpEL resolves a getter from the capitalized
+	 * property name, so both {@code bytes} and {@code Bytes} reach {@code getBytes()}.
+	 */
+	private static final Set<String> DENIED_PROPERTIES = Set.of("class", "bytes", "length");
+
 	private final CriteriaFunctions functions = new CriteriaFunctions();
 
 	public ConceptReferenceRangeUtility() {
@@ -114,8 +127,10 @@ public class ConceptReferenceRangeUtility {
 	 * Rejects expression constructs that let a stored criteria escape the intended "read a few values
 	 * and compare them" surface: constructor calls, type references, bean references, indexing
 	 * (including into strings, e.g. {@code $patient.uuid[0]}), the {@code matches} regex operator (a
-	 * string-inspection primitive equivalent to the blocked String methods, and also a ReDoS vector)
-	 * and any method outside {@link #ALLOWED_METHODS}.
+	 * string-inspection primitive equivalent to the blocked String methods, and also a ReDoS vector),
+	 * any method outside {@link #ALLOWED_METHODS}, and any property in {@link #DENIED_PROPERTIES}
+	 * (which would otherwise reach a getter, e.g. {@code getBytes()}, that the method allow-list
+	 * excludes).
 	 */
 	private static void validateNode(SpelNode node) {
 		if (node instanceof ConstructorReference || node instanceof TypeReference || node instanceof BeanReference
@@ -125,6 +140,11 @@ public class ConceptReferenceRangeUtility {
 		}
 		if (node instanceof MethodReference && !ALLOWED_METHODS.contains(((MethodReference) node).getName())) {
 			throw new IllegalArgumentException("Criteria may not call method: " + ((MethodReference) node).getName());
+		}
+		if (node instanceof PropertyOrFieldReference
+		        && DENIED_PROPERTIES.contains(((PropertyOrFieldReference) node).getName().toLowerCase(Locale.ROOT))) {
+			throw new IllegalArgumentException(
+			        "Criteria may not read property: " + ((PropertyOrFieldReference) node).getName());
 		}
 		for (int i = 0; i < node.getChildCount(); i++) {
 			validateNode(node.getChild(i));

--- a/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
+++ b/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
@@ -1075,7 +1075,8 @@ class ConceptReferenceRangeUtilityTest extends BaseContextSensitiveTest {
 	 * Guards against the stored-criteria data-exfiltration oracle (GHSA-cf7m): the SpEL surface must
 	 * not permit string inspection (String methods or the {@code matches} regex operator) or indexing,
 	 * arbitrary getters, constructors or type references, but must still allow the documented value
-	 * comparisons.
+	 * comparisons. This includes getters reached through property syntax rather than a method call,
+	 * e.g. {@code $patient.uuid.bytes.length} (which recovers a value's length via {@code getBytes()}).
 	 */
 	@Test
 	public void evaluateCriteria_shouldRejectExfiltrationConstructsButAllowValueComparisons() {
@@ -1086,7 +1087,8 @@ class ConceptReferenceRangeUtilityTest extends BaseContextSensitiveTest {
 		        "$patient.uuid.substring(0, 1) == 'a'", "$patient.uuid.length() > 5", "$patient.uuid.compareTo('a') > 0",
 		        "$patient.uuid.getBytes()[0] > 50", "$patient.uuid matches 'a.*'", "$patient.uuid[0] == 'a'",
 		        "$patient.getUuid().startsWith('a')", "$patient.names[0].familyName == 'x'",
-		        "T(java.lang.Runtime).getRuntime()", "new java.net.URL('http://evil')" };
+		        "T(java.lang.Runtime).getRuntime()", "new java.net.URL('http://evil')", "$patient.uuid.bytes.length > 5",
+		        "$patient.uuid.Bytes.length > 5", "$patient.uuid.bytes != null", "$patient.uuid.class != null" };
 		for (String criteria : blocked) {
 			assertThrows(APIException.class, () -> conceptReferenceRangeUtility.evaluateCriteria(criteria, obs),
 			    "criteria should be rejected: " + criteria);

--- a/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
+++ b/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
@@ -1073,8 +1073,9 @@ class ConceptReferenceRangeUtilityTest extends BaseContextSensitiveTest {
 
 	/**
 	 * Guards against the stored-criteria data-exfiltration oracle (GHSA-cf7m): the SpEL surface must
-	 * not permit string inspection or indexing, arbitrary getters, constructors or type references, but
-	 * must still allow the documented value comparisons.
+	 * not permit string inspection (String methods or the {@code matches} regex operator) or indexing,
+	 * arbitrary getters, constructors or type references, but must still allow the documented value
+	 * comparisons.
 	 */
 	@Test
 	public void evaluateCriteria_shouldRejectExfiltrationConstructsButAllowValueComparisons() {
@@ -1083,9 +1084,9 @@ class ConceptReferenceRangeUtilityTest extends BaseContextSensitiveTest {
 
 		String[] blocked = { "$patient.uuid.startsWith('a')", "$patient.uuid.charAt(0) == 'a'",
 		        "$patient.uuid.substring(0, 1) == 'a'", "$patient.uuid.length() > 5", "$patient.uuid.compareTo('a') > 0",
-		        "$patient.uuid.getBytes()[0] > 50", "$patient.uuid[0] == 'a'", "$patient.getUuid().startsWith('a')",
-		        "$patient.names[0].familyName == 'x'", "T(java.lang.Runtime).getRuntime()",
-		        "new java.net.URL('http://evil')" };
+		        "$patient.uuid.getBytes()[0] > 50", "$patient.uuid matches 'a.*'", "$patient.uuid[0] == 'a'",
+		        "$patient.getUuid().startsWith('a')", "$patient.names[0].familyName == 'x'",
+		        "T(java.lang.Runtime).getRuntime()", "new java.net.URL('http://evil')" };
 		for (String criteria : blocked) {
 			assertThrows(APIException.class, () -> conceptReferenceRangeUtility.evaluateCriteria(criteria, obs),
 			    "criteria should be rejected: " + criteria);

--- a/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
+++ b/api/src/test/java/org/openmrs/util/ConceptReferenceRangeUtilityTest.java
@@ -1070,4 +1070,31 @@ class ConceptReferenceRangeUtilityTest extends BaseContextSensitiveTest {
 
 		return obs;
 	}
+
+	/**
+	 * Guards against the stored-criteria data-exfiltration oracle (GHSA-cf7m): the SpEL surface must
+	 * not permit string inspection or indexing, arbitrary getters, constructors or type references, but
+	 * must still allow the documented value comparisons.
+	 */
+	@Test
+	public void evaluateCriteria_shouldRejectExfiltrationConstructsButAllowValueComparisons() {
+		Obs obs = buildObs();
+		obs.setPerson(person);
+
+		String[] blocked = { "$patient.uuid.startsWith('a')", "$patient.uuid.charAt(0) == 'a'",
+		        "$patient.uuid.substring(0, 1) == 'a'", "$patient.uuid.length() > 5", "$patient.uuid.compareTo('a') > 0",
+		        "$patient.uuid.getBytes()[0] > 50", "$patient.uuid[0] == 'a'", "$patient.getUuid().startsWith('a')",
+		        "$patient.names[0].familyName == 'x'", "T(java.lang.Runtime).getRuntime()",
+		        "new java.net.URL('http://evil')" };
+		for (String criteria : blocked) {
+			assertThrows(APIException.class, () -> conceptReferenceRangeUtility.evaluateCriteria(criteria, obs),
+			    "criteria should be rejected: " + criteria);
+		}
+
+		// documented comparisons must keep working (null values simply evaluate to false)
+		assertFalse(conceptReferenceRangeUtility.evaluateCriteria("$patient.getGender() == 'M'", obs));
+		assertFalse(conceptReferenceRangeUtility.evaluateCriteria("$patient.getGender().equals('M')", obs));
+		assertTrue(conceptReferenceRangeUtility.evaluateCriteria("$fn.getCurrentHour() >= 0", obs));
+	}
+
 }


### PR DESCRIPTION
### Summary
Follow-up to CVE-2026-41258 / GHSA-xj4f-8jjg-vx4q. That fix replaced Velocity with SpEL in `ConceptReferenceRangeUtility`, using a `SimpleEvaluationContext` that correctly blocks `T(...)` type references and `new` constructors — so this is **not** RCE. But it binds live patient-graph objects (`$patient`, `$obs`, `$encounter`, …) and, via `DataBindingMethodResolver.forInstanceMethodInvocation()`, permits arbitrary instance-method calls and indexing on them.

A user with `Manage Concepts` can store a criteria like `$patient.uuid.startsWith('a')`, `$patient.uuid[0] == 'a'`, or `$patient.names[0].familyName == 'x'`. Thereafter every clinician with `Get Concepts` who views a matching obs evaluates that expression server-side against **their** patient, and which `referenceRange` is selected leaks one boolean bit. Combined with `startsWith`/`charAt`/`substring`/indexing, that bisects arbitrary string PHI across the whole patient population. I confirmed each of these vectors evaluates on current `master`.

### Fix
Validate the parsed SpEL AST before evaluation (`parseAndValidate` → `validateNode`, run once per unique criteria inside the existing cache):
- reject `ConstructorReference`, `TypeReference`, `BeanReference`, and `Indexer` (indexing, including into strings), and
- reject any `MethodReference` whose name is not in an allow-list.

The allow-list is the `$fn` helper API, a curated set of scalar/value accessors (`getAge`, `getAgeInMonths`, `getGender`, `getAttribute`, `getValueNumeric`, …), and `equals`/`equalsIgnoreCase`. String inspection methods and arbitrary getters are no longer callable, so the oracle collapses to equality comparisons on the values the feature already intends to expose.

### Validation
- All 71 existing `ConceptReferenceRangeUtilityTest` cases still pass, so the documented criteria surface (age, gender, `getAttribute(...).getValue()`, obs values, `$fn.*`, dates) is preserved.
- New `evaluateCriteria_shouldRejectExfiltrationConstructsButAllowValueComparisons` asserts every bisection/exfiltration vector is rejected while the documented comparisons still work.

### For reviewers
The allow-list is derived from the documented/tested criteria surface. Please confirm it covers criteria real deployments have stored — anything relying on other methods will now be rejected (fail-closed). A residual equality oracle on intentionally-exposed fields (gender, attributes) remains by design; if that is also unacceptable, exposing detached value snapshots instead of live entities would be the next step.

Addresses GHSA-cf7m-74mw-c4wv.