### PR TITLE
TRUNK-6715: Improve Javadocs and comment consistency.

### DIFF
--- a/api/src/main/java/org/openmrs/collection/ListPart.java
+++ b/api/src/main/java/org/openmrs/collection/ListPart.java
@@ -27,6 +27,7 @@ public class ListPart<E> extends CollectionPart<E> {
 	 * @param firstElement
 	 * @param maxElements
 	 * @param totalElements
+	 * @param totalElementsExact
 	 */
 	public ListPart(List<E> list, Long firstElement, Long maxElements, Long totalElements, Boolean totalElementsExact) {
 		super(list, firstElement, maxElements, totalElements, totalElementsExact);

--- a/api/src/main/java/org/openmrs/customdatatype/SingleCustomValue.java
+++ b/api/src/main/java/org/openmrs/customdatatype/SingleCustomValue.java
@@ -16,7 +16,7 @@ import org.openmrs.VisitAttribute;
 /**
  * Either a one-off custom value (e.g. a {@link GlobalProperty}) or a single custom value within a
  * {@link Customizable} object that may hold multiple (e.g. a {@link VisitAttribute} within a
- * {@link Visit}). The "referenceString" property is a String suitable for persistance in a database
+ * {@link Visit}). The "referenceString" property is a String suitable for persistence in a database
  * varchar column. It is typically a reference to the real value (e.g. it is the UUID of a location
  * or the URI of an image in a PACS). The "objectValue" property accessors are convenience methods
  * that use a {@link CustomDatatype} to convert to/from the String serializedValue.

--- a/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/CohortEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Cohort
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptAnswerEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ConceptAnswer
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptClassEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ConceptClass
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptDatatypeEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ConceptDatatype
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Concept
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNameEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ConceptName
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptNumericEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ConceptNumeric
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ConceptSourceEditor.java
@@ -14,7 +14,7 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  *

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Encounter
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/EncounterTypeEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see EncounterType
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/FormEditor.java
@@ -14,7 +14,7 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
  * In version 1.9, added ability for this to also retrieve objects by uuid
  *

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Location
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/LocationTagEditor.java
@@ -14,7 +14,7 @@ import org.openmrs.api.context.Context;
 
 /**
  * Property editor for {@link LocationTag}s In version 1.9, added ability for this to also retrieve
- * objects by uuid
+ * objects by UUID
  *
  * @since 1.7
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/OpenmrsPropertyEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/OpenmrsPropertyEditor.java
@@ -21,7 +21,7 @@ import org.openmrs.OpenmrsObject;
  * and if that fails using its uuid.
  * </p>
  *
- * @param <T> the openmrs object to convert to and from
+ * @param <T> the OpenMRS object to convert to and from
  * @since 2.2.0
  * @see org.openmrs.OpenmrsObject
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/OrderEditor.java
@@ -14,8 +14,8 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing a Order object to a string so that Spring knows how to pass
- * a Order back and forth through an html form or other medium <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * an Order back and forth through an HTML form or other medium <br>
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Order
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PatientIdentifierTypeEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see PatientIdentifierType
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see PersonAttribute
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonAttributeTypeEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see PersonAttributeType
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PersonEditor.java
@@ -18,9 +18,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing a Person object to a string so that Spring knows how to pass
- * a Person back and forth through an html form or other medium. <br>
+ * a Person back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve Person objects by uuid
+ * In version 1.9, added ability for this to also retrieve Person objects by UUID
  *
  * @see Person
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/PrivilegeEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/PrivilegeEditor.java
@@ -20,9 +20,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Privilege
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramEditor.java
@@ -20,11 +20,11 @@ import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * If string value starts with "concept.", then the text after the dot is treated as a concept_id or
  * uuid The name of the concept associated with that id is treated as the name of the program to
  * fetch. <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Program
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ProgramWorkflow
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProgramWorkflowStateEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see ProgramWorkflowState
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/ProviderEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/ProviderEditor.java
@@ -20,7 +20,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing a provider to a string so that Spring knows how to pass a
- * provider back and forth through an html form or other medium. <br>
+ * provider back and forth through an HTML form or other medium. <br>
  *
  * @see Provider
  * @since 1.10.0

--- a/api/src/main/java/org/openmrs/propertyeditor/RoleEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/RoleEditor.java
@@ -20,9 +20,9 @@ import org.springframework.util.StringUtils;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see Role
  */

--- a/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
+++ b/api/src/main/java/org/openmrs/propertyeditor/UserEditor.java
@@ -14,9 +14,9 @@ import org.openmrs.api.context.Context;
 
 /**
  * Allows for serializing/deserializing an object to a string so that Spring knows how to pass an
- * object back and forth through an html form or other medium. <br>
+ * object back and forth through an HTML form or other medium. <br>
  * <br>
- * In version 1.9, added ability for this to also retrieve objects by uuid
+ * In version 1.9, added ability for this to also retrieve objects by UUID
  *
  * @see User
  */


### PR DESCRIPTION
Improved **Javadocs** and **inline comments** across multiple files by fixing **grammar**, **capitalization**, and **wording** to improve **consistency** and **readability**. Also updated the **`totalElementsExact`** parameter documentation and standardized the use of terms such as **"HTML"**, **"UUID"**, and **"OpenMRS"**.

JIRA TICKET : https://openmrs.atlassian.net/browse/TRUNK-6715