### PR TITLE
TRUNK-6726: Refactor ObsValidator to unify interpretation handling and populate coded observation interpretations

### DIFF
--- a/api/src/main/java/org/openmrs/validator/ObsValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ObsValidator.java
@@ -13,11 +13,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDatatype;
+import org.openmrs.ConceptMap;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.ConceptReferenceRange;
 import org.openmrs.ConceptReferenceRangeContext;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.Obs;
 import org.openmrs.ObsReferenceRange;
 import org.openmrs.annotation.Handler;
@@ -41,7 +44,9 @@ import org.springframework.validation.Validator;
 public class ObsValidator implements Validator {
 	
 	public static final int VALUE_TEXT_MAX_LENGTH = 65535;
-	
+
+	private static final String GROUP_MEMBERS_FIELD = "groupMembers";
+
 	/**
 	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
 	 * <strong>Should</strong> support Obs class
@@ -157,61 +162,10 @@ public class ObsValidator implements Validator {
 		// if there is a concept, and this isn't a group, perform validation tests specific to the concept datatype
 		else if (!isObsGroup) {
 			ConceptDatatype dt = c.getDatatype();
-			if (dt != null) {
-				if (dt.isBoolean() && obs.getValueBoolean() == null) {
-					if (atRootNode) {
-						errors.rejectValue("valueBoolean", "error.null");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				} else if (dt.isCoded() && obs.getValueCoded() == null) {
-					if (atRootNode) {
-						errors.rejectValue("valueCoded", "error.null");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				} else if ((dt.isDateTime() || dt.isDate() || dt.isTime()) && obs.getValueDatetime() == null) {
-					if (atRootNode) {
-						errors.rejectValue("valueDatetime", "error.null");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				} else if (dt.isNumeric() && obs.getValueNumeric() == null) {
-					if (atRootNode) {
-						errors.rejectValue("valueNumeric", "error.null");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				} else if (dt.isNumeric()) {
-					ConceptNumeric cn = Context.getConceptService().getConceptNumeric(c.getConceptId());
-					// If the concept numeric is not precise, the value cannot be a float, so raise an error 
-					if (!cn.getAllowDecimal() && Math.ceil(obs.getValueNumeric()) != obs.getValueNumeric()) {
-						if (atRootNode) {
-							errors.rejectValue("valueNumeric", "Obs.error.precision");
-						} else {
-							errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-						}
-					}
-					
-					validateConceptReferenceRange(obs, errors, atRootNode);
-				} else if (dt.isText() && obs.getValueText() == null) {
-					if (atRootNode) {
-						errors.rejectValue("valueText", "error.null");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				}
-				
-				//If valueText is longer than the maxlength, raise an error as well.
-				if (dt.isText() && obs.getValueText() != null && obs.getValueText().length() > VALUE_TEXT_MAX_LENGTH) {
-					if (atRootNode) {
-						errors.rejectValue("valueText", "error.exceededMaxLengthOfField");
-					} else {
-						errors.rejectValue("groupMembers", "Obs.error.inGroupMember");
-					}
-				}
-			} else { // dt is null
+			if (dt == null) {
 				errors.rejectValue("concept", "must have a datatype");
+			} else {
+				validateValueForDatatype(obs, dt, errors, atRootNode);
 			}
 		}
 		
@@ -221,7 +175,7 @@ public class ObsValidator implements Validator {
 		}
 		
 		if (ancestors.contains(obs)) {
-			errors.rejectValue("groupMembers", "Obs.error.groupContainsItself");
+			errors.rejectValue(GROUP_MEMBERS_FIELD, "Obs.error.groupContainsItself");
 		}
 		
 		Set<Obs> groupMembers = obs.getGroupMembers();
@@ -242,6 +196,150 @@ public class ObsValidator implements Validator {
 				errors.rejectValue("valueDrug", "Obs.error.invalidDrug");
 			}
 		}
+	}
+
+	/**
+	 * Performs the value presence/precision checks specific to a concept's datatype, and triggers
+	 * interpretation derivation for datatypes that support it. Extracted out of {@link #validateHelper}
+	 * so that method's cognitive complexity stays within this project's SonarCloud quality gate.
+	 *
+	 * @param obs Observation to validate
+	 * @param dt the datatype of obs' concept
+	 * @param errors Errors to record validation issues
+	 * @param atRootNode whether or not this is the obs that validate() was originally called on
+	 */
+	private void validateValueForDatatype(Obs obs, ConceptDatatype dt, Errors errors, boolean atRootNode) {
+		if (dt.isBoolean() && obs.getValueBoolean() == null) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueBoolean", "error.null");
+		} else if (dt.isCoded() && obs.getValueCoded() == null) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueCoded", "error.null");
+		} else if (dt.isCoded()) {
+			validateAndInterpret(obs, errors, atRootNode);
+		} else if ((dt.isDateTime() || dt.isDate() || dt.isTime()) && obs.getValueDatetime() == null) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueDatetime", "error.null");
+		} else if (dt.isNumeric() && obs.getValueNumeric() == null) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueNumeric", "error.null");
+		} else if (dt.isNumeric()) {
+			validateNumericPrecision(obs, errors, atRootNode);
+			validateAndInterpret(obs, errors, atRootNode);
+		} else if (dt.isText() && obs.getValueText() == null) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueText", "error.null");
+		}
+
+		//If valueText is longer than the maxlength, raise an error as well.
+		if (dt.isText() && obs.getValueText() != null && obs.getValueText().length() > VALUE_TEXT_MAX_LENGTH) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueText", "error.exceededMaxLengthOfField");
+		}
+	}
+
+	/**
+	 * Raises the given field error when validating the root obs, or the generic "in group member" error
+	 * otherwise. Centralizes a check that was previously duplicated across every datatype branch in
+	 * {@link #validateValueForDatatype}.
+	 *
+	 * @param errors Errors to record validation issues
+	 * @param atRootNode whether or not this is the obs that validate() was originally called on
+	 * @param field the field to reject when atRootNode is true
+	 * @param errorCode the error code to use when atRootNode is true
+	 */
+	private void rejectValueOrGroupMember(Errors errors, boolean atRootNode, String field, String errorCode) {
+		if (atRootNode) {
+			errors.rejectValue(field, errorCode);
+		} else {
+			errors.rejectValue(GROUP_MEMBERS_FIELD, "Obs.error.inGroupMember");
+		}
+	}
+
+	/**
+	 * Rejects the Obs' numeric value if the concept requires an integer value but a decimal was
+	 * supplied.
+	 *
+	 * @param obs Observation to validate
+	 * @param errors Errors to record validation issues
+	 * @param atRootNode whether or not this is the obs that validate() was originally called on
+	 */
+	private void validateNumericPrecision(Obs obs, Errors errors, boolean atRootNode) {
+		ConceptNumeric cn = Context.getConceptService().getConceptNumeric(obs.getConcept().getConceptId());
+		// If the concept numeric is not precise, the value cannot be a float, so raise an error
+		if (!cn.getAllowDecimal() && Math.ceil(obs.getValueNumeric()) != obs.getValueNumeric()) {
+			rejectValueOrGroupMember(errors, atRootNode, "valueNumeric", "Obs.error.precision");
+		}
+	}
+
+	/**
+	 * Single dispatch point for deriving an Obs' interpretation. Routes to the interpretation strategy
+	 * appropriate for the concept's datatype so that {@link #validateHelper} does not need to know how
+	 * each datatype derives its interpretation:
+	 * <ul>
+	 * <li>numeric observations are validated against their reference range, which also derives their
+	 * numeric interpretation (see {@link #validateConceptReferenceRange})</li>
+	 * <li>coded observations have their interpretation resolved from the value coded answer's concept
+	 * mappings (see {@link #getConceptInterpretation})</li>
+	 * </ul>
+	 *
+	 * @param obs Observation to validate/interpret
+	 * @param errors Errors to record validation issues
+	 * @param atRootNode whether or not this is the obs that validate() was originally called on
+	 */
+	private void validateAndInterpret(Obs obs, Errors errors, boolean atRootNode) {
+		ConceptDatatype dt = obs.getConcept().getDatatype();
+
+		if (dt.isNumeric()) {
+			validateConceptReferenceRange(obs, errors, atRootNode);
+			return;
+		}
+
+		if (dt.isCoded()) {
+			interpretCodedObs(obs);
+		}
+	}
+
+	/**
+	 * Resolves and sets the interpretation of a new coded Obs. Only applies to new observations (i.e.
+	 * not yet persisted); edited or copied observations (see {@link Obs#newInstance(Obs)}) already
+	 * carry over whatever interpretation they had, so they are left untouched here.
+	 *
+	 * @param obs Observation whose interpretation should be resolved
+	 */
+	private void interpretCodedObs(Obs obs) {
+		if (obs.getId() != null) {
+			return;
+		}
+
+		Obs.Interpretation interpretation = getConceptInterpretation(obs);
+		if (interpretation != null) {
+			obs.setInterpretation(interpretation);
+		}
+	}
+
+	/**
+	 * Resolves the {@link Obs.Interpretation} for a coded Obs by looking for a concept mapping on the
+	 * value coded answer whose reference term code matches one of the {@link Obs.Interpretation}
+	 * constants, e.g. a "Positive" answer concept mapped to a reference term coded "ABNORMAL".
+	 *
+	 * @param obs Observation whose value coded answer should be resolved to an interpretation
+	 * @return the resolved Interpretation, or null if no mapping matches
+	 */
+	private Obs.Interpretation getConceptInterpretation(Obs obs) {
+		Concept valueCoded = obs.getValueCoded();
+		if (valueCoded == null) {
+			return null;
+		}
+
+		for (ConceptMap conceptMap : valueCoded.getConceptMappings()) {
+			ConceptReferenceTerm term = conceptMap.getConceptReferenceTerm();
+			if (term == null || StringUtils.isBlank(term.getCode())) {
+				continue;
+			}
+
+			try {
+				return Obs.Interpretation.valueOf(term.getCode().toUpperCase());
+			} catch (IllegalArgumentException e) {
+				// reference term code does not match a known interpretation; keep looking
+			}
+		}
+
+		return null;
 	}
 
 	/**
@@ -305,12 +403,7 @@ public class ObsValidator implements Validator {
 					null
 				);
 			} else {
-				errors.rejectValue(
-					"groupMembers",
-					"Obs.error.inGroupMember",
-					new Object[] {},
-					null
-				);
+				errors.rejectValue(GROUP_MEMBERS_FIELD, "Obs.error.inGroupMember", new Object[] {}, null);
 			}
 		}
 		
@@ -323,12 +416,7 @@ public class ObsValidator implements Validator {
 					null
 				);
 			} else {
-				errors.rejectValue(
-					"groupMembers",
-					"Obs.error.inGroupMember",
-					new Object[] { },
-					null
-				);
+				errors.rejectValue(GROUP_MEMBERS_FIELD, "Obs.error.inGroupMember", new Object[] {}, null);
 			}
 		}
 	}

--- a/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
+++ b/api/src/test/java/org/openmrs/validator/ObsValidatorTest.java
@@ -28,7 +28,9 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDatatype;
+import org.openmrs.ConceptMap;
 import org.openmrs.ConceptReferenceRange;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.Drug;
 import org.openmrs.Obs;
 import org.openmrs.Person;
@@ -879,4 +881,133 @@ public class ObsValidatorTest extends BaseContextSensitiveTest {
 		obs.setObsDatetime(new Date());
 		return obs;
 	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void shouldSetInterpretationForCodedObsWithMatchingConceptMapping() {
+		Obs obs = getCodedObs(getAnswerConceptMappedTo("ABNORMAL"));
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+		assertEquals(Obs.Interpretation.ABNORMAL, obs.getInterpretation());
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void shouldNotSetInterpretationForCodedObsWithoutMatchingConceptMapping() {
+		Concept answer = new Concept();
+		answer.setDatatype(getCodedDatatype());
+
+		Obs obs = getCodedObs(answer);
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+		assertNull(obs.getInterpretation());
+	}
+
+	/**
+	 * Coded observations must only be interpreted, never validated as numeric ranges.
+	 *
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void shouldNotCreateReferenceRangeForCodedObs() {
+		Obs obs = getCodedObs(getAnswerConceptMappedTo("ABNORMAL"));
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+		assertNull(obs.getReferenceRange());
+	}
+
+	/**
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void shouldPreserveInterpretationWhenEditingExistingCodedObs() {
+		Obs obs = getCodedObs(getAnswerConceptMappedTo("ABNORMAL"));
+		// simulate a previously saved obs that already carries an interpretation
+		obs.setId(1);
+		obs.setInterpretation(Obs.Interpretation.NORMAL);
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+		assertEquals(Obs.Interpretation.NORMAL, obs.getInterpretation());
+	}
+
+	/**
+	 * @see Obs#newInstance(org.openmrs.Obs)
+	 */
+	@Test
+	public void shouldPreserveCodedInterpretationAfterNewInstanceCopy() {
+		Obs obs = getCodedObs(getAnswerConceptMappedTo("ABNORMAL"));
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+		assertEquals(Obs.Interpretation.ABNORMAL, obs.getInterpretation());
+
+		Obs copy = Obs.newInstance(obs);
+
+		assertEquals(Obs.Interpretation.ABNORMAL, copy.getInterpretation());
+	}
+
+	/**
+	 * Numeric regression: routing a numeric Obs through the validateAndInterpret dispatcher must
+	 * continue to produce the same reference range based interpretation as before the refactor.
+	 *
+	 * @see ObsValidator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void shouldRouteNumericObsThroughValidateAndInterpretDispatcher() {
+		Obs obs = getObs(60, 4090, 100.0);
+
+		Errors errors = new BindException(obs, "obs");
+		obsValidator.validate(obs, errors);
+
+		assertFalse(errors.hasErrors());
+		assertNotNull(obs.getReferenceRange());
+		assertEquals(Obs.Interpretation.NORMAL, obs.getInterpretation());
+	}
+
+	private static ConceptDatatype getCodedDatatype() {
+		return Context.getConceptService().getConcept(4).getDatatype();
+	}
+
+	private static Concept getAnswerConceptMappedTo(String referenceTermCode) {
+		Concept answer = new Concept();
+		answer.setDatatype(getCodedDatatype());
+
+		ConceptReferenceTerm term = new ConceptReferenceTerm();
+		term.setCode(referenceTermCode);
+
+		ConceptMap conceptMap = new ConceptMap();
+		conceptMap.setConceptReferenceTerm(term);
+		answer.addConceptMapping(conceptMap);
+
+		return answer;
+	}
+
+	private static Obs getCodedObs(Concept answer) {
+		Concept question = new Concept();
+		question.setDatatype(getCodedDatatype());
+
+		Obs obs = new Obs();
+		obs.setPerson(Context.getPersonService().getPerson(2));
+		obs.setConcept(question);
+		obs.setValueCoded(answer);
+		obs.setObsDatetime(new Date());
+		return obs;
+	}
+
 }


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
This pull request refactors and enhances the validation logic for observations (`Obs`) in the OpenMRS codebase, specifically improving how different concept datatypes are validated and interpreted. The main changes include extracting datatype-specific validation into dedicated methods, introducing support for auto-deriving coded observation interpretations from concept mappings, and adding comprehensive tests to cover these behaviors.

**Validation and Interpretation Refactor:**
- Extracted datatype-specific validation logic from the large `validateHelper` method into smaller, focused methods, reducing cognitive complexity and improving maintainability. (`ObsValidator.java`) [[1]](diffhunk://#diff-c02cac2b2b517f1f573434fc3e6ff2d42346294abbc3f3f468fbf58bf2dc1ac6L167-R173) [[2]](diffhunk://#diff-c02cac2b2b517f1f573434fc3e6ff2d42346294abbc3f3f468fbf58bf2dc1ac6R208-R351)
- Centralized common error handling for missing or invalid values via a new helper method. (`ObsValidator.java`)
- Ensured that coded observations are interpreted (i.e., their `interpretation` field is set) based on matching reference term codes in their concept mappings, without performing numeric reference range validation on them. (`ObsValidator.java`)

**Coded Observation Interpretation:**
- Added logic to automatically set the `interpretation` of new coded `Obs` by matching the reference term code of the answer concept to a known `Obs.Interpretation` value (e.g., "ABNORMAL"). Existing or copied observations retain their interpretation. (`ObsValidator.java`)

**Testing Enhancements:**
- Introduced new unit tests to verify that:
  - Coded observations with matching concept mappings are correctly interpreted.
  - Coded observations without matching mappings are not interpreted.
  - Editing or copying coded observations preserves their interpretation.
  - Coded observations do not trigger numeric reference range validation.
  - Numeric observations are still routed through the new dispatcher and validated as before. (`ObsValidatorTest.java`)

**Imports and Minor Code Cleanups:**
- Added necessary imports for `ConceptMap`, `ConceptReferenceTerm`, and utility classes in both the validator and its tests. (`ObsValidator.java`, `ObsValidatorTest.java`) [[1]](diffhunk://#diff-c02cac2b2b517f1f573434fc3e6ff2d42346294abbc3f3f468fbf58bf2dc1ac6R16-R23) [[2]](diffhunk://#diff-92786df50546ee5a07a3af981b6772f3d65553cf6bf9d42afe14b50be91dc85aR22-R24)

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/TRUNK-6726

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

