### PR TITLE
TRUNK-6692: Make test resource path constants immutable

### DIFF
--- a/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/AbstractSnapshotTunerTest.java
@@ -37,7 +37,7 @@ public class AbstractSnapshotTunerTest {
 
 	private static final String HTTP_OPENMRS_ORG_LICENSE = "http://openmrs.org/license";
 
-	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
+	private static final String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 
 	/*
 	 * An instance of org.openmrs.liquibase.SchemaOnlyTuner is used to test behaviour implemented in the

--- a/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/CoreDataTunerTest.java
@@ -44,7 +44,7 @@ public class CoreDataTunerTest {
 	        .get("org", "openmrs", "liquibase", "snapshots", "core-data", "liquibase-core-data-UPDATED-SNAPSHOT.xml")
 	        .toString();
 
-	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
+	private static final String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 
 	public static final int TWENTY_FIVE = 25;
 

--- a/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
+++ b/liquibase/src/test/java/org/openmrs/liquibase/SchemaOnlyTunerTest.java
@@ -47,7 +47,7 @@ public class SchemaOnlyTunerTest {
 	        .get("org", "openmrs", "liquibase", "snapshots", "schema-only", "liquibase-schema-only-UPDATED-SNAPSHOT.xml")
 	        .toString();
 
-	private static String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
+	private static final String PATH_TO_TEST_RESOURCES = Paths.get("src", "test", "resources").toString();
 
 	private Document document;
 


### PR DESCRIPTION
## **What does this PR do?**

Marks the test resource path constants as **`final`** in the Liquibase test classes, as they are initialized only once and are never reassigned.

## **Why is this needed?**

This is a small **code quality improvement** that makes the code's intent clearer by indicating that these values are **immutable**, without introducing any functional changes.

JIRA TICKET : https://openmrs.atlassian.net/browse/TRUNK-6692