### PR TITLE
TRUNK-6680: Restore lazy fetch semantics after JPA migration

### DIFF
--- a/api/src/main/java/org/openmrs/ConceptAnswer.java
+++ b/api/src/main/java/org/openmrs/ConceptAnswer.java
@@ -13,6 +13,7 @@ import java.util.Date;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -47,14 +48,14 @@ public class ConceptAnswer extends BaseOpenmrsObject implements Auditable, java.
 	/**
 	 * The question concept that this object is answering
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "concept_id", nullable = false)
 	private Concept concept;
 
 	/**
 	 * The answer to the question
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "answer_concept", nullable = false)
 	private Concept answerConcept;
 
@@ -62,11 +63,11 @@ public class ConceptAnswer extends BaseOpenmrsObject implements Auditable, java.
 	 * The {@link Drug} answer to the question. This can be null if this does not represent a drug type
 	 * of answer
 	 */
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "answer_drug")
 	private Drug answerDrug;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "creator", nullable = false)
 	private User creator;
 

--- a/api/src/main/java/org/openmrs/DrugIngredient.java
+++ b/api/src/main/java/org/openmrs/DrugIngredient.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -31,12 +32,12 @@ public class DrugIngredient extends BaseOpenmrsObject implements Serializable, O
 	public static final long serialVersionUID = 94023L;
 
 	// Fields
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "drug_id", updatable = false, insertable = false)
 	@Id
 	private Drug drug;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ingredient_id", updatable = false, insertable = false)
 	@Id
 	private Concept ingredient;
@@ -45,7 +46,7 @@ public class DrugIngredient extends BaseOpenmrsObject implements Serializable, O
 	private Double strength;
 
 	@JoinColumn(name = "units")
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Concept units;
 
 	// Constructors

--- a/api/src/main/java/org/openmrs/DrugIngredient.java
+++ b/api/src/main/java/org/openmrs/DrugIngredient.java
@@ -32,12 +32,12 @@ public class DrugIngredient extends BaseOpenmrsObject implements Serializable, O
 	public static final long serialVersionUID = 94023L;
 
 	// Fields
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne
 	@JoinColumn(name = "drug_id", updatable = false, insertable = false)
 	@Id
 	private Drug drug;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne
 	@JoinColumn(name = "ingredient_id", updatable = false, insertable = false)
 	@Id
 	private Concept ingredient;

--- a/api/src/main/java/org/openmrs/DrugReferenceMap.java
+++ b/api/src/main/java/org/openmrs/DrugReferenceMap.java
@@ -49,18 +49,18 @@ public class DrugReferenceMap extends BaseOpenmrsObject implements Auditable, Se
 	@Column(name = "drug_reference_map_id")
 	private Integer drugReferenceMapId;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "drug_id", nullable = false)
 	private Drug drug;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "term_id", nullable = false)
 	@Cascade({ CascadeType.MERGE, CascadeType.PERSIST })
 	@IndexedEmbedded(includeEmbeddedObjectId = true)
 	@IndexingDependency(reindexOnUpdate = ReindexOnUpdate.SHALLOW)
 	private ConceptReferenceTerm conceptReferenceTerm;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "concept_map_type", nullable = false)
 	private ConceptMapType conceptMapType;
 

--- a/api/src/main/java/org/openmrs/FormResource.java
+++ b/api/src/main/java/org/openmrs/FormResource.java
@@ -56,7 +56,7 @@ public class FormResource extends BaseOpenmrsObject implements CustomValueDescri
 	@Column(name = "form_resource_id")
 	private Integer formResourceId;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "form_id", nullable = false)
 	private Form form;
 

--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -63,7 +63,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer locationId;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "location_type_concept_id")
 	private Concept type;
 
@@ -133,7 +133,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	@Column(name = "address15")
 	private String address15;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent_location")
 	private Location parentLocation;
 

--- a/api/src/main/java/org/openmrs/OrderType.java
+++ b/api/src/main/java/org/openmrs/OrderType.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -55,7 +56,7 @@ public class OrderType extends BaseChangeableOpenmrsMetadata {
 	@Column(name = "java_class_name", nullable = false)
 	private String javaClassName;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "parent")
 	private OrderType parent;
 

--- a/api/src/main/java/org/openmrs/PatientState.java
+++ b/api/src/main/java/org/openmrs/PatientState.java
@@ -13,6 +13,7 @@ import java.util.Date;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -42,11 +43,11 @@ public class PatientState extends BaseFormRecordableOpenmrsData implements java.
 	@Column(name = "patient_state_id")
 	private Integer patientStateId;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "patient_program_id", nullable = false)
 	private PatientProgram patientProgram;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "state", nullable = false)
 	private ProgramWorkflowState state;
 
@@ -56,7 +57,7 @@ public class PatientState extends BaseFormRecordableOpenmrsData implements java.
 	@Column(name = "end_date", length = 19)
 	private Date endDate;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "encounter_id")
 	private Encounter encounter;
 

--- a/api/src/main/java/org/openmrs/PersonAddress.java
+++ b/api/src/main/java/org/openmrs/PersonAddress.java
@@ -15,6 +15,7 @@ import java.util.Date;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -52,7 +53,7 @@ public class PersonAddress extends BaseChangeableOpenmrsData implements java.io.
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer personAddressId;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "person_id")
 	private Person person;
 

--- a/api/src/main/java/org/openmrs/PersonAttributeType.java
+++ b/api/src/main/java/org/openmrs/PersonAttributeType.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -55,7 +56,7 @@ public class PersonAttributeType extends BaseChangeableOpenmrsMetadata implement
 	@Column(name = "searchable", nullable = false)
 	private Boolean searchable = false;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "edit_privilege")
 	private Privilege editPrivilege;
 

--- a/api/src/main/java/org/openmrs/Relationship.java
+++ b/api/src/main/java/org/openmrs/Relationship.java
@@ -13,6 +13,7 @@ import java.util.Date;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,15 +39,15 @@ public class Relationship extends BaseChangeableOpenmrsData {
 	@Column(name = "relationship_id")
 	private Integer relationshipId;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "person_a", nullable = false)
 	private Person personA;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "relationship", nullable = false)
 	private RelationshipType relationshipType;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(name = "person_b", nullable = false)
 	private Person personB;
 

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -1264,4 +1264,13 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		assertThat(concept.getSetMembers(), hasItem(setMember3));
 		assertThat(concept.getSetMembers().size(), is(3));
 	}
+
+	@Test
+	public void shouldLoadConceptAnswersLazily() throws Exception {
+		Context.clearSession();
+		Concept concept = Context.getConceptService().getConcept(21);
+		ConceptAnswer answer = concept.getAnswers().iterator().next();
+		assertFalse(org.hibernate.Hibernate.isInitialized(answer.getAnswerConcept()),
+		    "Answer Concept should be loaded lazily");
+	}
 }

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -1267,7 +1267,7 @@ public class ConceptTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldLoadConceptAnswersLazily() throws Exception {
+	public void getAnswers_shouldLoadConceptAnswersLazily() throws Exception {
 		Context.clearSession();
 		Concept concept = Context.getConceptService().getConcept(21);
 		ConceptAnswer answer = concept.getAnswers().iterator().next();

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptNameType;
@@ -1270,7 +1271,6 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		Context.clearSession();
 		Concept concept = Context.getConceptService().getConcept(21);
 		ConceptAnswer answer = concept.getAnswers().iterator().next();
-		assertFalse(org.hibernate.Hibernate.isInitialized(answer.getAnswerConcept()),
-		    "Answer Concept should be loaded lazily");
+		assertFalse(Hibernate.isInitialized(answer.getAnswerConcept()), "Answer Concept should be loaded lazily");
 	}
 }

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1446,4 +1446,20 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 		assertEquals(filtered.get(1).getLocationId(), paged.get(0).getLocationId());
 	}
 
+	@Test
+	public void shouldLoadLocationParentLazily() throws Exception {
+		LocationService ls = Context.getLocationService();
+		Location child = new Location();
+		child.setName("Child");
+		Location parent = ls.getLocation(1);
+		child.setParentLocation(parent);
+		ls.saveLocation(child);
+
+		Context.flushSession();
+		Context.clearSession();
+
+		Location fetchedChild = ls.getLocation(child.getId());
+		org.junit.jupiter.api.Assertions.assertFalse(org.hibernate.Hibernate.isInitialized(fetchedChild.getParentLocation()),
+		    "Parent Location should be loaded lazily");
+	}
 }

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1448,7 +1448,7 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldLoadLocationParentLazily() throws Exception {
+	public void getLocation_shouldLoadLocationParentLazily() throws Exception {
 		LocationService ls = Context.getLocationService();
 		Location child = new Location();
 		child.setName("Child");

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import org.hibernate.Hibernate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
@@ -1459,7 +1460,6 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 		Context.clearSession();
 
 		Location fetchedChild = ls.getLocation(child.getId());
-		org.junit.jupiter.api.Assertions.assertFalse(org.hibernate.Hibernate.isInitialized(fetchedChild.getParentLocation()),
-		    "Parent Location should be loaded lazily");
+		assertFalse(Hibernate.isInitialized(fetchedChild.getParentLocation()), "Parent Location should be loaded lazily");
 	}
 }


### PR DESCRIPTION
## Description of what I changed

- Restored lazy fetching for associations that unintentionally became eager during the hbm.xml to JPA annotation migration.
- Added regression tests to verify that key associations remain lazily initialized until accessed.

## Issue I worked on

TRUNK-6680

https://issues.openmrs.org/browse/TRUNK-6680