### PR TITLE
TRUNK-6734: Batch-fetch Patient.identifiers so patient search does not issue one query per result

### DIFF
--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Patient.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Patient.hbm.xml
@@ -50,7 +50,8 @@
 		<!-- bi-directional one-to-many association to PatientIdentifier -->
 		<!-- list is unsorted due so that its put into a LinkedHashSet which uses .hashcode() instead of .compareTo() -->
 		<set name="identifiers" lazy="true" cascade="all-delete-orphan"
-			table="patient_identifier" inverse="true" sort="natural">
+			table="patient_identifier" inverse="true" sort="natural" batch-size="1000">
+			<cache usage="read-write"/>
 			<key not-null="true" column="patient_id" />
 			<one-to-many class="PatientIdentifier" />
 		</set>

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Patient.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Patient.hbm.xml
@@ -51,7 +51,6 @@
 		<!-- list is unsorted due so that its put into a LinkedHashSet which uses .hashcode() instead of .compareTo() -->
 		<set name="identifiers" lazy="true" cascade="all-delete-orphan"
 			table="patient_identifier" inverse="true" sort="natural" batch-size="1000">
-			<cache usage="read-write"/>
 			<key not-null="true" column="patient_id" />
 			<one-to-many class="PatientIdentifier" />
 		</set>

--- a/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
@@ -57,7 +57,7 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		Statistics stats = sessionFactory.getStatistics();
 		stats.clear();
 
-		// Search for "Batch" patients (504, 505, 506, 507) - 4 patients
+		// Search for "Batch" patients (7004, 7005, 7006, 7007) - 4 patients
 		List<Patient> patients = patientService.getPatients("Batch", null, null, false);
 		assertEquals(4, patients.size(), "Should find all 4 Batch patients");
 
@@ -76,8 +76,8 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		executeDataSet(IDENTIFIERS_DATASET);
 		updateSearchIndex();
 
-		Patient patient = patientService.getPatient(501);
-		assertNotNull(patient, "Patient 501 should exist");
+		Patient patient = patientService.getPatient(7001);
+		assertNotNull(patient, "Patient 7001 should exist");
 		assertEquals("NoIdent", patient.getGivenName());
 		assertNotNull(patient.getIdentifiers(), "Identifiers collection should not be null");
 		assertTrue(patient.getIdentifiers().isEmpty(), "Patient with no identifiers should have empty set");
@@ -91,8 +91,8 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		executeDataSet(IDENTIFIERS_DATASET);
 		updateSearchIndex();
 
-		Patient patient = patientService.getPatient(502);
-		assertNotNull(patient, "Patient 502 should exist");
+		Patient patient = patientService.getPatient(7002);
+		assertNotNull(patient, "Patient 7002 should exist");
 		assertEquals("Single", patient.getGivenName());
 		assertEquals(1, patient.getIdentifiers().size(), "Patient should have exactly 1 identifier");
 
@@ -111,8 +111,8 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		executeDataSet(IDENTIFIERS_DATASET);
 		updateSearchIndex();
 
-		Patient patient = patientService.getPatient(503);
-		assertNotNull(patient, "Patient 503 should exist");
+		Patient patient = patientService.getPatient(7003);
+		assertNotNull(patient, "Patient 7003 should exist");
 		assertEquals("Multi", patient.getGivenName());
 
 		// getIdentifiers() returns all (3 total: 2 non-voided + 1 voided)
@@ -144,28 +144,24 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * Verifies that identifier ordering follows natural ordering (PatientIdentifier's compareTo).
-	 * Uses getActiveIdentifiers() to get only non-voided identifiers in natural order.
-	 * Natural order: voided (false first), then preferred (true first), then dateCreated, then type, then identifier.
+	 * Verifies that the mapped collection comes back in PatientIdentifier's natural order:
+	 * non-voided first, then preferred ascending (Boolean.compareTo puts false before true),
+	 * then dateCreated, then type, then identifier.
 	 */
 	@Test
 	public void getPatient_shouldReturnIdentifiersInNaturalOrder() {
 		executeDataSet(IDENTIFIERS_DATASET);
 		updateSearchIndex();
 
-		Patient patient = patientService.getPatient(503);
+		Patient patient = patientService.getPatient(7003);
 		assertNotNull(patient);
 
-		// getActiveIdentifiers() returns non-voided identifiers in natural order
-		PatientIdentifier[] identifiers = patient.getActiveIdentifiers().toArray(new PatientIdentifier[0]);
-		assertEquals(2, identifiers.length);
+		PatientIdentifier[] identifiers = patient.getIdentifiers().toArray(new PatientIdentifier[0]);
+		assertEquals(3, identifiers.length);
 
-		// Natural order: preferred=true comes before preferred=false
-		// ID-503-B (preferred=true) comes before ID-503-A (preferred=false)
-		assertEquals("ID-503-B", identifiers[0].getIdentifier(),
-		    "First identifier should be ID-503-B (preferred=true comes first)");
-		assertEquals("ID-503-A", identifiers[1].getIdentifier(),
-		    "Second identifier should be ID-503-A (preferred=false comes second)");
+		assertEquals("ID-503-A", identifiers[0].getIdentifier());
+		assertEquals("ID-503-B", identifiers[1].getIdentifier());
+		assertEquals("ID-503-C-VOIDED", identifiers[2].getIdentifier());
 	}
 
 	/**
@@ -177,7 +173,7 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		updateSearchIndex();
 
 		// Patient with multiple identifiers, preferred is ID-503-B
-		Patient patient = patientService.getPatient(503);
+		Patient patient = patientService.getPatient(7003);
 		assertNotNull(patient);
 		PatientIdentifier preferred = patient.getPatientIdentifier();
 		assertNotNull(preferred, "Preferred identifier should not be null");
@@ -185,14 +181,14 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		    "getPatientIdentifier() should return the preferred identifier");
 
 		// Patient with single identifier
-		Patient singlePatient = patientService.getPatient(502);
+		Patient singlePatient = patientService.getPatient(7002);
 		assertNotNull(singlePatient);
 		PatientIdentifier singlePreferred = singlePatient.getPatientIdentifier();
 		assertNotNull(singlePreferred, "Single identifier patient should have a preferred identifier");
 		assertEquals("ID-502-A", singlePreferred.getIdentifier());
 
 		// Patient with no identifiers
-		Patient noIdPatient = patientService.getPatient(501);
+		Patient noIdPatient = patientService.getPatient(7001);
 		assertNotNull(noIdPatient);
 		assertNull(noIdPatient.getPatientIdentifier(),
 		    "Patient with no identifiers should return null from getPatientIdentifier()");
@@ -215,7 +211,7 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 			totalIdentifiers += p.getIdentifiers().size();
 		}
 
-		// Patient 504: 1 identifier, Patient 505: 2 identifiers, Patient 506: 0, Patient 507: 1
+		// Patient 7004: 1 identifier, Patient 7005: 2 identifiers, Patient 7006: 0, Patient 7007: 1
 		assertEquals(4, totalIdentifiers,
 		    "Total non-voided identifiers across all Batch patients should be 4");
 	}

--- a/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
@@ -1,0 +1,233 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tests for Patient.identifiers batch-fetching behavior. Verifies that loading a page of patients
+ * issues a bounded number of queries for identifiers instead of one per patient.
+ */
+public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
+
+	private static final String IDENTIFIERS_DATASET = "org/openmrs/api/include/PatientServiceTest-identifiers.xml";
+
+	@Autowired
+	private PatientService patientService;
+
+	private SessionFactory sessionFactory;
+
+	@BeforeEach
+	public void setup() {
+		sessionFactory = (SessionFactory) applicationContext.getBean("sessionFactory");
+	}
+
+	/**
+	 * Verifies that hydrating a page of N patients issues a bounded number of queries for
+	 * identifiers, rather than one per patient. Before the batch-size fix, each patient's
+	 * identifiers collection was initialized separately, producing N identifier selects.
+	 */
+	@Test
+	public void getPatients_shouldLoadIdentifiersInBoundedNumberOfQueries() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		Statistics stats = sessionFactory.getStatistics();
+		stats.setStatisticsEnabled(true);
+		stats.clear();
+
+		// Search for "Batch" patients (504, 505, 506, 507) - 4 patients
+		List<Patient> patients = patientService.getPatients("Batch", null, null, false);
+		assertEquals(4, patients.size(), "Should find all 4 Batch patients");
+
+		// Count queries to patient_identifier table
+		long identifierQueries = 0;
+		String[] queries = stats.getQueries();
+		for (String query : queries) {
+			if (query.contains("patient_identifier")) {
+				identifierQueries += stats.getQueryStatistics(query).getExecutionCount();
+			}
+		}
+
+		// With batch-size="1000", all 4 patients' identifiers should load in 1 query
+		// (or 0 if cached). Without the fix, this would be 4 queries.
+		assertTrue(identifierQueries <= 1,
+		    "Expected at most 1 batched identifier query for 4 patients, but got " + identifierQueries);
+
+		stats.setStatisticsEnabled(false);
+	}
+
+	/**
+	 * Verifies that a patient with zero identifiers loads correctly and returns an empty set.
+	 */
+	@Test
+	public void getPatient_shouldHandlePatientWithZeroIdentifiers() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		Patient patient = patientService.getPatient(501);
+		assertNotNull(patient, "Patient 501 should exist");
+		assertEquals("NoIdent", patient.getGivenName());
+		assertNotNull(patient.getIdentifiers(), "Identifiers collection should not be null");
+		assertTrue(patient.getIdentifiers().isEmpty(), "Patient with no identifiers should have empty set");
+	}
+
+	/**
+	 * Verifies that a patient with exactly one identifier loads correctly.
+	 */
+	@Test
+	public void getPatient_shouldHandlePatientWithOneIdentifier() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		Patient patient = patientService.getPatient(502);
+		assertNotNull(patient, "Patient 502 should exist");
+		assertEquals("Single", patient.getGivenName());
+		assertEquals(1, patient.getIdentifiers().size(), "Patient should have exactly 1 identifier");
+
+		PatientIdentifier identifier = patient.getIdentifiers().iterator().next();
+		assertEquals("ID-502-A", identifier.getIdentifier());
+		assertTrue(identifier.getPreferred(), "The single identifier should be preferred");
+	}
+
+	/**
+	 * Verifies that a patient with several identifiers loads all identifiers.
+	 * Note: getIdentifiers() returns both voided and non-voided; getActiveIdentifiers() returns
+	 * only non-voided.
+	 */
+	@Test
+	public void getPatient_shouldHandlePatientWithSeveralIdentifiers() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		Patient patient = patientService.getPatient(503);
+		assertNotNull(patient, "Patient 503 should exist");
+		assertEquals("Multi", patient.getGivenName());
+
+		// getIdentifiers() returns all (3 total: 2 non-voided + 1 voided)
+		assertEquals(3, patient.getIdentifiers().size(),
+		    "Patient should have 3 total identifiers (including voided)");
+
+		// getActiveIdentifiers() returns only non-voided (2)
+		assertEquals(2, patient.getActiveIdentifiers().size(),
+		    "Patient should have 2 active (non-voided) identifiers");
+
+		boolean foundA = false;
+		boolean foundB = false;
+		boolean foundVoided = false;
+		for (PatientIdentifier pi : patient.getIdentifiers()) {
+			if ("ID-503-A".equals(pi.getIdentifier())) {
+				foundA = true;
+				assertFalse(pi.getPreferred(), "Identifier A should not be preferred");
+			} else if ("ID-503-B".equals(pi.getIdentifier())) {
+				foundB = true;
+				assertTrue(pi.getPreferred(), "Identifier B should be preferred");
+			} else if ("ID-503-C-VOIDED".equals(pi.getIdentifier())) {
+				foundVoided = true;
+				assertTrue(pi.getVoided(), "Identifier C should be voided");
+			}
+		}
+		assertTrue(foundA, "Should contain identifier ID-503-A");
+		assertTrue(foundB, "Should contain identifier ID-503-B");
+		assertTrue(foundVoided, "Should contain voided identifier ID-503-C-VOIDED");
+	}
+
+	/**
+	 * Verifies that identifier ordering follows natural ordering (PatientIdentifier's compareTo).
+	 * Uses getActiveIdentifiers() to get only non-voided identifiers in natural order.
+	 * Natural order: voided (false first), then preferred (true first), then dateCreated, then type, then identifier.
+	 */
+	@Test
+	public void getPatient_shouldReturnIdentifiersInNaturalOrder() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		Patient patient = patientService.getPatient(503);
+		assertNotNull(patient);
+
+		// getActiveIdentifiers() returns non-voided identifiers in natural order
+		PatientIdentifier[] identifiers = patient.getActiveIdentifiers().toArray(new PatientIdentifier[0]);
+		assertEquals(2, identifiers.length);
+
+		// Natural order: preferred=true comes before preferred=false
+		// ID-503-B (preferred=true) comes before ID-503-A (preferred=false)
+		assertEquals("ID-503-B", identifiers[0].getIdentifier(),
+		    "First identifier should be ID-503-B (preferred=true comes first)");
+		assertEquals("ID-503-A", identifiers[1].getIdentifier(),
+		    "Second identifier should be ID-503-A (preferred=false comes second)");
+	}
+
+	/**
+	 * Verifies that Patient.getPatientIdentifier() returns the preferred identifier.
+	 */
+	@Test
+	public void getPatientIdentifier_shouldReturnPreferredIdentifier() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		// Patient with multiple identifiers, preferred is ID-503-B
+		Patient patient = patientService.getPatient(503);
+		assertNotNull(patient);
+		PatientIdentifier preferred = patient.getPatientIdentifier();
+		assertNotNull(preferred, "Preferred identifier should not be null");
+		assertEquals("ID-503-B", preferred.getIdentifier(),
+		    "getPatientIdentifier() should return the preferred identifier");
+
+		// Patient with single identifier
+		Patient singlePatient = patientService.getPatient(502);
+		assertNotNull(singlePatient);
+		PatientIdentifier singlePreferred = singlePatient.getPatientIdentifier();
+		assertNotNull(singlePreferred, "Single identifier patient should have a preferred identifier");
+		assertEquals("ID-502-A", singlePreferred.getIdentifier());
+
+		// Patient with no identifiers
+		Patient noIdPatient = patientService.getPatient(501);
+		assertNotNull(noIdPatient);
+		assertNull(noIdPatient.getPatientIdentifier(),
+		    "Patient with no identifiers should return null from getPatientIdentifier()");
+	}
+
+	/**
+	 * Verifies that batch loading works correctly when fetching multiple patients at once,
+	 * confirming the identifiers for all patients are loaded.
+	 */
+	@Test
+	public void getPatients_shouldLoadAllIdentifiersForBatchOfPatients() {
+		executeDataSet(IDENTIFIERS_DATASET);
+		updateSearchIndex();
+
+		List<Patient> patients = patientService.getPatients("Batch", null, null, false);
+		assertEquals(4, patients.size());
+
+		int totalIdentifiers = 0;
+		for (Patient p : patients) {
+			totalIdentifiers += p.getIdentifiers().size();
+		}
+
+		// Patient 504: 1 identifier, Patient 505: 2 identifiers, Patient 506: 0, Patient 507: 1
+		assertEquals(4, totalIdentifiers,
+		    "Total non-voided identifiers across all Batch patients should be 4");
+	}
+}

--- a/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientIdentifierBatchLoadTest.java
@@ -55,28 +55,17 @@ public class PatientIdentifierBatchLoadTest extends BaseContextSensitiveTest {
 		updateSearchIndex();
 
 		Statistics stats = sessionFactory.getStatistics();
-		stats.setStatisticsEnabled(true);
 		stats.clear();
 
 		// Search for "Batch" patients (504, 505, 506, 507) - 4 patients
 		List<Patient> patients = patientService.getPatients("Batch", null, null, false);
 		assertEquals(4, patients.size(), "Should find all 4 Batch patients");
 
-		// Count queries to patient_identifier table
-		long identifierQueries = 0;
-		String[] queries = stats.getQueries();
-		for (String query : queries) {
-			if (query.contains("patient_identifier")) {
-				identifierQueries += stats.getQueryStatistics(query).getExecutionCount();
-			}
-		}
+		// hydrate the identifiers for the whole page to trigger collection initialization
+		patients.forEach(p -> p.getIdentifiers().size());
 
-		// With batch-size="1000", all 4 patients' identifiers should load in 1 query
-		// (or 0 if cached). Without the fix, this would be 4 queries.
-		assertTrue(identifierQueries <= 1,
-		    "Expected at most 1 batched identifier query for 4 patients, but got " + identifierQueries);
-
-		stats.setStatisticsEnabled(false);
+		assertEquals(1, stats.getCollectionStatistics("org.openmrs.Patient.identifiers").getFetchCount(),
+		    "a page of patients should load its identifiers in one batched select");
 	}
 
 	/**

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-identifiers.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-identifiers.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <!-- Patient with zero identifiers -->
+  <person person_id="501" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000501"/>
+  <person_name person_name_id="501" preferred="true" person_id="501" given_name="NoIdent" middle_name=" " family_name="Patient" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000501"/>
+  <patient patient_id="501" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+
+  <!-- Patient with one identifier -->
+  <person person_id="502" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000502"/>
+  <person_name person_name_id="502" preferred="true" person_id="502" given_name="Single" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000502"/>
+  <patient patient_id="502" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="501" patient_id="502" identifier="ID-502-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000501"/>
+
+  <!-- Patient with several identifiers (3 identifiers, one preferred, one voided) -->
+  <person person_id="503" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000503"/>
+  <person_name person_name_id="503" preferred="true" person_id="503" given_name="Multi" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000503"/>
+  <patient patient_id="503" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="502" patient_id="503" identifier="ID-503-A" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000502"/>
+  <patient_identifier patient_identifier_id="503" patient_id="503" identifier="ID-503-B" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-02 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000503"/>
+  <patient_identifier patient_identifier_id="504" patient_id="503" identifier="ID-503-C-VOIDED" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-03 00:00:00.0" voided="true" void_reason="test" uuid="c0000000-0000-0000-0000-000000000504"/>
+
+  <!-- Additional patients to ensure batch loading works across multiple patients -->
+  <person person_id="504" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000504"/>
+  <person_name person_name_id="504" preferred="true" person_id="504" given_name="Batch" middle_name=" " family_name="Patient1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000504"/>
+  <patient patient_id="504" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="505" patient_id="504" identifier="ID-504-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000505"/>
+
+  <person person_id="505" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000505"/>
+  <person_name person_name_id="505" preferred="true" person_id="505" given_name="Batch" middle_name=" " family_name="Patient2" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000505"/>
+  <patient patient_id="505" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="506" patient_id="505" identifier="ID-505-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000506"/>
+  <patient_identifier patient_identifier_id="507" patient_id="505" identifier="ID-505-B" identifier_type="2" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000507"/>
+
+  <person person_id="506" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000506"/>
+  <person_name person_name_id="506" preferred="true" person_id="506" given_name="Batch" middle_name=" " family_name="Patient3" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000506"/>
+  <patient patient_id="506" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+
+  <person person_id="507" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000507"/>
+  <person_name person_name_id="507" preferred="true" person_id="507" given_name="Batch" middle_name=" " family_name="Patient4" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000507"/>
+  <patient patient_id="507" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="508" patient_id="507" identifier="ID-507-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000508"/>
+</dataset>

--- a/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-identifiers.xml
+++ b/api/src/test/resources/org/openmrs/api/include/PatientServiceTest-identifiers.xml
@@ -12,42 +12,42 @@
 -->
 <dataset>
   <!-- Patient with zero identifiers -->
-  <person person_id="501" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000501"/>
-  <person_name person_name_id="501" preferred="true" person_id="501" given_name="NoIdent" middle_name=" " family_name="Patient" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000501"/>
-  <patient patient_id="501" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <person person_id="7001" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007001"/>
+  <person_name person_name_id="7001" preferred="true" person_id="7001" given_name="NoIdent" middle_name=" " family_name="Patient" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007001"/>
+  <patient patient_id="7001" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
 
   <!-- Patient with one identifier -->
-  <person person_id="502" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000502"/>
-  <person_name person_name_id="502" preferred="true" person_id="502" given_name="Single" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000502"/>
-  <patient patient_id="502" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="501" patient_id="502" identifier="ID-502-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000501"/>
+  <person person_id="7002" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007002"/>
+  <person_name person_name_id="7002" preferred="true" person_id="7002" given_name="Single" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007002"/>
+  <patient patient_id="7002" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="7101" patient_id="7002" identifier="ID-502-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007101"/>
 
   <!-- Patient with several identifiers (3 identifiers, one preferred, one voided) -->
-  <person person_id="503" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000503"/>
-  <person_name person_name_id="503" preferred="true" person_id="503" given_name="Multi" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000503"/>
-  <patient patient_id="503" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="502" patient_id="503" identifier="ID-503-A" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000502"/>
-  <patient_identifier patient_identifier_id="503" patient_id="503" identifier="ID-503-B" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-02 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000503"/>
-  <patient_identifier patient_identifier_id="504" patient_id="503" identifier="ID-503-C-VOIDED" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-03 00:00:00.0" voided="true" void_reason="test" uuid="c0000000-0000-0000-0000-000000000504"/>
+  <person person_id="7003" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007003"/>
+  <person_name person_name_id="7003" preferred="true" person_id="7003" given_name="Multi" middle_name=" " family_name="Ident" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007003"/>
+  <patient patient_id="7003" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="7102" patient_id="7003" identifier="ID-503-A" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007102"/>
+  <patient_identifier patient_identifier_id="7103" patient_id="7003" identifier="ID-503-B" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-02 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007103"/>
+  <patient_identifier patient_identifier_id="7104" patient_id="7003" identifier="ID-503-C-VOIDED" identifier_type="1" preferred="0" location_id="1" creator="1" date_created="2026-01-03 00:00:00.0" voided="true" void_reason="test" uuid="c0000000-0000-0000-0000-000000007104"/>
 
   <!-- Additional patients to ensure batch loading works across multiple patients -->
-  <person person_id="504" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000504"/>
-  <person_name person_name_id="504" preferred="true" person_id="504" given_name="Batch" middle_name=" " family_name="Patient1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000504"/>
-  <patient patient_id="504" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="505" patient_id="504" identifier="ID-504-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000505"/>
+  <person person_id="7004" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007004"/>
+  <person_name person_name_id="7004" preferred="true" person_id="7004" given_name="Batch" middle_name=" " family_name="Patient1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007004"/>
+  <patient patient_id="7004" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="7105" patient_id="7004" identifier="ID-504-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007105"/>
 
-  <person person_id="505" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000505"/>
-  <person_name person_name_id="505" preferred="true" person_id="505" given_name="Batch" middle_name=" " family_name="Patient2" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000505"/>
-  <patient patient_id="505" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="506" patient_id="505" identifier="ID-505-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000506"/>
-  <patient_identifier patient_identifier_id="507" patient_id="505" identifier="ID-505-B" identifier_type="2" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000507"/>
+  <person person_id="7005" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007005"/>
+  <person_name person_name_id="7005" preferred="true" person_id="7005" given_name="Batch" middle_name=" " family_name="Patient2" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007005"/>
+  <patient patient_id="7005" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="7106" patient_id="7005" identifier="ID-505-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007106"/>
+  <patient_identifier patient_identifier_id="7107" patient_id="7005" identifier="ID-505-B" identifier_type="2" preferred="0" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007107"/>
 
-  <person person_id="506" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000506"/>
-  <person_name person_name_id="506" preferred="true" person_id="506" given_name="Batch" middle_name=" " family_name="Patient3" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000506"/>
-  <patient patient_id="506" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <person person_id="7006" gender="F" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007006"/>
+  <person_name person_name_id="7006" preferred="true" person_id="7006" given_name="Batch" middle_name=" " family_name="Patient3" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007006"/>
+  <patient patient_id="7006" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
 
-  <person person_id="507" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000000507"/>
-  <person_name person_name_id="507" preferred="true" person_id="507" given_name="Batch" middle_name=" " family_name="Patient4" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000000507"/>
-  <patient patient_id="507" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="508" patient_id="507" identifier="ID-507-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000000508"/>
+  <person person_id="7007" gender="M" dead="false" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="a0000000-0000-0000-0000-000000007007"/>
+  <person_name person_name_id="7007" preferred="true" person_id="7007" given_name="Batch" middle_name=" " family_name="Patient4" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="b0000000-0000-0000-0000-000000007007"/>
+  <patient patient_id="7007" creator="1" date_created="2026-01-01 00:00:00.0" voided="false"/>
+  <patient_identifier patient_identifier_id="7108" patient_id="7007" identifier="ID-507-A" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2026-01-01 00:00:00.0" voided="false" uuid="c0000000-0000-0000-0000-000000007108"/>
 </dataset>


### PR DESCRIPTION

<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

I added batch-size="1000" to Patient.identifiers in Patient.hbm.xml, matching the existing configuration for Person.names, Person.addresses, and Person.attributes. This resolves the N+1 identifier query issue during patient search (previously causing 50 additional SELECT queries for a 50-patient page) without changing query results, ordering, or preferred-identifier logic. I also added PatientIdentifierBatchLoadTest with 7 tests, along with a supporting test dataset, to verify query counts, identifier-count edge cases, and voided/preferred-identifier behavior.

The second-level cache configuration originally included in the acceptance criteria was dropped from this PR (#6400) because second-level cache is not consistently enabled across all deployments. The batch-size change alone addresses the N+1 query issue.






## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
https://openmrs.atlassian.net/browse/TRUNK-6734

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

