### PR TITLE
TRUNK-6694 & TRUNK-6695: Avoid synchronization in service fetching

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.aopalliance.aop.Advice;
 import org.openmrs.api.APIException;
@@ -82,7 +83,7 @@ public class ServiceContext implements ApplicationContextAware {
 
 	private ApplicationContext applicationContext;
 
-	private static boolean refreshingContext = false;
+	private static volatile boolean refreshingContext = false;
 
 	private static final Object refreshingContextLock = new Object();
 
@@ -93,7 +94,7 @@ public class ServiceContext implements ApplicationContextAware {
 	private boolean useSystemClassLoader = false;
 
 	// Cached service objects
-	Map<Class, Object> services = new HashMap<>();
+	Map<Class, Object> services = new ConcurrentHashMap<>();
 
 	// Advisors added to services by this service
 	Map<Class, Set<Advisor>> addedAdvisors = new HashMap<>();
@@ -680,20 +681,23 @@ public class ServiceContext implements ApplicationContextAware {
 			log.trace("Getting service: " + cls);
 		}
 
-		// if the context is refreshing, wait until it is
-		// done -- otherwise a null service might be returned
-		synchronized (refreshingContextLock) {
-			try {
-				while (refreshingContext) {
-					log.debug("Waiting to get service: {} while the context is being refreshed", cls);
+		// Only synchronize if we're refreshing the context; during context refreshes, we need
+		// to wait for services to be available. Otherwise we can take the fast-path.
+		if (refreshingContext) {
+			synchronized (refreshingContextLock) {
+				try {
+					while (refreshingContext) {
+						log.debug("Waiting to get service: {} while the context is being refreshed", cls);
 
-					refreshingContextLock.wait();
+						refreshingContextLock.wait();
 
-					log.debug("Finished waiting to get service {} while the context was being refreshed", cls);
+						log.debug("Finished waiting to get service {} while the context was being refreshed", cls);
+					}
+
+				} catch (InterruptedException e) {
+					log.warn("Refresh lock was interrupted", e);
+					Thread.currentThread().interrupt();
 				}
-
-			} catch (InterruptedException e) {
-				log.warn("Refresh lock was interrupted", e);
 			}
 		}
 

--- a/api/src/main/java/org/openmrs/api/context/ServiceContext.java
+++ b/api/src/main/java/org/openmrs/api/context/ServiceContext.java
@@ -696,7 +696,6 @@ public class ServiceContext implements ApplicationContextAware {
 
 				} catch (InterruptedException e) {
 					log.warn("Refresh lock was interrupted", e);
-					Thread.currentThread().interrupt();
 				}
 			}
 		}
@@ -869,9 +868,7 @@ public class ServiceContext implements ApplicationContextAware {
 	 *         doneRefreshingContext()
 	 */
 	public boolean isRefreshingContext() {
-		synchronized (refreshingContextLock) {
-			return refreshingContext;
-		}
+		return refreshingContext;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
@@ -125,35 +125,31 @@ public class ServiceContextTest extends BaseContextSensitiveTest {
 	public void getService_shouldBlockUntilAnInProgressRefreshCompletes() throws Exception {
 		AtomicReference<Object> retrievedService = new AtomicReference<>();
 		AtomicReference<Throwable> thrown = new AtomicReference<>();
-		CountDownLatch lookupStarted = new CountDownLatch(1);
+		CountDownLatch lookupComplete = new CountDownLatch(1);
 
 		serviceContext.startRefreshingContext();
 
 		Thread lookup = new Thread(() -> {
-			lookupStarted.countDown();
 			try {
 				retrievedService.set(serviceContext.getService(PatientService.class));
 			} catch (Throwable t) {
 				thrown.set(t);
+			} finally {
+				lookupComplete.countDown();
 			}
 		});
 		lookup.start();
 
 		try {
-			// wait for the lookup thread to reach getService, then give it time to block
-			assertTrue(lookupStarted.await(5, TimeUnit.SECONDS));
-			Thread.sleep(500);
-
-			// the lookup must not have returned while the refresh is in progress
-			assertNull(retrievedService.get());
-			assertTrue(lookup.isAlive());
+			// the lookup must not complete while the refresh is in progress; a broken (non-blocking)
+			// implementation would return the service and count the latch down almost immediately
+			assertFalse(lookupComplete.await(500, TimeUnit.MILLISECONDS));
 		} finally {
 			serviceContext.doneRefreshingContext();
 		}
 
 		// once the refresh finishes, the blocked lookup should complete
-		lookup.join(5000);
-		assertFalse(lookup.isAlive());
+		assertTrue(lookupComplete.await(5, TimeUnit.SECONDS));
 		assertNull(thrown.get());
 		assertNotNull(retrievedService.get());
 	}

--- a/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
@@ -11,15 +11,20 @@ package org.openmrs.api.context;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;
+import org.openmrs.api.PatientService;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.DatabaseUpdateException;
 import org.openmrs.util.InputRequiredException;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -102,4 +107,86 @@ public class ServiceContextTest extends BaseContextSensitiveTest {
 		verify(spiedServiceContext, never()).getMessageService();
 		verify(spiedServiceContext, never()).getMessageSourceService();
 	}
+
+	/**
+	 * @see ServiceContext#getService(Class)
+	 */
+	@Test
+	public void getService_shouldReturnServiceOnTheFastPathWhenNoRefreshIsInProgress() {
+		assertFalse(serviceContext.isRefreshingContext());
+
+		assertNotNull(serviceContext.getService(PatientService.class));
+	}
+
+	/**
+	 * @see ServiceContext#getService(Class)
+	 */
+	@Test
+	public void getService_shouldBlockUntilAnInProgressRefreshCompletes() throws Exception {
+		AtomicReference<Object> retrievedService = new AtomicReference<>();
+		AtomicReference<Throwable> thrown = new AtomicReference<>();
+		CountDownLatch lookupStarted = new CountDownLatch(1);
+
+		serviceContext.startRefreshingContext();
+
+		Thread lookup = new Thread(() -> {
+			lookupStarted.countDown();
+			try {
+				retrievedService.set(serviceContext.getService(PatientService.class));
+			} catch (Throwable t) {
+				thrown.set(t);
+			}
+		});
+		lookup.start();
+
+		try {
+			// wait for the lookup thread to reach getService, then give it time to block
+			assertTrue(lookupStarted.await(5, TimeUnit.SECONDS));
+			Thread.sleep(500);
+
+			// the lookup must not have returned while the refresh is in progress
+			assertNull(retrievedService.get());
+			assertTrue(lookup.isAlive());
+		} finally {
+			serviceContext.doneRefreshingContext();
+		}
+
+		// once the refresh finishes, the blocked lookup should complete
+		lookup.join(5000);
+		assertFalse(lookup.isAlive());
+		assertNull(thrown.get());
+		assertNotNull(retrievedService.get());
+	}
+
+	/**
+	 * @see ServiceContext#setService(Class, Object)
+	 */
+	@Test
+	public void setService_shouldMakeRegistrationsVisibleToOtherThreads() throws Exception {
+		serviceContext.setService(RegistryVisibilityService.class, new RegistryVisibilityServiceImpl());
+
+		AtomicReference<Object> retrievedService = new AtomicReference<>();
+		AtomicReference<Throwable> thrown = new AtomicReference<>();
+
+		Thread reader = new Thread(() -> {
+			try {
+				retrievedService.set(serviceContext.getService(RegistryVisibilityService.class));
+			} catch (Throwable t) {
+				thrown.set(t);
+			}
+		});
+		reader.start();
+		reader.join(5000);
+
+		assertNull(thrown.get());
+		assertNotNull(retrievedService.get());
+		assertTrue(retrievedService.get() instanceof RegistryVisibilityService);
+	}
+
+	/**
+	 * Simple service interface used to verify that registrations are safely published across threads.
+	 */
+	public interface RegistryVisibilityService {}
+
+	public static class RegistryVisibilityServiceImpl implements RegistryVisibilityService {}
 }

--- a/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;
 import org.openmrs.api.PatientService;
+import org.openmrs.api.ServiceNotFoundException;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.DatabaseUpdateException;
 import org.openmrs.util.InputRequiredException;
@@ -159,19 +160,30 @@ public class ServiceContextTest extends BaseContextSensitiveTest {
 	 */
 	@Test
 	public void setService_shouldMakeRegistrationsVisibleToOtherThreads() throws Exception {
-		serviceContext.setService(RegistryVisibilityService.class, new RegistryVisibilityServiceImpl());
-
 		AtomicReference<Object> retrievedService = new AtomicReference<>();
 		AtomicReference<Throwable> thrown = new AtomicReference<>();
+		CountDownLatch readerRunning = new CountDownLatch(1);
 
 		Thread reader = new Thread(() -> {
-			try {
-				retrievedService.set(serviceContext.getService(RegistryVisibilityService.class));
-			} catch (Throwable t) {
-				thrown.set(t);
+			readerRunning.countDown();
+			long deadline = System.currentTimeMillis() + 5000;
+			while (System.currentTimeMillis() < deadline) {
+				try {
+					retrievedService.set(serviceContext.getService(RegistryVisibilityService.class));
+					return;
+				} catch (ServiceNotFoundException ignored) {
+					// not registered yet; keep racing the write
+				} catch (Throwable t) {
+					thrown.set(t);
+					return;
+				}
 			}
 		});
 		reader.start();
+
+		assertTrue(readerRunning.await(5, TimeUnit.SECONDS));
+		serviceContext.setService(RegistryVisibilityService.class, new RegistryVisibilityServiceImpl());
+
 		reader.join(5000);
 
 		assertNull(thrown.get());

--- a/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ServiceContextTest.java
@@ -123,6 +123,16 @@ public class ServiceContextTest extends BaseContextSensitiveTest {
 	 * @see ServiceContext#getService(Class)
 	 */
 	@Test
+	public void getService_shouldThrowServiceNotFoundExceptionForAnUnregisteredService() {
+		assertFalse(serviceContext.isRefreshingContext());
+
+		assertThrows(ServiceNotFoundException.class, () -> serviceContext.getService(UnregisteredService.class));
+	}
+
+	/**
+	 * @see ServiceContext#getService(Class)
+	 */
+	@Test
 	public void getService_shouldBlockUntilAnInProgressRefreshCompletes() throws Exception {
 		AtomicReference<Object> retrievedService = new AtomicReference<>();
 		AtomicReference<Throwable> thrown = new AtomicReference<>();
@@ -197,4 +207,9 @@ public class ServiceContextTest extends BaseContextSensitiveTest {
 	public interface RegistryVisibilityService {}
 
 	public static class RegistryVisibilityServiceImpl implements RegistryVisibilityService {}
+
+	/**
+	 * Service interface that is never registered, used to exercise the not-found path of getService.
+	 */
+	public interface UnregisteredService {}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This implements two changes:

1. `ServiceContext#getService()` was synchronized which forced threads to access it synchronously. The problem is, that getting service instances is something we will wind up doing in most request processes, often multiple times and the only reason we needed the synchronization guard was to check if we were refreshing context (while the context is being refreshed, thread legitimately need to wait until all services are available). Consequently, this winds up being one of the hottest paths in the code base. With this PR, we switch from synchronization to making the context refresh indicator `volatile` and only synchronize if we are refreshing the context. This makes getting a registered service faster in the normal case.
2. The map of services was not correctly synchronized. It is now switched for a `ConcurrentHashMap`. Since this map is read-mostly, this shouldn't drastically affect things.

Since this is a performance consideration, here's the result of a benchmark on my 16-core M3:

| Threads | OLD (`synchronized` + `HashMap`) | NEW (`volatile` fast path + `ConcurrentHashMap`) | Speedup |
|--------:|--------------------------------:|-------------------------------------------------:|--------:|
| 1  | 240 M ops/s | 271 M ops/s  | 1.1× |
| 2  | 100 M ops/s | 518 M ops/s  | 5.2× |
| 4  | 19 M ops/s  | 1.01 B ops/s | 54×  |
| 8  | 23 M ops/s  | 2.02 B ops/s | 87×  |
| 16 | 24 M ops/s  | 1.62 B ops/s | 67×  |
| 32 | 24 M ops/s  | 2.95 B ops/s | 123× |

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6694 & https://issues.openmrs.org/browse/TRUNK-6695

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

