### PR TITLE
Require Add Patient Identifiers privilege when savePatient adds an identifier

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -168,6 +168,15 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	 * enforces. Any not-yet-persisted identifier in the graph therefore requires the Add Patient
 	 * Identifiers privilege. Existing identifiers are left untouched so that editing a patient's
 	 * demographics does not require identifier privileges.
+	 * <p>
+	 * This check relies on a newly added identifier still being transient (its id {@code null}) when it
+	 * runs. Requests served through the REST and web layers satisfy that: the session is opened with
+	 * {@code FlushMode.MANUAL} and no read-write transaction wraps the request, so no query flushes the
+	 * pending identifier beforehand, and the identifier-uniqueness validation runs in an advice ordered
+	 * outside this method's transaction. A caller that instead invokes savePatient from within its own
+	 * read-write transaction, on a session-managed patient, could have the new identifier auto-flushed
+	 * and assigned an id before this point, which would skip the check; closing that residual for such
+	 * callers would require enforcing the privilege at the persistence layer rather than here.
 	 */
 	private void requireAppropriatePatientIdentifierPrivilege(Patient patient) {
 		for (PatientIdentifier identifier : patient.getIdentifiers()) {

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -163,20 +163,8 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	}
 
 	/**
-	 * Adding a patient identifier through the aggregate {@link #savePatient(Patient)} path must not
-	 * bypass the identifier-specific privilege that {@link #savePatientIdentifier(PatientIdentifier)}
-	 * enforces. Any not-yet-persisted identifier in the graph therefore requires the Add Patient
-	 * Identifiers privilege. Existing identifiers are left untouched so that editing a patient's
-	 * demographics does not require identifier privileges.
-	 * <p>
-	 * This check relies on a newly added identifier still being transient (its id {@code null}) when it
-	 * runs. Requests served through the REST and web layers satisfy that: the session is opened with
-	 * {@code FlushMode.MANUAL} and no read-write transaction wraps the request, so no query flushes the
-	 * pending identifier beforehand, and the identifier-uniqueness validation runs in an advice ordered
-	 * outside this method's transaction. A caller that instead invokes savePatient from within its own
-	 * read-write transaction, on a session-managed patient, could have the new identifier auto-flushed
-	 * and assigned an id before this point, which would skip the check; closing that residual for such
-	 * callers would require enforcing the privilege at the persistence layer rather than here.
+	 * Ensures that the user has the appropriate privilege to add a patient identifier if they try to do
+	 * so through {@link #savePatient(Patient)}.
 	 */
 	private void requireAppropriatePatientIdentifierPrivilege(Patient patient) {
 		for (PatientIdentifier identifier : patient.getIdentifiers()) {

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -134,6 +134,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	@Override
 	public Patient savePatient(Patient patient) throws APIException {
 		requireAppropriatePatientModificationPrivilege(patient);
+		requireAppropriatePatientIdentifierPrivilege(patient);
 
 		if (!patient.getVoided() && patient.getIdentifiers().size() == 1) {
 			patient.getPatientIdentifier().setPreferred(true);
@@ -158,6 +159,22 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		}
 		if (patient.getVoided()) {
 			Context.requirePrivilege(PrivilegeConstants.DELETE_PATIENTS);
+		}
+	}
+
+	/**
+	 * Adding a patient identifier through the aggregate {@link #savePatient(Patient)} path must not
+	 * bypass the identifier-specific privilege that {@link #savePatientIdentifier(PatientIdentifier)}
+	 * enforces. Any not-yet-persisted identifier in the graph therefore requires the Add Patient
+	 * Identifiers privilege. Existing identifiers are left untouched so that editing a patient's
+	 * demographics does not require identifier privileges.
+	 */
+	private void requireAppropriatePatientIdentifierPrivilege(Patient patient) {
+		for (PatientIdentifier identifier : patient.getIdentifiers()) {
+			if (identifier.getPatientIdentifierId() == null) {
+				Context.requirePrivilege(PrivilegeConstants.ADD_PATIENT_IDENTIFIERS);
+				break;
+			}
 		}
 	}
 

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -57,6 +57,7 @@ import org.openmrs.RelationshipType;
 import org.openmrs.User;
 import org.openmrs.Visit;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.context.ContextAuthenticationException;
 import org.openmrs.api.impl.PatientServiceImpl;
 import org.openmrs.api.impl.PatientServiceImplTest;
 import org.openmrs.comparator.PatientIdentifierTypeDefaultComparator;
@@ -3775,6 +3776,45 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 			Context.removeProxyPrivilege(PrivilegeConstants.ADD_ALLERGIES);
 		}
 		assertNotNull(allergy.getAllergyId());
+	}
+
+	/**
+	 * Adding a patient identifier through the aggregate savePatient path must honour the
+	 * identifier-specific privilege, not just the patient-level one, so a user denied Add Patient
+	 * Identifiers cannot inject an identifier via savePatient.
+	 *
+	 * @see PatientService#savePatient(Patient)
+	 */
+	@Test
+	public void savePatient_shouldRequireAddPatientIdentifiersPrivilegeToAddAnIdentifier() {
+		// build the change as the super user, then detach so the new identifier stays transient,
+		// mirroring a patient deserialized from a REST request
+		Patient patient = patientService.getPatient(2);
+		PatientIdentifier newIdentifier = new PatientIdentifier("cw94-new-mrn", new PatientIdentifierType(2),
+		        new Location(1));
+		patient.addIdentifier(newIdentifier);
+		Context.evictFromSession(patient);
+
+		// become a user granted Edit Patients (and reads validation needs) but not Add Patient Identifiers
+		User user = Context.getUserService().getUserByUsername("butch");
+		assertNotNull(user);
+		Context.becomeUser(user.getSystemId());
+		String[] granted = { PrivilegeConstants.EDIT_PATIENTS, PrivilegeConstants.GET_PATIENTS,
+		        PrivilegeConstants.GET_GLOBAL_PROPERTIES, PrivilegeConstants.GET_IDENTIFIER_TYPES,
+		        PrivilegeConstants.GET_PATIENT_IDENTIFIERS, PrivilegeConstants.GET_LOCATIONS };
+		for (String privilege : granted) {
+			Context.addProxyPrivilege(privilege);
+		}
+		try {
+			assertNull(newIdentifier.getPatientIdentifierId(), "identifier must still be transient at save time");
+			assertFalse(Context.hasPrivilege(PrivilegeConstants.ADD_PATIENT_IDENTIFIERS));
+			assertThrows(ContextAuthenticationException.class, () -> patientService.savePatient(patient));
+		} finally {
+			for (String privilege : granted) {
+				Context.removeProxyPrivilege(privilege);
+			}
+			Context.logout();
+		}
 	}
 
 }


### PR DESCRIPTION
### Summary
`PatientService.savePatient` is guarded by `ADD_PATIENTS`/`EDIT_PATIENTS`, and `savePatientIdentifier` separately by `ADD_PATIENT_IDENTIFIERS`/`EDIT_PATIENT_IDENTIFIERS`. But `savePatient` persists the patient's identifiers by Hibernate cascade without applying the identifier privilege, so a user with `Edit Patients` who is deliberately denied `Add Patient Identifiers` can still inject an identifier (e.g. an MRN) through the aggregate save. This breaks the intended separation of duties.

### Change
Before saving, require `ADD_PATIENT_IDENTIFIERS` if the patient carries any not-yet-persisted (transient) identifier. Existing identifiers are not inspected, so editing a patient's demographics still requires only patient privileges — the check keys on `getPatientIdentifierId() == null`, which is exactly a newly added identifier.

### Tests
`savePatient_shouldRequireAddPatientIdentifiersPrivilegeToAddAnIdentifier`: a user with `Edit Patients` (plus the reads validation needs) but not `Add Patient Identifiers` is refused when adding an identifier via `savePatient`. The patient is evicted from the session first so the new identifier stays transient, mirroring a REST-deserialized patient. Full `PatientServiceTest` (182 tests) still passes.

### Scope / follow-up
This closes the add-an-identifier bypass. Modifying or voiding an *existing* identifier through `savePatient` (which would warrant `EDIT`/`DELETE_PATIENT_IDENTIFIERS`) is not covered here: distinguishing a genuine change from `savePatient`'s own internal `preferred`-flag updates needs field-level dirty tracking, which is best done as a separate change. Noting it so it isn't assumed covered.

Addresses GHSA-cw94-x75j-5vwx.