### PR TITLE
Stop the JVM aborting the openmrs-api test fork on Java 8 and 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1162,6 +1162,37 @@
 				<byteBuddyVersion>1.17.6</byteBuddyVersion>
 			</properties>
 		</profile>
+
+		<!-- Temurin 11.0.31 aborts the VM part way through the openmrs-api suite with
+		 "Internal Error (moduleEntry.cpp:263)",
+		 "guarantee(java_lang_Module::is_instance(module)) failed: The unnamed module for ClassLoader
+		 jdk.internal.reflect.DelegatingClassLoader, is null or not an instance of java.lang.Module".
+		 Every test passes; the JVM itself dies, so the build fails with exit code 134 and no test
+		 failures to point at.
+
+		 The crash needs the JDK to inflate a reflective accessor: once a reflective member has been
+		 invoked more than sun.reflect.inflationThreshold times (15 by default), the JDK generates a
+		 bytecode accessor and defines it into a DelegatingClassLoader, and creating that loader's
+		 unnamed module is what trips the guarantee. Mockito's inline mock maker reaches it while
+		 instantiating mocks, so a suite that creates thousands of mocks in one fork hits it.
+
+		 Raising the threshold out of reach keeps reflection on the native accessor for the whole run,
+		 so no accessor is ever generated and the crashing path is never entered. Verified on Temurin
+		 11 with -verbose:class: by default jdk.internal.reflect.GeneratedConstructorAccessor1 is
+		 defined via __JVM_DefineClass__, and with this set it never is.
+
+		 Java 17 and later do not hit this, so the workaround stays on the JDKs that do. Drop it once
+		 2.8.x no longer builds on Java 8 and 11, or once the JDKs ship a fix.
+		 -->
+		<profile>
+			<id>reflection-inflation-vm-crash-workaround</id>
+			<activation>
+				<jdk>(,17)</jdk>
+			</activation>
+			<properties>
+				<customArgLineForTesting>-Dsun.reflect.inflationThreshold=2147483647</customArgLineForTesting>
+			</properties>
+		</profile>
 	</profiles>
 
 	<reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -1181,8 +1181,24 @@
 		 11 with -verbose:class: by default jdk.internal.reflect.GeneratedConstructorAccessor1 is
 		 defined via __JVM_DefineClass__, and with this set it never is.
 
-		 Java 17 and later do not hit this, so the workaround stays on the JDKs that do. Drop it once
-		 2.8.x no longer builds on Java 8 and 11, or once the JDKs ship a fix.
+		 It also clears a second, separate crash on Temurin 8, where C2 dies with SIGSEGV in
+		 ciMemberName::get_vmtarget() while inlining a MethodHandle call
+		 (CallGenerator::for_method_handle_inline). That one reproduces deterministically: the api
+		 suite aborted at the same test class twice without this property and completed twice with it.
+		 The likely reason it helps is indirect rather than the same mechanism as above. Inflation
+		 defines a fresh accessor class per reflective member, so ConstructorAccessor.newInstance sees
+		 many receiver types and goes megamorphic; without it there is only
+		 NativeConstructorAccessorImpl. That changes what C2 chooses to inline around the neighbouring
+		 lambda call sites, and this JIT bug only shows up for some inlining shapes. Treat that as
+		 inference; the repeatable before-and-after is the evidence.
+
+		 Java 17 and later hit neither crash, so the workaround stays on the JDKs that do. Drop it once
+		 2.8.x no longer builds on Java 8 and 11, or once the JDKs ship fixes.
+
+		 Upgrading the test toolchain is not an alternative: with Mockito 4.11.0 and Byte Buddy 1.17.6
+		 the accessor generation is unchanged (231 generated constructor accessors over the same test
+		 selection, versus 231 on 3.12.4), Mockito still selects ReflectionMemberAccessor, and Java 8
+		 still crashes at the same place.
 		 -->
 		<profile>
 			<id>reflection-inflation-vm-crash-workaround</id>


### PR DESCRIPTION
## Description of what I changed

Since 24 July the `openmrs-api` surefire fork has been aborting part way through the suite on 2.8.x, which fails nearly every pull request against the branch (#6394, #6262, #6230, #6219, and the last two pushes to 2.8.x itself). Every test that ran passed, so the build reported `Process Exit Code: 134` with no test failures to point at, and contributors have been pushing empty "re-run CI" commits to get around it.

#6399 makes CI keep the JVM's own crash log, and with that the Java 11 failure is no longer a mystery:

```
#  Internal Error (moduleEntry.cpp:263), pid=2394, tid=2395
#  guarantee(java_lang_Module::is_instance(module)) failed: The unnamed module for ClassLoader
#  jdk.internal.reflect.DelegatingClassLoader, is null or not an instance of java.lang.Module.
#  The class loader has not been initialized correctly.
# JRE version: OpenJDK Runtime Environment Temurin-11.0.31+11
```

reached like this:

```
V  [libjvm.so+0xc1828a]  ModuleEntry::create_unnamed_module(ClassLoaderData*)+0xca
V  [libjvm.so+0x61eb86]  ClassLoaderDataGraph::add(Handle, bool)+0x216
V  [libjvm.so+0xf139db]  Unsafe_DefineClass0+0x37b
J  jdk.internal.reflect.MethodAccessorGenerator.generate(...)
J  jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(...)
J  org.mockito.internal.util.reflection.ReflectionMemberAccessor$$Lambda$1524.newInstance()
j  org.mockito.internal.creation.bytebuddy.InlineDelegateByteBuddyMockMaker.lambda$newInstance$4(...)
```

The crash needs the JDK to **inflate a reflective accessor**. Once a reflective member has been invoked more than `sun.reflect.inflationThreshold` times (15 by default), the JDK stops using the native accessor, generates a bytecode accessor, and defines it into a `jdk.internal.reflect.DelegatingClassLoader` — and creating that loader's unnamed module is what trips the guarantee. Mockito's inline mock maker reaches that path while instantiating a mock, so a suite creating thousands of mocks in one fork gets there reliably.

Raising the threshold out of reach keeps reflection on the native accessor for the whole run, so no accessor is ever generated and the crashing path is never entered.

I checked that rather than assuming it. On Temurin 11 with `-verbose:class`, reflectively invoking a constructor 200 times:

```
default:                    [class,load] jdk.internal.reflect.GeneratedConstructorAccessor1 source: __JVM_DefineClass__
inflationThreshold=MAX:     (never defined)
```

`__JVM_DefineClass__` is the same `Unsafe_DefineClass0` → `JVM_DefineClass` frame that appears in the crash stack, so this is the path being removed, not a proxy for it.

The workaround is scoped with `<jdk>(,17)</jdk>`, mirroring how the existing `mockito` profile uses `[17, )`, so it lands only on the JVMs that carry the bug and disappears when 2.8.x stops building on Java 8 and 11. Verified that the profile activates on 8 and 11 and not on 17 or 21 (using the `mockito` profile as a control), and that the resolved `argLine` gains the flag on Java 11 and not on 21.

## Results

Three full runs of the matrix in CI, all five jobs green each time, plus repeat runs of the api suite locally on both old JDKs. The two jobs that were failing, on the same JDK builds that were crashing:

| | Java 8 | Java 11 |
| --- | --- | --- |
| before, in CI | failed 2 of 3 runs | failed 3 of 3 runs |
| with this change, in CI | 3 of 3 pass | 3 of 3 pass |
| before, locally | crashed 2 of 2 runs, same test class each time | passes |
| with this change, locally | 2 of 2 pass | passes |

Every pass ran the whole suite, `Tests run: 5116, Failures: 0, Errors: 0, Skipped: 54`, with no `Process Exit Code: 134`, no `Aborted (core dumped)` and no `hs_err` file, so none of them passed by doing less work. Runtime is unchanged, which matters given #6377.

### Java 11

Confident. It failed every run before, its fatal error log names the code path, and the `-verbose:class` check above shows that path is no longer entered.

### Java 8

This is a **second and different bug**, which the same property also clears:

```
#  SIGSEGV (0xb) at pc=..., pid=2414
#  Problematic frame:
#  V  [libjvm.so+0x40468d]  ciMemberName::get_vmtarget() const+0xad
Current thread: JavaThread "C2 CompilerThread0" daemon [_thread_in_vm]

ciMemberName::get_vmtarget()
CallGenerator::for_method_handle_inline(JVMState*, ciMethod*, ciMethod*, bool&)
CallGenerator::for_method_handle_call(...)
Compile::call_generator(...)  ->  Parse::do_call()
```

C2 is inlining a MethodHandle call and reading a `MemberName`'s `vmtarget` off a bad pointer. In CI this only failed 2 runs in 3, which is too noisy to conclude anything from, and I initially wrote this PR saying it did **not** address Java 8. It reproduces deterministically outside CI though, aborting at the same test class each time, and there the before-and-after is clean: two crashes without the property, two full passes with it. That is what changed my mind.

Why a reflection property affects a JIT bug is **inference, not something I have proven**. Inflation defines a fresh accessor class per reflective member, so `ConstructorAccessor.newInstance` sees many receiver types and goes megamorphic; without it there is only `NativeConstructorAccessorImpl`. That changes what C2 chooses to inline around the neighbouring lambda call sites, and this bug only appears for some inlining shapes. The repeatable before-and-after is the evidence; the story is only a plausible reason for it.

### Upgrading the test toolchain is not an alternative

Worth recording, since it is the obvious next thing to reach for. With Mockito 4.11.0 and Byte Buddy 1.17.6 in place of 3.12.4 and 1.12.18, over the same test selection on Java 11:

| | Mockito 3.12.4 + BB 1.12.18 | Mockito 4.11.0 + BB 1.17.6 |
| --- | --- | --- |
| `GeneratedConstructorAccessor` defined | 231 | 231 |
| `__JVM_DefineClass__` defines | 919 | 931 |
| accessor Mockito selects | `ReflectionMemberAccessor` | `ReflectionMemberAccessor` |

Unchanged, and Java 8 still crashes at the same place with the newer toolchain, so the exposure is not a function of the Mockito version. 4.11.0 is also the ceiling while 2.8.x supports Java 8, since Mockito 5 is compiled to class file version 55.

## Issue I worked on

No Jira issue yet; happy to file one if we would rather track it there. Related: #6399, which is what produced the diagnosis.

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. This changes a JVM flag for the test fork rather than product code, so the verification is the `-verbose:class` check above (the generated accessor is defined by default and never defined with the flag), plus the profile-activation and `argLine` checks, plus a full `openmrs-api` run on Temurin 11.
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the 2.8.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
