### PR TITLE
getMaximumPropertyLength should degrade gracefully instead of throwing

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
@@ -225,10 +225,8 @@ public class HibernateAdministrationDAO implements AdministrationDAO, Applicatio
 	public long getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName) {
 		PersistentClass persistentClass = metadata.getEntityBinding(aClass.getName().split("_")[0]);
 		if (persistentClass == null) {
-			// The boot Metadata is captured once at startup, so it can fail to resolve an entity if it is
-			// ever consulted in an incomplete state (for example after a session factory rebuild). Treat
-			// the length as unknown (-1) instead of throwing: this method is called from validate() on
-			// every save, and validate() already skips the length check when it returns a negative value.
+			// Treat the length as unknown (-1) instead of throwing: this method is called from validate()
+			// on every save, and validate() skips the length check when the value is negative.
 			log.debug("Could not find a hibernate entity binding for {}; treating maximum length as unknown",
 			    aClass.getName());
 			return -1;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAO.java
@@ -36,7 +36,6 @@ import org.hibernate.type.BasicType;
 import org.hibernate.type.Type;
 import org.openmrs.GlobalProperty;
 import org.openmrs.OpenmrsObject;
-import org.openmrs.api.APIException;
 import org.openmrs.api.db.AdministrationDAO;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.util.DatabaseUtil;
@@ -226,29 +225,34 @@ public class HibernateAdministrationDAO implements AdministrationDAO, Applicatio
 	public long getMaximumPropertyLength(Class<? extends OpenmrsObject> aClass, String fieldName) {
 		PersistentClass persistentClass = metadata.getEntityBinding(aClass.getName().split("_")[0]);
 		if (persistentClass == null) {
-			throw new APIException("Couldn't find a class in the hibernate configuration named: " + aClass.getName());
-		} else {
-			long fieldLength;
-			try {
-				List<Column> columns = persistentClass.getProperty(fieldName).getColumns();
-				if (columns.isEmpty()) {
-					throw new Exception(
-					        String.format("No columns found for fieldName %s to determine maximum length", fieldName));
-				}
-				Column column = columns.get(0);
-				String columnDefinition = column.getSqlType();
-				if (columnDefinition != null && (columnDefinition.equalsIgnoreCase("LONGTEXT")
-				        || columnDefinition.equalsIgnoreCase("MEDIUMTEXT"))) {
-					fieldLength = Integer.MAX_VALUE;
-				} else {
-					fieldLength = column.getLength();
-				}
-			} catch (Exception e) {
-				log.debug("Could not determine maximum length", e);
-				return -1;
-			}
-			return fieldLength;
+			// The boot Metadata is captured once at startup, so it can fail to resolve an entity if it is
+			// ever consulted in an incomplete state (for example after a session factory rebuild). Treat
+			// the length as unknown (-1) instead of throwing: this method is called from validate() on
+			// every save, and validate() already skips the length check when it returns a negative value.
+			log.debug("Could not find a hibernate entity binding for {}; treating maximum length as unknown",
+			    aClass.getName());
+			return -1;
 		}
+		long fieldLength;
+		try {
+			List<Column> columns = persistentClass.getProperty(fieldName).getColumns();
+			if (columns.isEmpty()) {
+				throw new Exception(
+				        String.format("No columns found for fieldName %s to determine maximum length", fieldName));
+			}
+			Column column = columns.get(0);
+			String columnDefinition = column.getSqlType();
+			if (columnDefinition != null
+			        && (columnDefinition.equalsIgnoreCase("LONGTEXT") || columnDefinition.equalsIgnoreCase("MEDIUMTEXT"))) {
+				fieldLength = Integer.MAX_VALUE;
+			} else {
+				fieldLength = column.getLength();
+			}
+		} catch (Exception e) {
+			log.debug("Could not determine maximum length", e);
+			return -1;
+		}
+		return fieldLength;
 	}
 
 	@Override

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateAdministrationDAOTest.java
@@ -12,6 +12,7 @@ package org.openmrs.api.db.hibernate;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.BaseOpenmrsObject;
 import org.openmrs.Location;
 import org.openmrs.Role;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
@@ -20,6 +21,7 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -149,5 +151,30 @@ public class HibernateAdministrationDAOTest extends BaseContextSensitiveTest {
 		Errors errors = new BindException(role, "type");
 		dao.validate(role, errors);
 		assertFalse(errors.hasFieldErrors("role"));
+	}
+
+	/**
+	 * @see HibernateAdministrationDAO#getMaximumPropertyLength(Class, String)
+	 */
+	@Test
+	public void getMaximumPropertyLength_shouldReturnNegativeOneWhenTheClassIsNotAMappedEntity() {
+		// A missing entity binding must degrade to "unknown length" rather than throw, since validate()
+		// calls this on every save and only enforces the limit when the returned value is non-negative.
+		assertEquals(-1L, dao.getMaximumPropertyLength(UnmappedType.class, "uuid"));
+	}
+
+	/**
+	 * An {@link org.openmrs.OpenmrsObject} that is deliberately not registered as a hibernate entity.
+	 */
+	public static class UnmappedType extends BaseOpenmrsObject {
+
+		@Override
+		public Integer getId() {
+			return null;
+		}
+
+		@Override
+		public void setId(Integer id) {
+		}
 	}
 }


### PR DESCRIPTION
### Problem
`HibernateAdministrationDAO.getMaximumPropertyLength(aClass, fieldName)` throws an `APIException` when `metadata.getEntityBinding(aClass.getName())` returns null. That `metadata` is a boot-time Hibernate `Metadata` snapshot captured once in `setApplicationContext`, so if it is ever consulted in an incomplete state the method throws hard.

This method is called by `validate()` on every `OpenmrsObject` save. Two things show the hard throw is an inconsistent outlier:
- `validate()` already guards every use with `if (maxLength >= 0 && ...)`, i.e. a negative return means "length unknown, skip the check".
- The method itself already returns `-1` when it cannot determine a column's length (the `catch` block).

So a transient inability to resolve an entity should behave the same way, `-1`, not throw and fail the save.

### How it surfaced
Intermittent CI failure: `HibernateAdministrationDAOTest.getMaximumPropertyLength_*` errored with `Couldn't find a class in the hibernate configuration named: org.openmrs.event.outbox.OutboxEvent` in some full-suite orderings, while passing in isolation. The throw is the sharp edge; the underlying "the boot Metadata snapshot sometimes can't resolve an annotation-scanned entity" is what varies by test order.

### Change
Return `-1` (unknown length) instead of throwing when the entity binding cannot be resolved, consistent with the existing sentinel and with `validate()`'s `maxLength >= 0` guard. Adds a regression test asserting an unmapped class yields `-1` rather than an exception (it errors on the pre-change code with the same `APIException`, and passes after).

### Scope / what this does and doesn't do
This hardens the production `validate()` path so a transient metadata gap can no longer fail a save, and removes the exception that was erroring the test. It does not, on its own, make assertions that require a specific entity's column lengths deterministic; a test that asserts exact lengths still needs that entity registered. Verified: the class passes (5/5) with the change and spotless is clean; the new test errors on the pre-change code and passes after.
