### PR TITLE
TRUNK-6509: Do not re-copy and re-expand unchanged module jars on every restart

### DIFF
--- a/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
+++ b/api/src/main/java/org/openmrs/module/ModuleClassLoader.java
@@ -231,41 +231,41 @@ public class ModuleClassLoader extends URLClassLoader {
 			log.error("Failed to add development folder to the classpath", ex);
 		}
 		
+		// Whether the module's previously expanded cache is still up to date. This is read before
+		// getLibCacheFolderForModule() below because that method rewrites the .moduleLastModified
+		// marker it relies on. When the cache is up to date we skip re-copying the module jar and
+		// re-expanding its /lib folder, which otherwise happens on every restart (TRUNK-6509).
+		// getLibCacheFolderForModule() still deletes the folder when the module actually changed
+		// (TRUNK-6675), so work is only skipped for genuinely unchanged modules.
+		boolean cacheUpToDate = isModuleCacheUpToDate(module);
 		File tmpModuleDir = getLibCacheFolderForModule(module);
-		
+
 		//add module jar to classpath only if we are not in dev mode
 		if (devDir == null) {
 			File tmpModuleJar = new File(tmpModuleDir, module.getModuleId() + ".jar");
 			
-			if (!tmpModuleJar.exists()) {
+			// copy the module jar into that temporary folder, unless an up-to-date copy is already there
+			if (!(cacheUpToDate && tmpModuleJar.exists())) {
+				FileInputStream in = null;
+				FileOutputStream out = null;
 				try {
-					tmpModuleJar.createNewFile();
+					in = new FileInputStream(module.getFile());
+					out = new FileOutputStream(tmpModuleJar);
+					OpenmrsUtil.copyFile(in, out);
 				}
 				catch (IOException io) {
-					log.warn("Unable to create tmpModuleFile", io);
+					log.warn("Unable to copy tmpModuleFile", io);
 				}
-			}
-			
-			// copy the module jar into that temporary folder
-			FileInputStream in = null;
-			FileOutputStream out = null;
-			try {
-				in = new FileInputStream(module.getFile());
-				out = new FileOutputStream(tmpModuleJar);
-				OpenmrsUtil.copyFile(in, out);
-			}
-			catch (IOException io) {
-				log.warn("Unable to copy tmpModuleFile", io);
-			}
-			finally {
-				try {
-					in.close();
+				finally {
+					try {
+						in.close();
+					}
+					catch (Exception e) { /* pass */}
+					try {
+						out.close();
+					}
+					catch (Exception e) { /* pass */}
 				}
-				catch (Exception e) { /* pass */}
-				try {
-					out.close();
-				}
-				catch (Exception e) { /* pass */}
 			}
 			
 			// add the module jar as a url in the classpath of the classloader
@@ -281,11 +281,14 @@ public class ModuleClassLoader extends URLClassLoader {
 		
 		// add each defined jar in the /lib folder, add as a url in the classpath of the classloader
 		try {
-			log.debug("Expanding /lib folder in module");
-			
-			ModuleUtil.expandJar(module.getFile(), tmpModuleDir, "lib", true);
 			File libdir = new File(tmpModuleDir, "lib");
-			
+
+			// expand the module's /lib folder, unless it was already expanded for this version of the module
+			if (!(cacheUpToDate && libdir.exists())) {
+				log.debug("Expanding /lib folder in module");
+				ModuleUtil.expandJar(module.getFile(), tmpModuleDir, "lib", true);
+			}
+
 			if (libdir != null && libdir.exists()) {
 				Map<String, String> startedRelatedModules = new HashMap<>();
 				for (Module requiredModule : collectRequiredModuleImports(module)) {
@@ -513,6 +516,39 @@ public class ModuleClassLoader extends URLClassLoader {
 			return true;
 		} catch (IOException e) {
 			log.warn("Failed to delete lib cache dir {} for module {}", dir, moduleId, e);
+			return false;
+		}
+	}
+
+	/**
+	 * Checks whether the lib cache folder for the given module already holds an expansion that matches
+	 * the current module file, i.e. the module has not changed since the cache was last written. When it
+	 * has not, re-copying the module jar and re-expanding its <code>/lib</code> folder on startup can be
+	 * skipped (see <a href="https://issues.openmrs.org/browse/TRUNK-6509">TRUNK-6509</a>).
+	 * <p>
+	 * This reads the same <code>.moduleLastModified</code> marker that
+	 * {@link #getLibCacheFolderForModule(Module)} maintains, so it must be called <b>before</b> that
+	 * method on a given startup, since that method rewrites the marker.
+	 *
+	 * @param module the module whose cache to check
+	 * @return <code>true</code> only if optimized startup is enabled and the cached expansion is current
+	 */
+	private static boolean isModuleCacheUpToDate(Module module) {
+		if (!Context.isOptimizedStartup()) {
+			return false;
+		}
+
+		File tmpModuleDir = new File(OpenmrsClassLoader.getLibCacheFolder(), module.getModuleId());
+		File moduleLastModifiedFile = new File(tmpModuleDir, ".moduleLastModified");
+		if (!moduleLastModifiedFile.exists()) {
+			return false;
+		}
+
+		try {
+			String savedLastModified = FileUtils.readFileToString(moduleLastModifiedFile, Charset.defaultCharset());
+			return Long.valueOf(savedLastModified).equals(module.getFile().lastModified());
+		}
+		catch (IOException | NumberFormatException e) {
 			return false;
 		}
 	}

--- a/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
+++ b/api/src/test/java/org/openmrs/module/ModuleClassLoaderTest.java
@@ -15,16 +15,21 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -588,5 +593,83 @@ public class ModuleClassLoaderTest extends BaseContextSensitiveTest {
 		final URL fileUrl = URI.create(
 			"file:/atomfeed/lib/jackson-mapper-asl-1.9.13.jar").toURL();
 		assertFalse(ModuleClassLoader.isMatchingConditionalResource(moduleWithNullConfigVersions, fileUrl, conditionalResource));
+	}
+
+	/**
+	 * Verifies TRUNK-6509: the /lib folder of an unchanged module must not be re-expanded on every
+	 * restart, while a module that actually changed (TRUNK-6675) still is.
+	 *
+	 * @see ModuleClassLoader#getUrls(Module)
+	 */
+	@Test
+	public void getUrls_shouldNotReExpandLibForUnchangedModuleButShouldForChangedModule() throws Exception {
+		File tempLibCache = Files.createTempDirectory("libcache-test").toFile();
+		Field libCacheFolderField = OpenmrsClassLoader.class.getDeclaredField("libCacheFolder");
+		libCacheFolderField.setAccessible(true);
+		File savedLibCacheFolder = (File) libCacheFolderField.get(null);
+		libCacheFolderField.set(null, tempLibCache);
+
+		Field libCacheFoldersField = ModuleClassLoader.class.getDeclaredField("libCacheFolders");
+		libCacheFoldersField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<String, File> libCacheFolders = (Map<String, File>) libCacheFoldersField.get(null);
+
+		Method getUrls = ModuleClassLoader.class.getDeclaredMethod("getUrls", Module.class);
+		getUrls.setAccessible(true);
+
+		Properties savedRuntimeProperties = Context.getRuntimeProperties();
+		File omodFile = File.createTempFile("mockmodule", ".omod");
+		try {
+			Properties props = Context.getRuntimeProperties();
+			props.setProperty("optimized.startup", "true");
+			Context.setRuntimeProperties(props);
+
+			long originalLastModified = 1600000000000L;
+			writeOmodWithLibJar(omodFile, "original");
+			omodFile.setLastModified(originalLastModified);
+
+			Module module = new Module("mockmodule", "mockmodule", "org.openmrs.module.mockmodule",
+				"author", "description", "1.0", "1.0");
+			module.setFile(omodFile);
+			module.setRequiredModules(new ArrayList<>());
+			module.setAwareOfModulesMap(new HashMap<>());
+
+			// First startup expands the /lib folder
+			getUrls.invoke(null, module);
+			File expandedJar = new File(new File(tempLibCache, "mockmodule"), "lib/mockmodule-api.jar");
+			assertTrue(expandedJar.exists(), "the module's /lib should be expanded on first startup");
+
+			// Replace the expanded content with a sentinel so a re-expansion can be detected
+			FileUtils.writeStringToFile(expandedJar, "SENTINEL", Charset.defaultCharset());
+
+			// Restart with the SAME (unchanged) module: the sentinel must survive, i.e. no re-expansion
+			libCacheFolders.remove("mockmodule");
+			getUrls.invoke(null, module);
+			assertThat("an unchanged module must not be re-expanded on restart (TRUNK-6509)",
+				FileUtils.readFileToString(expandedJar, Charset.defaultCharset()), is("SENTINEL"));
+
+			// Restart after the module CHANGED: it must be re-expanded (TRUNK-6675)
+			libCacheFolders.remove("mockmodule");
+			writeOmodWithLibJar(omodFile, "updated");
+			omodFile.setLastModified(originalLastModified + 10000);
+			getUrls.invoke(null, module);
+			assertThat("a changed module must be re-expanded on restart (TRUNK-6675)",
+				FileUtils.readFileToString(expandedJar, Charset.defaultCharset()), is("updated"));
+		}
+		finally {
+			Context.setRuntimeProperties(savedRuntimeProperties);
+			libCacheFolderField.set(null, savedLibCacheFolder);
+			libCacheFolders.remove("mockmodule");
+			omodFile.delete();
+			FileUtils.deleteDirectory(tempLibCache);
+		}
+	}
+
+	private static void writeOmodWithLibJar(File omodFile, String libContent) throws Exception {
+		try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(omodFile))) {
+			zos.putNextEntry(new ZipEntry("lib/mockmodule-api.jar"));
+			zos.write(libContent.getBytes(Charset.defaultCharset()));
+			zos.closeEntry();
+		}
 	}
 }


### PR DESCRIPTION
## Summary

TRUNK-6509 ("Do not expand jars every restart") stopped deleting the whole lib cache and skipped Liquibase when the core version is unchanged, but `ModuleClassLoader.getUrls()` still **re-copied every module jar into the lib cache and re-expanded its `/lib` folder on every startup**, regardless of whether the module had changed. So the expansion the ticket is named after was never actually skipped.

On a module-heavy distribution that is several seconds of redundant disk I/O on every restart. 2.8.x does the same work, but 2.9.x was supposed to avoid it, so this quietly erodes the startup gains 2.9.x was expected to have over 2.8.x.

## Change

`getUrls()` now reads the module's `.moduleLastModified` marker (via a small `isModuleCacheUpToDate` helper) **before** `getLibCacheFolderForModule()` rewrites it, and skips both the jar copy and the `/lib` expansion when the cached expansion is already current.

Correctness is preserved: `getLibCacheFolderForModule()` still deletes the module's cache folder when the module actually changed (TRUNK-6675), so work is skipped only for genuinely unchanged modules. Changed modules are re-copied and re-expanded exactly as before, so the "module not updated when omod changes" fix is unaffected. When `optimized.startup` is `false`, nothing is skipped.

## Measured impact

Reference-application-3-backend (core 2.9, ~40 modules), same war built two ways (differing only by this change), mounted into the same image, steady-state restarts, Tomcat's own "Server startup in [N] ms":

| | restart 1 | restart 2 | mean |
|---|---|---|---|
| before | 22996 ms | 23086 ms | ~23.0 s |
| after | 20888 ms | 21054 ms | ~21.0 s |

~2.0 s (~9%) faster, entirely within the module-starting phase. Bare `openmrs-core` (no modules) is unaffected, as expected.

## Testing

- New `ModuleClassLoaderTest.getUrls_shouldNotReExpandLibForUnchangedModuleButShouldForChangedModule` asserts that an unchanged module is **not** re-expanded on a simulated restart while a changed module **is**.
- Full `ModuleClassLoaderTest` passes (42/42), including the existing TRUNK-6675 cases.
- Verified end-to-end on the O3 backend image: boots healthy, all modules load, no new errors and no `NoClassDefFound`/`ClassNotFound` compared to the unfixed war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RamM5GdnGvTDRs7asPhNtV
