### PR TITLE
Bind caller-supplied names as query parameters instead of concatenating

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProgramWorkflowDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProgramWorkflowDAO.java
@@ -475,12 +475,12 @@ public class HibernateProgramWorkflowDAO implements ProgramWorkflowDAO {
 		        + " from patient p " + " join patient_program pp on p.patient_id = pp.patient_id and p.patient_id in ("
 		        + commaSeperatedPatientIds + ")"
 		        + " join patient_program_attribute ppa on pp.patient_program_id = ppa.patient_program_id and ppa.voided=0"
-		        + " join program_attribute_type ppt on ppa.attribute_type_id = ppt.program_attribute_type_id and ppt.name ='"
-		        + attributeName + "' "
+		        + " join program_attribute_type ppt on ppa.attribute_type_id = ppt.program_attribute_type_id and ppt.name = :attributeName "
 		        + " LEFT OUTER JOIN concept_name cn on ppa.value_reference = cn.concept_id and cn.concept_name_type= 'FULLY_SPECIFIED' and cn.voided=0 and ppt.datatype like '%ConceptDataType%'"
 		        + " group by p.patient_id",
 		    Object.class).addScalar("person_id", StandardBasicTypes.INTEGER)
-		        .addScalar("patientProgramAttributeValue", StandardBasicTypes.STRING).list();
+		        .addScalar("patientProgramAttributeValue", StandardBasicTypes.STRING)
+		        .setParameter("attributeName", attributeName).list();
 
 		for (Object o : list) {
 			Object[] arr = (Object[]) o;

--- a/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ProgramWorkflowServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,7 @@ import org.openmrs.ConceptStateConversion;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.PatientProgram;
+import org.openmrs.PatientProgramAttribute;
 import org.openmrs.PatientState;
 import org.openmrs.Program;
 import org.openmrs.ProgramAttributeType;
@@ -1116,5 +1118,41 @@ public class ProgramWorkflowServiceTest extends BaseContextSensitiveTest {
 	//
 	//    	return props;
 	//    }
+
+	/**
+	 * Regression guard for the program-attribute lookup: the attribute name is bound as a query
+	 * parameter rather than concatenated into the native SQL, so a value carrying SQL control
+	 * characters is matched literally instead of altering the query.
+	 *
+	 * @see ProgramWorkflowService#getPatientProgramAttributeByAttributeName(List, String)
+	 */
+	@Test
+	public void getPatientProgramAttributeByAttributeName_shouldMatchTheAttributeNameLiterally() {
+		// attach a "ProgramId" attribute value to the existing enrollment for patient 2
+		ProgramAttributeType attributeType = pws.getProgramAttributeType(1);
+		assertEquals("ProgramId", attributeType.getName());
+
+		PatientProgramAttribute attribute = new PatientProgramAttribute();
+		attribute.setAttributeType(attributeType);
+		attribute.setValueReferenceInternal("1234");
+
+		PatientProgram patientProgram = pws.getPatientProgram(1);
+		patientProgram.addAttribute(attribute);
+		pws.savePatientProgram(patientProgram);
+		Context.flushSession();
+
+		List<Integer> patientIds = Arrays.asList(2);
+
+		// the real name resolves the stored value
+		Map<Object, Object> byName = pws.getPatientProgramAttributeByAttributeName(patientIds, "ProgramId");
+		assertTrue(byName.containsKey(2));
+		assertTrue(((String) byName.get(2)).contains("1234"));
+
+		// a name containing SQL quote characters is compared literally, so it resolves no attribute
+		// type and returns nothing, rather than being interpreted as part of the query
+		Map<Object, Object> byNameWithQuotes = pws.getPatientProgramAttributeByAttributeName(patientIds,
+		    "ProgramId' OR '1'='1");
+		assertTrue(byNameWithQuotes.isEmpty());
+	}
 
 }

--- a/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
+++ b/web/src/main/java/org/openmrs/web/filter/util/FilterUtil.java
@@ -13,11 +13,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.DatabaseUpdater;
-import org.openmrs.util.DatabaseUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -268,10 +266,14 @@ public class FilterUtil {
 
 		try {
 			connection = DatabaseUpdater.getConnection();
-			List<List<Object>> results = DatabaseUtil.executeSQL(connection,
-			    "select property_value from global_property where property = '" + globalPropertyName + "'", true);
-			if (results.size() == 1 && results.get(0).size() == 1) {
-				propertyValue = results.get(0).get(0).toString();
+			try (PreparedStatement statement = connection
+			        .prepareStatement("select property_value from global_property where property = ?")) {
+				statement.setString(1, globalPropertyName);
+				try (ResultSet resultSet = statement.executeQuery()) {
+					if (resultSet.next()) {
+						propertyValue = resultSet.getString(1);
+					}
+				}
 			}
 		} catch (Exception e) {
 			log.error("Error while retrieving value for global property:" + globalPropertyName, e);

--- a/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
@@ -16,6 +16,7 @@ import org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests some of the methods on the {@link FilterUtil}
@@ -59,6 +60,20 @@ public class FilterUtilTest extends BaseWebContextSensitiveTest {
 
 		FilterUtil.storeLocale(UPDATED_LOCALE);
 		assertNotEquals(UPDATED_LOCALE, FilterUtil.restoreLocale(FilterUtil.ADMIN_USERNAME));
+	}
+
+	/**
+	 * @see FilterUtil#getGlobalPropertyValue(String)
+	 */
+	@Test
+	public void getGlobalPropertyValue_shouldMatchThePropertyNameLiterally() {
+		// a real property name resolves its stored value
+		assertEquals("7", FilterUtil.getGlobalPropertyValue("concept.true"));
+
+		// a name carrying SQL control characters is bound as a literal, so it matches no property
+		// and returns null. On the earlier string-concatenated query this payload resolved a single
+		// row and returned "7", so this asserts the value is now treated as data, not query text.
+		assertNull(FilterUtil.getGlobalPropertyValue("nonexistent' OR property = 'concept.true"));
 	}
 
 }


### PR DESCRIPTION
### Summary
An audit for SQL string concatenation turned up two native/JDBC queries that concatenated a caller-supplied string directly into the SQL text instead of binding it. Every other value in these queries is already bound or type-safe, so these were the two places a caller-supplied string reached the SQL as literal text.

### Change
- `HibernateProgramWorkflowDAO.getPatientProgramAttributeByAttributeName`: bind `attributeName` as a named parameter (`:attributeName`) so it is always handled as a literal attribute-type name. The patient-id list stays inlined since those elements are `Integer`s.
- `FilterUtil.getGlobalPropertyValue(String)`: replace the concatenated `global_property` lookup with a `PreparedStatement` that binds the property name. This runs before the Spring context is up (setup/upgrade wizard) via a raw JDBC connection, so it does not go through the usual service layer. Not exploitable today since the only caller passes a hardcoded constant, but the signature accepts an arbitrary string.

There is no behaviour change for legitimate attribute or property names.

### Tests
- `ProgramWorkflowServiceTest#getPatientProgramAttributeByAttributeName_shouldMatchTheAttributeNameLiterally`: stores a `ProgramId` attribute on an existing enrollment and checks that a real name resolves the stored value, while a name containing quote characters is compared literally and resolves no attribute type.
- `FilterUtilTest#getGlobalPropertyValue_shouldMatchThePropertyNameLiterally`: a real property name resolves its stored value, while a name carrying SQL control characters is matched literally and returns null. The payload was chosen so it resolved a single row (returning a value) on the old concatenated query, so the test fails on the pre-change code and passes on the fix.

`ProgramWorkflowServiceTest` and `FilterUtilTest` pass and spotless is clean.