### PR TITLE
Hold UpdateFilter authentication state per session

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -81,6 +81,13 @@ public class UpdateFilter extends StartupFilter {
 	private static final String PROGRESS_VM_AJAXREQUEST = "updateProgress.vm.ajaxRequest";
 
 	/**
+	 * Session attribute set once a super user authenticates at the first step and checked on every
+	 * later step. Holding it on the session, rather than on the shared filter instance, stops one
+	 * user's successful authentication from being reused by another user's unauthenticated request.
+	 */
+	private static final String AUTHENTICATED_SUCCESSFULLY = "updateFilter.authenticatedSuccessfully";
+
+	/**
 	 * The model object behind this set of screens
 	 */
 	private UpdateFilterModel updateFilterModel = null;
@@ -90,12 +97,6 @@ public class UpdateFilter extends StartupFilter {
 	 * through this filter are a simple boolean check
 	 */
 	private static boolean updatesRequired = true;
-
-	/**
-	 * Used on all pages after the first to make sure the user isn't trying to cheat and do some url
-	 * magic to hack in.
-	 */
-	private volatile boolean authenticatedSuccessfully = false;
 
 	private UpdateFilterCompletion updateJob;
 
@@ -157,8 +158,8 @@ public class UpdateFilter extends StartupFilter {
 			log.debug("Attempting to authenticate user: " + username);
 			if (authenticateAsSuperUser(username, password)) {
 				log.debug("Authentication successful.  Redirecting to 'reviewupdates' page.");
-				// set a variable so we know that the user started here
-				authenticatedSuccessfully = true;
+				// mark this session as authenticated so later steps can verify it
+				httpRequest.getSession().setAttribute(AUTHENTICATED_SUCCESSFULLY, Boolean.TRUE);
 
 				//Set variable to tell us whether updates are already in progress
 				referenceMap.put("isDatabaseUpdateInProgress", isDatabaseUpdateInProgress);
@@ -211,7 +212,7 @@ public class UpdateFilter extends StartupFilter {
 		// step two of wizard in case if there were some warnings
 		else if (REVIEW_CHANGES.equals(page)) {
 
-			if (!authenticatedSuccessfully) {
+			if (!Boolean.TRUE.equals(httpRequest.getSession().getAttribute(AUTHENTICATED_SUCCESSFULLY))) {
 				// throw the user back to the main page because they are cheating
 				renderTemplate(DEFAULT_PAGE, referenceMap, httpResponse);
 				return;

--- a/web/src/test/java/org/openmrs/web/filter/update/UpdateFilterE2ETest.java
+++ b/web/src/test/java/org/openmrs/web/filter/update/UpdateFilterE2ETest.java
@@ -40,6 +40,9 @@ class UpdateFilterE2ETest {
 
 	private MockHttpServletResponse response;
 
+	/** Must match {@code UpdateFilter.AUTHENTICATED_SUCCESSFULLY}. */
+	private static final String AUTHENTICATED_SUCCESSFULLY_ATTR = "updateFilter.authenticatedSuccessfully";
+
 	/**
 	 * Testable subclass that overrides renderTemplate and authenticateAsSuperUser to avoid Velocity
 	 * rendering and database access.
@@ -77,7 +80,6 @@ class UpdateFilterE2ETest {
 				this.changes = null;
 			}
 		});
-		setAuthenticatedSuccessfully(false);
 		setDatabaseUpdateInProgress(false);
 		UpdateFilter.setLockReleased(false);
 
@@ -88,7 +90,6 @@ class UpdateFilterE2ETest {
 	@AfterEach
 	void cleanup() throws Exception {
 		setDatabaseUpdateInProgress(false);
-		setAuthenticatedSuccessfully(false);
 		UpdateFilter.setUpdatesRequired(true);
 		UpdateFilter.setLockReleased(false);
 	}
@@ -179,6 +180,23 @@ class UpdateFilterE2ETest {
 		setAuthenticatedSuccessfully(false);
 		request.setParameter("page", "reviewchanges.vm");
 
+		filter.doPost(request, response);
+
+		assertEquals("maintenance.vm", filter.lastRenderedTemplate);
+	}
+
+	@Test
+	void reviewChangesPage_shouldNotReuseAnotherSessionsAuthentication() throws Exception {
+		// one super user authenticates in their own session
+		filter.authResult = true;
+		MockHttpServletRequest authRequest = new MockHttpServletRequest();
+		authRequest.setParameter("page", "maintenance.vm");
+		authRequest.setParameter("username", "admin");
+		authRequest.setParameter("password", "Admin123");
+		filter.doPost(authRequest, new MockHttpServletResponse());
+
+		// a different, unauthenticated session must not inherit that authentication
+		request.setParameter("page", "reviewchanges.vm");
 		filter.doPost(request, response);
 
 		assertEquals("maintenance.vm", filter.lastRenderedTemplate);
@@ -431,20 +449,23 @@ class UpdateFilterE2ETest {
 	}
 
 	private void resetRequest() {
+		// carry the session forward so a follow-up request represents the same client (same session)
+		MockHttpServletRequest previous = request;
 		request = new MockHttpServletRequest();
+		request.setSession(previous.getSession());
 		response = new MockHttpServletResponse();
 	}
 
-	private void setAuthenticatedSuccessfully(boolean value) throws Exception {
-		Field field = UpdateFilter.class.getDeclaredField("authenticatedSuccessfully");
-		field.setAccessible(true);
-		field.setBoolean(filter, value);
+	private void setAuthenticatedSuccessfully(boolean value) {
+		if (value) {
+			request.getSession().setAttribute(AUTHENTICATED_SUCCESSFULLY_ATTR, Boolean.TRUE);
+		} else {
+			request.getSession().removeAttribute(AUTHENTICATED_SUCCESSFULLY_ATTR);
+		}
 	}
 
-	private boolean getAuthenticatedSuccessfully() throws Exception {
-		Field field = UpdateFilter.class.getDeclaredField("authenticatedSuccessfully");
-		field.setAccessible(true);
-		return field.getBoolean(filter);
+	private boolean getAuthenticatedSuccessfully() {
+		return Boolean.TRUE.equals(request.getSession().getAttribute(AUTHENTICATED_SUCCESSFULLY_ATTR));
 	}
 
 	private void setDatabaseUpdateInProgress(boolean value) throws Exception {


### PR DESCRIPTION
### Summary
`UpdateFilter.authenticatedSuccessfully` was a `private volatile boolean` instance field on the singleton filter. On the database-update wizard, step one sets it true after a super user authenticates, and step two (`reviewchanges.vm`, which launches the update) gates only on `if (!authenticatedSuccessfully)`. Because the flag is global to the filter instance rather than per-session, once any super user authenticates, a concurrent **unauthenticated** request can POST directly to the review-changes step and run the pending schema updates on the strength of the other user's login.

The window is narrow (only while DB updates are pending after a platform upgrade), but it is a real global-authentication-state reuse.

### Fix
Store the authenticated flag in the `HttpSession` (`AUTHENTICATED_SUCCESSFULLY` attribute) instead of on the filter instance, so each session must authenticate for itself. The shared update-in-progress state (`isDatabaseUpdateInProgress`, `updateJob`) stays global on purpose, so multiple authenticated super users can still watch a single running update.

### Tests
- Updated the E2E helpers to session scope and made `resetRequest()` carry the session forward (a follow-up request represents the same client).
- Added `reviewChangesPage_shouldNotReuseAnotherSessionsAuthentication`: one session authenticates, a second unauthenticated session posting to review-changes is bounced back to the maintenance page. All 33 UpdateFilter tests pass.

Addresses GHSA-5cxm-f3p9-h63q.