### PR TITLE
Make the openmrs-api surefire crash on 2.8.x explain itself

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,9 @@ permissions: read-all
 jobs:
   build:
     strategy:
+      # one crashing job used to cancel the rest, so a failure told us nothing about whether
+      # it was specific to a single Java version or hit the whole matrix
+      fail-fast: false
       matrix:
         platform:
           - ubuntu-latest
@@ -54,6 +57,45 @@ jobs:
         run: mvn clean install -DskipTests=true -D"maven.javadoc.skip"=true --batch-mode --show-version --file pom.xml
       - name: Build with Maven
         run: mvn clean install --batch-mode && mvn test -Pskip-default-test -Pintegration-test --batch-mode --file pom.xml
+      # The openmrs-api surefire fork has been dying with SIGABRT (exit code 134, "Aborted (core
+      # dumped)") partway through the suite while every test run so far reports zero failures.
+      # Surefire routes the JVM's own explanation for that to a .dumpstream file instead of the
+      # console ("Corrupted channel by directly writing to native stream"), and the runner is torn
+      # down before anyone can read it, which leaves the console log with no reason for the crash.
+      # Print those files and keep them so the next crash explains itself.
+      - name: Show test and JVM crash diagnostics
+        if: failure()
+        continue-on-error: true
+        shell: bash
+        run: |
+          echo "::group::Disk and memory"
+          df -h || true
+          free -m || true
+          echo "::endgroup::"
+          echo "::group::Surefire dump files"
+          find . \( -name '*.dumpstream' -o -name '*.dump' \) -print | while read -r f; do
+            echo "----- $f"
+            cat "$f" || true
+          done
+          echo "::endgroup::"
+          echo "::group::JVM fatal error logs"
+          find . \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -print | while read -r f; do
+            echo "----- $f"
+            head -n 120 "$f" || true
+          done
+          echo "::endgroup::"
+      - name: Upload test and JVM crash diagnostics
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: crash-diagnostics-${{ matrix.platform }}-java${{ matrix.java-version }}
+          path: |
+            **/target/surefire-reports/**
+            **/hs_err_pid*.log
+            **/replay_pid*.log
+          if-no-files-found: ignore
+          retention-days: 7
       # this is necessary to populate the environment variables for Coveralls properly
       - name: Set branch name and PR number
         id: refs

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,12 +87,13 @@ jobs:
           done || true
           echo "::endgroup::"
           echo "::group::JVM fatal error logs"
-          # the frame sections that name the triggering code sit well inside the first 400 lines
-          # (they ended at line 123 and 217 in the two crashes seen so far), while the dynamic
-          # library list and memory maps that would bloat the log start several hundred lines later
+          # stop at the dynamic library list, which is where the hundreds of lines of mappings and
+          # memory maps begin; everything that names the triggering code comes before it (the frame
+          # sections ended at line 123 and 217 in the two crashes seen so far). The 400 line cap is
+          # the backstop for a file that never reaches that marker.
           find . \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -print | while read -r f; do
             echo "----- $f"
-            head -n 400 "$f" || true
+            head -n 400 "$f" | sed -n '1,/^Dynamic libraries:/p' || true
           done || true
           echo "::endgroup::"
       # this one stays continue-on-error: it depends on the artifact service, and the step above has

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,33 +57,47 @@ jobs:
         run: mvn clean install -DskipTests=true -D"maven.javadoc.skip"=true --batch-mode --show-version --file pom.xml
       - name: Build with Maven
         run: mvn clean install --batch-mode && mvn test -Pskip-default-test -Pintegration-test --batch-mode --file pom.xml
-      # The openmrs-api surefire fork has been dying with SIGABRT (exit code 134, "Aborted (core
-      # dumped)") partway through the suite while every test run so far reports zero failures.
-      # Surefire routes the JVM's own explanation for that to a .dumpstream file instead of the
-      # console ("Corrupted channel by directly writing to native stream"), and the runner is torn
-      # down before anyone can read it, which leaves the console log with no reason for the crash.
-      # Print those files and keep them so the next crash explains itself.
+      # When a forked test JVM crashes rather than failing a test, surefire does not put the reason
+      # in the console log. It notices the JVM writing its own diagnostics straight to stdout
+      # ("Corrupted channel by directly writing to native stream") and diverts them to a .dumpstream
+      # file, which dies with the runner, so a red build shows an abort and zero test failures with
+      # nothing to explain it. That cost us several days on the July 2026 openmrs-api crashes
+      # (exit code 134); these steps exist so the next one explains itself.
+      #
+      # Deliberately not continue-on-error: the build has already failed by the time this runs, so
+      # letting a broken diagnostics script surface as a failed step costs nothing, and stops it
+      # from reporting success while quietly printing nothing.
       - name: Show test and JVM crash diagnostics
         if: failure()
-        continue-on-error: true
         shell: bash
         run: |
           echo "::group::Disk and memory"
           df -h || true
           free -m || true
           echo "::endgroup::"
+          # the trailing "|| true" on each pipeline matters: this step runs under -e -o pipefail,
+          # so a find that exits non-zero on a single unreadable directory would otherwise abort
+          # the step and take the sections below it with it
           echo "::group::Surefire dump files"
+          # a crashing JVM writes its abort message last, so show the tail; the full file is in
+          # the uploaded artifact
           find . \( -name '*.dumpstream' -o -name '*.dump' \) -print | while read -r f; do
-            echo "----- $f"
-            cat "$f" || true
-          done
+            echo "----- $f ($(wc -c <"$f") bytes)"
+            tail -c 50000 "$f" || true
+          done || true
           echo "::endgroup::"
           echo "::group::JVM fatal error logs"
+          # the frame sections that name the triggering code sit well inside the first 400 lines
+          # (they ended at line 123 and 217 in the two crashes seen so far), while the dynamic
+          # library list and memory maps that would bloat the log start several hundred lines later
           find . \( -name 'hs_err_pid*.log' -o -name 'replay_pid*.log' \) -print | while read -r f; do
             echo "----- $f"
-            head -n 120 "$f" || true
-          done
+            head -n 400 "$f" || true
+          done || true
           echo "::endgroup::"
+      # this one stays continue-on-error: it depends on the artifact service, and the step above has
+      # already put the same evidence in the log, so a transient upload failure is not worth
+      # confusing anyone over
       - name: Upload test and JVM crash diagnostics
         if: failure()
         continue-on-error: true
@@ -94,7 +108,9 @@ jobs:
             **/target/surefire-reports/**
             **/hs_err_pid*.log
             **/replay_pid*.log
-          if-no-files-found: ignore
+          # warn rather than ignore, so that if these paths ever stop matching we find out from the
+          # log instead of from an empty artifact the next time someone needs a crash dump
+          if-no-files-found: warn
           retention-days: 7
       # this is necessary to populate the environment variables for Coveralls properly
       - name: Set branch name and PR number


### PR DESCRIPTION
## Description of what I changed

Since 24 July the `openmrs-api` surefire fork has been aborting with `SIGABRT` (`Process Exit Code: 134`, `Aborted (core dumped)`) partway through the suite on 2.8.x, failing nearly every pull request against the branch (#6394, #6262, #6230, #6219 and the last two pushes to 2.8.x itself). Contributors have started pushing empty "re-run CI" commits to get around it.

Every test that ran passed, so the console log had nothing to point at:

```
[INFO] Running org.openmrs.liquibase.ChangeLogDetectiveTest
Aborted (core dumped)
[WARNING] Tests run: 1765, Failures: 0, Errors: 0, Skipped: 23
[WARNING] Corrupted channel by directly writing to native stream in forked JVM 1. See ... the dump file ....dumpstream
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
```

That "corrupted channel" warning is the JVM writing its own explanation for the abort to stdout. Surefire diverts it into a `.dumpstream` file instead of the console, and the runner is torn down before anyone can read it, so the one piece of evidence that identifies the cause was being discarded on every failure.

This PR keeps that evidence: on a failed build it prints the surefire dump files and any `hs_err_pid*.log` into the job log, uploads them with `target/surefire-reports` as a per-job artifact, and reports free disk and memory. It also sets `fail-fast: false`, because the first crashing job was cancelling the other four, so a red build could not show whether a crash was specific to one Java version.

Nothing here changes what gets built or tested; it is all gated on `if: failure()`.

## What the first run found

It worked, and the crash is no longer a mystery. **These are two different JVM bugs, not a test failure.**

`build (ubuntu-latest, 11)`, Temurin 11.0.31+11:

```
#  Internal Error (moduleEntry.cpp:263), pid=2394, tid=2395
#  guarantee(java_lang_Module::is_instance(module)) failed: The unnamed module for ClassLoader
#  jdk.internal.reflect.DelegatingClassLoader, is null or not an instance of java.lang.Module.
#  The class loader has not been initialized correctly.
```

with the crash reached through reflection accessor generation from Mockito's inline mock maker:

```
V  [libjvm.so+0xc1828a]  ModuleEntry::create_unnamed_module(ClassLoaderData*)+0xca
V  [libjvm.so+0xf139db]  Unsafe_DefineClass0+0x37b
J  jdk.internal.reflect.MethodAccessorGenerator.generate(...)
J  jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(...)
J  org.mockito.internal.util.reflection.ReflectionMemberAccessor$$Lambda$1524.newInstance()
j  org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.lambda$newInstance$4(...)
```

`build (ubuntu-latest, 8)`, Temurin 8.0.492-b09 — a C2 crash, on the compiler thread:

```
#  SIGSEGV (0xb) at pc=0x00007f07f4e0468d, pid=2414
#  Problematic frame:
#  V  [libjvm.so+0x40468d]  ciMemberName::get_vmtarget() const+0xad
Current thread: JavaThread "C2 CompilerThread0" daemon [_thread_in_vm]
```

And because the matrix no longer cancels itself, we can now see the shape of it:

| job | result |
| --- | --- |
| ubuntu-latest, Java 8 | **failure** — SIGSEGV in C2 |
| ubuntu-latest, Java 11 | **failure** — `moduleEntry.cpp` guarantee |
| ubuntu-latest, Java 17 | success |
| ubuntu-latest, Java 21 | success |
| windows-latest, Java 8 | success |

Two things worth recording, because both are tempting wrong turns:

- **It is not a JDK upgrade.** The last green run on 23 July used the *same* builds, Temurin 11.0.31-11 and 8.0.492-9. Nor is it the runner image bump: that run had its Java 8 job on the newer `ubuntu24/20260720.247` image and passed. The crash is intermittent, which is also why the failure rate looked like it started on a particular day.
- **It does not reproduce off the runners.** The full api suite passes locally on Java 11 with identical fork arguments (`-Xmx1g`, same JaCoCo agent), 5116 tests, and open files, threads and mapped regions stay flat, so it is not resource accumulation.

The leading lead for a fix is that the two failing jobs are exactly the ones on the old test toolchain. `mockitoVersion` is 3.12.4 with `byteBuddyVersion` 1.12.18 for Java below 17, against Mockito 5.6.0 and Byte Buddy 1.17.6 for 17 and up, and `api` forces `mock-maker-inline`, whose class generation is where the Java 11 crash lands. That correlation is not the whole story, since `windows-latest, 8` uses the old toolchain and passes, so I would rather test a toolchain bump against this now-reliable reproduction than assume it.

## Issue I worked on

No Jira issue yet; happy to file one if we would rather track it there.

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. CI-only change, so verified by extracting the step's script straight out of the workflow and running it under GitHub's exact shell (`bash --noprofile --norc -e -o pipefail`) against the real `hs_err` and `.dumpstream` files this PR captured, with a deliberately unreadable directory in the tree. It exits 0, still surfaces `find`'s own errors, and prints the Mockito frame that identifies the crash in 487 lines with no memory-map bloat; the first version of the script exits 1 and prints no fatal error log at all.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.8.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
