### PR TITLE
TRUNK-6714 ->  Fix operator precedence bug in getRefByUuid() exception message

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ObsServiceImpl.java
@@ -679,7 +679,7 @@ public class ObsServiceImpl extends BaseOpenmrsService implements ObsService, Re
 		if (Obs.class.equals(type)) {
 			return (T) getObsByUuid(uuid);
 		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+		throw new APIException("Unsupported type for getRefByUuid: " + (type != null ? type.getName() : "null"));
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderServiceImpl.java
@@ -1386,7 +1386,7 @@ public class OrderServiceImpl extends BaseOpenmrsService implements OrderService
 		if (OrderGroupAttributeType.class.equals(type)) {
 			return (T) getOrderGroupAttributeTypeByUuid(uuid);
 		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+		throw new APIException("Unsupported type for getRefByUuid: " + (type != null ? type.getName() : "null"));
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PersonServiceImpl.java
@@ -1031,7 +1031,7 @@ public class PersonServiceImpl extends BaseOpenmrsService implements PersonServi
 		if (PersonAddress.class.equals(type)) {
 			return (T) getPersonAddressByUuid(uuid);
 		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+		throw new APIException("Unsupported type for getRefByUuid: " + (type != null ? type.getName() : "null"));
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -833,7 +833,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 		if (User.class.equals(type)) {
 			return (T) getUserByUuid(uuid);
 		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+		throw new APIException("Unsupported type for getRefByUuid: " + (type != null ? type.getName() : "null"));
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/VisitServiceImpl.java
@@ -439,7 +439,7 @@ public class VisitServiceImpl extends BaseOpenmrsService implements VisitService
 		if (VisitAttributeType.class.equals(type)) {
 			return (T) getVisitAttributeTypeByUuid(uuid);
 		}
-		throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");
+		throw new APIException("Unsupported type for getRefByUuid: " + (type != null ? type.getName() : "null"));
 	}
 
 	@Override

--- a/api/src/test/java/org/openmrs/api/impl/ObsServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ObsServiceImplTest.java
@@ -1,0 +1,33 @@
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ 
+ */
+
+
+public class ObsServiceImplTest extends BaseContextSensitiveTest {
+	
+	@Autowired
+	private ObsServiceImpl obsServiceImpl;
+	
+	@Test
+	public void getRefByUuid_shouldThrowAPIExceptionForNullType() {
+		APIException exception = assertThrows(APIException.class, () -> obsServiceImpl.getRefByUuid(null, "some-random-uuid"));
+		assertEquals("Unsupported type for getRefByUuid: null", exception.getMessage());
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/api/impl/ObsServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ObsServiceImplTest.java
@@ -1,3 +1,4 @@
+package org.openmrs.api.impl;
 
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;

--- a/api/src/test/java/org/openmrs/api/impl/OrderServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/OrderServiceImplTest.java
@@ -1,0 +1,32 @@
+package org.openmrs.api.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+public class OrderServiceImplTest extends BaseContextSensitiveTest{
+	
+	
+	@Autowired
+	private OrderServiceImpl orderServiceImpl;
+	
+	@Test
+	public void getRefByUuid_shouldThrowAPIExceptionForNullType() {
+		APIException exception = assertThrows(APIException.class, () -> orderServiceImpl.getRefByUuid(null, "some-random-uuid"));
+		assertEquals("Unsupported type for getRefByUuid: null", exception.getMessage());
+	}
+}

--- a/api/src/test/java/org/openmrs/api/impl/PersonServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/PersonServiceImplTest.java
@@ -1,0 +1,32 @@
+package org.openmrs.api.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+public class PersonServiceImplTest extends BaseContextSensitiveTest {
+	
+	@Autowired
+	private PersonServiceImpl personServiceImpl;
+	
+	@Test
+	public void getRefByUuid_shouldThrowAPIExceptionForNullType() {
+		APIException exception = assertThrows(APIException.class, () -> personServiceImpl.getRefByUuid(null, "some-random-uuid"));
+		assertEquals("Unsupported type for getRefByUuid: null", exception.getMessage());
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/api/impl/UserServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/UserServiceImplTest.java
@@ -1,0 +1,32 @@
+package org.openmrs.api.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+public class UserServiceImplTest extends BaseContextSensitiveTest {
+	
+	@Autowired
+	private UserServiceImpl userServiceImpl;
+	
+	@Test
+	public void getRefByUuid_shouldThrowAPIExceptionForNullType() {
+		APIException exception = assertThrows(APIException.class, () -> userServiceImpl.getRefByUuid(null, "some-random-uuid"));
+		assertEquals("Unsupported type for getRefByUuid: null", exception.getMessage());
+	}
+	
+}

--- a/api/src/test/java/org/openmrs/api/impl/VisitServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/VisitServiceImplTest.java
@@ -1,0 +1,33 @@
+package org.openmrs.api.impl;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+public class VisitServiceImplTest extends BaseContextSensitiveTest {
+	
+	@Autowired
+	private VisitServiceImpl visitServiceImpl;
+	
+	@Test
+	public void getRefByUuid_shouldThrowAPIExceptionForNullType() {
+		APIException exception = assertThrows(APIException.class, () -> visitServiceImpl.getRefByUuid(null, "some-random-uuid"));
+		assertEquals("Unsupported type for getRefByUuid: null", exception.getMessage());
+	}
+	
+	
+}


### PR DESCRIPTION
The **getRefByUuid()** method contains an operator precedence issue in the **APIException** message construction:

`throw new APIException("Unsupported type for getRefByUuid: " + type != null ? type.getName() : "null");`

Due to Java operator precedence, the ternary operator is evaluated incorrectly, causing the exception message to be wrong and potentially leading to a **NullPointerException** when **type** is **null**.

**Proposed Fix**
Wrap the ternary expression in parentheses:

`throw new APIException(
    "Unsupported type for getRefByUuid: "
        + (type != null ? type.getName() : "null")
);`

**Impact**

- Generates the correct error message.
- Prevents incorrect evaluation of the ternary expression.
- Avoids a possible NullPointerException when type is null.

**Tests**
-All test cases passed

JIra Ticker : https://openmrs.atlassian.net/browse/TRUNK-6714