### PR TITLE
TRUNK-6712: Cache flattened role privileges for privilege and superuser checks

### DIFF
--- a/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
@@ -1,0 +1,93 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.util.RoleConstants;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+/**
+ * Caches the fully-flattened {@link RolePrivileges} for each role, keyed by role name.
+ * <p>
+ * This is a plain Spring {@link Component}, not a service method, so reading it during a privilege
+ * check does <b>not</b> re-enter the {@code @Authorized}/AOP service proxy (no overhead, and no
+ * risk of a privilege check triggering another privilege check). It holds a direct handle to the
+ * {@code rolePrivileges} cache declared in {@code cache-api.yaml}.
+ * <p>
+ * On a cache miss the role's entire inheritance chain is walked once by {@link #flatten(Role)},
+ * collecting every privilege (lowercased) and whether the chain grants superuser, and the result is
+ * stored so later checks are a single lookup with no recursion.
+ *
+ * @since 2.8.0
+ */
+@Component("rolePrivilegeCache")
+public class RolePrivilegeCache {
+
+	private final Cache cache;
+
+	public RolePrivilegeCache(@Qualifier("apiCacheManager") CacheManager cacheManager) {
+		this.cache = cacheManager.getCache("rolePrivileges");
+	}
+
+	/**
+	 * Returns the flattened privileges for the given role, computing and caching them on the first call
+	 * and returning the stored copy afterwards.
+	 *
+	 * @param role the role to resolve; must have a non-null name
+	 * @return the role's flattened privileges (never null)
+	 */
+	public RolePrivileges getPrivileges(Role role) {
+		// key by role NAME (a stable, unique String); compute via flatten() on a cache miss
+		return cache.get(role.getRole(), () -> flatten(role));
+	}
+
+	/**
+	 * Walks the given role plus everything it inherits, collecting all privilege names (lowercased) and
+	 * noticing superuser status in a single pass. A {@code visited} set of role names guards against
+	 * inheritance cycles so the walk always terminates.
+	 */
+	private RolePrivileges flatten(Role role) {
+		Set<String> privileges = new HashSet<>();
+		boolean grantsSuperuser = false;
+		Set<String> visited = new HashSet<>();
+		Deque<Role> stack = new ArrayDeque<>();
+		stack.push(role);
+		while (!stack.isEmpty()) {
+			Role current = stack.pop();
+			if (current == null || !visited.add(current.getRole())) {
+				// null role, or one we have already processed -> skip (prevents infinite loops)
+				continue;
+			}
+			if (RoleConstants.SUPERUSER.equals(current.getRole())) {
+				grantsSuperuser = true;
+			}
+			if (current.getPrivileges() != null) {
+				for (Privilege privilege : current.getPrivileges()) {
+					privileges.add(privilege.getPrivilege().toLowerCase(Locale.ENGLISH));
+				}
+			}
+			for (Role inherited : current.getInheritedRoles()) {
+				stack.push(inherited);
+			}
+		}
+		return new RolePrivileges(Collections.unmodifiableSet(privileges), grantsSuperuser);
+	}
+}

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
@@ -25,16 +25,10 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 
 /**
- * Caches the fully-flattened {@link RolePrivileges} for each role, keyed by role name.
- * <p>
- * This is a plain Spring {@link Component}, not a service method, so reading it during a privilege
- * check does <b>not</b> re-enter the {@code @Authorized}/AOP service proxy (no overhead, and no
- * risk of a privilege check triggering another privilege check). It holds a direct handle to the
- * {@code rolePrivileges} cache declared in {@code cache-api.yaml}.
- * <p>
- * On a cache miss the role's entire inheritance chain is walked once by {@link #flatten(Role)},
- * collecting every privilege (lowercased) and whether the chain grants superuser, and the result is
- * stored so later checks are a single lookup with no recursion.
+ * Caches the fully-flattened {@link RolePrivileges} for each role, keyed by role name. This is a
+ * plain Spring {@link Component}, not a service method, so reading it during a privilege check does
+ * not re-enter the {@code @Authorized} service proxy. On a cache miss {@link #flatten(Role)} walks
+ * the role's entire inheritance chain once; later checks are a single lookup with no recursion.
  *
  * @since 2.8.0
  */
@@ -55,7 +49,6 @@ public class RolePrivilegeCache {
 	 * @return the role's flattened privileges (never null)
 	 */
 	public RolePrivileges getPrivileges(Role role) {
-		// key by role NAME (a stable, unique String); compute via flatten() on a cache miss
 		return cache.get(role.getRole(), () -> flatten(role));
 	}
 
@@ -73,7 +66,6 @@ public class RolePrivilegeCache {
 		while (!stack.isEmpty()) {
 			Role current = stack.pop();
 			if (current == null || !visited.add(current.getRole())) {
-				// null role, or one we have already processed -> skip (prevents infinite loops)
 				continue;
 			}
 			if (RoleConstants.SUPERUSER.equals(current.getRole())) {

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
@@ -1,0 +1,62 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Immutable, cacheable snapshot of the fully-flattened privileges granted by a single role.
+ * <p>
+ * One instance represents "the answer for one role": every privilege that role grants (including
+ * everything it inherits), plus whether the role grants superuser status. It is computed once by
+ * {@link RolePrivilegeCache} and stored in the {@code rolePrivileges} cache, so privilege checks
+ * can read a pre-computed result instead of re-walking the role inheritance tree on every call.
+ * <p>
+ * Privilege names are stored already lowercased (see {@link RolePrivilegeCache}) so that
+ * case-insensitive matching becomes a fast {@link Set} lookup. The object is immutable and
+ * {@link Serializable} so it is safe to share across threads and move between cluster nodes.
+ *
+ * @since 2.8.0
+ */
+public final class RolePrivileges implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Set<String> privilegeNames;
+
+	private final boolean grantsSuperuser;
+
+	/**
+	 * @param privilegeNames the role's flattened privilege names, already lowercased
+	 * @param grantsSuperuser whether this role grants superuser status (directly or via inheritance)
+	 */
+	public RolePrivileges(Set<String> privilegeNames, boolean grantsSuperuser) {
+		this.privilegeNames = Collections.unmodifiableSet(new HashSet<>(privilegeNames));
+		this.grantsSuperuser = grantsSuperuser;
+	}
+
+	/**
+	 * @return true if this role grants superuser status, in which case every privilege check passes
+	 */
+	public boolean grantsSuperuser() {
+		return grantsSuperuser;
+	}
+
+	/**
+	 * @param alreadyLowercased the privilege name to look for, already lowercased by the caller
+	 * @return true if this role's flattened privilege set contains the given privilege
+	 */
+	public boolean containsPrivilege(String alreadyLowercased) {
+		return privilegeNames.contains(alreadyLowercased);
+	}
+}

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
@@ -15,16 +15,11 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Immutable, cacheable snapshot of the fully-flattened privileges granted by a single role.
- * <p>
- * One instance represents "the answer for one role": every privilege that role grants (including
- * everything it inherits), plus whether the role grants superuser status. It is computed once by
- * {@link RolePrivilegeCache} and stored in the {@code rolePrivileges} cache, so privilege checks
- * can read a pre-computed result instead of re-walking the role inheritance tree on every call.
- * <p>
- * Privilege names are stored already lowercased (see {@link RolePrivilegeCache}) so that
- * case-insensitive matching becomes a fast {@link Set} lookup. The object is immutable and
- * {@link Serializable} so it is safe to share across threads and move between cluster nodes.
+ * Immutable, cacheable snapshot of the fully-flattened privileges granted by a single role: the
+ * (lowercased) privilege names it grants, including everything it inherits, plus whether it grants
+ * superuser status. Computed once by {@link RolePrivilegeCache}. Lowercasing keeps case-insensitive
+ * matching while allowing a fast {@link Set} lookup; immutability and {@link Serializable} make it
+ * safe to share across threads and cluster nodes.
  *
  * @since 2.8.0
  */

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -394,53 +394,53 @@ public class UserContext implements Serializable {
 	 * @return true if authenticated user has given privilege
 	 */
 	public boolean hasPrivilege(String privilege) {
-		log.debug("Checking '{}' against proxies: {}", privilege, proxies);
-		// check proxied privileges
+		boolean authorized = isAuthorized(privilege);
+		notifyPrivilegeListeners(getAuthenticatedUser(), privilege, authorized);
+		return authorized;
+	}
+
+	/**
+	 * Resolves whether the current user has the given privilege, checking, in order: proxy privileges,
+	 * the authenticated user's own roles, the authenticated role, and the anonymous role.
+	 */
+	private boolean isAuthorized(String privilege) {
 		for (String s : new ArrayList<>(proxies)) {
 			if (s.equals(privilege)) {
-				notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
 				return true;
 			}
 		}
 
-		// grab the cache component (a plain component lookup, NOT a service proxy)
+		// a plain component lookup, so the read path does not re-enter the service proxy
 		RolePrivilegeCache cache = Context.getRegisteredComponent("rolePrivilegeCache", RolePrivilegeCache.class);
 		String normalizedPrivilege = (privilege == null) ? null : privilege.toLowerCase(Locale.ENGLISH);
 
-		// if a user has logged in, check their own roles plus the authenticated role
 		if (isAuthenticated()) {
-			User authenticatedUser = getAuthenticatedUser();
-
-			// keep the old rule: an empty privilege string always passes for logged-in users
+			// an empty privilege always passes for logged-in users
 			if (StringUtils.isEmpty(privilege)) {
-				notifyPrivilegeListeners(authenticatedUser, privilege, true);
 				return true;
 			}
-
-			if (authenticatedUser.getRoles() != null) {
-				// the user's DIRECT roles; each role's cached entry already contains its inherited closure
-				for (Role role : authenticatedUser.getRoles()) {
-					if (grants(cache, role, normalizedPrivilege)) {
-						notifyPrivilegeListeners(authenticatedUser, privilege, true);
-						return true;
-					}
-				}
-			}
-
-			if (grants(cache, getAuthenticatedRole(), normalizedPrivilege)) {
-				notifyPrivilegeListeners(authenticatedUser, privilege, true);
+			if (userRolesGrant(cache, normalizedPrivilege) || grants(cache, getAuthenticatedRole(), normalizedPrivilege)) {
 				return true;
 			}
 		}
 
-		// the anonymous role is checked for everyone
-		if (grants(cache, getAnonymousRole(), normalizedPrivilege)) {
-			notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
-			return true;
-		}
+		return grants(cache, getAnonymousRole(), normalizedPrivilege);
+	}
 
-		// default return value
-		notifyPrivilegeListeners(getAuthenticatedUser(), privilege, false);
+	/**
+	 * @return true if any of the authenticated user's direct roles grants the privilege; each role's
+	 *         cached entry already contains its inherited closure, so no recursion is needed here
+	 */
+	private boolean userRolesGrant(RolePrivilegeCache cache, String normalizedPrivilege) {
+		User authenticatedUser = getAuthenticatedUser();
+		if (authenticatedUser.getRoles() == null) {
+			return false;
+		}
+		for (Role role : authenticatedUser.getRoles()) {
+			if (grants(cache, role, normalizedPrivilege)) {
+				return true;
+			}
+		}
 		return false;
 	}
 

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -29,6 +29,8 @@ import org.openmrs.UserSessionListener.Event;
 import org.openmrs.UserSessionListener.Status;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.LocationService;
+import org.openmrs.api.cache.RolePrivilegeCache;
+import org.openmrs.api.cache.RolePrivileges;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.RoleConstants;
@@ -401,17 +403,38 @@ public class UserContext implements Serializable {
 			}
 		}
 
-		// if a user has logged in, check their privileges
-		if (isAuthenticated()
-		        && (getAuthenticatedUser().hasPrivilege(privilege) || getAuthenticatedRole().hasPrivilege(privilege))) {
+		// grab the cache component (a plain component lookup, NOT a service proxy)
+		RolePrivilegeCache cache = Context.getRegisteredComponent("rolePrivilegeCache", RolePrivilegeCache.class);
+		String normalizedPrivilege = (privilege == null) ? null : privilege.toLowerCase(Locale.ENGLISH);
 
-			// check user's privileges
-			notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
-			return true;
+		// if a user has logged in, check their own roles plus the authenticated role
+		if (isAuthenticated()) {
+			User authenticatedUser = getAuthenticatedUser();
 
+			// keep the old rule: an empty privilege string always passes for logged-in users
+			if (StringUtils.isEmpty(privilege)) {
+				notifyPrivilegeListeners(authenticatedUser, privilege, true);
+				return true;
+			}
+
+			if (authenticatedUser.getRoles() != null) {
+				// the user's DIRECT roles; each role's cached entry already contains its inherited closure
+				for (Role role : authenticatedUser.getRoles()) {
+					if (grants(cache, role, normalizedPrivilege)) {
+						notifyPrivilegeListeners(authenticatedUser, privilege, true);
+						return true;
+					}
+				}
+			}
+
+			if (grants(cache, getAuthenticatedRole(), normalizedPrivilege)) {
+				notifyPrivilegeListeners(authenticatedUser, privilege, true);
+				return true;
+			}
 		}
 
-		if (getAnonymousRole().hasPrivilege(privilege)) {
+		// the anonymous role is checked for everyone
+		if (grants(cache, getAnonymousRole(), normalizedPrivilege)) {
 			notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
 			return true;
 		}
@@ -419,6 +442,15 @@ public class UserContext implements Serializable {
 		// default return value
 		notifyPrivilegeListeners(getAuthenticatedUser(), privilege, false);
 		return false;
+	}
+
+	/**
+	 * @return true if this role's cached entry grants superuser, or contains the requested privilege
+	 */
+	private static boolean grants(RolePrivilegeCache cache, Role role, String normalizedPrivilege) {
+		RolePrivileges rolePrivileges = cache.getPrivileges(role);
+		return rolePrivileges.grantsSuperuser()
+		        || (normalizedPrivilege != null && rolePrivileges.containsPrivilege(normalizedPrivilege));
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -252,6 +252,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public void purgePrivilege(Privilege privilege) throws APIException {
 		if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
 			throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
@@ -264,6 +265,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public Privilege savePrivilege(Privilege privilege) throws APIException {
 		return dao.savePrivilege(privilege);
 	}
@@ -290,6 +292,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public void purgeRole(Role role) throws APIException {
 		if (role == null || role.getRole() == null) {
 			return;
@@ -310,6 +313,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public Role saveRole(Role role) throws APIException {
 		// make sure one of the parents of this role isn't itself...this would
 		// cause an infinite loop

--- a/api/src/main/resources/cache-api.yaml
+++ b/api/src/main/resources/cache-api.yaml
@@ -5,3 +5,5 @@ caches:
         configuration: "entity"
     serializerWhiteListTypes:
         configuration: "entity"
+    rolePrivileges:
+        configuration: "entity"

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheEvictionTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheEvictionTest.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Context-sensitive test proving that the {@code @CacheEvict} annotations on the role/privilege
+ * write methods actually clear the {@code rolePrivileges} cache, so edits through the service take
+ * effect immediately. Unlike {@link RolePrivilegeCacheTest} (which bypasses the service to prove
+ * caching), this test goes through the real {@link UserService} so the service proxy fires the
+ * eviction.
+ */
+public class RolePrivilegeCacheEvictionTest extends BaseContextSensitiveTest {
+
+	@Test
+	void saveRole_shouldEvictCacheSoPrivilegeChangesTakeEffectImmediately() {
+		RolePrivilegeCache cache = Context.getRegisteredComponent("rolePrivilegeCache", RolePrivilegeCache.class);
+		UserService userService = Context.getUserService();
+
+		// create a role that has a single privilege, saved through the service
+		Privilege privilegeA = userService.savePrivilege(new Privilege("Cache Test Privilege A", "test"));
+		Role role = new Role("Cache Test Role", "test");
+		role.addPrivilege(privilegeA);
+		role = userService.saveRole(role);
+
+		// populate the cache for this role
+		RolePrivileges before = cache.getPrivileges(role);
+		assertTrue(before.containsPrivilege("cache test privilege a"));
+		assertFalse(before.containsPrivilege("cache test privilege b"));
+
+		// add a second privilege and save -> @CacheEvict on saveRole must clear the cache
+		Privilege privilegeB = userService.savePrivilege(new Privilege("Cache Test Privilege B", "test"));
+		role.addPrivilege(privilegeB);
+		userService.saveRole(role);
+
+		// a fresh lookup must now reflect the new privilege; if eviction had NOT fired, this would
+		// return the stale cached entry (without privilege B) and the assertion would fail
+		RolePrivileges after = cache.getPrivileges(role);
+		assertTrue(after.containsPrivilege("cache test privilege b"));
+	}
+}

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
@@ -34,12 +34,10 @@ public class RolePrivilegeCacheTest {
 
 	@BeforeEach
 	void setUp() {
-		// a simple in-memory cache manager that hands out a cache named "rolePrivileges"
 		ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager("rolePrivileges");
 		cache = new RolePrivilegeCache(cacheManager);
 	}
 
-	/** Builds a role with the given name and (case-preserved) privilege names. */
 	private Role role(String name, String... privileges) {
 		Role role = new Role(name);
 		Set<Privilege> privilegeSet = new HashSet<>();
@@ -81,9 +79,9 @@ public class RolePrivilegeCacheTest {
 
 		RolePrivileges result = cache.getPrivileges(seniorClinician);
 
-		assertTrue(result.containsPrivilege("edit patients")); // from Senior Clinician itself
-		assertTrue(result.containsPrivilege("add visits")); // inherited from Clinician
-		assertTrue(result.containsPrivilege("view patients")); // inherited from Basic User
+		assertTrue(result.containsPrivilege("edit patients"));
+		assertTrue(result.containsPrivilege("add visits"));
+		assertTrue(result.containsPrivilege("view patients"));
 		assertFalse(result.grantsSuperuser());
 	}
 
@@ -110,7 +108,7 @@ public class RolePrivilegeCacheTest {
 
 		RolePrivileges result = cache.getPrivileges(admin);
 
-		assertTrue(result.grantsSuperuser()); // superuser status flows down through inheritance
+		assertTrue(result.grantsSuperuser());
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
@@ -1,0 +1,128 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.util.RoleConstants;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pure unit tests for {@link RolePrivilegeCache}. These do not touch the database or the Spring
+ * application context: an in-memory {@link ConcurrentMapCacheManager} stands in for the real cache,
+ * so the flattening logic (inheritance, superuser detection, cycle handling) can be verified in
+ * isolation.
+ */
+public class RolePrivilegeCacheTest {
+
+	private RolePrivilegeCache cache;
+
+	@BeforeEach
+	void setUp() {
+		// a simple in-memory cache manager that hands out a cache named "rolePrivileges"
+		ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager("rolePrivileges");
+		cache = new RolePrivilegeCache(cacheManager);
+	}
+
+	/** Builds a role with the given name and (case-preserved) privilege names. */
+	private Role role(String name, String... privileges) {
+		Role role = new Role(name);
+		Set<Privilege> privilegeSet = new HashSet<>();
+		for (String privilege : privileges) {
+			privilegeSet.add(new Privilege(privilege));
+		}
+		role.setPrivileges(privilegeSet);
+		return role;
+	}
+
+	@Test
+	void getPrivileges_shouldStoreLowercasedPrivilegeNames() {
+		Role basicUser = role("Basic User", "View Patients");
+
+		RolePrivileges result = cache.getPrivileges(basicUser);
+
+		assertTrue(result.containsPrivilege("view patients"));
+		assertFalse(result.grantsSuperuser());
+	}
+
+	@Test
+	void getPrivileges_shouldMatchCaseInsensitively() {
+		Role basicUser = role("Basic User", "View Patients");
+
+		RolePrivileges result = cache.getPrivileges(basicUser);
+
+		// stored lowercased; the caller is responsible for lowercasing its lookup key
+		assertTrue(result.containsPrivilege("view patients"));
+		assertFalse(result.containsPrivilege("View Patients")); // not lowercased -> no match, by design
+	}
+
+	@Test
+	void getPrivileges_shouldIncludeInheritedPrivileges() {
+		Role basicUser = role("Basic User", "View Patients");
+		Role clinician = role("Clinician", "Add Visits");
+		Role seniorClinician = role("Senior Clinician", "Edit Patients");
+		clinician.setInheritedRoles(new HashSet<>(Set.of(basicUser)));
+		seniorClinician.setInheritedRoles(new HashSet<>(Set.of(clinician)));
+
+		RolePrivileges result = cache.getPrivileges(seniorClinician);
+
+		assertTrue(result.containsPrivilege("edit patients")); // from Senior Clinician itself
+		assertTrue(result.containsPrivilege("add visits")); // inherited from Clinician
+		assertTrue(result.containsPrivilege("view patients")); // inherited from Basic User
+		assertFalse(result.grantsSuperuser());
+	}
+
+	@Test
+	void getPrivileges_shouldReturnCachedValueOnSecondLookup() {
+		Role basicUser = role("Basic User", "View Patients");
+
+		RolePrivileges first = cache.getPrivileges(basicUser);
+		assertTrue(first.containsPrivilege("view patients"));
+
+		// mutate the role in memory AFTER it was cached
+		basicUser.getPrivileges().add(new Privilege("Manage Concepts"));
+
+		RolePrivileges second = cache.getPrivileges(basicUser);
+		// still the OLD value -> proves it was served from the cache, not recomputed
+		assertFalse(second.containsPrivilege("manage concepts"));
+	}
+
+	@Test
+	void getPrivileges_shouldDetectInheritedSuperuser() {
+		Role superuserRole = role(RoleConstants.SUPERUSER);
+		Role admin = role("Admin", "Manage Users");
+		admin.setInheritedRoles(new HashSet<>(Set.of(superuserRole)));
+
+		RolePrivileges result = cache.getPrivileges(admin);
+
+		assertTrue(result.grantsSuperuser()); // superuser status flows down through inheritance
+	}
+
+	@Test
+	void getPrivileges_shouldTerminateOnInheritanceCycle() {
+		Role roleA = role("A", "Privilege A");
+		Role roleB = role("B", "Privilege B");
+		roleA.setInheritedRoles(new HashSet<>(Set.of(roleB)));
+		roleB.setInheritedRoles(new HashSet<>(Set.of(roleA))); // A <-> B cycle
+
+		RolePrivileges result = cache.getPrivileges(roleA); // must not hang
+
+		assertTrue(result.containsPrivilege("privilege a"));
+		assertTrue(result.containsPrivilege("privilege b"));
+	}
+}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-6712: Cache flattened role privileges for privilege and superuser checks' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
  Cache each role's fully-flattened privilege set (keyed by role name) so that                                                                                                       
  `UserContext.hasPrivilege` performs a cheap lookup instead of rebuilding the                                                                                                       
  user's entire expanded role tree and string-scanning privileges on every call.                                                                                                     
                                                                                                                                                                                     
  - Register a `rolePrivileges` cache in `cache-api.yaml`, reusing the shared                                                                                                        
    `entity` template so it inherits TTL expiry and clustered invalidation.                                                                                                          
  - Add an immutable, `Serializable` `RolePrivileges` value object (lowercased                                                                                                       
    privilege set + `grantsSuperuser` flag).                                                                                                                                         
  - Add a `RolePrivilegeCache` `@Component` that flattens a role's inheritance                                                                                                       
    chain once on a cache miss (with a cycle guard) and reads from the cache                                                                                                         
    thereafter. It is a plain component, so the read path does not re-enter the                                                                                                      
    `@Authorized` service proxy.                                                                                                                                                     
  - Rewrite `UserContext.hasPrivilege` to check each of the user's direct roles'                                                                                                     
    cached, fully-flattened entries. Behaviour is preserved: case-insensitive                                                                                                        
    matching, inherited roles, inherited superuser status, proxy privileges, and                                                                                                     
    the anonymous/authenticated roles.                                                                                                                                               
  - Evict the cache via `@CacheEvict(allEntries = true)` on `saveRole`,                                                                                                              
    `purgeRole`, `savePrivilege`, and `purgePrivilege`.                                                                                                                              
  - Add unit tests (population, cache hit, inherited superuser, inheritance                                                                                                          
    cycles) and a context-sensitive test proving eviction fires through the                                                                                                          
    service.  

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6712

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [ ] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [ ] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

