### PR TITLE
TRUNK-6687: Improve performance of searches using the search index

### DIFF
--- a/api/src/main/java/org/openmrs/api/PatientService.java
+++ b/api/src/main/java/org/openmrs/api/PatientService.java
@@ -880,6 +880,9 @@ public interface PatientService extends OpenmrsService {
 	 * Return the number of unvoided patients with names or patient identifiers or searchable person
 	 * attributes starting with or equal to the specified text
 	 * <p>
+	 * Note that after {@code person.searchMaxResults}, the count will be an upper bound, but not
+	 * necessarily an accurate count.
+	 * <p>
 	 * <strong>Should</strong> return the right count when a patient has multiple matching person
 	 * names<br/>
 	 * <strong>Should</strong> return the right count of patients with a matching identifier with no

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -741,6 +741,8 @@ public class HibernatePatientDAO implements PatientDAO {
 
 		PersonQuery personQuery = new PersonQuery();
 
+		// Bound the count deduplication to the maximum number of results a patient search can return: an
+		// exact count past that point costs a full hit-set scan for a total the caller cannot page to.
 		return SearchQueryUnique.searchCount(searchSessionFactory, SearchQueryUnique
 		        .newQuery(PatientIdentifier.class, f -> newPatientIdentifierSearchPredicate(f, query, includeVoided, false),
 		            "patient.personId", PatientIdentifier::getPatient)
@@ -749,7 +751,8 @@ public class HibernatePatientDAO implements PatientDAO {
 		                    "person.personId", pN -> getPatient(pN.getPerson().getId()))
 		                .join(SearchQueryUnique.newQuery(PersonAttribute.class,
 		                    f -> personQuery.getPatientAttributeQuery(f, query, includeVoided), "person.personId",
-		                    pA -> getPatient(pA.getPerson().getId())))));
+		                    pA -> getPatient(pA.getPerson().getId())))),
+		    HibernatePersonDAO.getMaximumSearchResults());
 	}
 
 	private List<Patient> findPatients(String query, boolean includeVoided) {

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePersonDAO.java
@@ -32,12 +32,12 @@ import org.openmrs.PersonAttributeType;
 import org.openmrs.PersonName;
 import org.openmrs.Relationship;
 import org.openmrs.RelationshipType;
-import org.openmrs.api.context.Context;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.PersonDAO;
 import org.openmrs.api.db.hibernate.search.SearchQueryUnique;
 import org.openmrs.api.db.hibernate.search.session.SearchSessionFactory;
 import org.openmrs.person.PersonMergeLog;
+import org.openmrs.util.ConfigUtil;
 import org.openmrs.util.OpenmrsConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -303,9 +303,12 @@ public class HibernatePersonDAO implements PersonDAO {
 	 */
 	public static Integer getMaximumSearchResults() {
 		try {
-			return Integer.valueOf(Context.getAdministrationService().getGlobalProperty(
-			    OpenmrsConstants.GLOBAL_PROPERTY_PERSON_SEARCH_MAX_RESULTS,
-			    String.valueOf(OpenmrsConstants.GLOBAL_PROPERTY_PERSON_SEARCH_MAX_RESULTS_DEFAULT_VALUE)));
+			String personSearchMaxGp = ConfigUtil
+			        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_PERSON_SEARCH_MAX_RESULTS);
+			if (personSearchMaxGp == null) {
+				personSearchMaxGp = String.valueOf(OpenmrsConstants.GLOBAL_PROPERTY_PERSON_SEARCH_MAX_RESULTS_DEFAULT_VALUE);
+			}
+			return Integer.valueOf(personSearchMaxGp);
 		} catch (Exception e) {
 			log.warn("Unable to convert the global property " + OpenmrsConstants.GLOBAL_PROPERTY_PERSON_SEARCH_MAX_RESULTS
 			        + "to a valid integer. Returning the default "

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
@@ -280,7 +280,7 @@ public class SearchQueryUnique<T, R> {
 	private static <T> SearchUniqueResults<T> searchWithResults(SearchSession searchSession,
 	        SearchQueryUnique<?, T> uniqueQuery, final Integer offset, final Integer limit) {
 		List<T> results = new ArrayList<>();
-		Collection<Object> uniqueKeys = new LinkedHashSet<>(); // Preserve the order
+		Set<Object> uniqueKeys = new LinkedHashSet<>(); // Preserve the order
 		final int maxClauseCount = Math.round(BooleanQuery.getMaxClauseCount() / 2.5f);
 		SearchQueryUnique<?, T> nextQuery = uniqueQuery;
 		Integer currentOffset = offset;
@@ -497,7 +497,7 @@ public class SearchQueryUnique<T, R> {
 	 * @param chunkSize the scroll chunk size
 	 * @return the collected duplicate ids together with counts describing the scan
 	 */
-	static DeduplicationResult collectDuplicateIds(SearchQuery<List<?>> uniqueKeyQuery, Collection<Object> uniqueKeys,
+	static DeduplicationResult collectDuplicateIds(SearchQuery<List<?>> uniqueKeyQuery, Set<Object> uniqueKeys,
 	        int maxClauseCount, Integer maxNewUniqueKeys, int chunkSize) {
 		final List<Object> duplicateIds = new ArrayList<>();
 		int newUniqueKeyCount = 0;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
@@ -11,8 +11,10 @@ package org.openmrs.api.db.hibernate.search;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -30,19 +32,33 @@ import org.openmrs.api.db.hibernate.search.session.SearchSessionFactory;
  * Provides methods for removing duplicate search results based on the given uniqueKey and combining
  * search results from multiple queries.
  * <p>
- * Due to max clause count limit dictated by performance reasons only first
- * <code>max = {@link BooleanQuery#getMaxClauseCount()} / 2.5</code> duplicate keys are removed from
- * results.
+ * When fetching results, deduplication is bounded to the requested page: the follow-up filtering
+ * query removes at most <code>max = {@link BooleanQuery#getMaxClauseCount()} / 2.5</code> duplicate
+ * keys, and up to <code>max</code> unique keys from previous queries are removed from results in
+ * the following queries.
  * <p>
- * The same <code>max</code> limit applies when combining results of multiple queries. Up to
- * <code>max</code> unique keys from the previous queries are removed from results in the following
- * queries.
+ * When calculating a total hit count, deduplication is exact by default but can be bounded by the
+ * caller via {@link #searchCount(SearchSessionFactory, SearchQueryUnique, int)}: the count is exact
+ * while the number of distinct hits stays within the given cap, and degrades to a raw upper bound
+ * (which counts duplicates) above it. This lets an expensive search (e.g. patient search over a
+ * huge hit set) bound the count cost while other callers keep exact counts.
  *
  * @param <T> query scope
  * @param <R> query return type
  * @since 2.8.0
  */
 public class SearchQueryUnique<T, R> {
+
+	/**
+	 * Cap value for {@link #searchCount(SearchSessionFactory, SearchQueryUnique, int)} that keeps the
+	 * total hit count exact by never falling back to the raw upper bound.
+	 */
+	public static final int UNBOUNDED_DEDUPLICATION = Integer.MAX_VALUE;
+
+	/**
+	 * The number of hits to pull from the index per scroll iteration when deduplicating.
+	 */
+	static final int DEFAULT_SCROLL_CHUNK_SIZE = 500;
 
 	Class<? extends T> scope;
 
@@ -161,15 +177,32 @@ public class SearchQueryUnique<T, R> {
 	}
 
 	/**
-	 * Runs the search calculating the total hit count only. See
-	 * {@link #search(SearchSessionFactory, SearchQueryUnique, Integer, Integer, Boolean)}.
+	 * Runs the search calculating the exact total hit count only.
 	 *
 	 * @param searchSessionFactory SearchSessionFactory
 	 * @param uniqueQuery unique query {@link #newQuery(Class, Function, String, Function)}
 	 * @return the total hit count
 	 */
 	public static Long searchCount(SearchSessionFactory searchSessionFactory, SearchQueryUnique<?, ?> uniqueQuery) {
-		return search(searchSessionFactory, uniqueQuery, 0, 0, true).getTotalHitCount();
+		return searchCount(searchSessionFactory, uniqueQuery, UNBOUNDED_DEDUPLICATION);
+	}
+
+	/**
+	 * Runs the search calculating the total hit count only, bounding the exact deduplication to
+	 * <code>deduplicationCap</code> distinct hits. The count is exact while the number of distinct hits
+	 * stays within the cap; above it the raw hit count (which counts duplicates, so an upper bound) is
+	 * returned instead of scanning the whole hit set. Pass {@link #UNBOUNDED_DEDUPLICATION} for an
+	 * always exact count.
+	 *
+	 * @param searchSessionFactory SearchSessionFactory
+	 * @param uniqueQuery unique query {@link #newQuery(Class, Function, String, Function)}
+	 * @param deduplicationCap the number of distinct hits to deduplicate exactly before falling back to
+	 *            the raw upper bound
+	 * @return the total hit count
+	 */
+	public static Long searchCount(SearchSessionFactory searchSessionFactory, SearchQueryUnique<?, ?> uniqueQuery,
+	        int deduplicationCap) {
+		return searchTotalHitCount(searchSessionFactory.getSearchSession(), uniqueQuery, deduplicationCap);
 	}
 
 	/**
@@ -203,36 +236,71 @@ public class SearchQueryUnique<T, R> {
 
 	/**
 	 * Executes unique queries applying joins and mapping to the result type.
+	 * <p>
+	 * When <code>includeTotalHitCount</code> is <code>true</code> only the exact total hit count is
+	 * calculated and the returned results are empty; use
+	 * {@link #searchCount(SearchSessionFactory, SearchQueryUnique, int)} to bound the count cost.
+	 * Otherwise the requested page of results is returned and the total hit count is <code>null</code>.
 	 *
 	 * @param searchSessionFactory search session factory
 	 * @param uniqueQuery unique query {@link #newQuery(Class, Function, String, Function)}
 	 * @param offset offset of results
 	 * @param limit limit of results
-	 * @param includeTotalHitCount calculate total hit count (it is more expensive query)
+	 * @param includeTotalHitCount calculate the total hit count instead of fetching results
 	 * @return the results
 	 * @param <T> the type of results
 	 */
 	public static <T> SearchUniqueResults<T> search(SearchSessionFactory searchSessionFactory,
 	        SearchQueryUnique<?, T> uniqueQuery, final Integer offset, final Integer limit, Boolean includeTotalHitCount) {
-		if (includeTotalHitCount == null) {
-			includeTotalHitCount = false;
+		SearchSession searchSession = searchSessionFactory.getSearchSession();
+
+		if (Boolean.TRUE.equals(includeTotalHitCount)) {
+			// The count path only needs the total number of distinct hits, so it skips fetching and
+			// hydrating a page of results entirely.
+			long totalHitCount = searchTotalHitCount(searchSession, uniqueQuery, UNBOUNDED_DEDUPLICATION);
+			return new SearchUniqueResults<>(new ArrayList<>(), offset, limit, totalHitCount);
 		}
 
-		SearchSession searchSession = searchSessionFactory.getSearchSession();
+		return searchWithResults(searchSession, uniqueQuery, offset, limit);
+	}
+
+	/**
+	 * Fetches the requested page of deduplicated results, walking the joined queries in order.
+	 * <p>
+	 * The deduplication scroll for each query is bounded to the requested page: it stops once
+	 * <code>offset + limit</code> unique keys have been found, because any hit beyond that point sorts
+	 * after the page and therefore cannot appear in it. This keeps the work proportional to the page
+	 * size rather than to the full hit set.
+	 * <p>
+	 * This bound relies on the deduplication scroll and the page fetch producing hits in the same
+	 * order. Both queries are left unsorted so they default to descending score, and the fetch's filter
+	 * clauses do not affect scoring; do not add an explicit sort to one without the other, or the bound
+	 * no longer holds.
+	 */
+	private static <T> SearchUniqueResults<T> searchWithResults(SearchSession searchSession,
+	        SearchQueryUnique<?, T> uniqueQuery, final Integer offset, final Integer limit) {
 		List<T> results = new ArrayList<>();
 		Collection<Object> uniqueKeys = new LinkedHashSet<>(); // Preserve the order
 		final int maxClauseCount = Math.round(BooleanQuery.getMaxClauseCount() / 2.5f);
 		SearchQueryUnique<?, T> nextQuery = uniqueQuery;
-		long totalHitCount = 0;
 		Integer currentOffset = offset;
 		Integer currentLimit = limit;
 		while (nextQuery != null) {
+			// A sub-query that is followed by another must define a unique key: the join deduplicates
+			// across sub-queries by unique key, and the offset carried to the next sub-query is derived
+			// from the number of unique keys this one contributed. A null key would leave both unsupported,
+			// so fail loudly rather than silently mis-paginate. All current callers satisfy this.
+			if (nextQuery.getJoinedQuery() != null && nextQuery.getUniqueKey() == null) {
+				throw new IllegalStateException("A joined SearchQueryUnique sub-query must define a unique key");
+			}
+
 			SearchScope<?> scope = searchSession.scope(nextQuery.getScope());
 			SearchPredicateFactory predicateFactory = scope.predicate();
 			SearchPredicate searchPredicate = nextQuery.getSearch().apply(predicateFactory);
 			SearchQuery<?> query;
 
 			final Collection<Object> previousQueryUniqueKeys = new ArrayList<>(uniqueKeys);
+			DeduplicationResult dedup = null;
 
 			if (nextQuery.getUniqueKey() != null) {
 				final String uniqueKey = nextQuery.getUniqueKey();
@@ -240,30 +308,22 @@ public class SearchQueryUnique<T, R> {
 				SearchQuery<List<?>> uniqueKeyQuery = searchSession.search(scope)
 				        .select(f -> f.composite(f.field(uniqueKey), f.id())).where(searchPredicate).toQuery();
 
-				final List<Object> duplicateIds = new ArrayList<>();
-				try (SearchScroll<List<?>> scroll = uniqueKeyQuery.scroll(500)) {
-					SearchScrollResult<List<?>> chunk = scroll.next();
-					while (chunk.hasHits()) {
-						boolean limitReached = false;
-						for (List<?> match : chunk.hits()) {
-							if (!uniqueKeys.add(match.get(0))) {
-								duplicateIds.add(match.get(1));
-								if (duplicateIds.size() > maxClauseCount) {
-									// stop at max clause count
-									limitReached = true;
-									break;
-								}
-							}
-						}
-						if (limitReached) {
-							break;
-						}
-						chunk = scroll.next();
-					}
+				// A null limit means "fetch everything", so scan the whole hit set; otherwise only scan
+				// far enough to fill the requested page.
+				final Integer maxNewUniqueKeys;
+				if (currentLimit == null) {
+					maxNewUniqueKeys = null;
+				} else {
+					maxNewUniqueKeys = (currentOffset == null ? 0 : currentOffset) + currentLimit;
 				}
+				dedup = collectDuplicateIds(uniqueKeyQuery, uniqueKeys, maxClauseCount, maxNewUniqueKeys,
+				    DEFAULT_SCROLL_CHUNK_SIZE);
+				final List<Object> duplicateIds = dedup.duplicateIds;
 
 				if (uniqueKeys.size() > maxClauseCount) {
-					uniqueKeys = new ArrayList<>(uniqueKeys).subList(0, maxClauseCount);
+					// Keep it a Set so later queries can still detect duplicates; a plain List here would
+					// make add() always return true and defeat deduplication for subsequent joined queries.
+					uniqueKeys = new LinkedHashSet<>(new ArrayList<>(uniqueKeys).subList(0, maxClauseCount));
 				}
 
 				query = searchSession.search(scope).where(f -> f.bool().with(b -> {
@@ -300,32 +360,194 @@ public class SearchQueryUnique<T, R> {
 				}
 			}
 
-			if (limit != null && results.size() == limit && !includeTotalHitCount) {
-				// End early as we don't need to calculate total hit count
+			if (limit != null && results.size() == limit) {
+				// The requested page is full, so there is no need to visit the remaining queries.
 				return new SearchUniqueResults<>(results, offset, limit, null);
 			}
 
-			if (includeTotalHitCount || (nextQuery.getJoinedQuery() != null && partialResults.isEmpty()
-			        && currentOffset != null && currentOffset != 0)) {
-				// Fetch total hit count only if explicitly requested or if offset caused the query to return 0 results,
-				// and we will be trying to fetch more results in the next query
-				totalHitCount += query.fetchTotalHitCount();
-			} else {
-				totalHitCount += partialResults.size();
-			}
-
-			if (currentLimit != null) {
-				currentLimit = limit - results.size();
-			}
-			if (currentOffset != null) {
-				currentOffset = currentOffset - (int) totalHitCount;
-				currentOffset = currentOffset < 0 ? 0 : currentOffset;
+			// The page was not filled by this query, so carry the remaining offset/limit to the next
+			// query. Because the page is not full, this query's whole deduplicated hit set was consumed,
+			// which is exactly the number of new unique keys the scroll found (barring the pathological
+			// maxClauseCount duplicate-id cap, which can stop the scroll early and understate the count for
+			// queries with more than maxClauseCount duplicates). The guard above guarantees dedup != null
+			// whenever there is a joined query to carry to.
+			if (nextQuery.getJoinedQuery() != null) {
+				int consumed = dedup.newUniqueKeyCount;
+				if (currentLimit != null) {
+					currentLimit = limit - results.size();
+				}
+				if (currentOffset != null) {
+					currentOffset = Math.max(0, currentOffset - consumed);
+				}
 			}
 
 			nextQuery = nextQuery.getJoinedQuery();
 		}
 
-		return new SearchUniqueResults<>(results, offset, limit, includeTotalHitCount ? totalHitCount : null);
+		return new SearchUniqueResults<>(results, offset, limit, null);
+	}
+
+	/**
+	 * Calculates the total number of distinct hits across the joined queries.
+	 * <p>
+	 * Deduplication is done by collecting distinct unique-key values from an index-level projection,
+	 * which avoids hydrating hits and avoids the follow-up filtering query used on the results path.
+	 * <p>
+	 * The exact deduplication is bounded by <code>cap</code>: once more than <code>cap</code> distinct
+	 * hits have been seen, the scroll stops and the raw hit count (which counts duplicates and so is an
+	 * upper bound on the distinct count) is returned instead of scanning the whole hit set. This lets a
+	 * caller keep the count exact for the result sizes users actually paginate through while bounding
+	 * the cost for very large hit sets; {@link #UNBOUNDED_DEDUPLICATION} keeps it always exact.
+	 */
+	private static long searchTotalHitCount(SearchSession searchSession, SearchQueryUnique<?, ?> uniqueQuery, int cap) {
+		final Set<Object> uniqueKeys = new HashSet<>();
+		long nonUniqueHitCount = 0;
+		boolean exceededCap = false;
+		SearchQueryUnique<?, ?> nextQuery = uniqueQuery;
+		while (nextQuery != null && !exceededCap) {
+			if (nextQuery.getUniqueKey() != null) {
+				SearchScope<?> scope = searchSession.scope(nextQuery.getScope());
+				SearchPredicate searchPredicate = nextQuery.getSearch().apply(scope.predicate());
+				final String uniqueKey = nextQuery.getUniqueKey();
+				SearchQuery<?> keyQuery = searchSession.search(scope).select(f -> f.field(uniqueKey)).where(searchPredicate)
+				        .toQuery();
+				collectUniqueKeys(keyQuery, uniqueKeys, cap, DEFAULT_SCROLL_CHUNK_SIZE);
+				exceededCap = uniqueKeys.size() > cap;
+			} else {
+				// Without a unique key we cannot deduplicate, so fall back to the raw hit count.
+				nonUniqueHitCount += fetchTotalHitCount(searchSession, nextQuery);
+			}
+			nextQuery = nextQuery.getJoinedQuery();
+		}
+
+		if (!exceededCap) {
+			return uniqueKeys.size() + nonUniqueHitCount;
+		}
+
+		// There are more than `cap` distinct hits, so return the raw hit count as an upper bound rather
+		// than scanning the entire hit set to determine the exact distinct count.
+		return rawHitCount(searchSession, uniqueQuery);
+	}
+
+	/**
+	 * Returns the raw (non-deduplicated) total hit count across the joined queries. This counts
+	 * documents that share a unique key more than once, so it is an upper bound on the distinct count.
+	 */
+	private static long rawHitCount(SearchSession searchSession, SearchQueryUnique<?, ?> uniqueQuery) {
+		long totalHitCount = 0;
+		SearchQueryUnique<?, ?> nextQuery = uniqueQuery;
+		while (nextQuery != null) {
+			totalHitCount += fetchTotalHitCount(searchSession, nextQuery);
+			nextQuery = nextQuery.getJoinedQuery();
+		}
+		return totalHitCount;
+	}
+
+	/**
+	 * Returns the raw (non-deduplicated) hit count for a single query.
+	 */
+	private static long fetchTotalHitCount(SearchSession searchSession, SearchQueryUnique<?, ?> query) {
+		SearchScope<?> scope = searchSession.scope(query.getScope());
+		SearchPredicate searchPredicate = query.getSearch().apply(scope.predicate());
+		return searchSession.search(scope).where(searchPredicate).fetchTotalHitCount();
+	}
+
+	/**
+	 * Scrolls the unique-key projection of the given query, adding each key to <code>uniqueKeys</code>
+	 * until more than <code>cap</code> distinct keys have been collected.
+	 *
+	 * @param keyQuery the unique-key projection query to scroll
+	 * @param uniqueKeys the running set of unique keys, mutated in place
+	 * @param cap the number of distinct keys to collect before stopping
+	 * @param chunkSize the scroll chunk size
+	 * @return the number of hits scanned before stopping
+	 */
+	static int collectUniqueKeys(SearchQuery<?> keyQuery, Collection<Object> uniqueKeys, int cap, int chunkSize) {
+		int scannedHitCount = 0;
+		try (SearchScroll<?> scroll = keyQuery.scroll(chunkSize)) {
+			SearchScrollResult<?> chunk = scroll.next();
+			scan: while (chunk.hasHits()) {
+				for (Object key : chunk.hits()) {
+					scannedHitCount++;
+					uniqueKeys.add(key);
+					if (uniqueKeys.size() > cap) {
+						break scan;
+					}
+				}
+				chunk = scroll.next();
+			}
+		}
+		return scannedHitCount;
+	}
+
+	/**
+	 * Scrolls the (uniqueKey, id) projection of the given query, adding newly seen unique keys to
+	 * <code>uniqueKeys</code> and collecting the ids of documents whose unique key was already seen.
+	 * <p>
+	 * The scroll stops early once <code>maxNewUniqueKeys</code> new unique keys have been collected
+	 * (when non-null), bounding the work to the requested page. It also stops once more than
+	 * <code>maxClauseCount</code> duplicate ids have been collected, since those ids become clauses of
+	 * the follow-up filtering query and are subject to the Lucene clause limit.
+	 *
+	 * @param uniqueKeyQuery the (uniqueKey, id) projection query to scroll
+	 * @param uniqueKeys the running set of unique keys, mutated in place
+	 * @param maxClauseCount the maximum number of duplicate ids to collect
+	 * @param maxNewUniqueKeys the number of new unique keys to collect before stopping, or
+	 *            <code>null</code> to scan the whole hit set
+	 * @param chunkSize the scroll chunk size
+	 * @return the collected duplicate ids together with counts describing the scan
+	 */
+	static DeduplicationResult collectDuplicateIds(SearchQuery<List<?>> uniqueKeyQuery, Collection<Object> uniqueKeys,
+	        int maxClauseCount, Integer maxNewUniqueKeys, int chunkSize) {
+		final List<Object> duplicateIds = new ArrayList<>();
+		int newUniqueKeyCount = 0;
+		int scannedHitCount = 0;
+		try (SearchScroll<List<?>> scroll = uniqueKeyQuery.scroll(chunkSize)) {
+			SearchScrollResult<List<?>> chunk = scroll.next();
+			scan: while (chunk.hasHits()) {
+				for (List<?> match : chunk.hits()) {
+					scannedHitCount++;
+					if (uniqueKeys.add(match.get(0))) {
+						newUniqueKeyCount++;
+						if (maxNewUniqueKeys != null && newUniqueKeyCount >= maxNewUniqueKeys) {
+							// We have enough unique keys to satisfy the requested page.
+							break scan;
+						}
+					} else {
+						duplicateIds.add(match.get(1));
+						if (duplicateIds.size() > maxClauseCount) {
+							// stop at max clause count
+							break scan;
+						}
+					}
+				}
+				chunk = scroll.next();
+			}
+		}
+		return new DeduplicationResult(duplicateIds, newUniqueKeyCount, scannedHitCount);
+	}
+
+	/**
+	 * Holds the outcome of {@link #collectDuplicateIds}: the duplicate ids to filter out, the number of
+	 * new unique keys found, and the number of hits actually scanned (which is bounded when the page
+	 * limit is reached).
+	 */
+	static final class DeduplicationResult {
+
+		final List<Object> duplicateIds;
+
+		final int newUniqueKeyCount;
+
+		/**
+		 * Total hits scanned before the scroll stopped; exposed only for test assertions on boundedness.
+		 */
+		final int scannedHitCount;
+
+		DeduplicationResult(List<Object> duplicateIds, int newUniqueKeyCount, int scannedHitCount) {
+			this.duplicateIds = duplicateIds;
+			this.newUniqueKeyCount = newUniqueKeyCount;
+			this.scannedHitCount = scannedHitCount;
+		}
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/search/SearchQueryUnique.java
@@ -462,7 +462,7 @@ public class SearchQueryUnique<T, R> {
 	 * @param chunkSize the scroll chunk size
 	 * @return the number of hits scanned before stopping
 	 */
-	static int collectUniqueKeys(SearchQuery<?> keyQuery, Collection<Object> uniqueKeys, int cap, int chunkSize) {
+	static int collectUniqueKeys(SearchQuery<?> keyQuery, Set<Object> uniqueKeys, int cap, int chunkSize) {
 		int scannedHitCount = 0;
 		try (SearchScroll<?> scroll = keyQuery.scroll(chunkSize)) {
 			SearchScrollResult<?> chunk = scroll.next();

--- a/api/src/test/java/org/openmrs/api/db/hibernate/search/SearchQueryUniqueTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/search/SearchQueryUniqueTest.java
@@ -1,0 +1,354 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.db.hibernate.search;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.hibernate.search.engine.search.predicate.SearchPredicate;
+import org.hibernate.search.engine.search.predicate.dsl.SearchPredicateFactory;
+import org.hibernate.search.engine.search.query.SearchQuery;
+import org.hibernate.search.mapper.orm.scope.SearchScope;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Person;
+import org.openmrs.PersonName;
+import org.openmrs.api.PersonService;
+import org.openmrs.api.db.hibernate.search.SearchQueryUnique.DeduplicationResult;
+import org.openmrs.api.db.hibernate.search.session.SearchSessionFactory;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Verifies that {@link SearchQueryUnique} deduplicates correctly while bounding its work to the
+ * requested page (list path) and to a single index scan per query (count path).
+ */
+public class SearchQueryUniqueTest extends BaseContextSensitiveTest {
+
+	private static final String FAMILY_NAME = "zzzbound";
+
+	private static final int PERSON_COUNT = 20;
+
+	private static final int DUPLICATE_COUNT = 5;
+
+	private static final int TOTAL_NAME_HITS = PERSON_COUNT + DUPLICATE_COUNT;
+
+	// Fixture for the joined (multi-sub-query) tests: persons matching only the first sub-query, only
+	// the second, and both (which must be deduplicated to one person across the join).
+	private static final String FAMILY_A = "aaajoin";
+
+	private static final String FAMILY_B = "bbbjoin";
+
+	private static final int ONLY_A = 6;
+
+	private static final int ONLY_B = 4;
+
+	private static final int BOTH = 3;
+
+	private static final int DISTINCT_JOINED = ONLY_A + ONLY_B + BOTH;
+
+	private static final int RAW_JOINED = (ONLY_A + BOTH) + (ONLY_B + BOTH);
+
+	@Autowired
+	private SearchSessionFactory searchSessionFactory;
+
+	@Autowired
+	private PersonService personService;
+
+	@BeforeEach
+	public void createMatchingPersons() {
+		// Every person shares the same family name so a single predicate matches them all. The first
+		// DUPLICATE_COUNT persons get a second matching name, producing hits that share a person id and
+		// therefore must be deduplicated.
+		for (int i = 0; i < PERSON_COUNT; i++) {
+			Person person = new Person();
+			person.setGender("M");
+			person.addName(new PersonName("Given" + i, null, FAMILY_NAME));
+			if (i < DUPLICATE_COUNT) {
+				person.addName(new PersonName("Alt" + i, null, FAMILY_NAME));
+			}
+			personService.savePerson(person);
+		}
+
+		updateSearchIndex();
+	}
+
+	private Function<SearchPredicateFactory, SearchPredicate> matchingPredicate() {
+		return matchingPredicate(FAMILY_NAME);
+	}
+
+	private Function<SearchPredicateFactory, SearchPredicate> matchingPredicate(String familyName) {
+		return f -> f.match().field("familyNameExact").matching(familyName).toPredicate();
+	}
+
+	private SearchQueryUnique<PersonName, Person> personNameQuery() {
+		return SearchQueryUnique.newQuery(PersonName.class, matchingPredicate(), "person.personId", PersonName::getPerson);
+	}
+
+	/**
+	 * Builds a two-sub-query join over PersonName: the first sub-query matches {@link #FAMILY_A}, the
+	 * second {@link #FAMILY_B}. Persons matching both must be returned/counted once across the join.
+	 */
+	private SearchQueryUnique<?, Person> joinedQuery() {
+		return SearchQueryUnique
+		        .newQuery(PersonName.class, matchingPredicate(FAMILY_A), "person.personId", PersonName::getPerson)
+		        .join(SearchQueryUnique.newQuery(PersonName.class, matchingPredicate(FAMILY_B), "person.personId",
+		            PersonName::getPerson));
+	}
+
+	private void createJoinedFixture() {
+		for (int i = 0; i < ONLY_A; i++) {
+			savePersonWithFamilyNames(FAMILY_A);
+		}
+		for (int i = 0; i < ONLY_B; i++) {
+			savePersonWithFamilyNames(FAMILY_B);
+		}
+		for (int i = 0; i < BOTH; i++) {
+			savePersonWithFamilyNames(FAMILY_A, FAMILY_B);
+		}
+		updateSearchIndex();
+	}
+
+	private void savePersonWithFamilyNames(String... familyNames) {
+		Person person = new Person();
+		person.setGender("F");
+		int i = 0;
+		for (String familyName : familyNames) {
+			person.addName(new PersonName("Join" + (i++), null, familyName));
+		}
+		personService.savePerson(person);
+	}
+
+	private static List<Integer> personIds(List<Person> persons) {
+		return persons.stream().map(Person::getPersonId).collect(Collectors.toList());
+	}
+
+	@Test
+	public void searchCount_shouldPerformOnlyOneQueryExecutionPerQuery() {
+		// Regression test for the count path: when the result set is within the deduplication cap the
+		// total hit count is computed from a single index-level scroll per query, so the follow-up
+		// filtering query and the separate total-hit-count query that the previous implementation issued
+		// must no longer be executed.
+		SearchSession spySession = spy(searchSessionFactory.getSearchSession());
+		SearchSessionFactory spyFactory = () -> spySession;
+
+		Long count = SearchQueryUnique.searchCount(spyFactory, personNameQuery());
+
+		assertEquals(Long.valueOf(PERSON_COUNT), count);
+		verify(spySession, times(1)).search(any(SearchScope.class));
+	}
+
+	@Test
+	public void searchCount_shouldReturnExactCountByDefault() {
+		// The no-cap overload deduplicates without bound, so even the duplicate names collapse to the
+		// exact distinct person count.
+		Long count = SearchQueryUnique.searchCount(searchSessionFactory, personNameQuery());
+
+		assertEquals(Long.valueOf(PERSON_COUNT), count);
+	}
+
+	@Test
+	public void searchCount_shouldReturnRawUpperBoundWhenDistinctHitsExceedCap() {
+		// With a cap below the number of distinct persons the exact deduplication is abandoned and the
+		// raw hit count (which counts the duplicate names) is returned as an upper bound.
+		Long count = SearchQueryUnique.searchCount(searchSessionFactory, personNameQuery(), DUPLICATE_COUNT);
+
+		assertEquals(Long.valueOf(TOTAL_NAME_HITS), count);
+	}
+
+	@Test
+	public void collectUniqueKeys_shouldStopScanningOnceCapExceeded() {
+		int cap = DUPLICATE_COUNT;
+		int chunkSize = 10;
+		Set<Object> uniqueKeys = new LinkedHashSet<>();
+
+		int scannedHitCount = SearchQueryUnique.collectUniqueKeys(uniqueKeyOnlyQuery(), uniqueKeys, cap, chunkSize);
+
+		assertEquals(cap + 1, uniqueKeys.size(), "should collect one key past the cap and then stop");
+		assertTrue(scannedHitCount <= chunkSize,
+		    "expected the scroll to stop within the first chunk but scanned " + scannedHitCount);
+		assertTrue(scannedHitCount < TOTAL_NAME_HITS, "expected fewer scanned hits than the full result set");
+	}
+
+	@Test
+	public void collectUniqueKeys_shouldScanEverythingWhenBelowCap() {
+		Set<Object> uniqueKeys = new LinkedHashSet<>();
+
+		int scannedHitCount = SearchQueryUnique.collectUniqueKeys(uniqueKeyOnlyQuery(), uniqueKeys, 1000, 10);
+
+		assertEquals(TOTAL_NAME_HITS, scannedHitCount);
+		assertEquals(PERSON_COUNT, uniqueKeys.size());
+	}
+
+	@Test
+	public void search_shouldReturnDeduplicatedResultsForFullResultSet() {
+		List<Person> results = SearchQueryUnique.search(searchSessionFactory, personNameQuery(), 0, PERSON_COUNT);
+
+		assertEquals(PERSON_COUNT, results.size());
+		Set<Integer> personIds = results.stream().map(Person::getPersonId).collect(Collectors.toSet());
+		assertEquals(PERSON_COUNT, personIds.size(), "results must not contain duplicate persons");
+	}
+
+	@Test
+	public void search_shouldReturnAllDeduplicatedResultsWhenNoOffsetOrLimit() {
+		// The no-offset/no-limit overload fetches the entire deduplicated result set (the "fetch
+		// everything" path); the deduplication scroll is unbounded in this case.
+		List<Person> results = SearchQueryUnique.search(searchSessionFactory, personNameQuery());
+
+		assertEquals(PERSON_COUNT, results.size());
+		Set<Integer> personIds = results.stream().map(Person::getPersonId).collect(Collectors.toSet());
+		assertEquals(PERSON_COUNT, personIds.size(), "results must not contain duplicate persons");
+	}
+
+	@Test
+	public void search_shouldReturnDeduplicatedPage() {
+		int pageSize = 5;
+
+		List<Person> results = SearchQueryUnique.search(searchSessionFactory, personNameQuery(), 0, pageSize);
+
+		assertEquals(pageSize, results.size());
+		Set<Integer> personIds = results.stream().map(Person::getPersonId).collect(Collectors.toSet());
+		assertEquals(pageSize, personIds.size(), "results must not contain duplicate persons");
+	}
+
+	@Test
+	public void search_shouldReturnCorrectPageForNonZeroOffset() {
+		// The second page must be the corresponding slice of the full ordered result, with no overlap or
+		// gap relative to the first page.
+		List<Integer> all = personIds(SearchQueryUnique.search(searchSessionFactory, personNameQuery(), 0, PERSON_COUNT));
+		List<Integer> page = personIds(SearchQueryUnique.search(searchSessionFactory, personNameQuery(), 5, 5));
+
+		assertEquals(all.subList(5, 10), page);
+	}
+
+	@Test
+	public void searchCount_shouldDeduplicateAcrossJoinedQueries() {
+		// A person matching both sub-queries must be counted once, so the count is the distinct person
+		// count, not the summed raw hit count of the two sub-queries.
+		createJoinedFixture();
+
+		Long count = SearchQueryUnique.searchCount(searchSessionFactory, joinedQuery());
+
+		assertEquals(Long.valueOf(DISTINCT_JOINED), count);
+	}
+
+	@Test
+	public void search_shouldDeduplicatePersonsMatchedByMultipleJoinedQueries() {
+		createJoinedFixture();
+
+		List<Person> results = SearchQueryUnique.search(searchSessionFactory, joinedQuery(), 0, DISTINCT_JOINED);
+
+		assertEquals(DISTINCT_JOINED, results.size());
+		Set<Integer> distinct = results.stream().map(Person::getPersonId).collect(Collectors.toSet());
+		assertEquals(DISTINCT_JOINED, distinct.size(), "a person matched by both sub-queries must appear once");
+	}
+
+	@Test
+	public void search_shouldPageAcrossJoinedQueryBoundary() {
+		// The first sub-query yields ONLY_A + BOTH distinct persons; a page whose offset lands near that
+		// boundary must straddle both sub-queries correctly, matching the corresponding slice of the full
+		// ordered result.
+		createJoinedFixture();
+
+		int offset = ONLY_A + BOTH - 2;
+		int limit = 4;
+		List<Integer> all = personIds(SearchQueryUnique.search(searchSessionFactory, joinedQuery(), 0, DISTINCT_JOINED));
+		List<Integer> page = personIds(SearchQueryUnique.search(searchSessionFactory, joinedQuery(), offset, limit));
+
+		assertEquals(all.subList(offset, offset + limit), page);
+		assertEquals(limit, page.stream().distinct().count(), "page must not contain duplicate persons");
+	}
+
+	@Test
+	public void searchCount_shouldReturnRawUpperBoundAcrossJoinedQueriesWhenCapExceeded() {
+		createJoinedFixture();
+
+		Long count = SearchQueryUnique.searchCount(searchSessionFactory, joinedQuery(), BOTH);
+
+		assertEquals(Long.valueOf(RAW_JOINED), count);
+	}
+
+	@Test
+	public void collectDuplicateIds_shouldStopScanningOncePageIsSatisfied() {
+		SearchQuery<List<?>> uniqueKeyQuery = uniqueKeyQuery();
+
+		int pageSize = DUPLICATE_COUNT; // fits within a single (small) scroll chunk
+		int chunkSize = 10;
+		DeduplicationResult bounded = SearchQueryUnique.collectDuplicateIds(uniqueKeyQuery, new LinkedHashSet<>(), 1000,
+		    pageSize, chunkSize);
+
+		assertEquals(pageSize, bounded.newUniqueKeyCount);
+		assertTrue(bounded.scannedHitCount <= chunkSize,
+		    "expected the scroll to stop within the first chunk but scanned " + bounded.scannedHitCount);
+		assertTrue(bounded.scannedHitCount < TOTAL_NAME_HITS, "expected fewer scanned hits than the full result set");
+	}
+
+	@Test
+	public void collectDuplicateIds_shouldScanEverythingWhenUnbounded() {
+		SearchQuery<List<?>> uniqueKeyQuery = uniqueKeyQuery();
+
+		DeduplicationResult unbounded = SearchQueryUnique.collectDuplicateIds(uniqueKeyQuery, new LinkedHashSet<>(), 1000,
+		    null, 10);
+
+		assertEquals(TOTAL_NAME_HITS, unbounded.scannedHitCount);
+		assertEquals(PERSON_COUNT, unbounded.newUniqueKeyCount);
+		assertEquals(DUPLICATE_COUNT, unbounded.duplicateIds.size());
+	}
+
+	@Test
+	public void collectDuplicateIds_shouldStopScanningOnceMaxClauseCountReached() {
+		// With more duplicates than maxClauseCount, the scroll must stop once the clause limit is
+		// reached (it collects one duplicate id past the limit) rather than scanning the whole hit set.
+		int maxClauseCount = 2;
+		DeduplicationResult bounded = SearchQueryUnique.collectDuplicateIds(uniqueKeyQuery(), new LinkedHashSet<>(),
+		    maxClauseCount, null, SearchQueryUnique.DEFAULT_SCROLL_CHUNK_SIZE);
+
+		assertEquals(maxClauseCount + 1, bounded.duplicateIds.size());
+		assertTrue(bounded.scannedHitCount < TOTAL_NAME_HITS, "expected fewer scanned hits than the full result set");
+	}
+
+	@Test
+	public void search_shouldRejectJoinedSubQueryWithoutUniqueKey() {
+		// A joined sub-query cannot participate in cross-sub-query dedup / offset carry without a unique
+		// key, so this unsupported configuration must fail loudly rather than mis-paginate.
+		SearchQueryUnique<?, Person> query = SearchQueryUnique
+		        .newQuery(PersonName.class, matchingPredicate(FAMILY_A), null, PersonName::getPerson).join(SearchQueryUnique
+		                .newQuery(PersonName.class, matchingPredicate(FAMILY_B), "person.personId", PersonName::getPerson));
+
+		assertThrows(IllegalStateException.class, () -> SearchQueryUnique.search(searchSessionFactory, query, 0, 10));
+	}
+
+	private SearchQuery<List<?>> uniqueKeyQuery() {
+		SearchSession searchSession = searchSessionFactory.getSearchSession();
+		SearchScope<PersonName> scope = searchSession.scope(PersonName.class);
+		SearchPredicate predicate = matchingPredicate().apply(scope.predicate());
+		return searchSession.search(scope).select(f -> f.composite(f.field("person.personId"), f.id())).where(predicate)
+		        .toQuery();
+	}
+
+	private SearchQuery<?> uniqueKeyOnlyQuery() {
+		SearchSession searchSession = searchSessionFactory.getSearchSession();
+		SearchScope<PersonName> scope = searchSession.scope(PersonName.class);
+		SearchPredicate predicate = matchingPredicate().apply(scope.predicate());
+		return searchSession.search(scope).select(f -> f.field("person.personId")).where(predicate).toQuery();
+	}
+}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This introduces two optimizations that should greatly speed up queries for patients:

1. When querying for patients, concepts, etc. (but not counts of the same) we only read and de-duplicate results until we have hit the required number of items. This means that for the first few set of pages, the results should be returned substantially faster.
2. Adds a bounded count mechanism so we don't have to scroll through all pages of data. However, this does mean that numbers of patients found over 1000 (or rather whatever the `person.searchMaxResults` GP is set to) are approximate and will be larger than the number of unique patients found.

I ran some benchmarking on this with 100k synthetic patients:

```
==================================================================
 Comparison (median ms; speedup = master / branch)
==================================================================
scenario/operation          branch (ms)    master (ms)    speedup 
------------------------   ------------   ------------   -------- 
name-huge/count                   19.26         138.03      7.17x 
name-huge/firstPage               54.87         171.49      3.13x 
name-huge/deepPage@950            56.97         168.53      2.96x 
name-medium/count                  7.87           8.38      1.06x 
name-medium/firstPage             47.19          52.31      1.11x 
name-rare/count                    3.47           3.56      1.03x 
name-rare/firstPage                9.80          13.12      1.34x 
attr-medium/count                 10.76           9.66      0.90x 
attr-medium/firstPage             20.59          27.16      1.32x 
id-start-huge/count               13.07         129.22      9.89x 
id-start-huge/firstPage           22.60         148.09      6.55x 
id-start-huge/deepPage@950        24.59         150.14      6.11x
id-exact/count                     4.23           3.99      0.94x 
id-exact/firstPage                10.51           9.02      0.86x 
```

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6687

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

