### PR TITLE
TRUNK-6733: Use java-uuid-generator for entity UUIDs instead of UUID.randomUUID()

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -35,6 +35,7 @@ The following dependencies are licensed under the [Apache License, Version 2.0](
 - Infinispan (`org.infinispan:infinispan-spring6-embedded`, `infinispan-hibernate-cache-v62`)
 - Jackson JSON (`com.fasterxml.jackson.core:jackson-core`, `jackson-annotations`, `jackson-databind`, `com.fasterxml.jackson.datatype:jackson-datatype-jsr310`)
 - Jakarta Validation API (`jakarta.validation:jakarta.validation-api`)
+- Java UUID Generator (`com.fasterxml.uuid:java-uuid-generator`)
 - JBoss Logging (`org.jboss.logging:jboss-logging`)
 - Joda-Time (`joda-time:joda-time`)
 - Liquibase (`org.liquibase:liquibase-core`)

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -286,6 +286,10 @@
 			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.uuid</groupId>
+			<artifactId>java-uuid-generator</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.angus</groupId>
 			<artifactId>angus-mail</artifactId>
 			<scope>runtime</scope>

--- a/api/src/main/java/liquibase/ext/change/core/InsertWithUuidDataChange.java
+++ b/api/src/main/java/liquibase/ext/change/core/InsertWithUuidDataChange.java
@@ -9,6 +9,8 @@
  */
 package liquibase.ext.change.core;
 
+import org.openmrs.util.UuidUtil;
+
 import liquibase.change.ChangeMetaData;
 import liquibase.change.ColumnConfig;
 import liquibase.change.DatabaseChange;
@@ -16,8 +18,6 @@ import liquibase.change.core.InsertDataChange;
 import liquibase.database.Database;
 import liquibase.statement.SqlStatement;
 import liquibase.structure.core.Column;
-
-import static java.util.UUID.randomUUID;
 
 @DatabaseChange(name = "insertWithUuid", description = "Inserts data into an existing table and generates and inserts an uuid", priority = ChangeMetaData.PRIORITY_DEFAULT, appliesTo = "table")
 public class InsertWithUuidDataChange extends InsertDataChange {
@@ -38,7 +38,7 @@ public class InsertWithUuidDataChange extends InsertDataChange {
 		// Add the uuid column to the insert statement.
 		//
 		ColumnConfig uuid = new ColumnConfig(new Column(UUID));
-		uuid.setValue(randomUUID().toString());
+		uuid.setValue(UuidUtil.newUuidString());
 		addColumn(uuid);
 		return super.generateStatements(database);
 	}

--- a/api/src/main/java/org/openmrs/Allergy.java
+++ b/api/src/main/java/org/openmrs/Allergy.java
@@ -13,7 +13,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -30,6 +29,7 @@ import jakarta.persistence.Table;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.envers.Audited;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.UuidUtil;
 
 /**
  * Represent allergy
@@ -370,7 +370,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 	 */
 	public void copy(Allergy allergy) {
 		setAllergyId(null);
-		setUuid(UUID.randomUUID().toString());
+		setUuid(UuidUtil.newUuidString());
 		setPatient(allergy.getPatient());
 		setAllergen(allergy.getAllergen());
 		setSeverity(allergy.getSeverity());
@@ -380,7 +380,7 @@ public class Allergy extends BaseFormRecordableOpenmrsData {
 		for (AllergyReaction reaction : allergy.getReactions()) {
 			reactions.add(reaction);
 			reaction.setAllergyReactionId(null);
-			reaction.setUuid(UUID.randomUUID().toString());
+			reaction.setUuid(UuidUtil.newUuidString());
 		}
 	}
 

--- a/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
+++ b/api/src/main/java/org/openmrs/BaseOpenmrsObject.java
@@ -10,7 +10,6 @@
 package org.openmrs;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
@@ -19,6 +18,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hibernate.Hibernate;
 import org.hibernate.envers.Audited;
+import org.openmrs.util.UuidUtil;
 
 /**
  * This is the base implementation of the {@link OpenmrsObject} interface.<br>
@@ -29,7 +29,7 @@ import org.hibernate.envers.Audited;
 public abstract class BaseOpenmrsObject implements Serializable, OpenmrsObject {
 
 	@Column(name = "uuid", unique = true, nullable = false, length = 38, updatable = false)
-	private String uuid = UUID.randomUUID().toString();
+	private String uuid = UuidUtil.newUuidString();
 
 	/**
 	 * @see org.openmrs.OpenmrsObject#getUuid()

--- a/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/OpenmrsObjectSaveHandler.java
@@ -12,7 +12,6 @@ package org.openmrs.api.handler;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Date;
-import java.util.UUID;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.openmrs.Obs;
@@ -24,6 +23,7 @@ import org.openmrs.annotation.AllowLeadingOrTrailingWhitespace;
 import org.openmrs.annotation.Handler;
 import org.openmrs.aop.RequiredDataAdvice;
 import org.openmrs.api.APIException;
+import org.openmrs.util.UuidUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public class OpenmrsObjectSaveHandler implements SaveHandler<OpenmrsObject> {
 	@Override
 	public void handle(OpenmrsObject openmrsObject, User creator, Date dateCreated, String reason) {
 		if (openmrsObject.getUuid() == null) {
-			openmrsObject.setUuid(UUID.randomUUID().toString());
+			openmrsObject.setUuid(UuidUtil.newUuidString());
 		}
 
 		//Set all empty string properties, that do not have the AllowEmptyStrings annotation, to null.

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.beanutils.BeanUtils;
 import org.apache.commons.collections.CollectionUtils;
@@ -73,6 +72,7 @@ import org.openmrs.parameter.ConceptSearchCriteriaBuilder;
 import org.openmrs.util.ConceptReferenceRangeUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.UuidUtil;
 import org.openmrs.validator.ValidateUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -182,7 +182,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 				// create a new concept name from the matching cloned
 				// conceptName
 				ConceptName clone = uuidClonedConceptNameMap.get(changedName.getUuid());
-				clone.setUuid(UUID.randomUUID().toString());
+				clone.setUuid(UuidUtil.newUuidString());
 				clone.setDateCreated(null);
 				clone.setCreator(null);
 				concept.addName(clone);
@@ -810,7 +810,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			conceptName.setCreator(Context.getAuthenticatedUser());
 			//If this is pre 1.9
 			if (conceptName.getUuid() == null) {
-				conceptName.setUuid(UUID.randomUUID().toString());
+				conceptName.setUuid(UuidUtil.newUuidString());
 			}
 			mappedConcept.addName(conceptName);
 			mappedConcept.setChangedBy(Context.getAuthenticatedUser());
@@ -835,7 +835,7 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 			ob.setLocation(cp.getEncounter().getLocation());
 			ob.setPerson(cp.getEncounter().getPatient());
 			if (ob.getUuid() == null) {
-				ob.setUuid(UUID.randomUUID().toString());
+				ob.setUuid(UuidUtil.newUuidString());
 			}
 			Context.getObsService().saveObs(ob, null);
 			cp.setObs(ob);

--- a/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/FormServiceImpl.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.openmrs.Concept;
@@ -45,6 +44,7 @@ import org.openmrs.obs.ComplexObsHandler;
 import org.openmrs.obs.SerializableComplexObsHandler;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.UuidUtil;
 import org.openmrs.validator.FormValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -563,7 +563,7 @@ public class FormServiceImpl extends BaseOpenmrsService implements FormService, 
 
 		// set the uuid here because the RequiredDataAdvice only looks at child lists
 		if (field.getUuid() == null) {
-			field.setUuid(UUID.randomUUID().toString());
+			field.setUuid(UuidUtil.newUuidString());
 		}
 
 		FormField tmpFormField = dao.saveFormField(formField);

--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -19,7 +19,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -76,6 +75,7 @@ import org.openmrs.serialization.SerializationException;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.util.UuidUtil;
 import org.openmrs.validator.PatientIdentifierValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -811,7 +811,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 				tmpIdentifier.setVoided(false);
 				tmpIdentifier.setVoidedBy(null);
 				tmpIdentifier.setVoidReason(null);
-				tmpIdentifier.setUuid(UUID.randomUUID().toString());
+				tmpIdentifier.setUuid(UuidUtil.newUuidString());
 				// we don't want to change the preferred identifier of the preferred patient
 				tmpIdentifier.setPreferred(false);
 				preferred.addIdentifier(tmpIdentifier);
@@ -851,7 +851,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 			if (!attr.getVoided()) {
 				PersonAttribute tmpAttr = attr.copy();
 				tmpAttr.setPerson(null);
-				tmpAttr.setUuid(UUID.randomUUID().toString());
+				tmpAttr.setUuid(UuidUtil.newUuidString());
 				preferred.addAttribute(tmpAttr);
 				mergedData.addCreatedAttribute(tmpAttr.getUuid());
 			}
@@ -894,7 +894,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 		tmpName.setVoidReason(null);
 		// we don't want to change the preferred name of the preferred patient
 		tmpName.setPreferred(false);
-		tmpName.setUuid(UUID.randomUUID().toString());
+		tmpName.setUuid(UuidUtil.newUuidString());
 		return tmpName;
 	}
 
@@ -917,7 +917,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 				tmpAddress.setVoidedBy(null);
 				tmpAddress.setVoidReason(null);
 				tmpAddress.setPreferred(false); // addresses from non-preferred patient shouldn't be marked as preferred
-				tmpAddress.setUuid(UUID.randomUUID().toString());
+				tmpAddress.setUuid(UuidUtil.newUuidString());
 				preferred.addAddress(tmpAddress);
 				mergedData.addCreatedAddress(tmpAddress.getUuid());
 				log.debug("Merging address " + newAddress.getPersonAddressId() + " to " + preferred.getPatientId());
@@ -929,7 +929,7 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 			if (!attr.getVoided()) {
 				PersonAttribute tmpAttr = attr.copy();
 				tmpAttr.setPerson(null);
-				tmpAttr.setUuid(UUID.randomUUID().toString());
+				tmpAttr.setUuid(UuidUtil.newUuidString());
 				preferred.addAttribute(tmpAttr);
 				mergedData.addCreatedAttribute(tmpAttr.getUuid());
 			}

--- a/api/src/main/java/org/openmrs/scheduler/jobrunr/JobRunrSchedulerService.java
+++ b/api/src/main/java/org/openmrs/scheduler/jobrunr/JobRunrSchedulerService.java
@@ -53,6 +53,7 @@ import org.openmrs.scheduler.TaskDetails;
 import org.openmrs.scheduler.TaskState;
 import org.openmrs.scheduler.db.SchedulerDAO;
 import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.util.UuidUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.orm.ObjectRetrievalFailureException;
@@ -154,7 +155,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 						updateRecurringJobWithName(recurringJobId, name);
 					} else {
 						Date nextExecution = SchedulerUtil.getNextExecution(task);
-						JobId jobId = jobScheduler.schedule(UUID.randomUUID(), nextExecution.toInstant(),
+						JobId jobId = jobScheduler.schedule(UuidUtil.newUuid(), nextExecution.toInstant(),
 						    (JobRunrSchedulerService service) -> service.scheduleRecurrently(task.getUuid()));
 						updateJobWithName(jobId, task.getName());
 						// Create a placeholder recurring task that will be updated by the above task to the correct interval
@@ -412,7 +413,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public TaskDetails schedule(TaskData taskData, String name) {
-		return schedule(UUID.randomUUID().toString(), taskData, name);
+		return schedule(UuidUtil.newUuidString(), taskData, name);
 	}
 
 	@Override
@@ -460,7 +461,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public TaskDetails schedule(TaskData taskData, Instant runAt, String name) {
-		return schedule(UUID.randomUUID().toString(), taskData, runAt, name);
+		return schedule(UuidUtil.newUuidString(), taskData, runAt, name);
 	}
 
 	@Override
@@ -484,7 +485,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public TaskDetails schedule(TaskData taskData, ZonedDateTime runAt, String name) {
-		return schedule(UUID.randomUUID().toString(), taskData, runAt, name);
+		return schedule(UuidUtil.newUuidString(), taskData, runAt, name);
 	}
 
 	@Override
@@ -508,7 +509,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public RecurringTaskDetails scheduleRecurrently(TaskData taskData, String cron, String name) {
-		return scheduleRecurrently(UUID.randomUUID().toString(), taskData, cron, name);
+		return scheduleRecurrently(UuidUtil.newUuidString(), taskData, cron, name);
 	}
 
 	@Override
@@ -539,7 +540,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public RecurringTaskDetails scheduleRecurrently(TaskData taskData, String cron, ZoneId zoneId, String name) {
-		return scheduleRecurrently(UUID.randomUUID().toString(), taskData, cron, zoneId, name);
+		return scheduleRecurrently(UuidUtil.newUuidString(), taskData, cron, zoneId, name);
 	}
 
 	@Override
@@ -567,7 +568,7 @@ public class JobRunrSchedulerService extends BaseOpenmrsService implements Sched
 
 	@Override
 	public RecurringTaskDetails scheduleRecurrently(TaskData taskData, Duration interval, String name) {
-		return scheduleRecurrently(UUID.randomUUID().toString(), taskData, interval, name);
+		return scheduleRecurrently(UuidUtil.newUuidString(), taskData, interval, name);
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/util/UuidUtil.java
+++ b/api/src/main/java/org/openmrs/util/UuidUtil.java
@@ -1,0 +1,145 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import java.security.SecureRandom;
+import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.UUID;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.NoArgGenerator;
+
+/**
+ * Generates the uuids that identify OpenMRS objects.
+ * <p>
+ * All uuid generation should go through this class rather than calling {@link UUID#randomUUID()},
+ * which draws from a single, JVM-wide {@link SecureRandom} whose {@code nextBytes} is synchronized.
+ * Since {@link org.openmrs.BaseOpenmrsObject} generates a uuid in a field initializer, that one
+ * monitor is entered for every object Hibernate hydrates - even though the generated value is then
+ * immediately overwritten by the uuid read from the database - which makes it a significant point
+ * of contention on read paths that load many rows.
+ * <p>
+ * A cryptographically strong source is not needed here: uuids identify objects, they are not
+ * secrets. Access to a record is granted by privilege checks rather than by a uuid being
+ * unguessable, and security-sensitive tokens (such as user activation keys) are generated
+ * separately. This class therefore hands java-uuid-generator a thread-confined random number
+ * generator: each thread draws from its own {@link SplittableRandom} stream, so threads never queue
+ * up behind a shared generator. {@link SecureRandom} is read exactly once, to seed the root stream
+ * that all of the others are split from, which is what keeps uuids unique across threads, restarts
+ * and servers.
+ * <p>
+ * Generated values are canonical, 36 character, version 4 (random) uuid strings, exactly as before,
+ * so they still fit the 38 character uuid columns and existing uuids are unaffected. Should
+ * time-ordered (version 7) uuids ever be wanted for their better insert locality on the uuid
+ * indexes, the generator below is the only place that needs to change.
+ *
+ * @since 3.0.0
+ */
+public class UuidUtil {
+
+	/**
+	 * Seeded once per JVM from a cryptographically strong source and thereafter only ever split. The
+	 * cost of the strong source does not matter for a single draw, while the seed quality it provides
+	 * does: it is what stops the streams of different JVMs and servers from overlapping.
+	 * <p>
+	 * Reading {@link SecureRandom} exactly once and then letting it go is the whole point here rather
+	 * than an oversight, so the "save and re-use this Random" warning is suppressed.
+	 */
+	@SuppressWarnings("java:S2119")
+	private static final SplittableRandom ROOT = new SplittableRandom(new SecureRandom().nextLong());
+
+	/**
+	 * The random number stream a thread draws its uuids from.
+	 */
+	private static final ThreadLocal<SplittableRandom> STREAMS = ThreadLocal.withInitial(UuidUtil::newStream);
+
+	/**
+	 * java-uuid-generator's version 4 generator, drawing from the thread-confined streams above.
+	 * <p>
+	 * Two properties of {@code RandomBasedGenerator} are relied on here, and both are pinned by
+	 * {@code UuidUtilTest}, because supplying a generator buys nothing if either of them changes: it
+	 * does not synchronize on the generator it is handed, and it draws through
+	 * {@link Random#nextLong()} rather than {@link Random#nextBytes(byte[])} for anything that is not a
+	 * {@link SecureRandom}. Both hold as of 5.2.0.
+	 */
+	private static final NoArgGenerator UUID_GENERATOR = Generators.randomBasedGenerator(new ThreadConfinedRandom());
+
+	private UuidUtil() {
+	}
+
+	/**
+	 * Hands out the stream for a thread that is generating its first uuid. Splitting gives the stream
+	 * its own increment as well as its own starting point, so that streams stay independent of one
+	 * another rather than being offsets into a single shared sequence.
+	 * <p>
+	 * The root has to be guarded because {@link SplittableRandom#split()} advances the instance it is
+	 * called on, but the monitor is entered once per thread rather than once per uuid, and it is held
+	 * for nothing more than a few arithmetic operations.
+	 *
+	 * @return the calling thread's own random number stream
+	 */
+	private static SplittableRandom newStream() {
+		synchronized (ROOT) {
+			return ROOT.split();
+		}
+	}
+
+	/**
+	 * Generates a new uuid.
+	 *
+	 * @return a newly generated version 4 uuid
+	 * @since 3.0.0
+	 */
+	public static UUID newUuid() {
+		return UUID_GENERATOR.generate();
+	}
+
+	/**
+	 * Generates a new uuid in the canonical 36 character string form used by the uuid columns, for
+	 * example {@code 6e9a0b1c-6d3a-4f0e-8a1b-2c3d4e5f6a7b}.
+	 *
+	 * @return a newly generated version 4 uuid as a string
+	 * @since 3.0.0
+	 */
+	public static String newUuidString() {
+		return newUuid().toString();
+	}
+
+	/**
+	 * A {@link Random} that serves every draw from the calling thread's own stream. It holds no state
+	 * of its own, so handing the single generator instance to every thread is safe and, unlike the
+	 * {@link SecureRandom} java-uuid-generator would use by default, involves no locking.
+	 */
+	private static final class ThreadConfinedRandom extends Random {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public long nextLong() {
+			return STREAMS.get().nextLong();
+		}
+
+		@Override
+		public int nextInt() {
+			return STREAMS.get().nextInt();
+		}
+
+		@Override
+		public void nextBytes(byte[] bytes) {
+			STREAMS.get().nextBytes(bytes);
+		}
+
+		@Override
+		protected int next(int bits) {
+			return STREAMS.get().nextInt() >>> (Integer.SIZE - bits);
+		}
+	}
+}

--- a/api/src/main/java/org/openmrs/util/UuidUtil.java
+++ b/api/src/main/java/org/openmrs/util/UuidUtil.java
@@ -9,10 +9,9 @@
  */
 package org.openmrs.util;
 
-import java.security.SecureRandom;
 import java.util.Random;
-import java.util.SplittableRandom;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.NoArgGenerator;
@@ -20,74 +19,24 @@ import com.fasterxml.uuid.NoArgGenerator;
 /**
  * Generates the uuids that identify OpenMRS objects.
  * <p>
- * It is preferable to use this class to generate random UUIDs, as the JDK's default implementation can be slow under a high volume of requests.
- * <p>
- * A cryptographically strong source is not needed here: uuids identify objects, they are not
- * secrets. Access to a record is granted by privilege checks rather than by a uuid being
- * unguessable, and security-sensitive tokens (such as user activation keys) are generated
- * separately. This class therefore hands java-uuid-generator a thread-confined random number
- * generator: each thread draws from its own {@link SplittableRandom} stream, so threads never queue
- * up behind a shared generator. {@link SecureRandom} is read exactly once, to seed the root stream
- * that all of the others are split from, which is what keeps uuids unique across threads, restarts
- * and servers.
- * <p>
- * Generated values are canonical, 36 character, version 4 (random) uuid strings, exactly as before,
- * so they still fit the 38 character uuid columns and existing uuids are unaffected. Should
- * time-ordered (version 7) uuids ever be wanted for their better insert locality on the uuid
- * indexes, the generator below is the only place that needs to change.
+ * It is preferable to use this class to generate random UUIDs, as the JDK's default implementation
+ * can be slow under a high volume of requests. The uuids it generates are not suitable for
+ * security-sensitive purposes.
  *
  * @since 3.0.0, 2.9.0
  */
 public class UuidUtil {
 
-	/**
-	 * Seeded once per JVM from a cryptographically strong source and thereafter only ever split. The
-	 * cost of the strong source does not matter for a single draw, while the seed quality it provides
-	 * does: it is what stops the streams of different JVMs and servers from overlapping.
-	 * <p>
-	 * Reading {@link SecureRandom} exactly once and then letting it go is the whole point here rather
-	 * than an oversight, so the "save and re-use this Random" warning is suppressed.
-	 */
-	@SuppressWarnings("java:S2119")
-	private static final SplittableRandom ROOT = new SplittableRandom(new SecureRandom().nextLong());
-
-	/**
-	 * The random number stream a thread draws its uuids from.
-	 */
-	private static final ThreadLocal<SplittableRandom> STREAMS = ThreadLocal.withInitial(UuidUtil::newStream);
-
-	/**
-	 * java-uuid-generator's version 4 generator, drawing from the thread-confined streams above.
-	 * <p>
-	 * Two properties of {@code RandomBasedGenerator} are relied on here, and both are pinned by
-	 * {@code UuidUtilTest}, because supplying a generator buys nothing if either of them changes: it
-	 * does not synchronize on the generator it is handed, and it draws through
-	 * {@link Random#nextLong()} rather than {@link Random#nextBytes(byte[])} for anything that is not a
-	 * {@link SecureRandom}. Both hold as of 5.2.0.
-	 */
-	private static final NoArgGenerator UUID_GENERATOR = Generators.randomBasedGenerator(new ThreadConfinedRandom());
+	private static final NoArgGenerator UUID_GENERATOR = Generators.randomBasedGenerator(new ThreadLocalRandomSource());
 
 	private UuidUtil() {
-	}
-
-	/**
-	 * Used to create a new per-thread random generator. Needs to be
-	 * synchronized because {@code SplittableRandom} itself is not
-	 * thread-safe.
-	 *
-	 * @return the calling thread's own random number stream
-	 */
-	private static SplittableRandom newStream() {
-		synchronized (ROOT) {
-			return ROOT.split();
-		}
 	}
 
 	/**
 	 * Generates a new uuid.
 	 *
 	 * @return a newly generated version 4 uuid
-	 * @since 3.0.0
+	 * @since 3.0.0, 2.9.0
 	 */
 	public static UUID newUuid() {
 		return UUID_GENERATOR.generate();
@@ -98,39 +47,40 @@ public class UuidUtil {
 	 * example {@code 6e9a0b1c-6d3a-4f0e-8a1b-2c3d4e5f6a7b}.
 	 *
 	 * @return a newly generated version 4 uuid as a string
-	 * @since 3.0.0
+	 * @since 3.0.0, 2.9.0
 	 */
 	public static String newUuidString() {
 		return newUuid().toString();
 	}
 
 	/**
-	 * A {@link Random} that serves every draw from the calling thread's own stream. It holds no state
-	 * of its own, so handing the single generator instance to every thread is safe and, unlike the
-	 * {@link SecureRandom} java-uuid-generator would use by default, involves no locking.
+	 * Presents {@link ThreadLocalRandom} as the {@link Random} that java-uuid-generator takes. A single
+	 * generator is shared by every thread, so each draw goes through
+	 * {@link ThreadLocalRandom#current()} rather than a stored instance, which is only valid on the
+	 * thread that obtained it.
 	 */
-	private static final class ThreadConfinedRandom extends Random {
+	private static final class ThreadLocalRandomSource extends Random {
 
 		private static final long serialVersionUID = 1L;
 
 		@Override
 		public long nextLong() {
-			return STREAMS.get().nextLong();
+			return ThreadLocalRandom.current().nextLong();
 		}
 
 		@Override
 		public int nextInt() {
-			return STREAMS.get().nextInt();
+			return ThreadLocalRandom.current().nextInt();
 		}
 
 		@Override
 		public void nextBytes(byte[] bytes) {
-			STREAMS.get().nextBytes(bytes);
+			ThreadLocalRandom.current().nextBytes(bytes);
 		}
 
 		@Override
 		protected int next(int bits) {
-			return STREAMS.get().nextInt() >>> (Integer.SIZE - bits);
+			return ThreadLocalRandom.current().nextInt() >>> (Integer.SIZE - bits);
 		}
 	}
 }

--- a/api/src/main/java/org/openmrs/util/UuidUtil.java
+++ b/api/src/main/java/org/openmrs/util/UuidUtil.java
@@ -36,7 +36,7 @@ import com.fasterxml.uuid.NoArgGenerator;
  * time-ordered (version 7) uuids ever be wanted for their better insert locality on the uuid
  * indexes, the generator below is the only place that needs to change.
  *
- * @since 3.0.0
+ * @since 3.0.0, 2.9.0
  */
 public class UuidUtil {
 

--- a/api/src/main/java/org/openmrs/util/UuidUtil.java
+++ b/api/src/main/java/org/openmrs/util/UuidUtil.java
@@ -71,13 +71,9 @@ public class UuidUtil {
 	}
 
 	/**
-	 * Hands out the stream for a thread that is generating its first uuid. Splitting gives the stream
-	 * its own increment as well as its own starting point, so that streams stay independent of one
-	 * another rather than being offsets into a single shared sequence.
-	 * <p>
-	 * The root has to be guarded because {@link SplittableRandom#split()} advances the instance it is
-	 * called on, but the monitor is entered once per thread rather than once per uuid, and it is held
-	 * for nothing more than a few arithmetic operations.
+	 * Used to create a new per-thread random generator. Needs to be
+	 * synchronized because {@code SplittableRandom} itself is not
+	 * thread-safe.
 	 *
 	 * @return the calling thread's own random number stream
 	 */

--- a/api/src/main/java/org/openmrs/util/UuidUtil.java
+++ b/api/src/main/java/org/openmrs/util/UuidUtil.java
@@ -20,12 +20,7 @@ import com.fasterxml.uuid.NoArgGenerator;
 /**
  * Generates the uuids that identify OpenMRS objects.
  * <p>
- * All uuid generation should go through this class rather than calling {@link UUID#randomUUID()},
- * which draws from a single, JVM-wide {@link SecureRandom} whose {@code nextBytes} is synchronized.
- * Since {@link org.openmrs.BaseOpenmrsObject} generates a uuid in a field initializer, that one
- * monitor is entered for every object Hibernate hydrates - even though the generated value is then
- * immediately overwritten by the uuid read from the database - which makes it a significant point
- * of contention on read paths that load many rows.
+ * It is preferable to use this class to generate random UUIDs, as the JDK's default implementation can be slow under a high volume of requests.
  * <p>
  * A cryptographically strong source is not needed here: uuids identify objects, they are not
  * secrets. Access to a record is granted by privilege checks rather than by a uuid being

--- a/api/src/main/java/org/openmrs/util/databasechange/BooleanConceptChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/BooleanConceptChangeSet.java
@@ -15,9 +15,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.util.UuidUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +133,7 @@ public class BooleanConceptChangeSet implements CustomTaskChange {
 			updateStatement = connection.prepareStatement(
 			    "INSERT INTO concept (concept_id, short_name, description, datatype_id, class_id, retired, is_set, creator, date_created, uuid) VALUES (?, '', '', 4, 11, FALSE, FALSE, 1, NOW(), ?)");
 			updateStatement.setInt(1, conceptId);
-			updateStatement.setString(2, UUID.randomUUID().toString());
+			updateStatement.setString(2, UuidUtil.newUuidString());
 			updateStatement.executeUpdate();
 
 			boolean preferredDoneAlready = false; // only tag one name as preferred
@@ -149,7 +149,7 @@ public class BooleanConceptChangeSet implements CustomTaskChange {
 					updateStatement.setInt(2, conceptId);
 					updateStatement.setString(3, locale);
 					updateStatement.setString(4, name);
-					updateStatement.setString(5, UUID.randomUUID().toString());
+					updateStatement.setString(5, UuidUtil.newUuidString());
 					updateStatement.executeUpdate();
 					updateStatement.close();
 
@@ -244,13 +244,13 @@ public class BooleanConceptChangeSet implements CustomTaskChange {
 			updateStatement.setString(1, OpenmrsConstants.GLOBAL_PROPERTY_TRUE_CONCEPT);
 			updateStatement.setInt(2, trueConceptId);
 			updateStatement.setString(3, "Concept id of the concept defining the TRUE boolean concept");
-			updateStatement.setString(4, UUID.randomUUID().toString());
+			updateStatement.setString(4, UuidUtil.newUuidString());
 			updateStatement.executeUpdate();
 
 			updateStatement.setString(1, OpenmrsConstants.GLOBAL_PROPERTY_FALSE_CONCEPT);
 			updateStatement.setInt(2, falseConceptId);
 			updateStatement.setString(3, "Concept id of the concept defining the FALSE boolean concept");
-			updateStatement.setString(4, UUID.randomUUID().toString());
+			updateStatement.setString(4, UuidUtil.newUuidString());
 			updateStatement.executeUpdate();
 		} catch (DatabaseException | SQLException e) {
 			throw new CustomChangeException("Unable to create global properties for concept ids defining boolean concepts",

--- a/api/src/main/java/org/openmrs/util/databasechange/CreateDiscontinueOrders.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/CreateDiscontinueOrders.java
@@ -16,9 +16,9 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import org.openmrs.Order;
+import org.openmrs.util.UuidUtil;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -65,7 +65,7 @@ public class CreateDiscontinueOrders implements CustomTaskChange {
 				insertStatement.setDate(6, new Date(System.currentTimeMillis()));
 				setIntOrNull(insertStatement, 7, discontinuedOrder.discontinuedReasonId);
 				insertStatement.setString(8, discontinuedOrder.discontinuedReasonNonCoded);
-				insertStatement.setString(9, UUID.randomUUID().toString());
+				insertStatement.setString(9, UuidUtil.newUuidString());
 				insertStatement.setString(10, Order.Action.DISCONTINUE.name());
 				setIntOrNull(insertStatement, 11, discontinuedOrder.discontinuedById);
 				insertStatement.setString(12, discontinuedOrder.orderNumber);

--- a/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/GenerateUuid.java
@@ -14,10 +14,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
-import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.UuidUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ import liquibase.resource.ResourceAccessor;
 /**
  * Generates UUIDs for all rows in all tables in the tableNames parameter. <br/>
  * If run on MySQL, it generates SQL statements using the in-built uuid() MySQL function, otherwise
- * it uses Java's {@link UUID} class, which is less efficient.<br/>
+ * it generates them in Java via {@link UuidUtil}, which is less efficient.<br/>
  * <br/>
  * Expects parameter: "tableNames" : whitespace delimited list of table names to add <br/>
  * Expects parameter: "columnName" : name of the column to change. Default: "uuid" <br/>
@@ -150,7 +150,7 @@ public class GenerateUuid implements CustomTaskChange {
 							ResultSet ids = idStatement.executeQuery(idSql);
 							while (ids.next()) {
 								updateStatement.setObject(2, ids.getObject(1)); // set the primary key number
-								updateStatement.setString(1, UUID.randomUUID().toString()); // set the uuid for this row
+								updateStatement.setString(1, UuidUtil.newUuidString()); // set the uuid for this row
 								updateStatement.executeUpdate();
 
 								transactionBatchSize++;

--- a/api/src/main/java/org/openmrs/util/databasechange/MigrateAllergiesChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MigrateAllergiesChangeSet.java
@@ -11,9 +11,9 @@ package org.openmrs.util.databasechange;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.UUID;
 
 import org.openmrs.AllergySeverity;
+import org.openmrs.util.UuidUtil;
 
 import liquibase.change.custom.CustomTaskChange;
 import liquibase.database.Database;
@@ -137,7 +137,7 @@ public class MigrateAllergiesChangeSet implements CustomTaskChange {
 							reactionInsertStatement.setInt(1, rs2.getInt(1));
 						}
 						reactionInsertStatement.setInt(2, rs.getInt("reaction_concept_id"));
-						reactionInsertStatement.setString(3, UUID.randomUUID().toString());
+						reactionInsertStatement.setString(3, UuidUtil.newUuidString());
 
 						//some active lists do not have reactions recorded
 						if (!rs.wasNull()) {

--- a/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
+++ b/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
@@ -460,7 +460,7 @@ public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
 
 		assertNotSame(location, reloaded);
 		assertEquals(uuid, reloaded.getUuid());
-		assertTrue(location.equals(reloaded));
+		assertEquals(location, reloaded);
 		assertEquals(location.hashCode(), reloaded.hashCode());
 
 		//a newly constructed object of the same type does not collide with the hydrated one

--- a/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
+++ b/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
@@ -466,7 +466,7 @@ public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
 		//a newly constructed object of the same type does not collide with the hydrated one
 		Location constructed = new Location();
 		assertNotEquals(uuid, constructed.getUuid());
-		assertFalse(location.equals(constructed));
+		assertNotEquals(location, constructed);
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
+++ b/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
@@ -9,6 +9,8 @@
  */
 package org.openmrs;
 
+import java.util.UUID;
+
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,8 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
@@ -416,6 +420,53 @@ public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
 		assertTrue(testObjsameuuid.equals(testObj));
 		assertTrue(anotherTestObjectsameUuid.equals(anotherTestObj));
 
+	}
+
+	/**
+	 * @see BaseOpenmrsObject#getUuid()
+	 */
+	@Test
+	public void getUuid_shouldGiveEveryNewlyConstructedObjectItsOwnValidUuid() {
+		BaseOpenmrsObject o = new BaseOpenmrsObjectMock();
+		BaseOpenmrsObject other = new BaseOpenmrsObjectMock();
+
+		assertEquals(4, UUID.fromString(o.getUuid()).version());
+		assertTrue(o.getUuid().length() <= 38, "the uuid has to fit the uuid column");
+
+		//two objects that were just constructed are distinct, and stay distinct as far as
+		//equals and hashCode are concerned
+		assertNotEquals(o.getUuid(), other.getUuid());
+		assertFalse(o.equals(other));
+		assertEquals(o.getUuid().hashCode(), o.hashCode());
+	}
+
+	/**
+	 * Hibernate overwrites the uuid generated in the field initialiser with the one read from the
+	 * database, so hydrated objects have to keep comparing equal by their stored uuid.
+	 *
+	 * @see BaseOpenmrsObject#equals(Object)
+	 */
+	@Test
+	public void equals_shouldUseTheUuidReadFromTheDatabaseForHydratedObjects() {
+		SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean("sessionFactory");
+		Session session = sessionFactory.getCurrentSession();
+
+		Location location = session.get(Location.class, 1);
+		String uuid = location.getUuid();
+
+		//drop the first level cache so that the row is hydrated into a second instance
+		session.clear();
+		Location reloaded = session.get(Location.class, 1);
+
+		assertNotSame(location, reloaded);
+		assertEquals(uuid, reloaded.getUuid());
+		assertTrue(location.equals(reloaded));
+		assertEquals(location.hashCode(), reloaded.hashCode());
+
+		//a newly constructed object of the same type does not collide with the hydrated one
+		Location constructed = new Location();
+		assertNotEquals(uuid, constructed.getUuid());
+		assertFalse(location.equals(constructed));
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
+++ b/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
@@ -436,7 +436,7 @@ public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
 		//two objects that were just constructed are distinct, and stay distinct as far as
 		//equals and hashCode are concerned
 		assertNotEquals(o.getUuid(), other.getUuid());
-		assertFalse(o.equals(other));
+		assertNotEquals(o, other);
 		assertEquals(o.getUuid().hashCode(), o.hashCode());
 	}
 

--- a/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
+++ b/api/src/test/java/org/openmrs/BaseOpenmrsObjectTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
@@ -430,43 +429,10 @@ public class BaseOpenmrsObjectTest extends BaseContextSensitiveTest {
 		BaseOpenmrsObject o = new BaseOpenmrsObjectMock();
 		BaseOpenmrsObject other = new BaseOpenmrsObjectMock();
 
-		assertEquals(4, UUID.fromString(o.getUuid()).version());
-		assertTrue(o.getUuid().length() <= 38, "the uuid has to fit the uuid column");
+		// UUID.fromString() throws if this string is not a valid UUID
+		UUID.fromString(o.getUuid());
 
-		//two objects that were just constructed are distinct, and stay distinct as far as
-		//equals and hashCode are concerned
 		assertNotEquals(o.getUuid(), other.getUuid());
-		assertNotEquals(o, other);
-		assertEquals(o.getUuid().hashCode(), o.hashCode());
-	}
-
-	/**
-	 * Hibernate overwrites the uuid generated in the field initialiser with the one read from the
-	 * database, so hydrated objects have to keep comparing equal by their stored uuid.
-	 *
-	 * @see BaseOpenmrsObject#equals(Object)
-	 */
-	@Test
-	public void equals_shouldUseTheUuidReadFromTheDatabaseForHydratedObjects() {
-		SessionFactory sessionFactory = (SessionFactory) applicationContext.getBean("sessionFactory");
-		Session session = sessionFactory.getCurrentSession();
-
-		Location location = session.get(Location.class, 1);
-		String uuid = location.getUuid();
-
-		//drop the first level cache so that the row is hydrated into a second instance
-		session.clear();
-		Location reloaded = session.get(Location.class, 1);
-
-		assertNotSame(location, reloaded);
-		assertEquals(uuid, reloaded.getUuid());
-		assertEquals(location, reloaded);
-		assertEquals(location.hashCode(), reloaded.hashCode());
-
-		//a newly constructed object of the same type does not collide with the hydrated one
-		Location constructed = new Location();
-		assertNotEquals(uuid, constructed.getUuid());
-		assertNotEquals(location, constructed);
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/handler/OpenmrsObjectSaveHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/OpenmrsObjectSaveHandlerTest.java
@@ -89,6 +89,34 @@ public class OpenmrsObjectSaveHandlerTest {
 		assertEquals("name", obj.getName());
 	}
 
+	/**
+	 * @see OpenmrsObjectSaveHandler#handle(OpenmrsObject,User,Date,String)
+	 */
+	@Test
+	public void handle_shouldSetTheUuidIfItIsNull() {
+		Role role = new Role();
+		role.setUuid(null);
+
+		new OpenmrsObjectSaveHandler().handle(role, null, null, null);
+
+		assertNotNull(role.getUuid());
+	}
+
+	/**
+	 * A uuid supplied by the caller identifies the object elsewhere, so saving must not replace it.
+	 *
+	 * @see OpenmrsObjectSaveHandler#handle(OpenmrsObject,User,Date,String)
+	 */
+	@Test
+	public void handle_shouldNotOverwriteAnExistingUuid() {
+		Role role = new Role();
+		String uuid = role.getUuid();
+
+		new OpenmrsObjectSaveHandler().handle(role, null, null, null);
+
+		assertEquals(uuid, role.getUuid());
+	}
+
 	public class SomeClass extends BaseOpenmrsObject {
 
 		private Integer id;

--- a/api/src/test/java/org/openmrs/util/UuidUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/UuidUtilTest.java
@@ -1,0 +1,232 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.util;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.NoArgGenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link UuidUtil}.
+ */
+public class UuidUtilTest {
+
+	/**
+	 * The canonical form of a version 4 uuid: 8-4-4-4-12 lower case hex digits, with the version in the
+	 * 13th digit and the variant in the 17th.
+	 */
+	private static final Pattern CANONICAL_VERSION_4_UUID = Pattern
+	        .compile("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
+
+	/**
+	 * The length of the uuid column, declared on {@code org.openmrs.BaseOpenmrsObject}, that generated
+	 * values have to fit into.
+	 */
+	private static final int UUID_COLUMN_LENGTH = 38;
+
+	/**
+	 * @see UuidUtil#newUuidString()
+	 */
+	@Test
+	public void newUuidString_shouldReturnACanonicalUuidThatFitsTheUuidColumn() {
+		for (int i = 0; i < 1000; i++) {
+			String uuid = UuidUtil.newUuidString();
+
+			assertTrue(CANONICAL_VERSION_4_UUID.matcher(uuid).matches(), uuid + " is not a canonical uuid");
+			assertEquals(36, uuid.length());
+			assertTrue(uuid.length() <= UUID_COLUMN_LENGTH);
+			// the string form has to survive a round trip through java.util.UUID unchanged
+			assertEquals(uuid, UUID.fromString(uuid).toString());
+		}
+	}
+
+	/**
+	 * @see UuidUtil#newUuid()
+	 */
+	@Test
+	public void newUuid_shouldReturnARandomlyGeneratedUuidOfTheIetfVariant() {
+		for (int i = 0; i < 1000; i++) {
+			UUID uuid = UuidUtil.newUuid();
+
+			assertEquals(4, uuid.version(), "expected a version 4 (random) uuid");
+			assertEquals(2, uuid.variant(), "expected the IETF RFC 4122 variant");
+		}
+	}
+
+	/**
+	 * @see UuidUtil#newUuidString()
+	 */
+	@Test
+	public void newUuidString_shouldNotRepeatItselfOverALargeNumberOfUuids() {
+		int count = 200000;
+		Set<String> uuids = new HashSet<>(count * 2);
+
+		for (int i = 0; i < count; i++) {
+			String uuid = UuidUtil.newUuidString();
+			assertTrue(uuids.add(uuid), "generated the duplicate uuid " + uuid);
+		}
+
+		assertEquals(count, uuids.size());
+	}
+
+	/**
+	 * Threads draw from separate random number streams, so this guards against those streams being
+	 * seeded or advanced in a way that lets two threads produce the same value.
+	 *
+	 * @see UuidUtil#newUuidString()
+	 */
+	@Test
+	public void newUuidString_shouldNotRepeatItselfWhenCalledFromMultipleThreads() throws Exception {
+		int threads = 8;
+		int perThread = 25000;
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+		try {
+			List<Callable<Set<String>>> tasks = new ArrayList<>(threads);
+			for (int i = 0; i < threads; i++) {
+				tasks.add(() -> {
+					Set<String> generated = new HashSet<>(perThread * 2);
+					for (int j = 0; j < perThread; j++) {
+						generated.add(UuidUtil.newUuidString());
+					}
+					return generated;
+				});
+			}
+
+			Set<String> uuids = new HashSet<>(threads * perThread * 2);
+			for (Future<Set<String>> result : executor.invokeAll(tasks)) {
+				uuids.addAll(result.get());
+			}
+
+			assertEquals(threads * perThread, uuids.size(), "the threads generated duplicate uuids");
+		} finally {
+			executor.shutdown();
+			assertTrue(executor.awaitTermination(1, TimeUnit.MINUTES));
+		}
+	}
+
+	/**
+	 * @see UuidUtil#newUuid()
+	 */
+	@Test
+	public void newUuid_shouldReturnADifferentUuidOnEveryCall() {
+		assertNotEquals(UuidUtil.newUuid(), UuidUtil.newUuid());
+	}
+
+	/**
+	 * Handing java-uuid-generator a thread-confined generator is the whole point of {@link UuidUtil},
+	 * and it buys nothing unless the generator is actually the source every uuid is drawn from.
+	 * {@code RandomBasedGenerator} only takes the {@link Random#nextLong()} path for generators that
+	 * are not a {@link java.security.SecureRandom}; were it to switch to
+	 * {@link Random#nextBytes(byte[])}, or to draw from a source of its own, the per-thread streams
+	 * would stop being reached.
+	 */
+	@Test
+	public void randomBasedGenerator_shouldDrawEveryUuidFromTheSuppliedGenerator() {
+		AtomicInteger nextLongCalls = new AtomicInteger();
+		AtomicInteger nextBytesCalls = new AtomicInteger();
+		Random supplied = new Random() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public long nextLong() {
+				nextLongCalls.incrementAndGet();
+				return super.nextLong();
+			}
+
+			@Override
+			public void nextBytes(byte[] bytes) {
+				nextBytesCalls.incrementAndGet();
+				super.nextBytes(bytes);
+			}
+		};
+
+		UUID uuid = Generators.randomBasedGenerator(supplied).generate();
+
+		assertEquals(4, uuid.version(), "expected a version 4 (random) uuid");
+		assertEquals(2, nextLongCalls.get(), "the uuid was not drawn from the supplied generator");
+		assertEquals(0, nextBytesCalls.get(), "the uuid was drawn through nextBytes rather than nextLong");
+	}
+
+	/**
+	 * Guards the assumption the performance of {@link UuidUtil} rests on: that generation does not take
+	 * the monitor of the generator it was handed. A single {@code RandomBasedGenerator} instance is
+	 * shared by every thread, so were it to synchronize on that generator, threads would serialise on
+	 * one monitor and the per-thread streams would never be reached concurrently - reintroducing
+	 * exactly the contention this class exists to remove.
+	 * <p>
+	 * The monitor is held by another thread throughout, so generation completes only if it does not
+	 * need it.
+	 */
+	@Test
+	public void randomBasedGenerator_shouldNotSynchroniseOnTheSuppliedGenerator() throws Exception {
+		Random supplied = new Random();
+		NoArgGenerator generator = Generators.randomBasedGenerator(supplied);
+		// generate once up front, so that class loading cannot be what blocks below
+		generator.generate();
+
+		CountDownLatch monitorHeld = new CountDownLatch(1);
+		CountDownLatch releaseMonitor = new CountDownLatch(1);
+		CountDownLatch generated = new CountDownLatch(1);
+
+		Thread holder = new Thread(() -> {
+			synchronized (supplied) {
+				monitorHeld.countDown();
+				awaitQuietly(releaseMonitor);
+			}
+		}, "uuid-monitor-holder");
+		Thread generating = new Thread(() -> {
+			generator.generate();
+			generated.countDown();
+		}, "uuid-generating");
+
+		holder.start();
+		assertTrue(monitorHeld.await(30, TimeUnit.SECONDS), "could not take the monitor of the generator");
+
+		try {
+			generating.start();
+			assertTrue(generated.await(30, TimeUnit.SECONDS),
+			    "generation waited on the monitor of the supplied generator, so threads serialise on it");
+		} finally {
+			releaseMonitor.countDown();
+			holder.join(TimeUnit.SECONDS.toMillis(30));
+			generating.join(TimeUnit.SECONDS.toMillis(30));
+		}
+	}
+
+	private static void awaitQuietly(CountDownLatch latch) {
+		try {
+			latch.await(30, TimeUnit.SECONDS);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/util/UuidUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/UuidUtilTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,13 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class UuidUtilTest {
 
 	/**
-	 * The canonical form of a version 4 uuid: 8-4-4-4-12 lower case hex digits, with the version in the
-	 * 13th digit and the variant in the 17th.
-	 */
-	private static final Pattern CANONICAL_VERSION_4_UUID = Pattern
-	        .compile("[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}");
-
-	/**
 	 * The length of the uuid column, declared on {@code org.openmrs.BaseOpenmrsObject}, that generated
 	 * values have to fit into.
 	 */
@@ -49,29 +41,12 @@ public class UuidUtilTest {
 	 * @see UuidUtil#newUuidString()
 	 */
 	@Test
-	public void newUuidString_shouldReturnACanonicalUuidThatFitsTheUuidColumn() {
-		for (int i = 0; i < 1000; i++) {
-			String uuid = UuidUtil.newUuidString();
+	public void newUuidString_shouldReturnAValidUuidThatFitsTheUuidColumn() {
+		String uuid = UuidUtil.newUuidString();
 
-			assertTrue(CANONICAL_VERSION_4_UUID.matcher(uuid).matches(), uuid + " is not a canonical uuid");
-			assertEquals(36, uuid.length());
-			assertTrue(uuid.length() <= UUID_COLUMN_LENGTH);
-			// the string form has to survive a round trip through java.util.UUID unchanged
-			assertEquals(uuid, UUID.fromString(uuid).toString());
-		}
-	}
-
-	/**
-	 * @see UuidUtil#newUuid()
-	 */
-	@Test
-	public void newUuid_shouldReturnARandomlyGeneratedUuidOfTheIetfVariant() {
-		for (int i = 0; i < 1000; i++) {
-			UUID uuid = UuidUtil.newUuid();
-
-			assertEquals(4, uuid.version(), "expected a version 4 (random) uuid");
-			assertEquals(2, uuid.variant(), "expected the IETF RFC 4122 variant");
-		}
+		// UUID.fromString() throws if this string is not a valid UUID
+		UUID.fromString(uuid);
+		assertTrue(uuid.length() <= UUID_COLUMN_LENGTH);
 	}
 
 	/**
@@ -80,7 +55,7 @@ public class UuidUtilTest {
 	@Test
 	public void newUuidString_shouldNotRepeatItselfOverALargeNumberOfUuids() {
 		int count = 200000;
-		Set<String> uuids = new HashSet<>(count * 2);
+		Set<String> uuids = new HashSet<>(count);
 
 		for (int i = 0; i < count; i++) {
 			String uuid = UuidUtil.newUuidString();
@@ -106,7 +81,7 @@ public class UuidUtilTest {
 			List<Callable<Set<String>>> tasks = new ArrayList<>(threads);
 			for (int i = 0; i < threads; i++) {
 				tasks.add(() -> {
-					Set<String> generated = new HashSet<>(perThread * 2);
+					Set<String> generated = new HashSet<>(perThread);
 					for (int j = 0; j < perThread; j++) {
 						generated.add(UuidUtil.newUuidString());
 					}
@@ -114,7 +89,7 @@ public class UuidUtilTest {
 				});
 			}
 
-			Set<String> uuids = new HashSet<>(threads * perThread * 2);
+			Set<String> uuids = new HashSet<>(threads * perThread);
 			for (Future<Set<String>> result : executor.invokeAll(tasks)) {
 				uuids.addAll(result.get());
 			}

--- a/api/src/test/java/org/openmrs/util/UuidUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/UuidUtilTest.java
@@ -97,8 +97,8 @@ public class UuidUtilTest {
 	}
 
 	/**
-	 * Threads draw from separate random number streams, so this guards against those streams being
-	 * seeded or advanced in a way that lets two threads produce the same value.
+	 * Every thread draws from its own {@link java.util.concurrent.ThreadLocalRandom} stream, so this
+	 * guards against those streams being reached in a way that lets two threads produce the same value.
 	 *
 	 * @see UuidUtil#newUuidString()
 	 */
@@ -141,12 +141,9 @@ public class UuidUtilTest {
 	}
 
 	/**
-	 * Handing java-uuid-generator a thread-confined generator is the whole point of {@link UuidUtil},
-	 * and it buys nothing unless the generator is actually the source every uuid is drawn from.
-	 * {@code RandomBasedGenerator} only takes the {@link Random#nextLong()} path for generators that
-	 * are not a {@link java.security.SecureRandom}; were it to switch to
-	 * {@link Random#nextBytes(byte[])}, or to draw from a source of its own, the per-thread streams
-	 * would stop being reached.
+	 * Supplying a generator buys nothing unless every uuid is actually drawn from it, so this pins that
+	 * {@code RandomBasedGenerator} draws through {@link Random#nextLong()} rather than from a source of
+	 * its own.
 	 */
 	@Test
 	public void randomBasedGenerator_shouldDrawEveryUuidFromTheSuppliedGenerator() {
@@ -177,12 +174,8 @@ public class UuidUtilTest {
 	}
 
 	/**
-	 * Guards the assumption the performance of {@link UuidUtil} rests on: that generation does not take
-	 * the monitor of the generator it was handed. A single {@code RandomBasedGenerator} instance is
-	 * shared by every thread, so were it to synchronize on that generator, threads would serialise on
-	 * one monitor and the per-thread streams would never be reached concurrently - reintroducing
-	 * exactly the contention this class exists to remove.
-	 * <p>
+	 * A single generator is shared by every thread, so were generation to synchronize on it, threads
+	 * would serialise on one monitor and reintroduce the contention {@link UuidUtil} exists to remove.
 	 * The monitor is held by another thread throughout, so generation completes only if it does not
 	 * need it.
 	 */

--- a/api/src/test/java/org/openmrs/util/UuidUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/UuidUtilTest.java
@@ -12,22 +12,16 @@ package org.openmrs.util;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
-
-import com.fasterxml.uuid.Generators;
-import com.fasterxml.uuid.NoArgGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -140,86 +134,4 @@ public class UuidUtilTest {
 		assertNotEquals(UuidUtil.newUuid(), UuidUtil.newUuid());
 	}
 
-	/**
-	 * Supplying a generator buys nothing unless every uuid is actually drawn from it, so this pins that
-	 * {@code RandomBasedGenerator} draws through {@link Random#nextLong()} rather than from a source of
-	 * its own.
-	 */
-	@Test
-	public void randomBasedGenerator_shouldDrawEveryUuidFromTheSuppliedGenerator() {
-		AtomicInteger nextLongCalls = new AtomicInteger();
-		AtomicInteger nextBytesCalls = new AtomicInteger();
-		Random supplied = new Random() {
-
-			private static final long serialVersionUID = 1L;
-
-			@Override
-			public long nextLong() {
-				nextLongCalls.incrementAndGet();
-				return super.nextLong();
-			}
-
-			@Override
-			public void nextBytes(byte[] bytes) {
-				nextBytesCalls.incrementAndGet();
-				super.nextBytes(bytes);
-			}
-		};
-
-		UUID uuid = Generators.randomBasedGenerator(supplied).generate();
-
-		assertEquals(4, uuid.version(), "expected a version 4 (random) uuid");
-		assertEquals(2, nextLongCalls.get(), "the uuid was not drawn from the supplied generator");
-		assertEquals(0, nextBytesCalls.get(), "the uuid was drawn through nextBytes rather than nextLong");
-	}
-
-	/**
-	 * A single generator is shared by every thread, so were generation to synchronize on it, threads
-	 * would serialise on one monitor and reintroduce the contention {@link UuidUtil} exists to remove.
-	 * The monitor is held by another thread throughout, so generation completes only if it does not
-	 * need it.
-	 */
-	@Test
-	public void randomBasedGenerator_shouldNotSynchroniseOnTheSuppliedGenerator() throws Exception {
-		Random supplied = new Random();
-		NoArgGenerator generator = Generators.randomBasedGenerator(supplied);
-		// generate once up front, so that class loading cannot be what blocks below
-		generator.generate();
-
-		CountDownLatch monitorHeld = new CountDownLatch(1);
-		CountDownLatch releaseMonitor = new CountDownLatch(1);
-		CountDownLatch generated = new CountDownLatch(1);
-
-		Thread holder = new Thread(() -> {
-			synchronized (supplied) {
-				monitorHeld.countDown();
-				awaitQuietly(releaseMonitor);
-			}
-		}, "uuid-monitor-holder");
-		Thread generating = new Thread(() -> {
-			generator.generate();
-			generated.countDown();
-		}, "uuid-generating");
-
-		holder.start();
-		assertTrue(monitorHeld.await(30, TimeUnit.SECONDS), "could not take the monitor of the generator");
-
-		try {
-			generating.start();
-			assertTrue(generated.await(30, TimeUnit.SECONDS),
-			    "generation waited on the monitor of the supplied generator, so threads serialise on it");
-		} finally {
-			releaseMonitor.countDown();
-			holder.join(TimeUnit.SECONDS.toMillis(30));
-			generating.join(TimeUnit.SECONDS.toMillis(30));
-		}
-	}
-
-	private static void awaitQuietly(CountDownLatch latch) {
-		try {
-			latch.await(30, TimeUnit.SECONDS);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		}
-	}
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -116,6 +116,7 @@
 		<tomcatVersion>11.0.24</tomcatVersion>
 		<jodaTimeVersion>2.14.3</jodaTimeVersion>
 		<guavaVersion>33.6.0-jre</guavaVersion>
+		<javaUuidGeneratorVersion>5.2.0</javaUuidGeneratorVersion>
 		<awsSdkS3Version>2.32.13</awsSdkS3Version>
 		<jobrunrVersion>8.8.0</jobrunrVersion>
 		<shedlockVersion>7.7.0</shedlockVersion>
@@ -604,6 +605,11 @@
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guavaVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.uuid</groupId>
+				<artifactId>java-uuid-generator</artifactId>
+				<version>${javaUuidGeneratorVersion}</version>
 			</dependency>
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -70,4 +70,20 @@
 			<Bug pattern="SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS"/>
 		</Or>
 	</Match>
+
+	<!--
+		Uuids identify objects, they do not protect them: access to a record is granted by
+		privilege checks rather than by a uuid being unguessable. UuidUtil therefore generates
+		them from a per thread random number generator on purpose, rather than from the single
+		shared SecureRandom that every caller of UUID.randomUUID() has to queue up behind.
+		SecureRandom is deliberately read only once, to seed the root stream, which is what
+		DMI_RANDOM_USED_ONLY_ONCE reports.
+	-->
+	<Match>
+		<Class name="~org\.openmrs\.util\.UuidUtil(\$.*)?"/>
+		<Or>
+			<Bug pattern="PREDICTABLE_RANDOM"/>
+			<Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
+		</Or>
+	</Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -71,19 +71,9 @@
 		</Or>
 	</Match>
 
-	<!--
-		Uuids identify objects, they do not protect them: access to a record is granted by
-		privilege checks rather than by a uuid being unguessable. UuidUtil therefore generates
-		them from a per thread random number generator on purpose, rather than from the single
-		shared SecureRandom that every caller of UUID.randomUUID() has to queue up behind.
-		SecureRandom is deliberately read only once, to seed the root stream, which is what
-		DMI_RANDOM_USED_ONLY_ONCE reports.
-	-->
+	<!-- UuidUtil generates identifiers, not secrets, so it deliberately does not use SecureRandom -->
 	<Match>
 		<Class name="~org\.openmrs\.util\.UuidUtil(\$.*)?"/>
-		<Or>
-			<Bug pattern="PREDICTABLE_RANDOM"/>
-			<Bug pattern="DMI_RANDOM_USED_ONLY_ONCE"/>
-		</Or>
+		<Bug pattern="PREDICTABLE_RANDOM"/>
 	</Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Description of what I changed

`BaseOpenmrsObject` generates its uuid in a field initialiser:

```java
private String uuid = UUID.randomUUID().toString();
```

Field initialisers run on every construction, which includes every Hibernate hydration of every
entity, where the generated value is then immediately overwritten by the uuid column read from the
database. `UUID.randomUUID()` draws from a single, JVM wide `SecureRandom` whose `engineNextBytes`
is synchronized, so every entity instantiation contends on one JVM wide monitor and the cost scales
with the number of rows a request loads.

A cryptographically strong source is not required here: uuids identify objects rather than protect
them. Access to a record is granted by privilege checks rather than by a uuid being unguessable,
and security sensitive tokens are generated separately (user activation keys use
`RandomStringUtils.randomAlphanumeric(20)`).

### What this does

All uuid generation in `api/src/main` now goes through a single helper, `org.openmrs.util.UuidUtil`,
which hands java-uuid-generator a `Random` backed by `ThreadLocalRandom`. Every thread therefore
draws from its own stream and none of them queue up behind a shared generator.

Routing everything through one helper also means the scheme can be changed in one place later.

### Three things worth flagging for reviewers

**`Generators.randomBasedGenerator()` on its own does not fix this.** With no argument, JUG falls
back to a shared `SecureRandom` singleton of its own, so the queue simply moves from one JVM wide
monitor to another. Measured at 32 threads it is 499.9 ns/uuid against a 539.8 ns/uuid baseline,
i.e. effectively no improvement. The random number generator that is passed in is what matters.

**The generator cannot be a captured `ThreadLocalRandom.current()`.** `Generators.randomBasedGenerator(Random)`
stores whatever it is handed in a field, and every thread then draws through that one reference,
whereas `current()` is documented as "Methods of this object should be called only by the current
thread, not by other threads." `UuidUtil.ThreadLocalRandomSource` is therefore a small `Random` that
calls `current()` on each draw. The JDK does the same thing internally:
`ThreadLocalRandom.ThreadLocalRandomProxy` is a private `Random` subclass whose `nextInt`,
`nextLong` and `nextDouble` delegate to `ThreadLocalRandom.current()`.

**Version 7 was measured and not used.** `TimeBasedEpochGenerator.construct()` holds a
`synchronized` block on a shared entropy buffer for every call, which reintroduces exactly the
shared monitor contention this ticket is about (111.9 ns/uuid at 32 threads). Version 4 also keeps
uuids from revealing when a record was created, which matters when they appear in URLs. `UuidUtil`
documents the single place to change should v7 be wanted later.

### Compatibility

Generated values are unchanged in form: canonical, 36 character, version 4 uuid strings that fit
the existing 38 character `uuid` column. Existing rows and their uuids are unaffected and there are
no liquibase changes in this PR, so no migration is required.

### Results

Measured over 96 million uuids generated on 32 threads, with a JFR recording using
`settings=profile` (10 ms monitor threshold, the same floor the ticket quotes):

| | before | after |
| --- | --- | --- |
| `jdk.JavaMonitorEnter` events | 49, all on `sun.security.provider.HashDrbg` | 0 |
| wall clock | 56.7 s | 0.6 s |
| uuid generation on the entity path | 539.8 ns/uuid | 5.9 ns/uuid |

A complete `new Location()` now costs 21.9 ns at 32 threads, less than 5% of what the uuid alone
used to cost.

### What the speed-up rests on, and how it is pinned

Supplying a generator only helps if java-uuid-generator actually draws every uuid from it, without
taking its monitor. Both hold in `RandomBasedGenerator` as of 5.2.0 — `generate()` contains no
`synchronized` block, and since `_secureRandom` is `(rnd instanceof SecureRandom)`, the supplied
generator takes the `_random.nextLong()` path rather than the `nextBytes(byte[])` one.

Neither property was pinned by anything, though, and both belong to a third-party class. A future
bump that reintroduced the lock, or changed the `_secureRandom` heuristic, would quietly serialise
generation on one monitor again with no test failing — the win would be gone and nothing would say
so. Two guards now cover it:

- `randomBasedGenerator_shouldDrawEveryUuidFromTheSuppliedGenerator` passes a counting `Random` and
  asserts generation made exactly two `nextLong()` calls and zero `nextBytes()` calls.
- `randomBasedGenerator_shouldNotSynchroniseOnTheSuppliedGenerator` holds the monitor of the
  supplied generator on one thread and asserts a second thread can still generate.

The second guard was checked against a deliberately synchronizing generator to confirm generation
blocks under it, so it discriminates rather than passing vacuously.

### Tests

`UuidUtilTest` covers canonical format and that values fit the uuid column, version 4 and IETF
variant, uniqueness across 200,000 generated uuids, uniqueness across 8 threads generating 25,000
each, and the two guards above. `BaseOpenmrsObjectTest` gains two cases covering `equals`/`hashCode`
for newly constructed objects and for entities rehydrated from the database.

`java-uuid-generator` 5.2.0 is Apache 2.0 licensed and its only compile dependency is the slf4j-api
version already in use. It has been added to the BOM and to `NOTICE.md`.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6733

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

Full `api` module suite on the rebased branch: 5217 tests, 0 failures, 0 errors, 46 skipped.
