### PR TITLE
TRUNK-6719 Fix String comparison in NameSupport.updateLayoutTemplates

### DIFF
--- a/api/src/main/java/org/openmrs/layout/name/NameSupport.java
+++ b/api/src/main/java/org/openmrs/layout/name/NameSupport.java
@@ -11,6 +11,7 @@ package org.openmrs.layout.name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -57,10 +58,12 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 		if (initialized) {
 			return;
 		}
+
 		Context.getAdministrationService().addGlobalPropertyListener(singleton);
-		// Get configured name template to override the existing one if any
+
 		String layoutTemplateXml = Context.getAdministrationService()
 		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_LAYOUT_NAME_TEMPLATE);
+
 		NameTemplate nameTemplate = deserializeXmlTemplate(layoutTemplateXml);
 
 		if (nameTemplate != null) {
@@ -77,12 +80,15 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 		if (getLayoutTemplates() == null) {
 			setLayoutTemplates(new ArrayList<>());
 		}
+
 		List<NameTemplate> list = new ArrayList<>();
-		// filter out unaffected templates to keep
+
 		list.addAll(getLayoutTemplates().stream()
-		        .filter(existingTemplate -> existingTemplate.getCodeName() != nameTemplate.getCodeName())
+		        .filter(existingTemplate -> !Objects.equals(existingTemplate.getCodeName(), nameTemplate.getCodeName()))
 		        .collect(Collectors.toList()));
+
 		list.add(nameTemplate);
+
 		setLayoutTemplates(list);
 	}
 
@@ -91,15 +97,18 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 	 */
 	private NameTemplate deserializeXmlTemplate(String xml) {
 		NameTemplate nameTemplate = null;
+
 		if (StringUtils.isBlank(xml)) {
 			return null;
 		}
+
 		try {
 			nameTemplate = Context.getSerializationService().getDefaultSerializer()
 			        .deserialize(StringEscapeUtils.unescapeXml(xml), NameTemplate.class);
 		} catch (Exception e) {
 			log.error("Error in deserializing provided name template", e);
 		}
+
 		return nameTemplate;
 	}
 
@@ -110,6 +119,7 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 	public String getDefaultLayoutFormat() {
 		String ret = Context.getAdministrationService()
 		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_LAYOUT_NAME_FORMAT);
+
 		return (ret != null && ret.length() > 0) ? ret : defaultLayoutFormat;
 	}
 
@@ -127,6 +137,7 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 	@Override
 	public void globalPropertyChanged(GlobalProperty newValue) {
 		NameTemplate nameTemplate = deserializeXmlTemplate(newValue.getPropertyValue());
+
 		if (nameTemplate != null) {
 			updateLayoutTemplates(nameTemplate);
 		}

--- a/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
+++ b/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
@@ -126,4 +126,24 @@ public class NameTemplateTest extends BaseContextSensitiveTest {
 		assertEquals("Moses Mujuzi", nameTemplate.format(personName));
 	}
 
+	@Test
+	public void shouldReplaceExistingTemplateWithSameCodeName() throws Exception {
+		NameTemplate existingTemplate = new NameTemplate();
+		existingTemplate.setCodeName(new String("duplicateCode"));
+
+		nameSupport.setLayoutTemplates(new ArrayList<>(Collections.singletonList(existingTemplate)));
+
+		NameTemplate newTemplate = new NameTemplate();
+		newTemplate.setCodeName(new String("duplicateCode"));
+
+		GlobalProperty property = new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_LAYOUT_NAME_TEMPLATE,
+		        Context.getSerializationService().getDefaultSerializer().serialize(newTemplate));
+
+		nameSupport.globalPropertyChanged(property);
+
+		List<NameTemplate> templates = nameSupport.getLayoutTemplates();
+
+		assertEquals(1, templates.size());
+		assertEquals(newTemplate.getCodeName(), templates.get(0).getCodeName());
+	}
 }


### PR DESCRIPTION
<## Description of what I changed

Fixed String comparison in `NameSupport.updateLayoutTemplates()`.

Previously, String references were compared using `!=`, which checks object references instead of actual String values. This caused templates with the same `codeName` value but different String objects to not be replaced correctly.

Updated the comparison to use `Objects.equals()` for proper value comparison.

Added a test case to verify that an existing template with the same `codeName` is replaced correctly.

## Issue I worked on

TRUNK-6719

https://issues.openmrs.org/browse/TRUNK-6719

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I ran `./mvnw clean package` right before creating this pull request.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.