### PR TITLE
TRUNK-6719: Fix reference-equality String comparison in NameSupport u…

### DIFF
--- a/api/src/main/java/org/openmrs/layout/name/NameSupport.java
+++ b/api/src/main/java/org/openmrs/layout/name/NameSupport.java
@@ -11,6 +11,7 @@ package org.openmrs.layout.name;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -80,7 +81,7 @@ public class NameSupport extends LayoutSupport<NameTemplate> implements GlobalPr
 		List<NameTemplate> list = new ArrayList<>();
 		// filter out unaffected templates to keep
 		list.addAll(getLayoutTemplates().stream()
-		        .filter(existingTemplate -> existingTemplate.getCodeName() != nameTemplate.getCodeName())
+		        .filter(existingTemplate -> !Objects.equals(existingTemplate.getCodeName(), nameTemplate.getCodeName()))
 		        .collect(Collectors.toList()));
 		list.add(nameTemplate);
 		setLayoutTemplates(list);

--- a/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
+++ b/api/src/test/java/org/openmrs/layout/name/NameTemplateTest.java
@@ -126,4 +126,28 @@ public class NameTemplateTest extends BaseContextSensitiveTest {
 		assertEquals("Moses Mujuzi", nameTemplate.format(personName));
 	}
 
+	@Test
+	public void shouldReplaceTemplateWithSameCodeNameByValue() throws Exception {
+		// Create the existing template
+		NameTemplate existingTemplate = new NameTemplate();
+		existingTemplate.setCodeName(new String("test-code-name"));
+		existingTemplate.setDisplayName("Old Template");
+		nameSupport.setLayoutTemplates(new ArrayList<>(Collections.singletonList(existingTemplate)));
+
+		// Create the new template with the same logical codeName but a different object reference
+		NameTemplate newTemplate = new NameTemplate();
+		newTemplate.setCodeName(new String("test-code-name"));
+		newTemplate.setDisplayName("New Template");
+
+		// Invoke the private updateLayoutTemplates method
+		java.lang.reflect.Method method = NameSupport.class.getDeclaredMethod("updateLayoutTemplates", NameTemplate.class);
+		method.setAccessible(true);
+		method.invoke(nameSupport, newTemplate);
+
+		// Assert that the old template was replaced and no duplicates exist
+		List<NameTemplate> templates = nameSupport.getLayoutTemplates();
+		assertEquals(1, templates.size(), "There should only be one template (no duplicates)");
+		assertEquals("New Template", templates.get(0).getDisplayName(), "The template should be the new one");
+	}
+
 }


### PR DESCRIPTION
## Description of what I changed

- Replaced the reference-based `String` comparison in `NameSupport.updateLayoutTemplates()` with a null-safe value comparison using `Objects.equals()`.
- Added a unit test to verify that an existing template is replaced when a new template with the same code name (equal value but different `String` reference) is added.

## Issue I worked on

TRUNK-6719

https://issues.openmrs.org/browse/TRUNK-6719