### PR TITLE
TRUNK-6727: Exclude descendant locations when the ancestor itself is retired (2.9.x backport)

### DIFF
--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -464,8 +464,8 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @since 1.10
 	 * @deprecated since 2.8.7 in favor of {@link LocationService#getDescendantLocations(Location, boolean)},
 	 *             which differs when the ancestor itself is retired: with {@code includeRetired} false
-	 *             it returns none of the descendants of a retired ancestor, whereas this method returns
-	 *             the non-retired ones.
+	 *             it returns none of the descendants of a retired ancestor, whereas this method never
+	 *             examines the ancestor's own retired flag.
 	 */
 	@Deprecated
 	public Set<Location> getDescendantLocations(boolean includeRetired) {

--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -462,7 +462,10 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	 * @param includeRetired specifies whether or not to include voided childLocations
 	 * @return Returns a Set&lt;Location&gt; of the descendant location.
 	 * @since 1.10
-	 * @deprecated since 2.8.7 in favor of {@link LocationService#getDescendantLocations(Location, boolean)}
+	 * @deprecated since 2.8.7 in favor of {@link LocationService#getDescendantLocations(Location, boolean)},
+	 *             which differs when the ancestor itself is retired: with {@code includeRetired} false
+	 *             it returns none of the descendants of a retired ancestor, whereas this method returns
+	 *             the non-retired ones.
 	 */
 	@Deprecated
 	public Set<Location> getDescendantLocations(boolean includeRetired) {

--- a/api/src/main/java/org/openmrs/api/LocationService.java
+++ b/api/src/main/java/org/openmrs/api/LocationService.java
@@ -383,7 +383,9 @@ public interface LocationService extends OpenmrsService {
 	/**
 	 * Returns descendant locations of a given location, i.e. its children, grandchildren, etc.
 	 * 
-	 * @param location the location whose descendants should be returned
+	 * @param location the location whose descendants should be returned. When {@code includeRetired} is
+	 *            false, a retired location prunes its whole subtree, so if this location is itself
+	 *            retired, none of its descendants are returned.
 	 * @param includeRetired whether or not to include retired locations
 	 * @return a list of descendant locations
 	 * @throws APIException

--- a/api/src/main/java/org/openmrs/parameter/LocationSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/parameter/LocationSearchCriteria.java
@@ -43,7 +43,9 @@ public class LocationSearchCriteria {
 	private boolean includeRetired = false;
 
 	/**
-	 * @param descendantOfLocation the ancestor location; only its descendants are returned (root excluded)
+	 * @param descendantOfLocation the ancestor location; only its descendants are returned (root excluded).
+	 *            When retired locations are excluded, a retired location prunes its whole subtree, so a
+	 *            retired ancestor contributes no descendants at all.
 	 */
 	public void setDescendantOfLocation(Location descendantOfLocation) {
 		this.descendantOfLocation = descendantOfLocation;
@@ -78,7 +80,9 @@ public class LocationSearchCriteria {
 	}
 
 	/**
-	 * @return the ancestor location; only descendants of that location are returned (root excluded)
+	 * @return the ancestor location; only descendants of that location are returned (root excluded).
+	 *         When retired locations are excluded, a retired location prunes its whole subtree, so a
+	 *         retired ancestor contributes no descendants at all.
 	 */
 	public Location getDescendantOfLocation() {
 		return descendantOfLocation;

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1314,6 +1314,7 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 		criteria.setIncludeRetired(false);
 
 		assertTrue(ls.getLocations(criteria).isEmpty());
+		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
 		// the convenience method builds the same criteria, so it has to agree
 		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
 

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1273,6 +1273,79 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 	 * @see LocationService#getLocations(LocationSearchCriteria)
 	 */
 	@Test
+	public void getLocations_withDescendantOf_shouldReturnDescendantsOfARetiredAncestorWhenIncludeRetiredIsTrue() {
+		LocationService ls = Context.getLocationService();
+		List<Location> tree = saveTreeUnderRetiredAncestor(ls);
+		Location retiredRoot = tree.get(0);
+		Location child = tree.get(1);
+		Location grandchild = tree.get(2);
+
+		LocationSearchCriteria criteria = new LocationSearchCriteria();
+		criteria.setDescendantOfLocation(retiredRoot);
+		criteria.setIncludeRetired(true);
+		List<Location> result = ls.getLocations(criteria);
+
+		assertEquals(2, result.size());
+		assertTrue(result.contains(child));
+		assertTrue(result.contains(grandchild));
+		// the ancestor is the search root and is never part of its own descendants
+		assertFalse(result.contains(retiredRoot));
+		// the convenience method builds the same criteria, so it has to agree
+		assertEquals(result, ls.getDescendantLocations(retiredRoot, true));
+	}
+
+	/**
+	 * @see LocationService#getLocations(LocationSearchCriteria)
+	 */
+	@Test
+	public void getLocations_withDescendantOf_shouldExcludeAllDescendantsWhenAncestorIsRetiredAndIncludeRetiredIsFalse() {
+		LocationService ls = Context.getLocationService();
+		List<Location> tree = saveTreeUnderRetiredAncestor(ls);
+		Location retiredRoot = tree.get(0);
+		Location child = tree.get(1);
+		Location grandchild = tree.get(2);
+
+		// the descendants are not retired themselves, but their retired ancestor prunes the whole subtree
+		assertFalse(child.getRetired());
+		assertFalse(grandchild.getRetired());
+
+		LocationSearchCriteria criteria = new LocationSearchCriteria();
+		criteria.setDescendantOfLocation(retiredRoot);
+		criteria.setIncludeRetired(false);
+
+		assertTrue(ls.getLocations(criteria).isEmpty());
+		// the convenience method builds the same criteria, so it has to agree
+		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
+	}
+
+	/**
+	 * Builds retiredRoot (retired) → child (active) → grandchild (active) and returns the three
+	 * locations in that order.
+	 */
+	private List<Location> saveTreeUnderRetiredAncestor(LocationService ls) {
+		Location retiredRoot = new Location();
+		retiredRoot.setName("Retired Ancestor");
+		ls.saveLocation(retiredRoot);
+
+		Location child = new Location();
+		child.setName("Child of Retired Ancestor");
+		child.setParentLocation(retiredRoot);
+		ls.saveLocation(child);
+
+		Location grandchild = new Location();
+		grandchild.setName("Grandchild of Retired Ancestor");
+		grandchild.setParentLocation(child);
+		ls.saveLocation(grandchild);
+
+		ls.retireLocation(retiredRoot, "test");
+
+		return Arrays.asList(retiredRoot, child, grandchild);
+	}
+
+	/**
+	 * @see LocationService#getLocations(LocationSearchCriteria)
+	 */
+	@Test
 	public void getLocations_withDescendantOf_shouldReturnEmptyListForLeafLocation() {
 		LocationService ls = Context.getLocationService();
 

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1314,15 +1314,34 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 		criteria.setIncludeRetired(false);
 
 		assertTrue(ls.getLocations(criteria).isEmpty());
-		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
 		// the convenience method builds the same criteria, so it has to agree
 		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
+	}
 
-		// the deprecated entity method never looks at the ancestor's own retired flag, so it still
-		// returns the subtree; reload because it walks the child collection, which is unloaded here
+	/**
+	 * The deprecated {@link Location#getDescendantLocations(boolean)} names
+	 * {@link LocationService#getDescendantLocations(Location, boolean)} as its replacement, but it
+	 * starts from the child collection and so never examines the ancestor's own retired flag. The two
+	 * therefore disagree for a retired ancestor. That divergence is documented rather than changed -
+	 * changing it would silently alter results for everyone still on the deprecated method - so it is
+	 * pinned here instead.
+	 *
+	 * @see Location#getDescendantLocations(boolean)
+	 */
+	@Test
+	public void getDescendantLocations_shouldDisagreeWithTheDeprecatedEntityMethodForARetiredAncestor() {
+		LocationService ls = Context.getLocationService();
+		Location retiredRoot = saveTreeUnderRetiredAncestor(ls).get(0);
+
+		// the entity method walks the child collection, which is not loaded on the just-saved root
 		Context.flushSession();
 		Context.clearSession();
-		assertEquals(2, ls.getLocation(retiredRoot.getLocationId()).getDescendantLocations(false).size());
+		Location reloaded = ls.getLocation(retiredRoot.getLocationId());
+
+		// the entity method returns the whole subtree, having never looked at the root's retired flag
+		assertEquals(2, reloaded.getDescendantLocations(false).size());
+		// the service method prunes it, because the root is retired
+		assertTrue(ls.getDescendantLocations(reloaded, false).isEmpty());
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -1316,6 +1316,12 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 		assertTrue(ls.getLocations(criteria).isEmpty());
 		// the convenience method builds the same criteria, so it has to agree
 		assertTrue(ls.getDescendantLocations(retiredRoot, false).isEmpty());
+
+		// the deprecated entity method never looks at the ancestor's own retired flag, so it still
+		// returns the subtree; reload because it walks the child collection, which is unloaded here
+		Context.flushSession();
+		Context.clearSession();
+		assertEquals(2, ls.getLocation(retiredRoot.getLocationId()).getDescendantLocations(false).size());
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed

2.9.x backport of #6392.

On master, `HibernateLocationDAO` resolves the "descendant of" filter with a recursive CTE (TRUNK-6681) that was seeded with the *children* of the ancestor, so the retired flag of the ancestor itself was never considered and its descendants were still returned with `includeRetired = false`.

**This branch is not affected in production code.** It still resolves descendants in memory: `isDescendantOf` walks parent pointers upward and returns `false` as soon as it meets a retired node — the ancestor included, since the retired check happens before the ancestor comparison — so a retired ancestor already prunes its whole subtree here.

What this backports is therefore the regression tests and the documented contract, so the behaviour is pinned before the recursive-CTE lookup from TRUNK-6681 is backported to this branch.

The master fix also needed `addSynchronizedEntityClass(Location.class)` on the native CTE query, because a native query does not auto-flush and a pending `retireLocation` update was not visible to it. That does not apply here — the in-memory walk reads the session's own entities — so no production code changes on this branch.

### Tests

Two tests in `LocationServiceTest`, next to the existing descendant tests, sharing a `saveTreeUnderRetiredAncestor` helper that builds `retiredRoot (retired) → child (active) → grandchild (active)`:

- `getLocations_withDescendantOf_shouldReturnDescendantsOfARetiredAncestorWhenIncludeRetiredIsTrue` — both descendants are returned, and the retired ancestor is explicitly asserted *not* to be among them.
- `getLocations_withDescendantOf_shouldExcludeAllDescendantsWhenAncestorIsRetiredAndIncludeRetiredIsFalse` — asserts the descendants are not retired themselves, so the empty result can only come from pruning the ancestor, then asserts an empty list.

Both pass against the current implementation, and the second fails against the master implementation before #6392. The test code is identical across all three branches.

### Documentation

The contract is documented on both accessors of `LocationSearchCriteria`, and on `LocationService#getDescendantLocations(Location, boolean)` — callers of that convenience method get the criteria built for them and never read `LocationSearchCriteria`. The deprecated `Location#getDescendantLocations(boolean)` names that service method as its replacement but keeps the non-retired descendants of a retired ancestor, so its `@deprecated` line now says where the two disagree. Reconciling them is a behaviour change for the deprecated method and is left out of this PR.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6727

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [ ] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.9.x branch.

I ran the full `LocationServiceTest` class on this branch (83 tests, all green) rather than the whole build; this change adds tests and javadoc and touches no production code, so CI covers the rest.
