### PR TITLE
TRUNK-6720: Refactor ORUR01Handler to avoid throwing from finally

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -334,8 +334,7 @@ public class ORUR01Handler implements Application {
 							log.debug("Done with this obs");
 						}
 					}
-				}
-				catch (ProposingConceptException proposingException) {
+				} catch (ProposingConceptException proposingException) {
 					Concept questionConcept = proposingException.getConcept();
 					String value = proposingException.getValueName();
 					
@@ -357,8 +356,7 @@ public class ORUR01Handler implements Application {
 							HL7Exception.DATA_TYPE_ERROR,
 							errorInHL7Queue);
 					}
-				}
-				catch (HL7Exception e) {
+				} catch (HL7Exception e) {
 					throw new HL7Exception(
 						Context.getMessageSourceService().getMessage(
 							"ORUR01.error.improperlyFormattedOBX",

--- a/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
+++ b/api/src/main/java/org/openmrs/hl7/handler/ORUR01Handler.java
@@ -304,23 +304,25 @@ public class ORUR01Handler implements Application {
 				if (log.isDebugEnabled()) {
 					log.debug("Processing OBS ({} of {})", j, numObs);
 				}
-
+				
 				OBX obx = orderObs.getOBSERVATION(j).getOBX();
+				
 				try {
 					log.debug("Parsing observation");
 					Obs obs = parseObs(encounter, obx, obr, messageControlId);
+					
 					if (obs != null) {
-
+						
 						// if we're backfilling an encounter, don't use
 						// the creator/dateCreated from the encounter
 						if (encounter.getEncounterId() != null) {
 							obs.setCreator(getEnterer(orc));
 							obs.setDateCreated(new Date());
 						}
-
+						
 						// set the obsGroup on this obs
 						if (obsGrouper != null) {
-							// set the obs to the group.  This assumes the group is already
+							// set the obs to the group. This assumes the group is already
 							// on the encounter and that when the encounter is saved it will
 							// propagate to the children obs
 							obsGrouper.addGroupMember(obs);
@@ -332,29 +334,40 @@ public class ORUR01Handler implements Application {
 							log.debug("Done with this obs");
 						}
 					}
-				} catch (ProposingConceptException proposingException) {
+				}
+				catch (ProposingConceptException proposingException) {
 					Concept questionConcept = proposingException.getConcept();
 					String value = proposingException.getValueName();
-					//if the sender never specified any text for the proposed concept
+					
+					// if the sender never specified any text for the proposed concept
 					if (!StringUtils.isEmpty(value)) {
 						conceptProposals.add(createConceptProposal(encounter, questionConcept, value));
 					} else {
-						errorInHL7Queue = new HL7Exception(
-						        Context.getMessageSourceService().getMessage("Hl7.proposed.concept.name.empty"),
-						        proposingException);
-						break;//stop any further processing of current message
-					}
-
-				} catch (HL7Exception e) {
-					errorInHL7Queue = e;
-				} finally {
-					// Handle obs-level exceptions
-					if (errorInHL7Queue != null) {
+						HL7Exception errorInHL7Queue = new HL7Exception(
+							Context.getMessageSourceService().getMessage("Hl7.proposed.concept.name.empty"),
+							proposingException);
+						
 						throw new HL7Exception(
-						        Context.getMessageSourceService().getMessage("ORUR01.error.improperlyFormattedOBX",
-						            new Object[] { PipeParser.encode(obx, new EncodingCharacters('|', "^~\\&")) }, null),
-						        HL7Exception.DATA_TYPE_ERROR, errorInHL7Queue);
+							Context.getMessageSourceService().getMessage(
+								"ORUR01.error.improperlyFormattedOBX",
+								new Object[] {
+									PipeParser.encode(obx, new EncodingCharacters('|', "^~\\&"))
+								},
+								null),
+							HL7Exception.DATA_TYPE_ERROR,
+							errorInHL7Queue);
 					}
+				}
+				catch (HL7Exception e) {
+					throw new HL7Exception(
+						Context.getMessageSourceService().getMessage(
+							"ORUR01.error.improperlyFormattedOBX",
+							new Object[] {
+								PipeParser.encode(obx, new EncodingCharacters('|', "^~\\&"))
+							},
+							null),
+						HL7Exception.DATA_TYPE_ERROR,
+						e);
 				}
 			}
 


### PR DESCRIPTION
## Description of what I changed

Refactored `ORUR01Handler` to address SonarCloud rule `java:S1143` by removing the `throw` statement from the `finally` block.

The existing behavior of wrapping observation-level `HL7Exception`s is preserved by moving the exception handling into normal control flow.

### Changes

* Removed the `throw` statement from the `finally` block.
* Refactored exception handling so wrapped `HL7Exception`s are thrown through normal control flow.
* Preserved the existing observation-level error wrapping behavior.

## Issue I worked on

See [[TRUNK-6720](https://issues.openmrs.org/browse/TRUNK-6720)](https://issues.openmrs.org/browse/TRUNK-6720)

## Checklist: I completed these to help reviewers :)

* [x] My IDE is configured to follow the [**[code style](https://wiki.openmrs.org/display/docs/Java+Conventions)**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

* [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

* [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.

* [x] All new and existing **tests passed**.

* [x] My pull request is **based on the latest changes** of the master branch.

[TRUNK-6720]: https://openmrs.atlassian.net/browse/TRUNK-6720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ