### PR TITLE
TRUNK-6712: Cache flattened role privileges for privilege and superuser checks

### DIFF
--- a/api/src/main/java/org/openmrs/api/cache/CacheConfig.java
+++ b/api/src/main/java/org/openmrs/api/cache/CacheConfig.java
@@ -132,7 +132,7 @@ public class CacheConfig {
 		return new SpringEmbeddedCacheManager(cacheManager);
 	}
 
-	private static InputStream buildFullConfig(Yaml yaml, URL configFile, Set<String> skipCaches, String cacheType)
+	private static InputStream buildFullConfig(Yaml yaml, URL configFile, Set<String> templateNames, String cacheType)
 	        throws IOException {
 		Map<String, Object> loadedConfig = yaml.load(configFile.openStream());
 
@@ -146,18 +146,20 @@ public class CacheConfig {
 		@SuppressWarnings("unchecked")
 		Map<String, Object> loadedCaches = (Map<String, Object>) loadedConfig.get("caches");
 		for (Map.Entry<String, Object> entry : loadedCaches.entrySet()) {
+			if (templateNames.contains(entry.getKey())) {
+				// already defined by the base configuration; don't redefine it
+				continue;
+			}
 			@SuppressWarnings("unchecked")
 			Map<String, Object> value = (Map<String, Object>) entry.getValue();
-			if ("entity".equals(value.get("configuration"))) {
+			if (templateNames.contains(value.get("configuration"))) {
+				// A cache referencing a base template must be wrapped in the mode's cache type
+				// (local-cache/invalidation-cache) so it inherits that template's settings.
 				Map<Object, Object> cache = new LinkedHashMap<>();
 				cache.put(cacheType, value);
-				if (!skipCaches.contains(entry.getKey())) {
-					cacheList.put(entry.getKey(), cache);
-				}
+				cacheList.put(entry.getKey(), cache);
 			} else {
-				if (!skipCaches.contains(entry.getKey())) {
-					cacheList.put(entry.getKey(), value);
-				}
+				cacheList.put(entry.getKey(), value);
 			}
 		}
 		if (!cacheList.isEmpty()) {

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
@@ -1,0 +1,275 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
+import org.openmrs.util.RoleConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+
+/**
+ * Per-role cache of flattened privilege resolutions, so privilege and superuser checks need not
+ * re-expand a user's role graph on every call. The cached value for a role is an immutable
+ * {@link RolePrivileges} covering that role and its entire inherited closure.
+ * <p>
+ * On a miss the closure is computed from a freshly loaded copy of the role, not the caller-supplied
+ * instance: a long-lived {@code UserContext} can hold a stale, detached role graph that, cached by
+ * role name, would serve out-of-date privileges to other sessions.
+ * <p>
+ * The fresh role is loaded and flattened inside a daemon thread, because loading a role through the
+ * secured {@code UserService} itself requires {@code Get Roles} — the very check being resolved.
+ * Daemon threads skip authorization (see {@link org.openmrs.aop.AuthorizationAdvice}), breaking
+ * that cycle without the security bypass of a direct DAO read and without emitting spurious
+ * {@code PrivilegeListener} notifications. Concurrent misses for the same role coalesce onto a
+ * single {@link Future}; the caller blocks on it, so resolution stays synchronous.
+ * <p>
+ * The component reaches into the {@code rolePrivileges} cache directly rather than exposing a
+ * {@code @Cacheable} service method, so a privilege check does not re-enter the service AOP stack
+ * (which performs its own privilege checks). The cache lives on {@code apiCacheManager}, so it
+ * participates in clustering when {@code cache.type=cluster} (as an invalidation cache: each node
+ * computes its own entries and eviction broadcasts an invalidation) and is cleared by
+ * {@code @CacheEvict} on role/privilege mutations and on context refresh.
+ * <p>
+ * Eviction is not atomic with an in-flight refresh: a daemon load can read a role, a concurrent
+ * {@code saveRole} evict, and the daemon's write then land after the eviction, briefly caching a
+ * pre-save closure. The window is bounded by the {@code role-privileges} cache template's expiry.
+ * <p>
+ * That template carries a {@code lifespan} TTL as a safety net against role changes made outside
+ * the API (eviction only fires on API mutations); it is configured declaratively in {@code
+ * infinispan-api.xml}/{@code infinispan-api-local.xml} rather than per entry here.
+ *
+ * @since 3.0.0, 2.9.0, 2.8.9
+ */
+@Component("rolePrivilegeCache")
+public class RolePrivilegeCache implements ApplicationListener<ContextRefreshedEvent> {
+
+	private static final Logger log = LoggerFactory.getLogger(RolePrivilegeCache.class);
+
+	public static final String CACHE_NAME = "rolePrivileges";
+
+	/**
+	 * Capability token issued by {@link Daemon}, letting this component launch a daemon thread to load
+	 * roles with full trust.
+	 */
+	private static volatile Daemon.CallerKey daemonCallerKey;
+
+	private final CacheManager cacheManager;
+
+	/**
+	 * In-flight refreshes keyed by normalized role name, so concurrent misses for the same role share a
+	 * single daemon computation instead of each launching their own.
+	 */
+	private final ConcurrentMap<String, Future<RolePrivileges>> inFlight = new ConcurrentHashMap<>();
+
+	@Autowired
+	public RolePrivilegeCache(@Qualifier("apiCacheManager") CacheManager cacheManager) {
+		this.cacheManager = cacheManager;
+	}
+
+	/**
+	 * Receives the {@link Daemon} caller key. Called only by {@link Daemon} during its initialization.
+	 *
+	 * @param callerKey the caller key issued by {@link Daemon}
+	 */
+	public static void setDaemonCallerKey(Daemon.CallerKey callerKey) {
+		if (callerKey != null && daemonCallerKey == null) {
+			daemonCallerKey = callerKey;
+		}
+	}
+
+	private static Daemon.CallerKey daemonCallerKey() {
+		if (daemonCallerKey == null) {
+			// Guarantee Daemon has initialized and therefore handed us the key, regardless of the order in
+			// which the two classes were first loaded.
+			Daemon.ensureInitialized();
+		}
+		return daemonCallerKey;
+	}
+
+	/**
+	 * Returns the flattened privileges for the given role, computing and caching the result on a miss.
+	 * Never returns {@code null}.
+	 *
+	 * @param role the directly assigned role to resolve
+	 * @return the flattened privilege closure for the role
+	 */
+	public RolePrivileges getRolePrivileges(Role role) {
+		if (role == null || role.getRole() == null) {
+			return new RolePrivileges(new HashSet<>(), false);
+		}
+
+		Cache cache = getCache();
+		String key = RolePrivileges.normalize(role.getRole());
+		if (cache != null) {
+			RolePrivileges cached = cache.get(key, RolePrivileges.class);
+			if (cached != null) {
+				return cached;
+			}
+		}
+
+		return refresh(key, role, cache);
+	}
+
+	/**
+	 * Loads and flattens a current copy of the role in a daemon thread, caches it, and returns it
+	 * synchronously; concurrent misses for the same role coalesce onto one {@link Future}.
+	 * <p>
+	 * If the refresh cannot be scheduled, fails (for example a transient database error), or is
+	 * interrupted, it falls back to flattening the caller-supplied instance <em>without caching it</em>
+	 * — a deliberate fail-open, since denying every privilege during a database hiccup would brick the
+	 * application, and not caching keeps a transient failure from poisoning other sessions. A role that
+	 * loads but is absent from the database instead fails closed (see {@link #loadAndCache}).
+	 *
+	 * @param key the normalized role name used as the cache and in-flight key
+	 * @param role the role supplied by the caller (used for its name, and as a fail-open fallback)
+	 * @param cache the target cache, or <code>null</code> if unavailable
+	 * @return the flattened privilege closure
+	 */
+	private RolePrivileges refresh(String key, Role role, Cache cache) {
+		Future<RolePrivileges> future;
+		try {
+			future = inFlight.computeIfAbsent(key, k -> Daemon
+			        .runNewDaemonTask((Callable<RolePrivileges>) () -> loadAndCache(k, role, cache), daemonCallerKey()));
+		} catch (RuntimeException e) {
+			log.warn("Could not schedule a daemon refresh for role '{}'; resolving against the supplied instance", key, e);
+			return computeRolePrivileges(role);
+		}
+
+		try {
+			return future.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.debug("Interrupted while refreshing role '{}'; resolving against the supplied instance", key, e);
+			return computeRolePrivileges(role);
+		} catch (ExecutionException e) {
+			log.warn("Daemon refresh for role '{}' failed; resolving against the supplied instance", key, e.getCause());
+			return computeRolePrivileges(role);
+		} finally {
+			inFlight.remove(key, future);
+		}
+	}
+
+	/**
+	 * Runs inside a daemon thread: loads a fresh copy of the role through the {@code UserService}
+	 * (authorization skipped for daemon threads), flattens it, and caches it.
+	 * <p>
+	 * A role absent from the database grants nothing. The caller-supplied instance is deliberately not
+	 * used as a fallback: it may be stale or purged, and caching it by name would serve out-of-date
+	 * privileges to every session holding that role name. Failing closed keeps a purge or out-of-API
+	 * deletion from being silently over-granted.
+	 *
+	 * @param key the normalized role name
+	 * @param role the caller-supplied role, used for its name
+	 * @param cache the target cache, or <code>null</code> if unavailable
+	 * @return the flattened closure, or an empty closure if the role no longer exists
+	 */
+	private RolePrivileges loadAndCache(String key, Role role, Cache cache) {
+		Role fresh = Context.getUserService().getRole(role.getRole());
+		RolePrivileges computed = (fresh != null) ? computeRolePrivileges(fresh)
+		        : new RolePrivileges(new HashSet<>(), false);
+		if (cache != null) {
+			// The lifespan TTL comes from the cache template (see the class-level note), so a plain put
+			// carries it; no per-entry expiry handling is needed here.
+			cache.put(key, computed);
+		}
+		return computed;
+	}
+
+	/**
+	 * Flattens a role and its transitively inherited roles into an immutable {@link RolePrivileges},
+	 * with a visited set guarding against inheritance cycles.
+	 * <p>
+	 * Resolves against the passed-in instance with <em>no freshness guarantee</em>, so it must not
+	 * drive a security decision on a possibly stale role; the cache uses it only on a freshly loaded
+	 * role or as a fail-open fallback.
+	 *
+	 * @param role the role to flatten
+	 * @return the flattened privilege closure
+	 */
+	public static RolePrivileges computeRolePrivileges(Role role) {
+		Set<String> privileges = new HashSet<>();
+		Set<String> visited = new HashSet<>();
+		boolean grantsSuperuser = collect(role, privileges, visited);
+		return new RolePrivileges(privileges, grantsSuperuser);
+	}
+
+	/**
+	 * Depth-first walk over a role and its inherited roles, collecting normalized privilege names.
+	 *
+	 * @param role the role currently being visited
+	 * @param privileges accumulates normalized privilege names
+	 * @param visited role names already visited, to break inheritance cycles
+	 * @return true if this role or any role reachable from it confers superuser status
+	 */
+	private static boolean collect(Role role, Set<String> privileges, Set<String> visited) {
+		if (role == null || role.getRole() == null || !visited.add(RolePrivileges.normalize(role.getRole()))) {
+			return false;
+		}
+
+		// Superuser status can be inherited, so a superuser role anywhere in the closure grants it.
+		boolean grantsSuperuser = RoleConstants.SUPERUSER.equalsIgnoreCase(role.getRole());
+
+		if (role.getPrivileges() != null) {
+			for (Privilege privilege : role.getPrivileges()) {
+				if (privilege != null && privilege.getPrivilege() != null) {
+					// RolePrivileges normalizes names on construction, so raw names are fine here.
+					privileges.add(privilege.getPrivilege());
+				}
+			}
+		}
+
+		for (Role inherited : role.getInheritedRoles()) {
+			grantsSuperuser |= collect(inherited, privileges, visited);
+		}
+
+		return grantsSuperuser;
+	}
+
+	/**
+	 * Clears the entire cache. Invoked on context refresh via {@link #onApplicationEvent}.
+	 */
+	public void clear() {
+		Cache cache = getCache();
+		if (cache != null) {
+			cache.clear();
+		}
+	}
+
+	private Cache getCache() {
+		return cacheManager == null ? null : cacheManager.getCache(CACHE_NAME);
+	}
+
+	/**
+	 * Clears the cache whenever the application context is refreshed, ensuring role graph changes
+	 * applied outside the API before or during startup are not served stale.
+	 */
+	@Override
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		clear();
+	}
+}

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivilegeCache.java
@@ -153,8 +153,16 @@ public class RolePrivilegeCache implements ApplicationListener<ContextRefreshedE
 	private RolePrivileges refresh(String key, Role role, Cache cache) {
 		Future<RolePrivileges> future;
 		try {
-			future = inFlight.computeIfAbsent(key, k -> Daemon
-			        .runNewDaemonTask((Callable<RolePrivileges>) () -> loadAndCache(k, role, cache), daemonCallerKey()));
+			future = inFlight.computeIfAbsent(key, k -> Daemon.runNewDaemonTask((Callable<RolePrivileges>) () -> {
+				try {
+					return loadAndCache(k, role, cache);
+				} finally {
+					// Clear on the daemon thread when the load finishes, not on the waiter's path: an
+					// interrupted waiter does not cancel this task, so removing there could drop a
+					// still-running refresh and let a concurrent miss schedule a duplicate.
+					inFlight.remove(k);
+				}
+			}, daemonCallerKey()));
 		} catch (RuntimeException e) {
 			log.warn("Could not schedule a daemon refresh for role '{}'; resolving against the supplied instance", key, e);
 			return computeRolePrivileges(role);
@@ -169,8 +177,6 @@ public class RolePrivilegeCache implements ApplicationListener<ContextRefreshedE
 		} catch (ExecutionException e) {
 			log.warn("Daemon refresh for role '{}' failed; resolving against the supplied instance", key, e.getCause());
 			return computeRolePrivileges(role);
-		} finally {
-			inFlight.remove(key, future);
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
+++ b/api/src/main/java/org/openmrs/api/cache/RolePrivileges.java
@@ -1,0 +1,106 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Immutable, pre-computed view of everything a single role grants: the flattened set of privilege
+ * names of the role and all of its transitively inherited roles, plus whether that closure confers
+ * superuser status. It is the cached value used by {@link RolePrivilegeCache} to answer privilege
+ * checks without re-expanding the role graph on every call.
+ * <p>
+ * Privilege names are stored case-normalized because privilege comparison in OpenMRS is
+ * case-insensitive (see {@link org.openmrs.Role#hasPrivilege(String)}). Lookups normalize the same
+ * way, so {@link #containsPrivilege(String)} preserves that behavior.
+ *
+ * @since 3.0.0, 2.9.0, 2.8.9
+ */
+public final class RolePrivileges implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Set<String> privilegeNames;
+
+	private final boolean grantsSuperuser;
+
+	/**
+	 * @param privilegeNames privilege names granted by the role and its inherited closure;
+	 *            case-normalized as copied, null elements ignored
+	 * @param grantsSuperuser whether the role or any inherited role confers superuser status
+	 */
+	public RolePrivileges(Set<String> privilegeNames, boolean grantsSuperuser) {
+		Objects.requireNonNull(privilegeNames, "privilegeNames must not be null");
+		Set<String> normalized = new HashSet<>();
+		for (String privilegeName : privilegeNames) {
+			if (privilegeName != null) {
+				normalized.add(normalize(privilegeName));
+			}
+		}
+		this.privilegeNames = Collections.unmodifiableSet(normalized);
+		this.grantsSuperuser = grantsSuperuser;
+	}
+
+	/**
+	 * @return true if this role's closure confers superuser status
+	 */
+	public boolean grantsSuperuser() {
+		return grantsSuperuser;
+	}
+
+	/**
+	 * @param privilege the privilege name to test (compared case-insensitively)
+	 * @return true if the role's closure grants the given privilege
+	 */
+	public boolean containsPrivilege(String privilege) {
+		return privilege != null && privilegeNames.contains(normalize(privilege));
+	}
+
+	/**
+	 * @return an unmodifiable view of the case-normalized privilege names in this closure
+	 */
+	public Set<String> getPrivilegeNames() {
+		return privilegeNames;
+	}
+
+	/**
+	 * Case-normalizes a privilege name for storage and lookup. Uses {@link Locale#ROOT} so the
+	 * normalization is stable across server locales.
+	 *
+	 * @param privilege the privilege name to normalize; must not be null
+	 * @return the lower-cased privilege name
+	 * @throws NullPointerException if <code>privilege</code> is null
+	 */
+	public static String normalize(String privilege) {
+		return privilege.toLowerCase(Locale.ROOT);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof RolePrivileges)) {
+			return false;
+		}
+		RolePrivileges other = (RolePrivileges) o;
+		return grantsSuperuser == other.grantsSuperuser && privilegeNames.equals(other.privilegeNames);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(privilegeNames, grantsSuperuser);
+	}
+}

--- a/api/src/main/java/org/openmrs/api/context/Context.java
+++ b/api/src/main/java/org/openmrs/api/context/Context.java
@@ -743,6 +743,27 @@ public class Context {
 	}
 
 	/**
+	 * Tests whether the currently authenticated user has a particular privilege, optionally excluding
+	 * proxy privileges. Passing <code>false</code> checks only the user's granted roles (and the
+	 * anonymous and authenticated roles), so a proxy privilege added merely to invoke a service method
+	 * cannot satisfy a per-resource access check.
+	 *
+	 * @param privilege the privilege to check
+	 * @param includeProxyPrivileges whether proxy privileges may satisfy the check
+	 * @return true if the current user has the given privilege
+	 * @see UserContext#hasPrivilege(String, boolean)
+	 * @since 3.0.0, 2.9.0, 2.8.9
+	 */
+	public static boolean hasPrivilege(String privilege, boolean includeProxyPrivileges) {
+		// the daemon threads have access to all things
+		if (Daemon.isDaemonThread()) {
+			return true;
+		}
+
+		return getUserContext().hasPrivilege(privilege, includeProxyPrivileges);
+	}
+
+	/**
 	 * Throws an exception if the currently authenticated user does not have the specified privilege.
 	 *
 	 * @param privilege

--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -22,6 +22,7 @@ import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.APIException;
 import org.openmrs.api.OpenmrsService;
+import org.openmrs.api.cache.RolePrivilegeCache;
 import org.openmrs.api.db.ContextDAO;
 import org.openmrs.api.db.hibernate.HibernateContextDAO;
 import org.openmrs.module.DaemonToken;
@@ -72,6 +73,7 @@ public final class Daemon {
 		HibernateContextDAO.setDaemonCallerKey(CALLER_KEY);
 		ModuleFactory.setDaemonCallerKey(CALLER_KEY);
 		JobRequestHandlerAdapter.setDaemonCallerKey(CALLER_KEY);
+		RolePrivilegeCache.setDaemonCallerKey(CALLER_KEY);
 		// WebDaemon lives in the web module, which the api module cannot reference at compile time, so
 		// hand it the key reflectively.
 		try {
@@ -301,6 +303,24 @@ public final class Daemon {
 		requireDaemonCaller(callerKey, "runNewDaemonTask can only be called by an authorized daemon entry point");
 
 		return runInDaemonThreadInternal(runnable);
+	}
+
+	/**
+	 * Runs the given task on a new daemon thread, authorized by a {@link CallerKey}, and returns a
+	 * {@link Future} for its result without blocking. This exists strictly for internal use by trusted
+	 * core entry points that must launch daemon work from a non-daemon thread and want to await the
+	 * result themselves (for example coalescing concurrent callers onto a single future).
+	 *
+	 * @param callable what to run in a new daemon thread
+	 * @param callerKey the {@link CallerKey} proving the caller is a trusted daemon entry point
+	 * @return a future that completes with the task's result
+	 * @since 3.0.0, 2.9.0, 2.8.9
+	 */
+	@SuppressWarnings("squid:S1217")
+	public static <T> Future<T> runNewDaemonTask(final Callable<T> callable, CallerKey callerKey) {
+		requireDaemonCaller(callerKey, "runNewDaemonTask can only be called by an authorized daemon entry point");
+
+		return runInDaemonThreadInternal(callable);
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/context/UserContext.java
+++ b/api/src/main/java/org/openmrs/api/context/UserContext.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Location;
@@ -29,6 +30,8 @@ import org.openmrs.UserSessionListener.Event;
 import org.openmrs.UserSessionListener.Status;
 import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.LocationService;
+import org.openmrs.api.cache.RolePrivilegeCache;
+import org.openmrs.api.cache.RolePrivileges;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.RoleConstants;
@@ -52,6 +55,13 @@ public class UserContext implements Serializable {
 	 * Logger - shared by entire class
 	 */
 	private static final Logger log = LoggerFactory.getLogger(UserContext.class);
+
+	/**
+	 * Guards the one-time warning emitted when the role privilege cache component cannot be obtained
+	 * outside of a context refresh. Static so the warning is emitted once across all user contexts
+	 * rather than once per session.
+	 */
+	private static final AtomicBoolean rolePrivilegeCacheUnavailableWarned = new AtomicBoolean(false);
 
 	/**
 	 * User object containing details about the authenticated user
@@ -392,33 +402,114 @@ public class UserContext implements Serializable {
 	 * @return true if authenticated user has given privilege
 	 */
 	public boolean hasPrivilege(String privilege) {
-		log.debug("Checking '{}' against proxies: {}", privilege, proxies);
-		// check proxied privileges
-		for (String s : new ArrayList<>(proxies)) {
-			if (s.equals(privilege)) {
-				notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
+		return hasPrivilege(privilege, true);
+	}
+
+	/**
+	 * Tests whether the current user has a particular privilege, optionally excluding proxy privileges.
+	 * <p>
+	 * Passing <code>false</code> resolves the privilege only from the user's roles (and the anonymous
+	 * and authenticated roles), ignoring any {@link #addProxyPrivilege(String...) proxy privileges}.
+	 * This is intended for per-resource access checks that must reflect the user's actual granted roles
+	 * and must not be satisfied by a proxy privilege added merely to invoke the surrounding service
+	 * method. Role privileges are still resolved authoritatively (from the role privilege cache),
+	 * unlike {@link User#hasPrivilege(String)} which reads a potentially stale in-memory role graph.
+	 *
+	 * @param privilege The privilege to check if it's available
+	 * @param includeProxyPrivileges whether proxy privileges may satisfy the check
+	 * @return true if the current user has the given privilege
+	 * @since 3.0.0, 2.9.0, 2.8.9
+	 */
+	public boolean hasPrivilege(String privilege, boolean includeProxyPrivileges) {
+		if (includeProxyPrivileges) {
+			log.debug("Checking '{}' against proxies: {}", privilege, proxies);
+			// check proxied privileges
+			for (String s : new ArrayList<>(proxies)) {
+				if (s.equals(privilege)) {
+					notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
+					return true;
+				}
+			}
+		}
+
+		boolean hasPrivilege = resolvePrivilege(privilege);
+		notifyPrivilegeListeners(getAuthenticatedUser(), privilege, hasPrivilege);
+		return hasPrivilege;
+	}
+
+	/**
+	 * Resolves whether the current user (authenticated or anonymous) holds the given privilege by
+	 * consulting the per-role privilege cache instead of recursively re-expanding the role graph on
+	 * every call. Proxy privileges are handled separately by {@link #hasPrivilege(String)}.
+	 *
+	 * @param privilege the privilege to check
+	 * @return true if the privilege is granted
+	 */
+	private boolean resolvePrivilege(String privilege) {
+		RolePrivilegeCache cache = getRolePrivilegeCache();
+
+		// if a user has logged in, check their privileges
+		if (isAuthenticated()) {
+			// All authenticated users have the "" (empty) privilege, matching User.hasPrivilege.
+			if (StringUtils.isEmpty(privilege)) {
+				return true;
+			}
+
+			User authenticatedUser = getAuthenticatedUser();
+			if (authenticatedUser.getRoles() != null) {
+				for (Role role : authenticatedUser.getRoles()) {
+					if (roleGrants(cache, role, privilege)) {
+						return true;
+					}
+				}
+			}
+
+			if (roleGrants(cache, getAuthenticatedRole(), privilege)) {
 				return true;
 			}
 		}
 
-		// if a user has logged in, check their privileges
-		if (isAuthenticated()
-		        && (getAuthenticatedUser().hasPrivilege(privilege) || getAuthenticatedRole().hasPrivilege(privilege))) {
+		return roleGrants(cache, getAnonymousRole(), privilege);
+	}
 
-			// check user's privileges
-			notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
-			return true;
+	/**
+	 * Tests whether a single role (and its inherited closure) grants the given privilege, using the
+	 * cached flattening when available and falling back to a direct computation otherwise.
+	 *
+	 * @param cache the role privilege cache, or <code>null</code> if unavailable
+	 * @param role the directly assigned role to test
+	 * @param privilege the privilege to check
+	 * @return true if the role grants superuser status or contains the privilege
+	 */
+	private boolean roleGrants(RolePrivilegeCache cache, Role role, String privilege) {
+		RolePrivileges rolePrivileges = (cache != null) ? cache.getRolePrivileges(role)
+		        : RolePrivilegeCache.computeRolePrivileges(role);
+		return rolePrivileges.grantsSuperuser() || rolePrivileges.containsPrivilege(privilege);
+	}
 
+	/**
+	 * Looks up the {@link RolePrivilegeCache} component, or returns <code>null</code> so callers fall
+	 * back to direct computation. Absence during a context refresh is expected (logged at debug);
+	 * absence otherwise is a misconfiguration that silently drops every check to the uncached path, so
+	 * it is warned once.
+	 *
+	 * @return the cache component, or <code>null</code> if unavailable
+	 */
+	private RolePrivilegeCache getRolePrivilegeCache() {
+		try {
+			return Context.getRegisteredComponent("rolePrivilegeCache", RolePrivilegeCache.class);
+		} catch (Exception e) {
+			if (Context.isRefreshingContext()) {
+				log.debug("Role privilege cache is unavailable while the context is refreshing; "
+				        + "computing role privileges directly",
+				    e);
+			} else if (rolePrivilegeCacheUnavailableWarned.compareAndSet(false, true)) {
+				log.warn("Could not obtain the rolePrivilegeCache component; privilege checks will recompute role "
+				        + "privileges on every call until this is resolved",
+				    e);
+			}
+			return null;
 		}
-
-		if (getAnonymousRole().hasPrivilege(privilege)) {
-			notifyPrivilegeListeners(getAuthenticatedUser(), privilege, true);
-			return true;
-		}
-
-		// default return value
-		notifyPrivilegeListeners(getAuthenticatedUser(), privilege, false);
-		return false;
 	}
 
 	/**

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -196,7 +196,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 			return true;
 		}
 
-		return Context.getAuthenticatedUser().hasPrivilege(property.getViewPrivilege().getPrivilege());
+		return Context.hasPrivilege(property.getViewPrivilege().getPrivilege(), false);
 	}
 
 	private boolean canDeleteGlobalProperty(GlobalProperty property) {
@@ -204,7 +204,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 			return true;
 		}
 
-		return Context.getAuthenticatedUser().hasPrivilege(property.getDeletePrivilege().getPrivilege());
+		return Context.hasPrivilege(property.getDeletePrivilege().getPrivilege(), false);
 	}
 
 	private boolean canEditGlobalProperty(GlobalProperty property) {
@@ -212,7 +212,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 			return true;
 		}
 
-		return Context.getAuthenticatedUser().hasPrivilege(property.getEditPrivilege().getPrivilege());
+		return Context.hasPrivilege(property.getEditPrivilege().getPrivilege(), false);
 	}
 
 	private List<GlobalProperty> filterGlobalPropertiesByViewPrivilege(List<GlobalProperty> properties) {
@@ -220,7 +220,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 			for (Iterator<GlobalProperty> iterator = properties.iterator(); iterator.hasNext();) {
 				GlobalProperty property = iterator.next();
 				Privilege vp = property.getViewPrivilege();
-				if (vp != null && !Context.getAuthenticatedUser().hasPrivilege(vp.getPrivilege())) {
+				if (vp != null && !Context.hasPrivilege(vp.getPrivilege(), false)) {
 					iterator.remove();
 				}
 			}

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -252,6 +252,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#purgePrivilege(org.openmrs.Privilege)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public void purgePrivilege(Privilege privilege) throws APIException {
 		if (OpenmrsUtil.getCorePrivileges().keySet().contains(privilege.getPrivilege())) {
 			throw new APIException("Privilege.cannot.delete.core", (Object[]) null);
@@ -264,6 +265,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#savePrivilege(org.openmrs.Privilege)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public Privilege savePrivilege(Privilege privilege) throws APIException {
 		return dao.savePrivilege(privilege);
 	}
@@ -290,6 +292,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#purgeRole(org.openmrs.Role)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public void purgeRole(Role role) throws APIException {
 		if (role == null || role.getRole() == null) {
 			return;
@@ -310,6 +313,7 @@ public class UserServiceImpl extends BaseOpenmrsService implements UserService, 
 	 * @see org.openmrs.api.UserService#saveRole(org.openmrs.Role)
 	 */
 	@Override
+	@CacheEvict(value = "rolePrivileges", allEntries = true)
 	public Role saveRole(Role role) throws APIException {
 		// make sure one of the parents of this role isn't itself...this would
 		// cause an infinite loop

--- a/api/src/main/resources/cache-api.yaml
+++ b/api/src/main/resources/cache-api.yaml
@@ -5,3 +5,5 @@ caches:
         configuration: "entity"
     serializerWhiteListTypes:
         configuration: "entity"
+    rolePrivileges:
+        configuration: "role-privileges"

--- a/api/src/main/resources/infinispan-api-local.xml
+++ b/api/src/main/resources/infinispan-api-local.xml
@@ -20,6 +20,15 @@
 			<expiration max-idle="100000" interval="5000"/>
 			<memory max-count="10000"/>
 		</local-cache-configuration>
-		
+
+		<!-- Like entity, but with a lifespan TTL: role/privilege eviction only fires on API mutations,
+		     so the lifespan is a safety net that bounds staleness from role changes made outside the API. -->
+		<local-cache-configuration name="role-privileges" simple-cache="true" statistics="false">
+			<encoding media-type="application/x-java-object"/>
+			<transaction mode="NONE" />
+			<expiration lifespan="3600000" max-idle="100000" interval="5000"/>
+			<memory max-count="10000"/>
+		</local-cache-configuration>
+
 	</cache-container>
 </infinispan>

--- a/api/src/main/resources/infinispan-api.xml
+++ b/api/src/main/resources/infinispan-api.xml
@@ -24,6 +24,16 @@
 			<expiration max-idle="100000" interval="5000"/>
 			<memory max-count="10000"/>
 		</invalidation-cache-configuration>
-		
+
+		<!-- Like entity, but with a lifespan TTL: role/privilege eviction only fires on API mutations,
+		     so the lifespan is a safety net that bounds staleness from role changes made outside the API. -->
+		<invalidation-cache-configuration name="role-privileges" remote-timeout="20000" statistics="false">
+			<encoding media-type="application/x-java-object"/>
+			<locking concurrency-level="1000" acquire-timeout="15000"/>
+			<transaction mode="NONE" />
+			<expiration lifespan="3600000" max-idle="100000" interval="5000"/>
+			<memory max-count="10000"/>
+		</invalidation-cache-configuration>
+
 	</cache-container>
 </infinispan>

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -10,7 +10,9 @@
 package org.openmrs.api;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
@@ -22,8 +24,9 @@ import org.mockito.Mockito;
 import org.openmrs.GlobalProperty;
 import org.openmrs.ImplementationId;
 import org.openmrs.Privilege;
-import org.openmrs.Role;
 import org.openmrs.User;
+import org.openmrs.api.cache.RolePrivilegeCache;
+import org.openmrs.api.cache.RolePrivileges;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.Credentials;
 import org.openmrs.api.context.UsernamePasswordCredentials;
@@ -609,11 +612,46 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		// authenticate new user without privileges
 		Context.logout();
 		Context.authenticate(getTestUserCredentials());
-		// add required privilege to user
-		Role role = Context.getUserService().getRole("Provider");
-		role.addPrivilege(property.getViewPrivilege());
-		Context.getAuthenticatedUser().addRole(role);
-		assertNotNull(adminService.getGlobalProperty(property.getProperty()));
+		// Grant the view privilege via the authoritative cache; role privileges resolve by role name,
+		// not from the in-memory role object, so no proxy privilege is involved.
+		Context.getAuthenticatedUser().addRole(Context.getUserService().getRole("Provider"));
+		setRolePrivilegesInCache("Provider", property.getViewPrivilege().getPrivilege());
+		try {
+			assertNotNull(adminService.getGlobalProperty(property.getProperty()));
+		} finally {
+			clearRolePrivilegeCache();
+		}
+	}
+
+	/**
+	 * A proxy privilege may satisfy the method's {@code @Authorized} gate but must not satisfy the
+	 * impl-level, proxy-excluding view check, so a caller holding the view privilege only as a proxy is
+	 * still denied the value.
+	 *
+	 * @see org.openmrs.api.AdministrationService#getGlobalProperty(java.lang.String)
+	 */
+	@Test
+	public void getGlobalProperty_shouldFailIfUserHasViewPrivilegeOnlyAsAProxyPrivilege() {
+		executeDataSet(ADMIN_INITIAL_DATA_XML);
+		GlobalProperty property = getGlobalPropertyWithViewPrivilege();
+
+		// authenticate new user without privileges
+		Context.logout();
+		Context.authenticate(getTestUserCredentials());
+
+		// The property's view privilege is also the privilege the @Authorized gate requires, so this proxy
+		// lets the call past the gate; the impl's proxy-excluding canViewGlobalProperty must still deny it.
+		Context.addProxyPrivilege(property.getViewPrivilege().getPrivilege());
+		try {
+			APIException exception = assertThrows(APIException.class,
+			    () -> adminService.getGlobalProperty(property.getProperty()));
+			// a plain APIException, not the gate's APIAuthenticationException, means the proxy passed the
+			// gate but the resource-level check denied it
+			assertFalse(exception instanceof APIAuthenticationException,
+			    "denial should come from the impl view check, not the @Authorized gate");
+		} finally {
+			Context.removeProxyPrivilege(property.getViewPrivilege().getPrivilege());
+		}
 	}
 
 	/**
@@ -644,12 +682,15 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 		// authenticate new user without privileges
 		Context.logout();
 		Context.authenticate(getTestUserCredentials());
-		// add required privilege to user
-		Role role = Context.getUserService().getRole("Provider");
-		role.addPrivilege(property.getViewPrivilege());
-		Context.getAuthenticatedUser().addRole(role);
-
-		assertNotNull(adminService.getGlobalPropertyObject(property.getProperty()));
+		// Grant the view privilege via the authoritative cache; role privileges resolve by role name,
+		// not from the in-memory role object, so no proxy privilege is involved.
+		Context.getAuthenticatedUser().addRole(Context.getUserService().getRole("Provider"));
+		setRolePrivilegesInCache("Provider", property.getViewPrivilege().getPrivilege());
+		try {
+			assertNotNull(adminService.getGlobalPropertyObject(property.getProperty()));
+		} finally {
+			clearRolePrivilegeCache();
+		}
 	}
 
 	/**
@@ -679,23 +720,25 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	public void updateGlobalProperty_shouldUpdateIfUserIsAllowedToEditGlobalProperty() {
 		executeDataSet(ADMIN_INITIAL_DATA_XML);
 		GlobalProperty property = getGlobalPropertyWithEditPrivilege();
-		GlobalProperty globalPropertyWithViewPrivilege = getGlobalPropertyWithViewPrivilege();
+		// also give the property a view privilege so the read-back below is privilege-gated too
+		getGlobalPropertyWithViewPrivilege();
 		assertEquals("anothervalue", property.getPropertyValue());
 
 		// authenticate new user without privileges
 		Context.logout();
 		Context.authenticate(getTestUserCredentials());
-		// add required privilege to user
-		Role role = Context.getUserService().getRole("Provider");
-		role.addPrivilege(property.getEditPrivilege());
-
-		role.addPrivilege(globalPropertyWithViewPrivilege.getViewPrivilege());
-
-		Context.getAuthenticatedUser().addRole(role);
-
-		adminService.updateGlobalProperty(property.getProperty(), "new-value");
-		String newValue = adminService.getGlobalProperty(property.getProperty());
-		assertEquals("new-value", newValue);
+		// Grant the edit + view privileges via the authoritative cache; role privileges resolve by role
+		// name, not from the in-memory role object, so no proxy privilege is involved.
+		Context.getAuthenticatedUser().addRole(Context.getUserService().getRole("Provider"));
+		setRolePrivilegesInCache("Provider", PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES,
+		    PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+		try {
+			adminService.updateGlobalProperty(property.getProperty(), "new-value");
+			String newValue = adminService.getGlobalProperty(property.getProperty());
+			assertEquals("new-value", newValue);
+		} finally {
+			clearRolePrivilegeCache();
+		}
 	}
 
 	/**
@@ -794,6 +837,20 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	 */
 	private Credentials getTestUserCredentials() {
 		return new UsernamePasswordCredentials("test_user", "test");
+	}
+
+	/**
+	 * Records, in the authoritative role-privilege cache, that the named role grants the given
+	 * privileges. Privilege resolution reads role privileges from this cache by role name, so this lets
+	 * a test grant privileges to a role without persisting them.
+	 */
+	private void setRolePrivilegesInCache(String roleName, String... privileges) {
+		cacheManager.getCache(RolePrivilegeCache.CACHE_NAME).put(RolePrivileges.normalize(roleName),
+		    new RolePrivileges(new HashSet<>(Arrays.asList(privileges)), false));
+	}
+
+	private void clearRolePrivilegeCache() {
+		cacheManager.getCache(RolePrivilegeCache.CACHE_NAME).clear();
 	}
 
 	@Test

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -655,6 +655,65 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
+	 * As with the view check, a proxy privilege may pass the method's {@code @Authorized} gate but must
+	 * not satisfy the impl-level, proxy-excluding edit check.
+	 *
+	 * @see org.openmrs.api.AdministrationService#updateGlobalProperty(String, String)
+	 */
+	@Test
+	public void updateGlobalProperty_shouldFailIfUserHasEditPrivilegeOnlyAsAProxyPrivilege() {
+		executeDataSet(ADMIN_INITIAL_DATA_XML);
+		GlobalProperty property = getGlobalPropertyWithEditPrivilege();
+
+		// authenticate new user without privileges
+		Context.logout();
+		Context.authenticate(getTestUserCredentials());
+
+		// Get + Manage Global Properties as proxies get the call past the getGlobalPropertyObject and
+		// updateGlobalProperty gates; the impl's proxy-excluding canEditGlobalProperty must still deny it.
+		Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+		Context.addProxyPrivilege(property.getEditPrivilege().getPrivilege());
+		try {
+			APIException exception = assertThrows(APIException.class,
+			    () -> adminService.updateGlobalProperty(property.getProperty(), "new-value"));
+			assertFalse(exception instanceof APIAuthenticationException,
+			    "denial should come from the impl edit check, not the @Authorized gate");
+		} finally {
+			Context.removeProxyPrivilege(property.getEditPrivilege().getPrivilege());
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+		}
+	}
+
+	/**
+	 * As with the view check, a proxy privilege may pass the method's {@code @Authorized} gate but must
+	 * not satisfy the impl-level, proxy-excluding delete check.
+	 *
+	 * @see org.openmrs.api.AdministrationService#purgeGlobalProperty(GlobalProperty)
+	 */
+	@Test
+	public void purgeGlobalProperty_shouldFailIfUserHasDeletePrivilegeOnlyAsAProxyPrivilege() {
+		executeDataSet(ADMIN_INITIAL_DATA_XML);
+		GlobalProperty property = getGlobalPropertyWithDeletePrivilege();
+
+		// authenticate new user without privileges
+		Context.logout();
+		Context.authenticate(getTestUserCredentials());
+
+		// Purge Global Properties as a proxy gets the call past the purgeGlobalProperty gate; the impl's
+		// proxy-excluding canDeleteGlobalProperty must still deny it even with the delete privilege proxied.
+		Context.addProxyPrivilege(PrivilegeConstants.PURGE_GLOBAL_PROPERTIES);
+		Context.addProxyPrivilege(property.getDeletePrivilege().getPrivilege());
+		try {
+			APIException exception = assertThrows(APIException.class, () -> adminService.purgeGlobalProperty(property));
+			assertFalse(exception instanceof APIAuthenticationException,
+			    "denial should come from the impl delete check, not the @Authorized gate");
+		} finally {
+			Context.removeProxyPrivilege(property.getDeletePrivilege().getPrivilege());
+			Context.removeProxyPrivilege(PrivilegeConstants.PURGE_GLOBAL_PROPERTIES);
+		}
+	}
+
+	/**
 	 * @see org.openmrs.api.AdministrationService#getGlobalPropertyObject(java.lang.String)
 	 */
 	@Test

--- a/api/src/test/java/org/openmrs/api/UserServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/UserServiceTest.java
@@ -296,8 +296,17 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 			u.setUsername("bwolfe");
 			u.getPerson().setGender("M");
 			u.addRole(role);
-			// here we expect the exception to be thrown
-			userService.createUser(u, "Openmr5xy");
+			// Add Users is held only as a proxy so the createUser gate passes; role privileges resolve from
+			// the database by name, so stubbing them on an in-memory role no longer grants them.
+			Context.addProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			try {
+				// here we expect the exception to be thrown
+				userService.createUser(u, "Openmr5xy");
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+				Context.removeProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			}
 		}));
 		assertThat(exception.getMessage(), is("You must have privilege {0} in order to assign it."));
 	}
@@ -331,8 +340,17 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 			u.setUsername("bwolfe");
 			u.getPerson().setGender("M");
 			u.addRole(role);
-			// here we expect the exception to be thrown
-			userService.createUser(u, "Openmr5xy");
+			// Add Users is held only as a proxy so the createUser gate passes; role privileges resolve from
+			// the database by name, so stubbing them on an in-memory role no longer grants them.
+			Context.addProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			try {
+				// here we expect the exception to be thrown
+				userService.createUser(u, "Openmr5xy");
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+				Context.removeProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			}
 		}));
 		assertThat(exception.getMessage(),
 		    is("You must have the following privileges in order to assign them: Another Privilege, Custom Privilege"));
@@ -369,8 +387,17 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 			u.getPerson().setGender("M");
 			u.isSuperUser();
 			u.addRole(role);
-			// here we expect the exception to be thrown
-			userService.createUser(u, "Openmr5xy");
+			// Add Users is held only as a proxy so the createUser gate passes; role privileges resolve from
+			// the database by name, so stubbing them on an in-memory role no longer grants them.
+			Context.addProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			try {
+				// here we expect the exception to be thrown
+				userService.createUser(u, "Openmr5xy");
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+				Context.removeProxyPrivilege(PrivilegeConstants.ADD_USERS);
+			}
 		}));
 		assertThat(exception.getMessage(), is("You must have the role {0} in order to assign it."));
 	}
@@ -1207,18 +1234,22 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void saveRole_shouldThrowErrorWhenCurrentUserLacksPrivilegeAssignedToRole() throws IllegalAccessException {
-		Role adminRole = new Role("my role");
-		adminRole.addPrivilege(new Privilege(PrivilegeConstants.MANAGE_ROLES));
-
 		User currentUser = new User();
-		currentUser.addRole(adminRole);
 
 		Privilege myPrivilege = new Privilege("custom privilege");
 
 		APIException exception = assertThrows(APIException.class, () -> withCurrentUserAs(currentUser, () -> {
-			Role newRole = new Role("another role");
-			newRole.addPrivilege(myPrivilege);
-			userService.saveRole(newRole);
+			// Manage Roles is held only as a proxy so the saveRole gate passes; role privileges resolve from
+			// the database by name. The assigned privilege is deliberately not held, so the assignment check
+			// fails on it.
+			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_ROLES);
+			try {
+				Role newRole = new Role("another role");
+				newRole.addPrivilege(myPrivilege);
+				userService.saveRole(newRole);
+			} finally {
+				Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_ROLES);
+			}
 		}));
 		assertThat(exception.getMessage(),
 		    is("You must have the following privileges in order to assign them: custom privilege"));
@@ -1226,21 +1257,25 @@ public class UserServiceTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void saveRole_shouldThrowErrorWhenCurrentUserLacksAPrivilegeAssignedToRole() throws IllegalAccessException {
+		User currentUser = new User();
+
 		Privilege myFirstPrivilege = new Privilege("custom privilege");
 		Privilege mySecondPrivilege = new Privilege("another privilege");
 
-		Role adminRole = new Role("my role");
-		adminRole.addPrivilege(new Privilege(PrivilegeConstants.MANAGE_ROLES));
-		adminRole.addPrivilege(myFirstPrivilege);
-
-		User currentUser = new User();
-		currentUser.addRole(adminRole);
-
 		APIException exception = assertThrows(APIException.class, () -> withCurrentUserAs(currentUser, () -> {
-			Role newRole = new Role("another role");
-			newRole.addPrivilege(myFirstPrivilege);
-			newRole.addPrivilege(mySecondPrivilege);
-			userService.saveRole(newRole);
+			// Manage Roles (the gate) and the already-held "custom privilege" are proxies; "another
+			// privilege" is withheld so the assignment check fails only on it.
+			Context.addProxyPrivilege(PrivilegeConstants.MANAGE_ROLES);
+			Context.addProxyPrivilege(myFirstPrivilege.getPrivilege());
+			try {
+				Role newRole = new Role("another role");
+				newRole.addPrivilege(myFirstPrivilege);
+				newRole.addPrivilege(mySecondPrivilege);
+				userService.saveRole(newRole);
+			} finally {
+				Context.removeProxyPrivilege(myFirstPrivilege.getPrivilege());
+				Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_ROLES);
+			}
 		}));
 		assertThat(exception.getMessage(),
 		    is("You must have the following privileges in order to assign them: another privilege"));

--- a/api/src/test/java/org/openmrs/api/cache/CacheConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/CacheConfigTest.java
@@ -39,7 +39,7 @@ public class CacheConfigTest extends BaseContextSensitiveTest {
 	@Test
 	public void shouldContainSpecificCacheConfigurations() {
 		String[] expectedCaches = { "conceptDatatype", "subscription", "userSearchLocales", "conceptIdsByMapping",
-		        "testCache", "serializerWhiteListTypes" };
+		        "testCache", "serializerWhiteListTypes", "rolePrivileges" };
 		Collection<String> actualCaches = cacheManager.getCacheNames();
 		assertThat(actualCaches, containsInAnyOrder(expectedCaches));
 	}

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheIntegrationTest.java
@@ -1,0 +1,185 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.api.UserService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests verifying that {@link RolePrivilegeCache} populates the shared
+ * {@code apiCacheManager} cache and that it is evicted on role and privilege mutations.
+ */
+public class RolePrivilegeCacheIntegrationTest extends BaseContextSensitiveTest {
+
+	@Autowired
+	private RolePrivilegeCache rolePrivilegeCache;
+
+	@Autowired
+	private UserService userService;
+
+	private CacheManager cacheManager;
+
+	@BeforeEach
+	public void setup() {
+		cacheManager = Context.getRegisteredComponent("apiCacheManager", CacheManager.class);
+		cache().clear();
+	}
+
+	private Cache cache() {
+		return cacheManager.getCache(RolePrivilegeCache.CACHE_NAME);
+	}
+
+	private RolePrivileges cachedEntry(Role role) {
+		return cache().get(RolePrivileges.normalize(role.getRole()), RolePrivileges.class);
+	}
+
+	@Test
+	public void cache_shouldBeConfiguredWithALifespanTtl() {
+		// The TTL safety net now comes from the dedicated role-privileges cache template rather than a
+		// per-entry put, so assert the backing Infinispan cache actually carries a lifespan; a default
+		// (-1) would mean the template was not wired and the safety net silently lost.
+		org.infinispan.Cache<?, ?> nativeCache = (org.infinispan.Cache<?, ?>) cache().getNativeCache();
+
+		assertEquals(3_600_000L, nativeCache.getCacheConfiguration().expiration().lifespan());
+	}
+
+	@Test
+	public void getRolePrivileges_shouldPopulateCacheOnMiss() {
+		// "Provider" is a committed role in the standard dataset, so the daemon thread's own session can
+		// load it; a freshly saved role would not be visible across the daemon's separate transaction.
+		Role role = userService.getRole("Provider");
+		assertNull(cachedEntry(role), "cache should start empty for this role");
+
+		RolePrivileges result = rolePrivilegeCache.getRolePrivileges(role);
+
+		assertNotNull(result);
+		assertNotNull(cachedEntry(role), "cache should be populated after lookup");
+		assertEquals(result, cachedEntry(role), "the cached entry should match the returned value");
+	}
+
+	@Test
+	public void getRolePrivileges_shouldServeSubsequentLookupsFromCache() {
+		// Pre-seed the cache directly, then verify the lookup returns that value rather than recomputing.
+		// The role name is not in the database, so a miss would fail-closed to an empty closure and drop
+		// the seeded privilege; this also keeps the test independent of daemon-thread visibility.
+		RolePrivileges seeded = new RolePrivileges(Collections.singleton("Cache Hit Privilege"), false);
+		cache().put(RolePrivileges.normalize("Cache Hit Role"), seeded);
+
+		RolePrivileges result = rolePrivilegeCache.getRolePrivileges(new Role("Cache Hit Role"));
+
+		assertEquals(seeded, result, "lookup should return the value already in the cache");
+		assertTrue(result.containsPrivilege("Cache Hit Privilege"));
+	}
+
+	@Test
+	public void getRolePrivileges_shouldGrantNothingForARoleThatNoLongerExists() {
+		// A detached role still held by a session after it was purged: the instance carries privileges but
+		// the role is gone from the database. Fail-closed resolution must grant nothing and must not write
+		// the stale privileges into the shared cache.
+		Role purged = new Role("Nonexistent Role");
+		purged.addPrivilege(new Privilege("Ghost Privilege"));
+
+		RolePrivileges resolved = rolePrivilegeCache.getRolePrivileges(purged);
+
+		assertFalse(resolved.containsPrivilege("Ghost Privilege"), "a role absent from the database must grant nothing");
+		assertFalse(resolved.grantsSuperuser());
+		RolePrivileges cached = cachedEntry(purged);
+		assertNotNull(cached, "the empty closure should be cached to avoid repeated daemon loads for a missing role");
+		assertFalse(cached.containsPrivilege("Ghost Privilege"),
+		    "stale caller-supplied privileges must not be written to the shared cache");
+	}
+
+	@Test
+	public void getRolePrivileges_shouldResolveFromAFreshRoleNotACallerSuppliedStaleInstance() {
+		// "Provider" is a committed role with no privileges, so the daemon session sees it. A stale copy
+		// carrying a phantom privilege must not grant it: the closure comes from the freshly loaded role,
+		// not the caller-supplied instance.
+		Role stale = new Role("Provider");
+		stale.addPrivilege(new Privilege("Phantom Privilege"));
+
+		cache().clear();
+		RolePrivileges resolved = rolePrivilegeCache.getRolePrivileges(stale);
+
+		assertFalse(resolved.containsPrivilege("Phantom Privilege"),
+		    "caller-supplied privileges must be ignored in favor of the freshly loaded role");
+	}
+
+	@Test
+	public void saveRole_shouldEvictTheCache() {
+		primeCache();
+
+		Role role = new Role("Evicting Save Role", "role saved to trigger eviction");
+		userService.saveRole(role);
+
+		assertCacheCleared();
+	}
+
+	@Test
+	public void purgeRole_shouldEvictTheCache() {
+		Role role = new Role("Purgeable Role", "role that will be purged");
+		userService.saveRole(role);
+
+		primeCache();
+
+		userService.purgeRole(role);
+
+		assertCacheCleared();
+	}
+
+	@Test
+	public void savePrivilege_shouldEvictTheCache() {
+		primeCache();
+
+		Privilege privilege = new Privilege("Evicting Save Privilege", "privilege saved to trigger eviction");
+		userService.savePrivilege(privilege);
+
+		assertCacheCleared();
+	}
+
+	@Test
+	public void purgePrivilege_shouldEvictTheCache() {
+		Privilege privilege = new Privilege("Purgeable Privilege", "privilege that will be purged");
+		userService.savePrivilege(privilege);
+
+		primeCache();
+
+		userService.purgePrivilege(privilege);
+
+		assertCacheCleared();
+	}
+
+	private void primeCache() {
+		Role role = new Role("Primed Role");
+		role.addPrivilege(new Privilege("Primed Privilege"));
+		rolePrivilegeCache.getRolePrivileges(role);
+		assertNotNull(cachedEntry(role), "cache should be primed");
+	}
+
+	private void assertCacheCleared() {
+		Role primed = new Role("Primed Role");
+		assertNull(cachedEntry(primed), "cache should be cleared after mutation");
+	}
+}

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegeCacheTest.java
@@ -1,0 +1,135 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.Privilege;
+import org.openmrs.Role;
+import org.openmrs.util.RoleConstants;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the pure role-flattening logic in {@link RolePrivilegeCache}, which does not
+ * require a Spring context.
+ */
+public class RolePrivilegeCacheTest {
+
+	@Test
+	public void computeRolePrivileges_shouldCollectDirectPrivileges() {
+		Role role = new Role("Clerk");
+		role.addPrivilege(new Privilege("View Patients"));
+		role.addPrivilege(new Privilege("Edit Patients"));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(role);
+
+		assertTrue(result.containsPrivilege("View Patients"));
+		assertTrue(result.containsPrivilege("Edit Patients"));
+		assertFalse(result.containsPrivilege("Delete Patients"));
+		assertFalse(result.grantsSuperuser());
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldMatchPrivilegesCaseInsensitively() {
+		Role role = new Role("Clerk");
+		role.addPrivilege(new Privilege("View Patients"));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(role);
+
+		assertTrue(result.containsPrivilege("VIEW PATIENTS"));
+		assertTrue(result.containsPrivilege("view patients"));
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldIncludeInheritedPrivileges() {
+		Role parent = new Role("Parent");
+		parent.addPrivilege(new Privilege("Parent Privilege"));
+
+		Role child = new Role("Child");
+		child.addPrivilege(new Privilege("Child Privilege"));
+		child.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(parent)));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(child);
+
+		assertTrue(result.containsPrivilege("Child Privilege"));
+		assertTrue(result.containsPrivilege("Parent Privilege"));
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldFlattenMultipleLevelsOfInheritance() {
+		Role grandparent = new Role("Grandparent");
+		grandparent.addPrivilege(new Privilege("Grandparent Privilege"));
+
+		Role parent = new Role("Parent");
+		parent.addPrivilege(new Privilege("Parent Privilege"));
+		parent.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(grandparent)));
+
+		Role child = new Role("Child");
+		child.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(parent)));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(child);
+
+		assertTrue(result.containsPrivilege("Grandparent Privilege"));
+		assertTrue(result.containsPrivilege("Parent Privilege"));
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldGrantSuperuserWhenRoleIsSuperuser() {
+		Role role = new Role(RoleConstants.SUPERUSER);
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(role);
+
+		assertTrue(result.grantsSuperuser());
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldInheritSuperuserStatus() {
+		Role superuser = new Role(RoleConstants.SUPERUSER);
+
+		Role role = new Role("Delegated Admin");
+		role.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(superuser)));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(role);
+
+		assertTrue(result.grantsSuperuser());
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldTerminateOnInheritanceCycle() {
+		Role a = new Role("A");
+		a.addPrivilege(new Privilege("Privilege A"));
+		Role b = new Role("B");
+		b.addPrivilege(new Privilege("Privilege B"));
+
+		// A inherits B and B inherits A, forming a cycle
+		a.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(b)));
+		b.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(a)));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(a);
+
+		assertTrue(result.containsPrivilege("Privilege A"));
+		assertTrue(result.containsPrivilege("Privilege B"));
+		assertFalse(result.grantsSuperuser());
+	}
+
+	@Test
+	public void computeRolePrivileges_shouldTerminateWhenRoleInheritsItself() {
+		Role role = new Role("Self");
+		role.addPrivilege(new Privilege("Self Privilege"));
+		role.setInheritedRoles(new HashSet<>(java.util.Collections.singletonList(role)));
+
+		RolePrivileges result = RolePrivilegeCache.computeRolePrivileges(role);
+
+		assertTrue(result.containsPrivilege("Self Privilege"));
+	}
+}

--- a/api/src/test/java/org/openmrs/api/cache/RolePrivilegesTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/RolePrivilegesTest.java
@@ -1,0 +1,102 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the {@link RolePrivileges} value type. Its {@code equals}/{@code hashCode} are
+ * load-bearing: the clustered cache may store and return an equal-but-not-identical deserialized
+ * value, and callers compare returned values rather than instances.
+ */
+public class RolePrivilegesTest {
+
+	@Test
+	public void containsPrivilege_shouldMatchCaseInsensitively() {
+		RolePrivileges privileges = new RolePrivileges(Collections.singleton("View Patients"), false);
+
+		assertTrue(privileges.containsPrivilege("View Patients"));
+		assertTrue(privileges.containsPrivilege("VIEW PATIENTS"));
+		assertTrue(privileges.containsPrivilege("view patients"));
+		assertFalse(privileges.containsPrivilege("Edit Patients"));
+	}
+
+	@Test
+	public void containsPrivilege_shouldReturnFalseForNull() {
+		RolePrivileges privileges = new RolePrivileges(Collections.singleton("View Patients"), false);
+
+		assertFalse(privileges.containsPrivilege(null));
+	}
+
+	@Test
+	public void constructor_shouldIgnoreNullElements() {
+		RolePrivileges privileges = new RolePrivileges(new HashSet<>(Arrays.asList("View Patients", null)), false);
+
+		assertTrue(privileges.containsPrivilege("View Patients"));
+		assertEquals(1, privileges.getPrivilegeNames().size());
+	}
+
+	@Test
+	public void constructor_shouldRejectANullSet() {
+		assertThrows(NullPointerException.class, () -> new RolePrivileges(null, false));
+	}
+
+	@Test
+	public void constructor_shouldAcceptAnEmptySet() {
+		RolePrivileges privileges = new RolePrivileges(Collections.emptySet(), false);
+
+		assertTrue(privileges.getPrivilegeNames().isEmpty());
+		assertFalse(privileges.grantsSuperuser());
+	}
+
+	@Test
+	public void getPrivilegeNames_shouldBeUnmodifiable() {
+		RolePrivileges privileges = new RolePrivileges(Collections.singleton("View Patients"), false);
+
+		assertThrows(UnsupportedOperationException.class, () -> privileges.getPrivilegeNames().add("Edit Patients"));
+	}
+
+	@Test
+	public void equals_shouldBeInsensitiveToInsertionOrderAndCase() {
+		RolePrivileges a = new RolePrivileges(new LinkedHashSet<>(Arrays.asList("View Patients", "Edit Patients")), false);
+		RolePrivileges b = new RolePrivileges(new LinkedHashSet<>(Arrays.asList("EDIT PATIENTS", "VIEW PATIENTS")), false);
+
+		assertEquals(a, b);
+		assertEquals(b, a);
+		assertEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	public void equals_shouldDistinguishBySuperuserFlag() {
+		RolePrivileges granting = new RolePrivileges(Collections.emptySet(), true);
+		RolePrivileges notGranting = new RolePrivileges(Collections.emptySet(), false);
+
+		assertNotEquals(granting, notGranting);
+	}
+
+	@Test
+	public void equals_shouldDistinguishByPrivilegeSet() {
+		RolePrivileges a = new RolePrivileges(Collections.singleton("View Patients"), false);
+		RolePrivileges b = new RolePrivileges(Collections.singleton("Edit Patients"), false);
+
+		assertNotEquals(a, b);
+	}
+}

--- a/api/src/test/java/org/openmrs/api/context/UserContextHasPrivilegeTest.java
+++ b/api/src/test/java/org/openmrs/api/context/UserContextHasPrivilegeTest.java
@@ -1,0 +1,156 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.context;
+
+import java.util.Collections;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Role;
+import org.openmrs.User;
+import org.openmrs.api.cache.RolePrivilegeCache;
+import org.openmrs.api.cache.RolePrivileges;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.RoleConstants;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Behavioral tests for {@link UserContext#hasPrivilege(String)}. Each test pre-populates the
+ * {@code rolePrivileges} cache so the check resolves against a known {@link RolePrivileges} value
+ * (a cache hit bypasses the daemon-backed fresh load), exercising the resolution wiring directly:
+ * proxy handling lives in {@link UserContextTest}, the flattening algorithm in
+ * {@code RolePrivilegeCacheTest}, and the daemon fresh load in
+ * {@code RolePrivilegeCacheIntegrationTest}.
+ */
+public class UserContextHasPrivilegeTest extends BaseContextSensitiveTest {
+
+	private static final String GRANTED = "Cache Test Granted Privilege";
+
+	private CacheManager cacheManager;
+
+	@BeforeEach
+	public void setup() {
+		cacheManager = Context.getRegisteredComponent("apiCacheManager", CacheManager.class);
+		rolePrivilegeCache().clear();
+	}
+
+	@AfterEach
+	public void clearCache() {
+		rolePrivilegeCache().clear();
+	}
+
+	private Cache rolePrivilegeCache() {
+		return cacheManager.getCache(RolePrivilegeCache.CACHE_NAME);
+	}
+
+	private void cacheRole(String roleName, RolePrivileges value) {
+		rolePrivilegeCache().put(RolePrivileges.normalize(roleName), value);
+	}
+
+	private User userWithRole(String roleName) {
+		User user = new User();
+		user.addRole(new Role(roleName));
+		return user;
+	}
+
+	/**
+	 * Runs the given action with the supplied user (or <code>null</code> for an unauthenticated
+	 * context) set on the current {@link UserContext}, restoring the previous user afterward.
+	 */
+	private void runAs(User user, Runnable action) throws IllegalAccessException {
+		UserContext userContext = Context.getUserContext();
+		User previous = userContext.getAuthenticatedUser();
+		try {
+			FieldUtils.getField(UserContext.class, "user", true).set(userContext, user);
+			action.run();
+		} finally {
+			FieldUtils.getField(UserContext.class, "user", true).set(userContext, previous);
+		}
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeWhenADirectlyAssignedRoleGrantsThePrivilege() throws Exception {
+		cacheRole("Clerk", new RolePrivileges(Collections.singleton(GRANTED), false));
+
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldMatchPrivilegesCaseInsensitively() throws Exception {
+		cacheRole("Clerk", new RolePrivileges(Collections.singleton(GRANTED), false));
+
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege(GRANTED.toUpperCase())));
+	}
+
+	@Test
+	public void hasPrivilege_shouldDenyWhenNoRoleGrantsThePrivilege() throws Exception {
+		cacheRole("Clerk", new RolePrivileges(Collections.singleton("Some Unrelated Privilege"), false));
+
+		runAs(userWithRole("Clerk"), () -> assertFalse(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeAnyPrivilegeWhenARoleGrantsSuperuser() throws Exception {
+		// grantsSuperuser is set by the flattening walk when the superuser role is the role itself or
+		// anywhere in its inherited closure, so this also covers inherited superuser status.
+		cacheRole("Delegated Admin", new RolePrivileges(Collections.emptySet(), true));
+
+		runAs(userWithRole("Delegated Admin"), () -> assertTrue(Context.hasPrivilege("Any Arbitrary Privilege")));
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeTheEmptyPrivilegeForAnyAuthenticatedUser() throws Exception {
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege("")));
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeWhenTheAuthenticatedRoleGrantsThePrivilege() throws Exception {
+		cacheRole(RoleConstants.AUTHENTICATED, new RolePrivileges(Collections.singleton(GRANTED), false));
+
+		// The user's own role does not grant it; the authenticated role does.
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeWhenTheAnonymousRoleGrantsThePrivilegeForUnauthenticatedUsers()
+	        throws Exception {
+		cacheRole(RoleConstants.ANONYMOUS, new RolePrivileges(Collections.singleton(GRANTED), false));
+
+		runAs(null, () -> assertTrue(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldNotAuthorizeViaAProxyPrivilegeWhenProxiesAreExcluded() throws Exception {
+		runAs(userWithRole("Clerk"), () -> {
+			Context.addProxyPrivilege(GRANTED);
+			try {
+				// proxy-inclusive check is satisfied by the proxy privilege...
+				assertTrue(Context.hasPrivilege(GRANTED));
+				// ...but the proxy-excluding check is not, since no role grants it
+				assertFalse(Context.hasPrivilege(GRANTED, false));
+			} finally {
+				Context.removeProxyPrivilege(GRANTED);
+			}
+		});
+	}
+
+	@Test
+	public void hasPrivilege_shouldAuthorizeViaARoleEvenWhenProxiesAreExcluded() throws Exception {
+		cacheRole("Clerk", new RolePrivileges(Collections.singleton(GRANTED), false));
+
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege(GRANTED, false)));
+	}
+}

--- a/api/src/test/java/org/openmrs/api/context/UserContextHasPrivilegeTest.java
+++ b/api/src/test/java/org/openmrs/api/context/UserContextHasPrivilegeTest.java
@@ -10,11 +10,13 @@
 package org.openmrs.api.context;
 
 import java.util.Collections;
+import java.util.HashSet;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openmrs.Privilege;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.cache.RolePrivilegeCache;
@@ -130,6 +132,32 @@ public class UserContextHasPrivilegeTest extends BaseContextSensitiveTest {
 		cacheRole(RoleConstants.ANONYMOUS, new RolePrivileges(Collections.singleton(GRANTED), false));
 
 		runAs(null, () -> assertTrue(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldHonorInheritedPrivilegesForTheAuthenticatedRole() throws Exception {
+		// The pre-cache code resolved the authenticated and anonymous roles via Role.hasPrivilege, which
+		// ignores inherited roles; routing them through the flattening cache deliberately honors inheritance.
+		// Seed the authenticated role's entry as the daemon flatten would for a role that inherits GRANTED.
+		Role inherited = new Role("Inherited Role");
+		inherited.addPrivilege(new Privilege(GRANTED));
+		Role authenticated = new Role(RoleConstants.AUTHENTICATED);
+		authenticated.setInheritedRoles(new HashSet<>(Collections.singletonList(inherited)));
+		cacheRole(RoleConstants.AUTHENTICATED, RolePrivilegeCache.computeRolePrivileges(authenticated));
+
+		runAs(userWithRole("Clerk"), () -> assertTrue(Context.hasPrivilege(GRANTED)));
+	}
+
+	@Test
+	public void hasPrivilege_shouldNotAuthorizeTheEmptyOrNullPrivilegeForUnauthenticatedUsers() throws Exception {
+		// The empty-privilege shortcut applies only to authenticated users; an unauthenticated caller is
+		// authorized solely by the anonymous role, which here grants nothing.
+		cacheRole(RoleConstants.ANONYMOUS, new RolePrivileges(Collections.emptySet(), false));
+
+		runAs(null, () -> {
+			assertFalse(Context.hasPrivilege(""));
+			assertFalse(Context.hasPrivilege(null));
+		});
 	}
 
 	@Test

--- a/api/src/test/resources/cache-api.yaml
+++ b/api/src/test/resources/cache-api.yaml
@@ -7,3 +7,5 @@ caches:
         configuration: "entity"
     testCache:
         configuration: "entity"
+    rolePrivileges:
+        configuration: "role-privileges"


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

This is a reworked version of #6372. Like #6372, it creates an Infinispan cache to store the role-privilege mappings that is leveraged to try to speed-up privilege checks. This PR adds the following:

* Cache is evicted after an application context refresh not just when a role is written
* Cache now has a TTL expiry of an hour. Hot-path roles should remain until evicted though
* Roles are _always_ loaded from the DB and not from in memory copies
* Loading is done on a Daemon thread to avoid depending on user privileges
* I also updated the GP privilege checks to run through the same machinery (this required a new version of `hasPrivilege()` which ignores proxy privileges added here)
* Some tests needed to be slightly reworked to accommodate the new setup

The "widening" @dkayiwa pointed out on #6372 is also present and intentional. I think the exclusion here was unintentional, but, in any case, it's mostly irrelevant unless you've made Authenticated inherit from another role (which wouldn't have consistently worked).

Thanks to @Rocker810 for the initial direction on this!

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6712

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

