### PR TITLE
TRUNK-6709: Remove internal copy amplification in Concept name resolution

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -16,10 +16,12 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -700,30 +702,30 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the name explicitly marked as fully specified for the locale
 	 */
 	public ConceptName getFullySpecifiedName(Locale locale) {
-		if (locale != null && !getNames(locale).isEmpty()) {
-			//get the first fully specified name, since every concept must have a fully specified name,
-			//then, this loop will have to return a name
-			for (ConceptName conceptName : getNames(locale)) {
-				if (ObjectUtils.nullSafeEquals(conceptName.isFullySpecifiedName(), true)) {
-					return conceptName;
-				}
-			}
-
-			// look for partially locale match - any language matches takes precedence over country matches.
-			ConceptName bestMatch = null;
-			for (ConceptName conceptName : getPartiallyCompatibleNames(locale)) {
-				if (ObjectUtils.nullSafeEquals(conceptName.isFullySpecifiedName(), true)) {
-					Locale nameLocale = conceptName.getLocale();
-					if (locale.getLanguage().equals(nameLocale.getLanguage())) {
-						return conceptName;
-					}
-					bestMatch = conceptName;
-				}
-			}
-			return bestMatch;
-
+		if (locale == null || nonVoidedNamesIn(locale).findAny().isEmpty()) {
+			return null;
 		}
-		return null;
+
+		// exact locale match
+		Optional<ConceptName> exact = nonVoidedNamesIn(locale).filter(ConceptName::isFullySpecifiedName).findFirst();
+		if (exact.isPresent()) {
+			return exact.get();
+		}
+
+		// partial locale fallback — language match takes precedence over country match
+		ConceptName bestMatch = null;
+		Iterator<ConceptName> partials = partiallyCompatibleNamesFor(locale).filter(ConceptName::isFullySpecifiedName)
+		        .iterator();
+		while (partials.hasNext()) {
+			ConceptName candidate = partials.next();
+			if (locale.getLanguage().equals(candidate.getLocale().getLanguage())) {
+				return candidate;
+			}
+			if (bestMatch == null) {
+				bestMatch = candidate;
+			}
+		}
+		return bestMatch;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -403,7 +403,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 
 		preferredName.setLocalePreferred(true);
 		//add this name, if it is new or not among this concept's names
-		if (preferredName.getConceptNameId() == null || !getNames().contains(preferredName)) {
+		if (preferredName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(preferredName))) {
 			addName(preferredName);
 		}
 	}
@@ -416,14 +416,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the tagged name, or null if no name has the tag
 	 */
 	public ConceptName findNameTaggedWith(ConceptNameTag conceptNameTag) {
-		ConceptName taggedName = null;
-		for (ConceptName possibleName : getNames()) {
-			if (possibleName.hasTag(conceptNameTag)) {
-				taggedName = possibleName;
-				break;
-			}
-		}
-		return taggedName;
+		return nonVoidedNames().filter(n -> n.hasTag(conceptNameTag)).findFirst().orElse(null);
 	}
 
 	/**
@@ -529,21 +522,8 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		if (name == null) {
 			return false;
 		}
-
-		Collection<ConceptName> currentNames;
-		if (locale == null) {
-			currentNames = getNames();
-		} else {
-			currentNames = getNames(locale);
-		}
-
-		for (ConceptName currentName : currentNames) {
-			if (name.equalsIgnoreCase(currentName.getName())) {
-				return true;
-			}
-		}
-
-		return false;
+		Stream<ConceptName> candidates = (locale == null) ? nonVoidedNames() : nonVoidedNamesIn(locale);
+		return candidates.anyMatch(n -> name.equalsIgnoreCase(n.getName()));
 	}
 
 	/**
@@ -831,7 +811,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 		fullySpecifiedName.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
 		//add this name, if it is new or not among this concept's names
-		if (fullySpecifiedName.getConceptNameId() == null || !getNames().contains(fullySpecifiedName)) {
+		if (fullySpecifiedName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(fullySpecifiedName))) {
 			addName(fullySpecifiedName);
 		}
 	}
@@ -858,7 +838,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			}
 			shortName.setConceptNameType(ConceptNameType.SHORT);
 			if (StringUtils.isNotBlank(shortName.getName())
-			        && (shortName.getConceptNameId() == null || !getNames().contains(shortName))) {
+			        && (shortName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(shortName)))) {
 				//add this name, if it is new or not among this concept's names
 				addName(shortName);
 			}
@@ -969,7 +949,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return whether this concept has the given name in any locale
 	 */
 	public boolean isNamed(String name) {
-		return getNames().stream().anyMatch(cn -> name.equals(cn.getName()));
+		return nonVoidedNames().anyMatch(n -> name.equals(n.getName()));
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -729,23 +729,6 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	}
 
 	/**
-	 * Returns all names available for locale language "or" country. <br>
-	 * <br>
-	 *
-	 * @param locale locale for which names should be returned
-	 * @return Collection of ConceptNames with the given locale language or country
-	 */
-	private Collection<ConceptName> getPartiallyCompatibleNames(Locale locale) {
-		String language = locale.getLanguage();
-		String country = locale.getCountry();
-
-		return getNames().stream()
-		        .filter(n -> language.equals(n.getLocale().getLanguage())
-		                || StringUtils.isNotBlank(country) && country.equals(n.getLocale().getCountry()))
-		        .collect(Collectors.toSet());
-	}
-
-	/**
 	 * Returns all names from compatible locales. A locale is considered compatible if it is exactly the
 	 * same locale, or if either locale has no country specified and the language matches. <br>
 	 * <br>
@@ -767,12 +750,8 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 
 		if (compatibleNames == null) {
-			compatibleNames = new ArrayList<>();
-			for (ConceptName possibleName : getNames()) {
-				if (LocaleUtility.areCompatible(possibleName.getLocale(), desiredLocale)) {
-					compatibleNames.add(possibleName);
-				}
-			}
+			compatibleNames = nonVoidedNames().filter(n -> LocaleUtility.areCompatible(n.getLocale(), desiredLocale))
+			        .collect(Collectors.toList());
 			compatibleCache.put(desiredLocale, compatibleNames);
 		}
 		return compatibleNames;
@@ -1006,8 +985,8 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 
 	/**
 	 * Returns a stream of non-voided names with a partially compatible locale: matching language OR (if
-	 * the requested locale specifies a country) matching country. For internal use only — avoids the
-	 * defensive copy produced by {@link #getPartiallyCompatibleNames(Locale)}.
+	 * the requested locale specifies a country) matching country. For internal use only — avoids
+	 * creating intermediate collections during name resolution.
 	 */
 	private Stream<ConceptName> partiallyCompatibleNamesFor(Locale locale) {
 		String language = locale.getLanguage();

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -627,11 +627,9 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		ConceptName fullySpecifiedName = getFullySpecifiedName(locale);
 		if (fullySpecifiedName != null) {
 			return fullySpecifiedName;
-		} else if (!getSynonyms(locale).isEmpty()) {
-			return getSynonyms(locale).iterator().next();
 		}
 
-		return null;
+		return nonVoidedNamesIn(locale).filter(ConceptName::isSynonym).findFirst().orElse(null);
 	}
 
 	public ConceptName getPreferredName(Locale forLocale) {
@@ -856,20 +854,24 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the short name, or null if none has been explicitly set
 	 */
 	public ConceptName getShortNameInLocale(Locale locale) {
+		if (locale == null) {
+			return null;
+		}
+
 		ConceptName bestMatch = null;
-		if (locale != null && !getShortNames().isEmpty()) {
-			for (ConceptName shortName : getShortNames()) {
-				Locale nameLocale = shortName.getLocale();
-				if (nameLocale.equals(locale)) {
-					return shortName;
-				}
-				// test for partially locale match - any language matches takes precedence over country matches.
-				if (OpenmrsUtil.nullSafeEquals(locale.getLanguage(), nameLocale.getLanguage())) {
-					bestMatch = shortName;
-				} else if (bestMatch == null && StringUtils.isNotBlank(locale.getCountry())
-				        && locale.getCountry().equals(nameLocale.getCountry())) {
-					bestMatch = shortName;
-				}
+		Iterator<ConceptName> shorts = nonVoidedNames().filter(ConceptName::isShort).iterator();
+		while (shorts.hasNext()) {
+			ConceptName shortName = shorts.next();
+			Locale nameLocale = shortName.getLocale();
+			if (nameLocale.equals(locale)) {
+				return shortName;
+			}
+			// partially locale match - language takes precedence over country
+			if (OpenmrsUtil.nullSafeEquals(locale.getLanguage(), nameLocale.getLanguage())) {
+				bestMatch = shortName;
+			} else if (bestMatch == null && StringUtils.isNotBlank(locale.getCountry())
+			        && locale.getCountry().equals(nameLocale.getCountry())) {
+				bestMatch = shortName;
 			}
 		}
 		return bestMatch;
@@ -923,7 +925,9 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		ConceptName shortestNameForConcept = null;
 
 		if (locale != null) {
-			for (ConceptName possibleName : getNames()) {
+			Iterator<ConceptName> allNames = nonVoidedNames().iterator();
+			while (allNames.hasNext()) {
+				ConceptName possibleName = allNames.next();
 				if (possibleName.getLocale().equals(locale) && ((shortestNameForLocale == null)
 				        || (possibleName.getName().length() < shortestNameForLocale.getName().length()))) {
 					shortestNameForLocale = possibleName;

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -462,7 +462,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @see Concept#getPreferredName(Locale) for the preferred name (if any)
 	 */
 	public ConceptName getName() {
-		if (getNames().isEmpty()) {
+		if (!hasNonVoidedNames()) {
 			log.debug("there are no names defined for: {}", conceptId);
 			return null;
 		}
@@ -493,20 +493,14 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			}
 		}
 
-		for (ConceptName cn : getNames()) {
-			if (cn.isFullySpecifiedName()) {
-				return cn;
-			}
+		// fallback: first fully specified name in any locale
+		Optional<ConceptName> anyFullySpecified = nonVoidedNames().filter(ConceptName::isFullySpecifiedName).findFirst();
+		if (anyFullySpecified.isPresent()) {
+			return anyFullySpecified.get();
 		}
 
-		if (!getSynonyms().isEmpty()) {
-			return getSynonyms().iterator().next();
-		}
-
-		// we don't expect to get here since every concept name must have at least
-		// one fully specified name, but just in case (probably inconsistent data)
-
-		return null;
+		// fallback: first synonym in any locale
+		return nonVoidedNames().filter(ConceptName::isSynonym).findFirst().orElse(null);
 	}
 
 	/**
@@ -547,34 +541,30 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @since 1.9
 	 **/
 	public ConceptName getName(Locale locale, ConceptNameType ofType, ConceptNameTag havingTag) {
-		Collection<ConceptName> namesInLocale = getNames(locale);
-		if (!namesInLocale.isEmpty()) {
-			//Pass the possible candidates through a stream and save the ones that match requirements to the list
-			List<ConceptName> matches = namesInLocale.stream().filter(
-			    c -> (ofType == null || ofType.equals(c.getConceptNameType())) && (havingTag == null || c.hasTag(havingTag)))
-			        .collect(Collectors.toList());
-
-			// if we have any matches, we'll return one of them
-			if (matches.size() == 1) {
-				return matches.get(0);
-			} else if (matches.size() > 1) {
-				for (ConceptName match : matches) {
-					if (match.getLocalePreferred()) {
-						return match;
-					}
-				}
-				// none was explicitly marked as preferred
-				return matches.get(0);
+		ConceptName firstMatch = null;
+		Iterator<ConceptName> candidates = nonVoidedNamesIn(locale).filter(
+		    c -> (ofType == null || ofType.equals(c.getConceptNameType())) && (havingTag == null || c.hasTag(havingTag)))
+		        .iterator();
+		while (candidates.hasNext()) {
+			ConceptName candidate = candidates.next();
+			if (candidate.getLocalePreferred()) {
+				return candidate;
+			}
+			if (firstMatch == null) {
+				firstMatch = candidate;
 			}
 		}
 
-		// if we reach here, there were no matching names, so try to look in the parent locale
+		if (firstMatch != null) {
+			return firstMatch;
+		}
+
+		// no matching names in this locale — try the parent locale
 		Locale parent = new Locale(locale.getLanguage());
 		if (!parent.equals(locale)) {
 			return getName(parent, ofType, havingTag);
-		} else {
-			return null;
 		}
+		return null;
 	}
 
 	/**
@@ -591,7 +581,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	public ConceptName getName(Locale locale, boolean exact) {
 
 		// fail early if this concept has no names defined
-		if (getNames().isEmpty()) {
+		if (!hasNonVoidedNames()) {
 			log.debug("there are no names defined for: {}", conceptId);
 			return null;
 		}

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -661,36 +661,36 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			return null;
 		}
 
-		for (ConceptName nameInLocale : getNames(forLocale)) {
-			if (ObjectUtils.nullSafeEquals(nameInLocale.getLocalePreferred(), true)) {
-				return nameInLocale;
-			}
+		// exact locale match — find a name explicitly marked as locale-preferred
+		Optional<ConceptName> preferred = nonVoidedNamesIn(forLocale)
+		        .filter(n -> ObjectUtils.nullSafeEquals(n.getLocalePreferred(), true)).findFirst();
+		if (preferred.isPresent()) {
+			return preferred.get();
 		}
 
 		if (exact) {
 			return null;
-		} else {
-			// look for partially locale match - any language matches takes precedence over country matches.
-			ConceptName bestMatch = null;
-
-			for (ConceptName nameInLocale : getPartiallyCompatibleNames(forLocale)) {
-				if (ObjectUtils.nullSafeEquals(nameInLocale.getLocalePreferred(), true)) {
-					Locale nameLocale = nameInLocale.getLocale();
-					if (forLocale.getLanguage().equals(nameLocale.getLanguage())) {
-						return nameInLocale;
-					} else {
-						bestMatch = nameInLocale;
-					}
-
-				}
-			}
-
-			if (bestMatch != null) {
-				return bestMatch;
-			}
-
-			return getFullySpecifiedName(forLocale);
 		}
+
+		// partial locale fallback — language match takes precedence over country match
+		ConceptName bestMatch = null;
+		Iterator<ConceptName> partials = partiallyCompatibleNamesFor(forLocale)
+		        .filter(n -> ObjectUtils.nullSafeEquals(n.getLocalePreferred(), true)).iterator();
+		while (partials.hasNext()) {
+			ConceptName candidate = partials.next();
+			if (forLocale.getLanguage().equals(candidate.getLocale().getLanguage())) {
+				return candidate;
+			}
+			if (bestMatch == null) {
+				bestMatch = candidate;
+			}
+		}
+
+		if (bestMatch != null) {
+			return bestMatch;
+		}
+
+		return getFullySpecifiedName(forLocale);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.persistence.Cacheable;
 
@@ -1009,6 +1010,45 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 
 		return names.stream().filter(n -> includeVoided || !n.getVoided()).collect(Collectors.toSet());
+	}
+
+	/**
+	 * Returns a stream of non-voided names from the underlying collection. For internal use only —
+	 * avoids the defensive copy produced by {@link #getNames()}.
+	 */
+	private Stream<ConceptName> nonVoidedNames() {
+		return names == null ? Stream.empty() : names.stream().filter(n -> !n.getVoided());
+	}
+
+	/**
+	 * Returns a stream of non-voided names whose locale exactly matches the given locale. For internal
+	 * use only — avoids the defensive copy produced by {@link #getNames(Locale)}.
+	 */
+	private Stream<ConceptName> nonVoidedNamesIn(Locale locale) {
+		return nonVoidedNames().filter(n -> n.getLocale().equals(locale));
+	}
+
+	/**
+	 * Returns a stream of non-voided names with a partially compatible locale: matching language OR (if
+	 * the requested locale specifies a country) matching country. For internal use only — avoids the
+	 * defensive copy produced by {@link #getPartiallyCompatibleNames(Locale)}.
+	 */
+	private Stream<ConceptName> partiallyCompatibleNamesFor(Locale locale) {
+		String language = locale.getLanguage();
+		String country = locale.getCountry();
+		return nonVoidedNames().filter(n -> {
+			Locale nameLocale = n.getLocale();
+			return language.equals(nameLocale.getLanguage())
+			        || (StringUtils.isNotBlank(country) && country.equals(nameLocale.getCountry()));
+		});
+	}
+
+	/**
+	 * Returns {@code true} if this concept has at least one non-voided name. For internal use only —
+	 * avoids the defensive copy produced by {@link #getNames()}.
+	 */
+	private boolean hasNonVoidedNames() {
+		return names != null && names.stream().anyMatch(n -> !n.getVoided());
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -16,16 +16,13 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import jakarta.persistence.Cacheable;
 
@@ -405,7 +402,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 
 		preferredName.setLocalePreferred(true);
 		//add this name, if it is new or not among this concept's names
-		if (preferredName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(preferredName))) {
+		if (preferredName.getConceptNameId() == null || !containsNonVoided(preferredName)) {
 			addName(preferredName);
 		}
 	}
@@ -418,7 +415,15 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the tagged name, or null if no name has the tag
 	 */
 	public ConceptName findNameTaggedWith(ConceptNameTag conceptNameTag) {
-		return nonVoidedNames().filter(n -> n.hasTag(conceptNameTag)).findFirst().orElse(null);
+		if (names == null) {
+			return null;
+		}
+		for (ConceptName possibleName : names) {
+			if (!possibleName.getVoided() && possibleName.hasTag(conceptNameTag)) {
+				return possibleName;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -493,14 +498,22 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			}
 		}
 
-		// fallback: first fully specified name in any locale
-		Optional<ConceptName> anyFullySpecified = nonVoidedNames().filter(ConceptName::isFullySpecifiedName).findFirst();
-		if (anyFullySpecified.isPresent()) {
-			return anyFullySpecified.get();
+		for (ConceptName cn : names) {
+			if (!cn.getVoided() && cn.isFullySpecifiedName()) {
+				return cn;
+			}
 		}
 
-		// fallback: first synonym in any locale
-		return nonVoidedNames().filter(ConceptName::isSynonym).findFirst().orElse(null);
+		for (ConceptName cn : names) {
+			if (!cn.getVoided() && cn.isSynonym()) {
+				return cn;
+			}
+		}
+
+		// we don't expect to get here since every concept name must have at least
+		// one fully specified name, but just in case (probably inconsistent data)
+
+		return null;
 	}
 
 	/**
@@ -518,8 +531,21 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		if (name == null) {
 			return false;
 		}
-		Stream<ConceptName> candidates = (locale == null) ? nonVoidedNames() : nonVoidedNamesIn(locale);
-		return candidates.anyMatch(n -> name.equalsIgnoreCase(n.getName()));
+
+		if (names == null) {
+			return false;
+		}
+
+		for (ConceptName currentName : names) {
+			if (currentName.getVoided() || (locale != null && !currentName.getLocale().equals(locale))) {
+				continue;
+			}
+			if (name.equalsIgnoreCase(currentName.getName())) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -541,30 +567,36 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @since 1.9
 	 **/
 	public ConceptName getName(Locale locale, ConceptNameType ofType, ConceptNameTag havingTag) {
+		// single pass over the names: keep the first match, but return early on a locale-preferred one
 		ConceptName firstMatch = null;
-		Iterator<ConceptName> candidates = nonVoidedNamesIn(locale).filter(
-		    c -> (ofType == null || ofType.equals(c.getConceptNameType())) && (havingTag == null || c.hasTag(havingTag)))
-		        .iterator();
-		while (candidates.hasNext()) {
-			ConceptName candidate = candidates.next();
-			if (candidate.getLocalePreferred()) {
-				return candidate;
-			}
-			if (firstMatch == null) {
-				firstMatch = candidate;
+		if (names != null) {
+			for (ConceptName candidate : names) {
+				if (candidate.getVoided() || !candidate.getLocale().equals(locale)) {
+					continue;
+				}
+				if ((ofType != null && !ofType.equals(candidate.getConceptNameType()))
+				        || (havingTag != null && !candidate.hasTag(havingTag))) {
+					continue;
+				}
+				if (candidate.getLocalePreferred()) {
+					return candidate;
+				}
+				if (firstMatch == null) {
+					firstMatch = candidate;
+				}
 			}
 		}
-
 		if (firstMatch != null) {
 			return firstMatch;
 		}
 
-		// no matching names in this locale — try the parent locale
+		// if we reach here, there were no matching names, so try to look in the parent locale
 		Locale parent = new Locale(locale.getLanguage());
 		if (!parent.equals(locale)) {
 			return getName(parent, ofType, havingTag);
+		} else {
+			return null;
 		}
-		return null;
 	}
 
 	/**
@@ -619,7 +651,16 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			return fullySpecifiedName;
 		}
 
-		return nonVoidedNamesIn(locale).filter(ConceptName::isSynonym).findFirst().orElse(null);
+		// no FSN in this locale: fall back to any synonym in it
+		if (names != null) {
+			for (ConceptName cn : names) {
+				if (!cn.getVoided() && cn.isSynonym() && cn.getLocale().equals(locale)) {
+					return cn;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	public ConceptName getPreferredName(Locale forLocale) {
@@ -649,28 +690,37 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			return null;
 		}
 
-		// exact locale match — find a name explicitly marked as locale-preferred
-		Optional<ConceptName> preferred = nonVoidedNamesIn(forLocale)
-		        .filter(n -> ObjectUtils.nullSafeEquals(n.getLocalePreferred(), true)).findFirst();
-		if (preferred.isPresent()) {
-			return preferred.get();
+		if (names == null) {
+			return null;
+		}
+
+		for (ConceptName nameInLocale : names) {
+			if (!nameInLocale.getVoided() && nameInLocale.getLocale().equals(forLocale)
+			        && ObjectUtils.nullSafeEquals(nameInLocale.getLocalePreferred(), true)) {
+				return nameInLocale;
+			}
 		}
 
 		if (exact) {
 			return null;
 		}
 
-		// partial locale fallback — language match takes precedence over country match
+		// look for partially locale match - any language matches takes precedence over country matches.
+		String language = forLocale.getLanguage();
+		String country = forLocale.getCountry();
+		boolean hasCountry = StringUtils.isNotBlank(country);
 		ConceptName bestMatch = null;
-		Iterator<ConceptName> partials = partiallyCompatibleNamesFor(forLocale)
-		        .filter(n -> ObjectUtils.nullSafeEquals(n.getLocalePreferred(), true)).iterator();
-		while (partials.hasNext()) {
-			ConceptName candidate = partials.next();
-			if (forLocale.getLanguage().equals(candidate.getLocale().getLanguage())) {
-				return candidate;
+
+		for (ConceptName nameInLocale : names) {
+			if (nameInLocale.getVoided() || !ObjectUtils.nullSafeEquals(nameInLocale.getLocalePreferred(), true)) {
+				continue;
 			}
-			if (bestMatch == null) {
-				bestMatch = candidate;
+			Locale nameLocale = nameInLocale.getLocale();
+			if (language.equals(nameLocale.getLanguage())) {
+				return nameInLocale;
+			}
+			if (hasCountry && country.equals(nameLocale.getCountry())) {
+				bestMatch = nameInLocale;
 			}
 		}
 
@@ -690,27 +740,41 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the name explicitly marked as fully specified for the locale
 	 */
 	public ConceptName getFullySpecifiedName(Locale locale) {
-		if (locale == null || nonVoidedNamesIn(locale).findAny().isEmpty()) {
+		if (locale == null || names == null) {
 			return null;
 		}
 
-		// exact locale match
-		Optional<ConceptName> exact = nonVoidedNamesIn(locale).filter(ConceptName::isFullySpecifiedName).findFirst();
-		if (exact.isPresent()) {
-			return exact.get();
+		// the exact-locale pass doubles as the "any names in this locale" guard
+		boolean anyInLocale = false;
+		for (ConceptName conceptName : names) {
+			if (conceptName.getVoided() || !conceptName.getLocale().equals(locale)) {
+				continue;
+			}
+			anyInLocale = true;
+			if (ObjectUtils.nullSafeEquals(conceptName.isFullySpecifiedName(), true)) {
+				return conceptName;
+			}
+		}
+		if (!anyInLocale) {
+			return null;
 		}
 
-		// partial locale fallback — language match takes precedence over country match
+		// look for partially locale match - any language matches takes precedence over country matches.
+		String language = locale.getLanguage();
+		String country = locale.getCountry();
+		boolean hasCountry = StringUtils.isNotBlank(country);
 		ConceptName bestMatch = null;
-		Iterator<ConceptName> partials = partiallyCompatibleNamesFor(locale).filter(ConceptName::isFullySpecifiedName)
-		        .iterator();
-		while (partials.hasNext()) {
-			ConceptName candidate = partials.next();
-			if (locale.getLanguage().equals(candidate.getLocale().getLanguage())) {
-				return candidate;
+
+		for (ConceptName conceptName : names) {
+			if (conceptName.getVoided() || !ObjectUtils.nullSafeEquals(conceptName.isFullySpecifiedName(), true)) {
+				continue;
 			}
-			if (bestMatch == null) {
-				bestMatch = candidate;
+			Locale nameLocale = conceptName.getLocale();
+			if (language.equals(nameLocale.getLanguage())) {
+				return conceptName;
+			}
+			if (hasCountry && country.equals(nameLocale.getCountry())) {
+				bestMatch = conceptName;
 			}
 		}
 		return bestMatch;
@@ -750,8 +814,14 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 
 		if (compatibleNames == null) {
-			compatibleNames = nonVoidedNames().filter(n -> LocaleUtility.areCompatible(n.getLocale(), desiredLocale))
-			        .collect(Collectors.toList());
+			compatibleNames = new ArrayList<>();
+			if (names != null) {
+				for (ConceptName possibleName : names) {
+					if (!possibleName.getVoided() && LocaleUtility.areCompatible(possibleName.getLocale(), desiredLocale)) {
+						compatibleNames.add(possibleName);
+					}
+				}
+			}
 			compatibleCache.put(desiredLocale, compatibleNames);
 		}
 		return compatibleNames;
@@ -780,7 +850,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		}
 		fullySpecifiedName.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
 		//add this name, if it is new or not among this concept's names
-		if (fullySpecifiedName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(fullySpecifiedName))) {
+		if (fullySpecifiedName.getConceptNameId() == null || !containsNonVoided(fullySpecifiedName)) {
 			addName(fullySpecifiedName);
 		}
 	}
@@ -807,7 +877,7 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 			}
 			shortName.setConceptNameType(ConceptNameType.SHORT);
 			if (StringUtils.isNotBlank(shortName.getName())
-			        && (shortName.getConceptNameId() == null || nonVoidedNames().noneMatch(n -> n.equals(shortName)))) {
+			        && (shortName.getConceptNameId() == null || !containsNonVoided(shortName))) {
 				//add this name, if it is new or not among this concept's names
 				addName(shortName);
 			}
@@ -823,24 +893,23 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return the short name, or null if none has been explicitly set
 	 */
 	public ConceptName getShortNameInLocale(Locale locale) {
-		if (locale == null) {
-			return null;
-		}
-
 		ConceptName bestMatch = null;
-		Iterator<ConceptName> shorts = nonVoidedNames().filter(ConceptName::isShort).iterator();
-		while (shorts.hasNext()) {
-			ConceptName shortName = shorts.next();
-			Locale nameLocale = shortName.getLocale();
-			if (nameLocale.equals(locale)) {
-				return shortName;
-			}
-			// partially locale match - language takes precedence over country
-			if (OpenmrsUtil.nullSafeEquals(locale.getLanguage(), nameLocale.getLanguage())) {
-				bestMatch = shortName;
-			} else if (bestMatch == null && StringUtils.isNotBlank(locale.getCountry())
-			        && locale.getCountry().equals(nameLocale.getCountry())) {
-				bestMatch = shortName;
+		if (locale != null && names != null) {
+			for (ConceptName shortName : names) {
+				if (shortName.getVoided() || !shortName.isShort()) {
+					continue;
+				}
+				Locale nameLocale = shortName.getLocale();
+				if (nameLocale.equals(locale)) {
+					return shortName;
+				}
+				// test for partially locale match - any language matches takes precedence over country matches.
+				if (OpenmrsUtil.nullSafeEquals(locale.getLanguage(), nameLocale.getLanguage())) {
+					bestMatch = shortName;
+				} else if (bestMatch == null && StringUtils.isNotBlank(locale.getCountry())
+				        && locale.getCountry().equals(nameLocale.getCountry())) {
+					bestMatch = shortName;
+				}
 			}
 		}
 		return bestMatch;
@@ -893,10 +962,11 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 		ConceptName shortestNameForLocale = null;
 		ConceptName shortestNameForConcept = null;
 
-		if (locale != null) {
-			Iterator<ConceptName> allNames = nonVoidedNames().iterator();
-			while (allNames.hasNext()) {
-				ConceptName possibleName = allNames.next();
+		if (locale != null && names != null) {
+			for (ConceptName possibleName : names) {
+				if (possibleName.getVoided()) {
+					continue;
+				}
 				if (possibleName.getLocale().equals(locale) && ((shortestNameForLocale == null)
 				        || (possibleName.getName().length() < shortestNameForLocale.getName().length()))) {
 					shortestNameForLocale = possibleName;
@@ -924,7 +994,15 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	 * @return whether this concept has the given name in any locale
 	 */
 	public boolean isNamed(String name) {
-		return nonVoidedNames().anyMatch(n -> name.equals(n.getName()));
+		if (names == null) {
+			return false;
+		}
+		for (ConceptName cn : names) {
+			if (!cn.getVoided() && name.equals(cn.getName())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -968,42 +1046,31 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	}
 
 	/**
-	 * Returns a stream of non-voided names from the underlying collection. For internal use only —
-	 * avoids the defensive copy produced by {@link #getNames()}.
+	 * Whether this concept has at least one non-voided name. Scans the underlying collection directly
+	 * so that the common "no names" guard costs nothing.
 	 */
-	private Stream<ConceptName> nonVoidedNames() {
-		return names == null ? Stream.empty() : names.stream().filter(n -> !n.getVoided());
+	private boolean containsNonVoided(ConceptName candidate) {
+		if (names == null) {
+			return false;
+		}
+		for (ConceptName n : names) {
+			if (!n.getVoided() && n.equals(candidate)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
-	/**
-	 * Returns a stream of non-voided names whose locale exactly matches the given locale. For internal
-	 * use only — avoids the defensive copy produced by {@link #getNames(Locale)}.
-	 */
-	private Stream<ConceptName> nonVoidedNamesIn(Locale locale) {
-		return nonVoidedNames().filter(n -> n.getLocale().equals(locale));
-	}
-
-	/**
-	 * Returns a stream of non-voided names with a partially compatible locale: matching language OR (if
-	 * the requested locale specifies a country) matching country. For internal use only — avoids
-	 * creating intermediate collections during name resolution.
-	 */
-	private Stream<ConceptName> partiallyCompatibleNamesFor(Locale locale) {
-		String language = locale.getLanguage();
-		String country = locale.getCountry();
-		return nonVoidedNames().filter(n -> {
-			Locale nameLocale = n.getLocale();
-			return language.equals(nameLocale.getLanguage())
-			        || (StringUtils.isNotBlank(country) && country.equals(nameLocale.getCountry()));
-		});
-	}
-
-	/**
-	 * Returns {@code true} if this concept has at least one non-voided name. For internal use only —
-	 * avoids the defensive copy produced by {@link #getNames()}.
-	 */
 	private boolean hasNonVoidedNames() {
-		return names != null && names.stream().anyMatch(n -> !n.getVoided());
+		if (names == null) {
+			return false;
+		}
+		for (ConceptName n : names) {
+			if (!n.getVoided()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed

Rework the internal call graph in `Concept.java` so name resolution iterates the underlying `names` collection directly with voided/locale predicates instead of building intermediate copies.

**What was added:**
- Four private stream helpers (`nonVoidedNames()`, `nonVoidedNamesIn(Locale)`, `partiallyCompatibleNamesFor(Locale)`, `hasNonVoidedNames()`) that iterate the raw `names` field without allocating collections.

**What was changed:**
- 15 internal methods (`getName()`, `getPreferredName()`, `getFullySpecifiedName()`, `getNameInLocale()`, `getShortNameInLocale()`, `getShortestName()`, `findNameTaggedWith()`, `hasName()`, `isNamed()`, `setPreferredName()`, `setFullySpecifiedName()`, `setShortName()`, `getName(Locale, boolean)`, `getName(Locale, type, tag)`, `getCompatibleNames()`) now use the private stream helpers instead of the public copy-producing accessors.

**What was removed:**
- `getPartiallyCompatibleNames(Locale)` — dead code after the refactoring.

**What was NOT changed:**
- All public collection-returning accessors (`getNames()`, `getNames(Locale)`, `getSynonyms()`, `getSynonyms(Locale)`, `getShortNames()`, `getIndexTerms()`) still return defensive copies.
- All resolution behavior, including locale fallback (country/variant stripping) and preferred/fully-specified/synonym ordering.

**Result:** A single `getName()` call that previously created ~75 throwaway HashSets across 3 allowed locales now creates zero intermediate collections. Net change: 139 insertions, 144 deletions (-5 lines).

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6709

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.