### PR TITLE
Harden UUID reference and updater authorization boundaries

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/DomainServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/DomainServiceImpl.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.api.impl;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -19,7 +20,6 @@ import java.util.Set;
 
 import org.openmrs.api.DomainService;
 import org.openmrs.api.OpenmrsService;
-import org.openmrs.api.RefByUuid;
 import org.openmrs.serialization.UuidReferenceModule;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -162,9 +162,8 @@ public class DomainServiceImpl extends BaseOpenmrsService implements DomainServi
 		/**
 		 * Fetches a domain object by its UUID.
 		 * <p>
-		 * If the service implements {@link RefByUuid}, delegates to
-		 * {@link RefByUuid#getRefByUuid(Class, String)}; otherwise, invokes the underlying method
-		 * reflectively.
+		 * Invokes the domain-specific getter on the service proxy so that authorization and other service
+		 * interceptors are applied.
 		 * </p>
 		 *
 		 * @param uuid the UUID of the object to fetch
@@ -173,12 +172,13 @@ public class DomainServiceImpl extends BaseOpenmrsService implements DomainServi
 		 */
 		public Object fetch(String uuid) {
 			try {
-				if (RefByUuid.class.isAssignableFrom(getService().getClass())) {
-					return ((RefByUuid) getService()).getRefByUuid(getReturnType(), uuid);
-				} else {
-					return getMethod().invoke(service, uuid);
+				return getMethod().invoke(getService(), uuid);
+			} catch (InvocationTargetException e) {
+				if (e.getCause() instanceof RuntimeException runtimeException) {
+					throw runtimeException;
 				}
-			} catch (Exception e) {
+				throw new RuntimeException("Failed to fetch " + returnType.getSimpleName() + " by UUID", e.getCause());
+			} catch (ReflectiveOperationException e) {
 				throw new RuntimeException("Failed to fetch " + returnType.getSimpleName() + " by UUID", e);
 			}
 		}

--- a/api/src/test/java/org/openmrs/api/RefByUuidTest.java
+++ b/api/src/test/java/org/openmrs/api/RefByUuidTest.java
@@ -16,7 +16,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.PatientProgram;
+import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+import org.openmrs.util.PrivilegeConstants;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -29,6 +32,9 @@ public class RefByUuidTest extends BaseContextSensitiveTest {
 
 	@Autowired
 	private List<RefByUuid> refByUuids;
+
+	@Autowired
+	private DomainService domainService;
 
 	@Test
 	public void getRefByUuid_shouldSupportAllGetByUuidReturnTypes() {
@@ -86,6 +92,17 @@ public class RefByUuidTest extends BaseContextSensitiveTest {
 			    () -> "Mismatch in declared vs discovered types for: " + refByUuid.getClass().getName() + "\nDiscovered: "
 			            + discoveredTypes + "\nDeclared: " + declaredTypeSet);
 		}
+	}
+
+	@Test
+	public void fetchByUuid_shouldEnforceAuthorizationOnTheServiceGetter() {
+		String uuid = "2edf272c-bf05-4208-9f93-2fa213ed0415";
+		Context.logout();
+
+		APIAuthenticationException exception = assertThrows(APIAuthenticationException.class,
+		    () -> domainService.fetchByUuid(PatientProgram.class, uuid));
+
+		assertTrue(exception.getMessage().contains(PrivilegeConstants.GET_PATIENT_PROGRAMS));
 	}
 
 	private boolean isGetByUuidMethod(Method method) {

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -158,6 +158,7 @@ public class UpdateFilter extends StartupFilter {
 			log.debug("Attempting to authenticate user: " + username);
 			if (authenticateAsSuperUser(username, password)) {
 				log.debug("Authentication successful.  Redirecting to 'reviewupdates' page.");
+				httpRequest.changeSessionId();
 				// mark this session as authenticated so later steps can verify it
 				httpRequest.getSession().setAttribute(AUTHENTICATED_SUCCESSFULLY, Boolean.TRUE);
 
@@ -239,6 +240,11 @@ public class UpdateFilter extends StartupFilter {
 			renderTemplate(REVIEW_CHANGES, referenceMap, httpResponse);
 
 		} else if (PROGRESS_VM_AJAXREQUEST.equals(page)) {
+
+			if (!Boolean.TRUE.equals(httpRequest.getSession().getAttribute(AUTHENTICATED_SUCCESSFULLY))) {
+				httpResponse.sendError(HttpServletResponse.SC_FORBIDDEN);
+				return;
+			}
 
 			httpResponse.setContentType("text/json");
 			httpResponse.setHeader("Cache-Control", "no-cache");

--- a/web/src/test/java/org/openmrs/web/filter/update/UpdateFilterE2ETest.java
+++ b/web/src/test/java/org/openmrs/web/filter/update/UpdateFilterE2ETest.java
@@ -24,6 +24,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -158,6 +159,20 @@ class UpdateFilterE2ETest {
 	}
 
 	@Test
+	void maintenancePage_shouldRotateSessionIdOnValidLogin() throws Exception {
+		filter.authResult = true;
+		String sessionIdBeforeAuthentication = request.getSession().getId();
+		request.setParameter("page", "maintenance.vm");
+		request.setParameter("username", "admin");
+		request.setParameter("password", "Admin123");
+
+		filter.doPost(request, response);
+
+		assertNotEquals(sessionIdBeforeAuthentication, request.getSession().getId());
+		assertTrue(getAuthenticatedSuccessfully());
+	}
+
+	@Test
 	void maintenancePage_shouldShowProgressWhenUpdateAlreadyInProgress() throws Exception {
 		filter.authResult = true;
 		setDatabaseUpdateInProgress(true);
@@ -239,6 +254,16 @@ class UpdateFilterE2ETest {
 	// ========== AJAX Progress Endpoint ==========
 
 	@Test
+	void progressAjax_shouldRejectUnauthenticatedRequests() throws Exception {
+		request.setParameter("page", "updateProgress.vm.ajaxRequest");
+
+		filter.doPost(request, response);
+
+		assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatus());
+		assertEquals("", response.getContentAsString());
+	}
+
+	@Test
 	void progressAjax_shouldReturnJsonContentType() throws Exception {
 		// Use a real response so we can check content type and written content
 		MockHttpServletResponse realResponse = new MockHttpServletResponse();
@@ -251,6 +276,7 @@ class UpdateFilterE2ETest {
 			}
 		});
 
+		setAuthenticatedSuccessfully(true);
 		request.setParameter("page", "updateProgress.vm.ajaxRequest");
 
 		ajaxFilter.doPost(request, realResponse);
@@ -262,6 +288,7 @@ class UpdateFilterE2ETest {
 	@Test
 	void progressAjax_shouldWriteJsonResponseBody() throws Exception {
 		MockHttpServletResponse realResponse = new MockHttpServletResponse();
+		setAuthenticatedSuccessfully(true);
 		request.setParameter("page", "updateProgress.vm.ajaxRequest");
 
 		filter.doPost(request, realResponse);


### PR DESCRIPTION
## Summary

This draft addresses the two concrete authorization-boundary follow-ups in #6334:

- route generic UUID reference resolution through each domain-specific service proxy, ensuring `@Authorized` advice is enforced
- require the updater session to authenticate before polling update progress
- rotate the updater session ID immediately after successful superuser authentication

Item 1 remains intentionally unchanged because it requires a broader decision about whether domain-object navigation or the service layer defines the authorization boundary.

## Root cause

`DomainServiceImpl` delegated services implementing `RefByUuid` to `getRefByUuid`. That method dispatched internally to `getXByUuid`, bypassing the Spring proxy and its authorization interceptor.

The updater's progress endpoint did not check the session authentication marker, and successful authentication retained the existing session ID.

## Impact

UUID-backed JSON references can no longer retrieve protected domain objects without the privilege required by their service getter. Update progress is limited to authenticated updater sessions, and successful updater authentication is protected against session fixation.

## Validation

- `./mvnw -pl api -Dtest=RefByUuidTest test`
- `./mvnw -pl web -am -Dtest=UpdateFilterE2ETest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw clean package` (all 13 reactor modules passed from a no-space build path; the repository's module-resource tests mis-handle URL-encoded spaces in the original checkout path)

The new tests were also run before the fix and failed at each reported boundary.

## Coordination

@ZahiqIbrahim previously asked to take these same two items, but there is no assignment or open PR yet. This is a draft so maintainers can decide whether to review this implementation directly or coordinate ownership.

Related to #6334.
