### PR TITLE
Keep the setup wizard closed when a configured database is unreachable

### DIFF
--- a/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
@@ -73,7 +73,7 @@ public class DatabaseDetective {
 			// already-configured deployment during a database outage, so only a genuinely
 			// unconfigured instance (no connection URL) counts as empty.
 			String url = props.getProperty(CONNECTION_URL);
-			return url == null || url.trim().isEmpty();
+			return url == null || url.isBlank();
 		} finally {
 			if (connection != null) {
 				try {

--- a/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
+++ b/web/src/main/java/org/openmrs/web/filter/initialization/DatabaseDetective.java
@@ -68,16 +68,19 @@ public class DatabaseDetective {
 			}
 			return true;
 		} catch (Exception e) {
-			// consider the database to be empty
-			return true;
+			// A configured instance (connection URL set) that we cannot reach is unreachable, not
+			// empty. Reporting it empty here would reopen the unauthenticated setup wizard on an
+			// already-configured deployment during a database outage, so only a genuinely
+			// unconfigured instance (no connection URL) counts as empty.
+			String url = props.getProperty(CONNECTION_URL);
+			return url == null || url.trim().isEmpty();
 		} finally {
-			try {
-				if (connection != null) {
+			if (connection != null) {
+				try {
 					connection.close();
+				} catch (Exception e) {
+					// ignore; a failure to close must not change the emptiness result
 				}
-			} catch (Exception e) {
-				// consider the database to be empty
-				return true;
 			}
 		}
 	}

--- a/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/initialization/DatabaseDetectiveTest.java
@@ -14,6 +14,7 @@ import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DatabaseDetectiveTest {
@@ -34,5 +35,17 @@ public class DatabaseDetectiveTest {
 	public void shouldRecogniseInvalidConnectionParameters() {
 		Properties properties = new Properties();
 		assertTrue(databaseDetective.isDatabaseEmpty(properties));
+	}
+
+	@Test
+	public void shouldNotReportConfiguredButUnreachableDatabaseAsEmpty() {
+		// a configured instance whose database is unreachable must not be reported as empty,
+		// otherwise the unauthenticated setup wizard would reopen on a production deployment
+		Properties properties = new Properties();
+		properties.setProperty("connection.url", "jdbc:h2:tcp://localhost:1/unreachable");
+		properties.setProperty("connection.driver_class", "org.h2.Driver");
+		properties.setProperty("connection.username", "sa");
+		properties.setProperty("connection.password", "");
+		assertFalse(databaseDetective.isDatabaseEmpty(properties));
 	}
 }


### PR DESCRIPTION
### Summary
`DatabaseDetective.isDatabaseEmpty(Properties)` treated any exception while connecting as "the database is empty" (`catch (Exception e) { return true; }`). Both callers, `Listener` at startup and `InitializationFilter`, use that to decide whether to show the unauthenticated setup wizard. So on an already-configured deployment, a database-connectivity failure at startup (a DB outage or restart) made the instance report itself empty and **reopen the unauthenticated setup wizard**, which renders the stored DB credentials and lets an unauthenticated user reconfigure the instance and persist their own settings back to `openmrs-runtime.properties`.

### Change
On a connection failure, only treat the instance as empty when it is genuinely unconfigured (no `connection.url`). A configured instance that cannot be reached is reported as not empty, so startup fails with a connection error instead of reopening setup. Unconfigured/fresh installs (null or empty properties) still return empty, so the normal first-run wizard is unaffected. Also removed the `return true` inside the `finally` block's `close()` handler, which could otherwise override a non-empty result.

### Tests
`DatabaseDetectiveTest.shouldNotReportConfiguredButUnreachableDatabaseAsEmpty`: a configured instance whose database is unreachable is not reported as empty. The existing null-properties and empty-properties cases (still empty) continue to pass.

Addresses GHSA-jqhq-p753-2hwj. This is the reopen root cause; it is distinct from #6152, which fixes credential wiping mid-flow (TRUNK-6645).