### PR TITLE
Move the Java 8 and 11 test toolchain off Mockito 3.12.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1147,10 +1147,12 @@
 			</properties>
 		</profile>
 		
-		<!-- When using mockito-core:3.12.4 with Java 17, we get the following error.
-		 java.lang.NullPointerException: Cannot read the array length because "this.buf" is null
-		 mockito-core:5.6.0 does not support Java 8.
-		 So this profile is required
+		<!-- Mockito has to be split by JDK: 5.x does not run on Java 8 (its classes are class file
+		 version 55), and older Mockito on Java 17 fails with
+		 java.lang.NullPointerException: Cannot read the array length because "this.buf" is null.
+		 So Java 8 and 11 get the newest line that still targets Java 8, and 17 and later get 5.x.
+		 Byte Buddy needs no such split: it is compiled to class file version 49, so one version
+		 serves every JDK we build on.
 		 -->
 		<profile>
 			<id>mockito</id>
@@ -1159,7 +1161,6 @@
 			</activation>
 			<properties>
 				<mockitoVersion>5.6.0</mockitoVersion>
-				<byteBuddyVersion>1.17.6</byteBuddyVersion>
 			</properties>
 		</profile>
 	</profiles>
@@ -1244,8 +1245,10 @@
 		<aspectjVersion>1.9.24</aspectjVersion>
 		<jacksonVersion>2.19.1</jacksonVersion>
 		<junitVersion>5.11.4</junitVersion>
-		<byteBuddyVersion>1.12.18</byteBuddyVersion>
-		<mockitoVersion>3.12.4</mockitoVersion>
+		<byteBuddyVersion>1.17.6</byteBuddyVersion>
+		<!-- 4.11.0 is the last Mockito that still targets Java 8 (its classes are version 52; 5.x is
+		 version 55 and will not load on 8). Java 17 and later move to 5.6.0 in the mockito profile. -->
+		<mockitoVersion>4.11.0</mockitoVersion>
 		<hamcrestVersion>3.0</hamcrestVersion>
 
 		<slf4jVersion>1.7.36</slf4jVersion>


### PR DESCRIPTION
## Description of what I changed

The Java 8 and 11 test toolchain is still on Mockito 3.12.4 (2021) and Byte Buddy 1.12.18 (2022), while Java 17 and later already run 5.6.0 and 1.17.6. This brings the older JDKs up to the newest Mockito that still targets Java 8, and removes the Byte Buddy split.

- `mockitoVersion` 3.12.4 → **4.11.0** for Java 8 and 11. That is the ceiling while 2.8.x supports Java 8: 4.11.0's classes are class file version 52, 5.x are version 55 and will not load on Java 8. Java 17 and later keep 5.6.0.
- `byteBuddyVersion` 1.12.18 → **1.17.6** for every JDK, and no longer overridden in the `mockito` profile. Byte Buddy is compiled to class file version 49, so one version serves Java 8 through 21 and the split was never needed.

The resolved configuration on Java 17 and 21 is **unchanged** — 5.6.0 with 1.17.6, exactly as today — so only Java 8 and 11 move.

No test changes were needed. Nothing in the test code uses anything Mockito 4 removed: no `verifyZeroInteractions`, no `org.mockito.Matchers`, no `InstantiatorProvider`, no `stubVoid`, no `anyObject`. The whole Mockito surface is 34 files, one of which uses `mockStatic`.

Verified locally:

| | Java 8 | Java 11 | Java 21 |
| --- | --- | --- | --- |
| resolves to | 4.11.0 / 1.17.6 | 4.11.0 / 1.17.6 | 5.6.0 / 1.17.6 (unchanged) |
| `test-compile` | passes | passes | — |
| full `openmrs-api` suite | see below | 5116 tests, 0 failures | — |

## Please read before merging: this is currency, not a fix

**This does not fix the JVM crashes on 2.8.x, and CI on this PR will fail the same way 2.8.x does today.** This branch does not include #6401, which is the actual fix; the failures you will see here are that pre-existing bug, not something this change introduced.

I can show that rather than just assert it. Running the full api suite on Java 8 locally, the crash is deterministic and lands at the same test class either way:

| Java 8, full api suite, no #6401 | result |
| --- | --- |
| Mockito 3.12.4 + Byte Buddy 1.12.18 | crash, `Process Exit Code: 134`, 3396 tests |
| Mockito 4.11.0 + Byte Buddy 1.17.6 | crash, `Process Exit Code: 134`, 3396 tests |

And the exposure that causes the Java 11 crash is unchanged, over the same test selection:

| | Mockito 3.12.4 + BB 1.12.18 | Mockito 4.11.0 + BB 1.17.6 |
| --- | --- | --- |
| `GeneratedConstructorAccessor` defined | 231 | 231 |
| `__JVM_DefineClass__` defines | 919 | 931 |
| accessor Mockito selects | `ReflectionMemberAccessor` | `ReflectionMemberAccessor` |

So the value here is a newer test toolchain and one fewer JDK-conditional version split, nothing more. I went looking for this expecting it to be the real fix instead of the workaround in #6401, and it is not. It is entirely reasonable to decline it, or to park it until 2.8.x drops Java 8 and can go straight to Mockito 5. If you do want it, #6401 should land first and this will need a rebase on top.

## Issue I worked on

No Jira issue. Related: #6401 (the fix for the crashes), #6399 (the CI diagnostics that identified them).

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. Dependency versions only; verification is the resolution check per JDK, `test-compile` on Java 8 and 11, and the full `openmrs-api` suite on Java 11 (5116 tests, 0 failures).
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed** — on Java 11. On Java 8 the suite hits the pre-existing crash described above, identically with and without this change.
- [x] My pull request is **based on the latest changes** of the 2.8.x branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
