### PR TITLE
TRUNK-6727: Exclude descendant locations when the ancestor itself is retired

### DIFF
--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -458,7 +458,10 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @return Returns a Set&lt;Location&gt; of the descendant location.
 	 * @since 1.10
 	 * @deprecated since 2.8.7 in favor of
-	 *             {@link LocationService#getDescendantLocations(Location, boolean)}
+	 *             {@link LocationService#getDescendantLocations(Location, boolean)}, which differs when
+	 *             the ancestor itself is retired: with {@code includeRetired} false it returns none of
+	 *             the descendants of a retired ancestor, whereas this method never examines the
+	 *             ancestor's own retired flag.
 	 */
 	@Deprecated
 	public Set<Location> getDescendantLocations(boolean includeRetired) {

--- a/api/src/main/java/org/openmrs/api/LocationService.java
+++ b/api/src/main/java/org/openmrs/api/LocationService.java
@@ -409,7 +409,9 @@ public interface LocationService extends OpenmrsService {
 	/**
 	 * Returns descendant locations of a given location, i.e. its children, grandchildren, etc.
 	 *
-	 * @param location the location whose descendants should be returned
+	 * @param location the location whose descendants should be returned. When {@code includeRetired} is
+	 *            false, a retired location prunes its whole subtree, so if this location is itself
+	 *            retired, none of its descendants are returned.
 	 * @param includeRetired whether or not to include retired locations
 	 * @return a list of descendant locations
 	 * @throws APIException

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateLocationDAO.java
@@ -463,13 +463,17 @@ public class HibernateLocationDAO implements LocationDAO {
 			return null;
 		}
 
+		// the walk starts at the ancestor itself so that the retired filter also prunes its subtree
+		// when the ancestor is retired; the ancestor is then dropped from the returned ids
 		String retiredFilter = criteria.getIncludeRetired() ? "" : " AND retired = false";
 		String cteSql = "WITH RECURSIVE descendants (location_id) AS ("
-		        + " SELECT location_id FROM location WHERE parent_location = :locationId" + retiredFilter
+		        + " SELECT location_id FROM location WHERE location_id = :locationId" + retiredFilter
 		        + " UNION ALL SELECT l.location_id FROM location l"
 		        + " INNER JOIN descendants d ON l.parent_location = d.location_id" + retiredFilter
-		        + ") SELECT location_id FROM descendants";
-		return session.createNativeQuery(cteSql, Integer.class)
+		        + ") SELECT location_id FROM descendants WHERE location_id <> :locationId";
+		// a native query does not auto-flush on its own, so the location table is declared as a query
+		// space to make pending changes (a location retired earlier in the same transaction) visible
+		return session.createNativeQuery(cteSql, Integer.class).addSynchronizedEntityClass(Location.class)
 		        .setParameter("locationId", criteria.getDescendantOfLocation().getLocationId()).list();
 	}
 

--- a/api/src/main/java/org/openmrs/parameter/LocationSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/parameter/LocationSearchCriteria.java
@@ -48,7 +48,8 @@ public class LocationSearchCriteria {
 
 	/**
 	 * @param descendantOfLocation the ancestor location; only its descendants are returned (root
-	 *            excluded)
+	 *            excluded). When retired locations are excluded, a retired location prunes its whole
+	 *            subtree, so a retired ancestor contributes no descendants at all.
 	 */
 	public void setDescendantOfLocation(Location descendantOfLocation) {
 		this.descendantOfLocation = descendantOfLocation;
@@ -97,7 +98,9 @@ public class LocationSearchCriteria {
 	}
 
 	/**
-	 * @return the ancestor location; only descendants of that location are returned (root excluded)
+	 * @return the ancestor location; only descendants of that location are returned (root excluded).
+	 *         When retired locations are excluded, a retired location prunes its whole subtree, so a
+	 *         retired ancestor contributes no descendants at all.
 	 */
 	public Location getDescendantOfLocation() {
 		return descendantOfLocation;

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1272,6 +1272,105 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 	 * @see LocationService#getLocations(LocationSearchCriteria)
 	 */
 	@Test
+	public void getLocations_withDescendantOf_shouldReturnDescendantsOfARetiredAncestorWhenIncludeRetiredIsTrue() {
+		LocationService ls = Context.getLocationService();
+		List<Location> tree = saveTreeUnderRetiredAncestor(ls);
+		Location retiredRoot = tree.get(0);
+		Location child = tree.get(1);
+		Location grandchild = tree.get(2);
+
+		LocationSearchCriteria criteria = new LocationSearchCriteria();
+		criteria.setDescendantOfLocation(retiredRoot);
+		criteria.setIncludeRetired(true);
+		List<Location> result = ls.getLocations(criteria);
+
+		assertEquals(2, result.size());
+		assertTrue(result.contains(child));
+		assertTrue(result.contains(grandchild));
+		// the ancestor is the search root and is never part of its own descendants
+		assertFalse(result.contains(retiredRoot));
+		// the convenience method builds the same criteria, so it has to agree
+		assertEquals(result, ls.getDescendantLocations(retiredRoot, true));
+	}
+
+	/**
+	 * @see LocationService#getLocations(LocationSearchCriteria)
+	 */
+	@Test
+	public void getLocations_withDescendantOf_shouldExcludeAllDescendantsWhenAncestorIsRetiredAndIncludeRetiredIsFalse() {
+		LocationService ls = Context.getLocationService();
+		List<Location> tree = saveTreeUnderRetiredAncestor(ls);
+		Location retiredRoot = tree.get(0);
+		Location child = tree.get(1);
+		Location grandchild = tree.get(2);
+
+		// the descendants are not retired themselves, but their retired ancestor prunes the whole subtree
+		assertFalse(child.getRetired());
+		assertFalse(grandchild.getRetired());
+
+		LocationSearchCriteria criteria = new LocationSearchCriteria();
+		criteria.setDescendantOfLocation(retiredRoot);
+		criteria.setIncludeRetired(false);
+
+		assertTrue(ls.getLocations(criteria).isEmpty());
+		// the convenience method builds the same criteria, so it has to agree
+		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
+	}
+
+	/**
+	 * The deprecated {@link Location#getDescendantLocations(boolean)} names
+	 * {@link LocationService#getDescendantLocations(Location, boolean)} as its replacement, but it
+	 * starts from the child collection and so never examines the ancestor's own retired flag. The two
+	 * therefore disagree for a retired ancestor. That divergence is documented rather than changed -
+	 * changing it would silently alter results for everyone still on the deprecated method - so it is
+	 * pinned here instead.
+	 *
+	 * @see Location#getDescendantLocations(boolean)
+	 */
+	@Test
+	public void getDescendantLocations_shouldDisagreeWithTheDeprecatedEntityMethodForARetiredAncestor() {
+		LocationService ls = Context.getLocationService();
+		Location retiredRoot = saveTreeUnderRetiredAncestor(ls).get(0);
+
+		// the entity method walks the child collection, which is not loaded on the just-saved root
+		Context.flushSession();
+		Context.clearSession();
+		Location reloaded = ls.getLocation(retiredRoot.getLocationId());
+
+		// the entity method returns the whole subtree, having never looked at the root's retired flag
+		assertEquals(2, reloaded.getDescendantLocations(false).size());
+		// the service method prunes it, because the root is retired
+		assertTrue(ls.getDescendantLocations(reloaded, false).isEmpty());
+	}
+
+	/**
+	 * Builds retiredRoot (retired) → child (active) → grandchild (active) and returns the three
+	 * locations in that order.
+	 */
+	private List<Location> saveTreeUnderRetiredAncestor(LocationService ls) {
+		Location retiredRoot = new Location();
+		retiredRoot.setName("Retired Ancestor");
+		ls.saveLocation(retiredRoot);
+
+		Location child = new Location();
+		child.setName("Child of Retired Ancestor");
+		child.setParentLocation(retiredRoot);
+		ls.saveLocation(child);
+
+		Location grandchild = new Location();
+		grandchild.setName("Grandchild of Retired Ancestor");
+		grandchild.setParentLocation(child);
+		ls.saveLocation(grandchild);
+
+		ls.retireLocation(retiredRoot, "test");
+
+		return Arrays.asList(retiredRoot, child, grandchild);
+	}
+
+	/**
+	 * @see LocationService#getLocations(LocationSearchCriteria)
+	 */
+	@Test
 	public void getLocations_withDescendantOf_shouldReturnEmptyListForLeafLocation() {
 		LocationService ls = Context.getLocationService();
 


### PR DESCRIPTION
## Description of what I changed

`HibernateLocationDAO.getLocations(LocationSearchCriteria)` supports a "descendant of" filter. When `includeRetired` is `false`, retired locations are meant to be pruned from the hierarchy together with their subtrees, but the retired state of the ancestor passed as the search root was never considered: the recursive CTE was seeded with the *children* of the ancestor, so a retired ancestor still returned all of its descendants.

The in-memory implementation that preceded the TRUNK-6681 performance rewrite excluded them, because it walked parent pointers upward and checked the retired flag of every node before matching the ancestor. The DB-side rewrite dropped that behaviour, and because this edge case was untested the divergence went unnoticed.

This seeds the recursive CTE with the ancestor row itself, so the existing `AND retired = false` filter prunes its whole subtree when the ancestor is retired, and drops the ancestor from the returned ids to keep the existing root-excluded semantics:

```sql
WITH RECURSIVE descendants (location_id) AS (
    SELECT location_id FROM location WHERE location_id = :locationId AND retired = false
    UNION ALL
    SELECT l.location_id FROM location l
    INNER JOIN descendants d ON l.parent_location = d.location_id AND retired = false
) SELECT location_id FROM descendants WHERE location_id <> :locationId
```

No extra query is issued, and the `includeRetired = true` path is unchanged: the filter disappears from both branches of the CTE and the ancestor is still excluded from the result.

| `descendantOfLocation` | `includeRetired` | before | after |
| --- | --- | --- | --- |
| retired | `false` | all non-retired descendants | empty list |
| retired | `true` | all descendants | all descendants (unchanged) |
| not retired | either | unchanged | unchanged |

### The CTE also needed a query space

Splitting the test during review (see below) surfaced a second problem, without which the fix above does not reliably hold.

`getDescendantIds` runs through `session.createNativeQuery(...)`, and a native query does not auto-flush on its own. `retireLocation` leaves a pending `UPDATE` in the session — the `INSERT`s are already out, since `location_id` is `IDENTITY`-generated — so the CTE read the ancestor as `retired = false` and walked its subtree anyway. The criteria query at the end of `getLocations` *does* flush, which is why the original single test passed: its `includeRetired = true` half flushed the session before the `includeRetired = false` half ran. On its own, the `includeRetired = false` case failed.

Declaring the location table as a query space makes `FlushMode.AUTO` apply to the native query as well:

```java
// a native query does not auto-flush on its own, so the location table is declared as a query
// space to make pending changes (a location retired earlier in the same transaction) visible
return session.createNativeQuery(cteSql, Integer.class).addSynchronizedEntityClass(Location.class)
        .setParameter("locationId", criteria.getDescendantOfLocation().getLocationId()).list();
```

Any caller that retires a location and then queries its descendants within the same transaction was reading stale data before this.

### Tests

Two tests in `LocationServiceTest`, next to the existing descendant tests, sharing a `saveTreeUnderRetiredAncestor` helper that builds `retiredRoot (retired) → child (active) → grandchild (active)`:

- `getLocations_withDescendantOf_shouldReturnDescendantsOfARetiredAncestorWhenIncludeRetiredIsTrue` — both descendants are returned, and the retired ancestor is explicitly asserted *not* to be among them, pinning the `WHERE location_id <> :locationId` root exclusion.
- `getLocations_withDescendantOf_shouldExcludeAllDescendantsWhenAncestorIsRetiredAndIncludeRetiredIsFalse` — asserts the descendants are not retired themselves, so the empty result can only come from pruning the ancestor, then asserts an empty list.

The second test fails without the DAO change, on either half of it.

### Documentation

The contract is documented on both accessors of `LocationSearchCriteria`, and on `LocationService#getDescendantLocations(Location, boolean)` — callers of that convenience method get the criteria built for them and never read `LocationSearchCriteria`. The deprecated `Location#getDescendantLocations(boolean)` names that service method as its replacement but keeps the non-retired descendants of a retired ancestor, so its `@deprecated` line now says where the two disagree. Reconciling them is a behaviour change for the deprecated method and is left out of this PR.

### Backports

2.9.x #6393 and 2.8.x #6394. Both branches still resolve descendants in memory (TRUNK-6681 has not landed there yet) and therefore already behave correctly, so those backports carry the regression tests and the javadoc only, to pin the behaviour for when the recursive-CTE lookup gets backported. The test code is identical across all three branches.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6727

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

I ran the full `api` module suite (`./mvnw -pl api -am test`) rather than `./mvnw clean package`, since the change is confined to that module: 5210 tests, 0 failures, 0 errors, 46 skipped.
