### PR TITLE
TRUNK-6706: Disable hibernate.generate_statistics by default

### DIFF
--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -26,7 +26,7 @@ hibernate.c3p0.acquire_increment=1
 hibernate.c3p0.checkoutTimeout=30000
 
 # Hibernate debugging options
-hibernate.generate_statistics=true
+hibernate.generate_statistics=false
 hibernate.cache.use_structured_entries=false
 
 # Hibernate cache

--- a/api/src/test/java/org/openmrs/api/context/ContextTest.java
+++ b/api/src/test/java/org/openmrs/api/context/ContextTest.java
@@ -297,20 +297,27 @@ public class ContextTest extends BaseContextSensitiveTest {
 	public void evictEntity_shouldClearTheEntityFromCaches() {
 		TestTransaction.end();
 
-		// Load the person name so that it is stored in the cache
-		PersonName name = Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+		// Statistics are disabled by default; enable them so hit counts below are meaningful
+		boolean statisticsEnabled = sf.getStatistics().isStatisticsEnabled();
+		sf.getStatistics().setStatisticsEnabled(true);
+		try {
+			// Load the person name so that it is stored in the cache
+			PersonName name = Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
 
-		// Clear session so that the first-level cache is empty
-		Context.flushSession();
-		Context.clearSession();
+			// Clear session so that the first-level cache is empty
+			Context.flushSession();
+			Context.clearSession();
 
-		// evictEntity
-		Context.evictEntity(name);
+			// evictEntity
+			Context.evictEntity(name);
 
-		// Assert that the entity name has been removed from cache
-		long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			// Assert that the entity name has been removed from cache
+			long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+		} finally {
+			sf.getStatistics().setStatisticsEnabled(statisticsEnabled);
+		}
 	}
 
 	/**
@@ -320,23 +327,30 @@ public class ContextTest extends BaseContextSensitiveTest {
 	public void evictAllEntities_shouldClearAllEntityFromCaches() {
 		TestTransaction.end();
 
-		// Load person names so that they are stored in the cache
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
+		// Statistics are disabled by default; enable them so hit counts below are meaningful
+		boolean statisticsEnabled = sf.getStatistics().isStatisticsEnabled();
+		sf.getStatistics().setStatisticsEnabled(true);
+		try {
+			// Load person names so that they are stored in the cache
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
 
-		// Clear session so that the first-level cache is empty
-		Context.flushSession();
-		Context.clearSession();
+			// Clear session so that the first-level cache is empty
+			Context.flushSession();
+			Context.clearSession();
 
-		// evictAllEntities
-		Context.evictAllEntities(PERSON_NAME_CLASS);
+			// evictAllEntities
+			Context.evictAllEntities(PERSON_NAME_CLASS);
 
-		// Assert that the class entities have been removed from cache
-		long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			// Assert that the class entities have been removed from cache
+			long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+		} finally {
+			sf.getStatistics().setStatisticsEnabled(statisticsEnabled);
+		}
 	}
 
 	/**
@@ -346,26 +360,33 @@ public class ContextTest extends BaseContextSensitiveTest {
 	public void clearEntireCache_shouldClearEntireCache() {
 		TestTransaction.end();
 
-		// Load person names and patient so that they are stored in the cache
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
-		Context.getPatientService().getPatient(PERSON_NAME_ID_2);
+		// Statistics are disabled by default; enable them so hit counts below are meaningful
+		boolean statisticsEnabled = sf.getStatistics().isStatisticsEnabled();
+		sf.getStatistics().setStatisticsEnabled(true);
+		try {
+			// Load person names and patient so that they are stored in the cache
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
+			Context.getPatientService().getPatient(PERSON_NAME_ID_2);
 
-		// Clear session so that the first-level cache is empty
-		Context.flushSession();
-		Context.clearSession();
+			// Clear session so that the first-level cache is empty
+			Context.flushSession();
+			Context.clearSession();
 
-		// clearEntireCache
-		Context.clearEntireCache();
+			// clearEntireCache
+			Context.clearEntireCache();
 
-		// Assert that all entities have been removed from cache
-		long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
-		Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
-		Context.getPatientService().getPatient(PERSON_NAME_ID_2);
-		assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			// Assert that all entities have been removed from cache
+			long hitCount = sf.getStatistics().getSecondLevelCacheHitCount();
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_2);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			Context.getPersonService().getPersonName(PERSON_NAME_ID_8);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+			Context.getPatientService().getPatient(PERSON_NAME_ID_2);
+			assertThat(sf.getStatistics().getSecondLevelCacheHitCount(), is(hitCount));
+		} finally {
+			sf.getStatistics().setStatisticsEnabled(statisticsEnabled);
+		}
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
+++ b/api/src/test/java/org/openmrs/api/db/ContextDAOTest.java
@@ -346,6 +346,27 @@ public class ContextDAOTest extends BaseContextSensitiveTest {
 		assertNotNull(properties.getProperty("hibernate.key"));
 	}
 
+	/**
+	 * @see org.openmrs.api.db.hibernate.HibernateContextDAO#mergeDefaultRuntimeProperties(java.util.Properties)
+	 */
+	@Test
+	public void should_defaultGenerateStatisticsToFalse() {
+		Properties properties = new Properties();
+		dao.mergeDefaultRuntimeProperties(properties);
+		assertEquals("false", properties.getProperty("hibernate.generate_statistics"));
+	}
+
+	/**
+	 * @see org.openmrs.api.db.hibernate.HibernateContextDAO#mergeDefaultRuntimeProperties(java.util.Properties)
+	 */
+	@Test
+	public void should_notOverrideExplicitGenerateStatisticsSetting() {
+		Properties properties = new Properties();
+		properties.setProperty("hibernate.generate_statistics", "true");
+		dao.mergeDefaultRuntimeProperties(properties);
+		assertEquals("true", properties.getProperty("hibernate.generate_statistics"));
+	}
+
 	@Component("testUserSessionListener")
 	public static class TestUserSessionListener implements UserSessionListener {
 


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
Changed the default value of `hibernate.generate_statistics` in `api/src/main/resources/hibernate.default.properties` from `true` to `false`. Statistics generation maintains counters on every query, entity, collection, and cache operation, and the only consumer in core is a shutdown-time debug log dump, so this default was adding overhead for data that's almost never read.

No code changes were needed to preserve explicit overrides:
`HibernateContextDAO.mergeDefaultRuntimeProperties()` already only applies a default when the key isn't already present in the user's runtime properties, so anyone setting `hibernate.generate_statistics=true` themselves will have that value preserved.

Added two unit tests to `ContextDAOTest.java`:
- `should_defaultGenerateStatisticsToFalse()`
- `should_notOverrideExplicitGenerateStatisticsSetting()`

Note: I noticed three tests in `ContextTest.java` check cache eviction using Hibernate's statistics counter, which no longer updates by default after this change. Flagging in case a follow-up is wanted, happy to help fix if so.

I noticed this ticket is labeled `backport`. Should this fix also be applied to older maintained branches, or is that handled separately by the team?

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6706

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

