### PR TITLE
TRUNK-6689: Fix spelling mistakes in test comments

### DIFF
--- a/api/src/test/java/org/openmrs/CohortTest.java
+++ b/api/src/test/java/org/openmrs/CohortTest.java
@@ -177,7 +177,7 @@ public class CohortTest {
 
 		Cohort cohort = new Cohort("name", "description", ids);
 
-		// create date in past to verify also non active patains are counted
+		// create date in past to verify also non active patients are counted
 		CohortMembership cohortMembershipOne = new CohortMembership(12, new Date());
 		Date dateInPast = new GregorianCalendar(1992, Calendar.SEPTEMBER, 30).getTime();
 		cohortMembershipOne.setEndDate(dateInPast);
@@ -194,7 +194,7 @@ public class CohortTest {
 
 		Cohort cohort = new Cohort("name", "description", ids);
 
-		// create date in past to verify also non active patains are counted
+		// create date in past to verify also non active patients are counted
 		CohortMembership cohortMembershipOne = new CohortMembership(12, new Date());
 		cohortMembershipOne.setVoided(true);
 		cohort.addMembership(cohortMembershipOne);

--- a/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/OpenmrsServiceTest.java
@@ -43,7 +43,7 @@ public class OpenmrsServiceTest extends BaseContextSensitiveTest {
 	@Disabled
 	public void shouldCheckThatAMethodIsNotRolledBackInCaseOfAnErrorInAnotherInvokedInsideIt()
 	        throws SerializationException {
-		//TODO FIx why this test fails when run with other tests
+		//TODO Fix why this test fails when run with other tests
 		PatientService patientService = Context.getPatientService();
 		EncounterService encounterService = Context.getEncounterService();
 		ProgramWorkflowService programService = Context.getProgramWorkflowService();


### PR DESCRIPTION
Corrected spelling mistakes in test comments to improve readability and consistency. These changes are documentation-only and do not affect the application's behavior.

JIRA TICKET : https://openmrs.atlassian.net/browse/TRUNK-6689