### PR TITLE
TRUNK-6737: Simplify LogicTransform implementation

### DIFF
--- a/api/src/main/java/org/openmrs/logic/LogicTransform.java
+++ b/api/src/main/java/org/openmrs/logic/LogicTransform.java
@@ -26,7 +26,7 @@ import org.openmrs.logic.result.Result;
  */
 public class LogicTransform {
 
-	private Operator transformOperator;
+	private final Operator transformOperator;
 
 	private Integer numResults = null;
 
@@ -96,11 +96,9 @@ public class LogicTransform {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (!(obj instanceof LogicTransform)) {
+		if (!(obj instanceof LogicTransform compTransform)) {
 			return false;
 		}
-
-		LogicTransform compTransform = (LogicTransform) obj;
 
 		return safeEquals(this.transformOperator, compTransform.getTransformOperator())
 		        && safeEquals(numResults, compTransform.getNumResults())


### PR DESCRIPTION
## Description of what I changed

This PR refactors the `LogicTransform` class **without changing its behavior**.

The changes include:
- Marked `transformOperator` as **final** since it is initialized only once.
- Simplified the `equals()` method by using **pattern matching for `instanceof`**.

## Issue I worked on

See: https://openmrs.atlassian.net/browse/TRUNK-6737

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(This is a refactoring of existing well-tested code, so no new tests were required.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**