### PR TITLE
Set useHttpOnly to true for the session cookie

### DIFF
--- a/webapp/src/main/webapp/META-INF/context.xml
+++ b/webapp/src/main/webapp/META-INF/context.xml
@@ -10,7 +10,7 @@
     graphic logo is a trademark of OpenMRS Inc.
 
 -->
-<Context antiJARLocking="true" reloadable="false" useHttpOnly="false">
+<Context antiJARLocking="true" reloadable="false" useHttpOnly="true">
   <!-- <loader loaderClass="org.openmrs.web.OpenmrsWebClassLoader" useSystemClassLoaderAsParent="false"></loader> -->
   <!--<Resource name="jdbc/openmrs"
 			auth="Container"


### PR DESCRIPTION
### What

`webapp/src/main/webapp/META-INF/context.xml:13` ships with HttpOnly turned off on the session cookie:

```xml
<Context antiJARLocking="true" reloadable="false" useHttpOnly="false">
```

### Why it matters

With HttpOnly off, any script executing in the page can read `JSESSIONID` through `document.cookie`. That means a single XSS anywhere in the application escalates to session theft and account takeover, rather than being contained to whatever the injected script can do in that one request.

Tomcat has defaulted `useHttpOnly` to `true` since 7.x, so this context is explicitly opting out of the safer default. I could not find a comment, commit message, or prior issue explaining why, which suggests it may be a leftover rather than a deliberate choice. If it is deliberate and I have missed the reason, I am happy to close this.

### Compatibility

I grepped the repository for anything reading the session cookie client side (`document.cookie`, `JSESSIONID`) and found only a comment in `csrfguard.js` about stripping a rewritten `;JSESSIONID=` from a URL path, which is unaffected by this flag. So this should be a no-op functionally and purely a hardening change.

### Change

One attribute, `false` to `true`. Happy to file a TRUNK ticket for tracking if you would prefer that for a change this size, just let me know.

Spotted while running [ClearMap](https://github.com/Vantage-IO/clearmap), an open-source HIPAA technical-risk scanner I work on, across a set of healthcare codebases.