### PR TITLE
TRUNK-6382/TRUNK-6360: Backport @Transactional/@Cacheable-on-classes-without-interface fix to 2.6.x

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -28,6 +28,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.openmrs.api.cache.CacheConfig;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
@@ -59,6 +60,12 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 	
 	private Metadata metadata;
 	
+	private CacheConfig cacheConfig;
+
+	public void setCacheConfig(CacheConfig cacheConfig) {
+		this.cacheConfig = cacheConfig;
+	}
+
 	/**
 	 * Collect the mapping resources for future use because the mappingResources object is defined
 	 * as 'private' instead of 'protected'

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -60,11 +60,8 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 	
 	private Metadata metadata;
 	
+	@Autowired
 	private CacheConfig cacheConfig;
-
-	public void setCacheConfig(CacheConfig cacheConfig) {
-		this.cacheConfig = cacheConfig;
-	}
 
 	/**
 	 * Collect the mapping resources for future use because the mappingResources object is defined

--- a/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/UserServiceImpl.java
@@ -9,6 +9,19 @@
  */
 package org.openmrs.api.impl;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Person;
@@ -17,9 +30,12 @@ import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.annotation.Logging;
-import org.openmrs.api.*;
+import org.openmrs.api.APIException;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.CannotDeleteRoleWithChildrenException;
+import org.openmrs.api.InvalidActivationKeyException;
+import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
-import org.openmrs.api.context.Daemon;
 import org.openmrs.api.db.DAOException;
 import org.openmrs.api.db.LoginCredential;
 import org.openmrs.api.db.UserDAO;
@@ -36,19 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Default implementation of the user service. This class should not be used on its own. The current

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -27,6 +27,21 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import ca.uhn.hl7v2.HL7Exception;
+import ca.uhn.hl7v2.app.Application;
+import ca.uhn.hl7v2.app.ApplicationException;
+import ca.uhn.hl7v2.app.MessageTypeRouter;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.model.v25.datatype.CX;
+import ca.uhn.hl7v2.model.v25.datatype.ID;
+import ca.uhn.hl7v2.model.v25.datatype.PL;
+import ca.uhn.hl7v2.model.v25.datatype.TS;
+import ca.uhn.hl7v2.model.v25.datatype.XCN;
+import ca.uhn.hl7v2.model.v25.datatype.XPN;
+import ca.uhn.hl7v2.model.v25.segment.NK1;
+import ca.uhn.hl7v2.model.v25.segment.PID;
+import ca.uhn.hl7v2.parser.EncodingNotSupportedException;
+import ca.uhn.hl7v2.parser.GenericParser;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.openmrs.Location;
@@ -60,22 +75,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
-import ca.uhn.hl7v2.HL7Exception;
-import ca.uhn.hl7v2.app.Application;
-import ca.uhn.hl7v2.app.ApplicationException;
-import ca.uhn.hl7v2.app.MessageTypeRouter;
-import ca.uhn.hl7v2.model.Message;
-import ca.uhn.hl7v2.model.v25.datatype.CX;
-import ca.uhn.hl7v2.model.v25.datatype.ID;
-import ca.uhn.hl7v2.model.v25.datatype.PL;
-import ca.uhn.hl7v2.model.v25.datatype.TS;
-import ca.uhn.hl7v2.model.v25.datatype.XCN;
-import ca.uhn.hl7v2.model.v25.datatype.XPN;
-import ca.uhn.hl7v2.model.v25.segment.NK1;
-import ca.uhn.hl7v2.model.v25.segment.PID;
-import ca.uhn.hl7v2.parser.EncodingNotSupportedException;
-import ca.uhn.hl7v2.parser.GenericParser;
-
 /**
  * OpenMRS HL7 API default methods This class shouldn't be instantiated by itself. Use the
  * {@link org.openmrs.api.context.Context}
@@ -87,34 +86,12 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service {
 	
 	private static final Logger log = LoggerFactory.getLogger(HL7ServiceImpl.class);
 	
-	private static HL7ServiceImpl instance;
-	
 	protected HL7DAO dao;
 	
 	private GenericParser parser;
 	
 	private MessageTypeRouter router;
-	
-	/**
-	 * Private constructor to only support on singleton instance.
-	 *
-	 * @see #getInstance()
-	 */
-	private HL7ServiceImpl() {
-	}
-	
-	/**
-	 * Singleton Factory method
-	 *
-	 * @return a singleton instance of this HL7ServiceImpl class
-	 */
-	public static HL7ServiceImpl getInstance() {
-		if (instance == null) {
-			instance = new HL7ServiceImpl();
-		}
-		return instance;
-	}
-	
+
 	/**
 	 * @see org.openmrs.hl7.HL7Service#setHL7DAO(org.openmrs.hl7.db.HL7DAO)
 	 */

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -14,54 +14,21 @@
 <!-- Application context definition for OpenMRS business services. -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:p="http://www.springframework.org/schema/p"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
-	   xmlns:jee="http://www.springframework.org/schema/jee"
 	   xmlns:tx="http://www.springframework.org/schema/tx"
-	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
        		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 			http://www.springframework.org/schema/context
 			http://www.springframework.org/schema/context/spring-context-3.0.xsd
-			http://www.springframework.org/schema/jee
-			http://www.springframework.org/schema/jee/spring-jee-3.0.xsd
 			http://www.springframework.org/schema/tx
 			http://www.springframework.org/schema/tx/spring-tx-3.0.xsd
-			http://www.springframework.org/schema/aop
-           	http://www.springframework.org/schema/aop/spring-aop-3.0.xsd
             http://www.springframework.org/schema/util
             http://www.springframework.org/schema/util/spring-util-3.0.xsd
 			http://www.springframework.org/schema/cache
 			http://www.springframework.org/schema/cache/spring-cache.xsd">
-	<!--  **************************  Transactional Intercepter  *************************  -->
-	<!--  	
-		Looks for advisors (TransactionAttributeSourceAdvisor) in the context, and automatically 
-		creates proxy objects which are the transactional wrappers.  This object looks at every 
-		class defined below to see whether it contains the Transactional annotation attribute. 
-		NOTE:  I believe this needs to be defined at the top of the file (or before all Transactional
-		components) because it needs to do processing on objects after they are initialized. 
-	-->
-	<bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"/>
-	<!-- 
-		AOP advisor: Contains TransactionAttributeSource which tells Spring what to do (advice) 
-		and when to do it (pointcut).  Pointcuts, in our case, are defined by the use of the 
-		Transactional annotation attribute.
-	-->
-	<bean class="org.springframework.transaction.interceptor.TransactionAttributeSourceAdvisor">
-		<property name="transactionInterceptor" ref="transactionInterceptor"/>
-	</bean>
-	<!-- 
-		AOP transaction advice: Intercepts method call and wraps it with a transaction.  The 
-		transactionAttributeSource is what reads/remembers all Transactional attributes of a given 
-		method or class (which is done during initialization)
-	-->
-	<bean id="transactionInterceptor" class="org.springframework.transaction.interceptor.TransactionInterceptor">
-		<property name="transactionManager" ref="transactionManager"/>
-		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
-	</bean>
-
+	
 	<bean class="org.openmrs.api.impl.GlobalLocaleList" id="globalLocaleList"/>
 
 	<!--  **************************  EVENT LISTENERS ***************************** -->
@@ -330,7 +297,7 @@
 	</bean>
 	<!-- /SerializationService setup -->
 
-	<bean id="hL7ServiceTarget" class="org.openmrs.hl7.impl.HL7ServiceImpl" factory-method="getInstance">
+	<bean id="hL7ServiceTarget" class="org.openmrs.hl7.impl.HL7ServiceImpl">
 		<property name="HL7DAO" ref="hL7DAO"/>
 		<property name="parser">
 			<bean class="ca.uhn.hl7v2.parser.GenericParser"/>
@@ -496,9 +463,7 @@
 		<property name="transactionManager" ref="transactionManager"/>
 		<property name="target" ref="serializationServiceTarget"/>
 		<property name="preInterceptors" ref="serviceInterceptors"/>
-		<property name="transactionAttributeSource">
-			<bean class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource"/>
-		</property>
+		<property name="transactionAttributeSource" ref="transactionAttributeSource" />
 	</bean>
 	<bean id="hL7Service" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
 		<property name="transactionManager" ref="transactionManager"/>
@@ -525,7 +490,6 @@
 		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
 	</bean>
 
-
 	<!--  **************************  SERVICE INTERCEPTORS  *************************  -->
 	<!-- AOP before advice that authorizes users according to annotations -->
 	<bean id="authorizationInterceptor" class="org.openmrs.aop.AuthorizationAdvice"/>
@@ -533,23 +497,15 @@
 	<bean id="loggingInterceptor" class="org.openmrs.aop.LoggingAdvice"/>
 	<!-- AOP before advice that calls the SetRequiredDataHandler methods -->
 	<bean id="requiredDataInterceptor" class="org.openmrs.aop.RequiredDataAdvice"/>
-	<!-- AOP cache interceptor -->
-	<bean id="cacheInterceptor" class="org.springframework.cache.interceptor.CacheInterceptor">
-		<property name="cacheManager" ref="apiCacheManager"/>
-		<property name="cacheOperationSources" ref="annotationCacheOperationSource"/>
-	</bean>
-
-	<!-- finds all cache-related annotations to create available cache operations for CacheInterceptor -->
-	<bean id="annotationCacheOperationSource" class="org.springframework.cache.annotation.AnnotationCacheOperationSource"/>
 
 	<util:list id="serviceInterceptors">
 		<ref bean="authorizationInterceptor"/>
 		<ref bean="requiredDataInterceptor"/>
 		<ref bean="loggingInterceptor"/>
-		<ref bean="cacheInterceptor"/>
+		<!-- Caching handled by cache:annotation-driven -->
+		<!-- Transactions handled by tx:annotation-driven -->
 	</util:list>
-
-
+	
 	<!--  **************************  SESSION FACTORY  *************************  -->
 
 	<util:list id="moduleTestingMappingJarLocations">
@@ -581,7 +537,8 @@
 				<value>org.openmrs</value>
 			</list>
 		</property>
-		<!--  default properties must be set in the hibernate.default.properties -->
+		<property name="cacheConfig" ref="cacheConfig" />
+		<!-- default properties must be set in the hibernate.default.properties -->
 	</bean>
 
 	<bean id="dbSessionFactory" class="org.openmrs.api.db.hibernate.DbSessionFactory">
@@ -682,9 +639,9 @@
 								expression="org.openmrs.util.TestTypeFilter"/>
 		<context:exclude-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileExcludeFilter"/>
 	</context:component-scan>
-	
-	<cache:annotation-driven cache-manager="apiCacheManager"/>
-	
-	<tx:annotation-driven />
+
+	<cache:annotation-driven cache-manager="apiCacheManager" proxy-target-class="true"/>
+
+	<tx:annotation-driven proxy-target-class="true" />
 
 </beans>

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -682,5 +682,9 @@
 								expression="org.openmrs.util.TestTypeFilter"/>
 		<context:exclude-filter type="custom" expression="org.openmrs.annotation.OpenmrsProfileExcludeFilter"/>
 	</context:component-scan>
+	
+	<cache:annotation-driven cache-manager="apiCacheManager"/>
+	
+	<tx:annotation-driven />
 
 </beans>

--- a/api/src/main/resources/applicationContext-service.xml
+++ b/api/src/main/resources/applicationContext-service.xml
@@ -537,7 +537,6 @@
 				<value>org.openmrs</value>
 			</list>
 		</property>
-		<property name="cacheConfig" ref="cacheConfig" />
 		<!-- default properties must be set in the hibernate.default.properties -->
 	</bean>
 

--- a/api/src/main/resources/ehcache-api.xml
+++ b/api/src/main/resources/ehcache-api.xml
@@ -40,4 +40,13 @@
         <persistence strategy="localTempSwap"/>
     </cache>
 
+    <cache name="testCache"
+           maxElementsInMemory="500"
+           eternal="false"
+           timeToIdleSeconds="300"
+           timeToLiveSeconds="300"
+           memoryStoreEvictionPolicy="LRU">
+        <persistence strategy="none"/>
+    </cache>
+
 </ehcache>

--- a/api/src/test/java/org/openmrs/api/cache/NonServiceTestBean.java
+++ b/api/src/test/java/org/openmrs/api/cache/NonServiceTestBean.java
@@ -1,0 +1,15 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+public interface NonServiceTestBean {
+	
+	String getCachedUUID();
+}

--- a/api/src/test/java/org/openmrs/api/cache/NonServiceTestBeanImpl.java
+++ b/api/src/test/java/org/openmrs/api/cache/NonServiceTestBeanImpl.java
@@ -1,0 +1,25 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.UUID;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NonServiceTestBeanImpl implements NonServiceTestBean {
+	
+	@Cacheable("testCache")
+	@Override
+	public String getCachedUUID() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/api/src/test/java/org/openmrs/api/cache/OpenmrsCacheManagerFactoryBeanTest.java
+++ b/api/src/test/java/org/openmrs/api/cache/OpenmrsCacheManagerFactoryBeanTest.java
@@ -10,7 +10,6 @@
 package org.openmrs.api.cache;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
@@ -21,16 +20,37 @@ import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 
-public class OpenmrsCacheManagerFactoryBeanTest extends BaseContextSensitiveTest{
-    
-    @Autowired
-    CacheManager cacheManager;
-    
-    @Test
-    public void shouldContainSpecificCacheConfigurations(){
-        String[] expectedCaches = {"conceptDatatype", "subscription", "userSearchLocales", "conceptIdsByMapping"};
-        Collection<String> actualCaches = cacheManager.getCacheNames();
-        assertThat(actualCaches.size(), is(expectedCaches.length));
-        assertThat(actualCaches, containsInAnyOrder(expectedCaches));
-    }
+public class OpenmrsCacheManagerFactoryBeanTest extends BaseContextSensitiveTest {
+
+	@Autowired
+	CacheManager cacheManager;
+
+	@Autowired
+	CacheConfig cacheConfig;
+
+	@Autowired
+	NonServiceTestBean nonServiceTestBean;
+
+	@Autowired
+	ServiceTestBean serviceTestBean;
+
+	@Test
+	public void shouldContainSpecificCacheConfigurations(){
+		String[] expectedCaches = {"conceptDatatype", "subscription", "userSearchLocales", "conceptIdsByMapping",
+			"testCache"};
+		Collection<String> actualCaches = cacheManager.getCacheNames();
+		assertThat(actualCaches, containsInAnyOrder(expectedCaches));
+	}
+
+	@Test
+	public void shouldCacheNonServiceMethods() {
+		String cachedValue = nonServiceTestBean.getCachedUUID();
+		assertThat(nonServiceTestBean.getCachedUUID(), is(cachedValue));
+	}
+
+	@Test
+	public void shouldCacheServiceMethods() {
+		String cachedValue = serviceTestBean.getCachedUUID();
+		assertThat(serviceTestBean.getCachedUUID(), is(cachedValue));
+	}
 }

--- a/api/src/test/java/org/openmrs/api/cache/ServiceTestBean.java
+++ b/api/src/test/java/org/openmrs/api/cache/ServiceTestBean.java
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import org.openmrs.api.OpenmrsService;
+
+public interface ServiceTestBean extends OpenmrsService {
+	
+	String getCachedUUID();
+}

--- a/api/src/test/java/org/openmrs/api/cache/ServiceTestBeanImpl.java
+++ b/api/src/test/java/org/openmrs/api/cache/ServiceTestBeanImpl.java
@@ -1,0 +1,24 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.cache;
+
+import java.util.UUID;
+
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.springframework.cache.annotation.Cacheable;
+
+public class ServiceTestBeanImpl extends BaseOpenmrsService implements ServiceTestBean {
+	
+	@Cacheable("testCache")
+	@Override
+	public String getCachedUUID() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
+++ b/api/src/test/java/org/openmrs/hl7/HL7ServiceTest.java
@@ -206,9 +206,8 @@ public class HL7ServiceTest extends BaseContextSensitiveTest {
 		Application classInstance = c.newInstance();
 		HashMap<String, Application> map = new HashMap<>();
 		map.put("ADR_A19", classInstance);
-		HL7ServiceImpl.getInstance().setHL7Handlers(map);
-		
-		HL7Service hl7service = Context.getHL7Service();
+		HL7ServiceImpl hl7service = (HL7ServiceImpl) Context.getHL7Service();
+		hl7service.setHL7Handlers(map);
 		Message message = hl7service
 		        .parseHL7String("MSH|^~\\&|FORMENTRY|AMRS.ELD|HL7LISTENER|AMRS.ELD|20080226102656||ADR^A19|JqnfhKKtouEz8kzTk6Zo|P|2.5|1||||||||16^AMRS.ELD.FORMID\r"
 		                + "PID|||3^^^^||John3^Doe^||\r"
@@ -258,9 +257,8 @@ public class HL7ServiceTest extends BaseContextSensitiveTest {
 		Application classInstance = c.newInstance();
 		HashMap<String, Application> map = new HashMap<>();
 		map.put("ORU_R01", classInstance);
-		HL7ServiceImpl.getInstance().setHL7Handlers(map);
-		
-		HL7Service hl7service = Context.getHL7Service();
+		HL7ServiceImpl hl7service = (HL7ServiceImpl) Context.getHL7Service();
+		hl7service.setHL7Handlers(map);
 		HL7InQueue queueItem = hl7service.getHL7InQueue(1); // a valid ORU_R01
 		
 		// this will create 1 HL7InError item

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -56,4 +56,13 @@
 			</list>
 		</property>
 	</bean>
+
+	<bean id="serviceTestBeanImpl" class="org.openmrs.api.cache.ServiceTestBeanImpl" />
+	
+	<bean id="serviceTestBean" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager" ref="transactionManager"/>
+		<property name="target" ref="serviceTestBeanImpl"/>
+		<property name="preInterceptors" ref="serviceInterceptors"/>
+		<property name="transactionAttributeSource" ref="transactionAttributeSource"/>
+	</bean>
 </beans>

--- a/test-module/api/src/main/java/org/openmrs/module/testmodule/api/TestModuleServiceNoInterface.java
+++ b/test-module/api/src/main/java/org/openmrs/module/testmodule/api/TestModuleServiceNoInterface.java
@@ -1,0 +1,22 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.testmodule.api;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class TestModuleServiceNoInterface {
+	
+	@Transactional
+	public String hello() {
+		return "Hello!";
+	}
+}

--- a/test-module/api/src/test/java/org/openmrs/module/testmodule/api/TestModuleServiceNoInterfaceTest.java
+++ b/test-module/api/src/test/java/org/openmrs/module/testmodule/api/TestModuleServiceNoInterfaceTest.java
@@ -1,0 +1,28 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.testmodule.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.test.jupiter.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TestModuleServiceNoInterfaceTest extends BaseModuleContextSensitiveTest {
+	
+	@Autowired
+	private TestModuleServiceNoInterface testModuleServiceNoInterface;
+	
+	@Test
+	public void testHello() {
+		assertThat(testModuleServiceNoInterface.hello(), is("Hello!"));
+	}
+}


### PR DESCRIPTION
## Summary

Backports the fix for **`@Transactional`/`@Cacheable` not working on classes without an interface** (TRUNK-6382, TRUNK-6360) from Core 2.8.0 onto the `2.6.x` maintenance branch.

## Problem

Upgrading the FHIR2 module (2.6.0+) on Platform 2.6.x causes OpenMRS to fail to start with:

```
BeanCreationException: Error creating bean with name 'appFrameworkService' ...
Cannot convert value of type 'com.sun.proxy.$ProxyNNN implementing
org.springframework.aop.SpringProxy, org.springframework.aop.framework.Advised,
org.springframework.cglib.proxy.Factory, org.springframework.core.DecoratingProxy'
to required type 'org.openmrs.module.appframework.repository.AllComponentsState':
no matching editors or conversion strategy found
```

This isn't unique to the App Framework module — we reproduced the same failure pattern against `dataexchange`'s `DataExporter` bean, and it's the same root cause reported for `stockmanagement` in TRUNK-6382.

Reported by our team here: [FHIR2 OMOD Upgrade Fails on OpenMRS Platform 2.6.17 with AllComponentsState Proxy Conversion Error](https://talk.openmrs.org/t/fhir2-omod-upgrade-2-5-0-2-6-0-fails-on-openmrs-platform-2-6-17-with-allcomponentsstate-proxy-conversion-error/49841).

## Root cause

Several modules (App Framework's `AllComponentsState`, `dataexchange`'s `DataExporter`, etc.) declare `@Transactional` on a concrete class with no interface. Before this fix, `@Transactional`/`@Cacheable` annotation processing silently did not apply to any bean that wasn't an `OpenmrsService`, so these beans were never actually proxied — the raw object was injected directly, and everything worked by accident.

Something in FHIR2 2.6.0+'s own bean graph correctly triggers Spring's transactional annotation-driven infrastructure to *actually* attempt to proxy these beans for the first time. Since they have no interface, Spring's default JDK-dynamic-proxy strategy can't produce a valid proxy assignable to the concrete class — hence the `IllegalStateException`.

This exact bug and fix already exist for Core 2.8.0+ (TRUNK-6382, TRUNK-6360), which switches `@Transactional`/`@Cacheable` proxying to CGLIB (class-based) via `<tx:annotation-driven proxy-target-class="true"/>` / `<cache:annotation-driven proxy-target-class="true"/>`, replacing the old `DefaultAdvisorAutoProxyCreator`/`TransactionAttributeSourceAdvisor` pair. CGLIB proxies subclass the real class, so they satisfy `instanceof AllComponentsState` correctly.

**This fix was never backported to 2.6.x or 2.7.x**, only released in Core 2.8.0 (2025-08-15). Implementers who can't yet take the 2.6→2.8 platform jump have no way to consume newer FHIR2/reporting/etc. releases without hitting this.

## What this PR does

Cherry-picks the three commits that implement and refine the fix on the 2.8.x branch:

- `7a42063` — TRUNK-6360: Cacheable needs to work not only on OpenmrsService methods but all beans
- `ec1f42c` — TRUNK-6382: @Transactional must work on classes without interface
- `77de212` — TRUNK-6382: Use Autowired for cacheConfig for backwards compatibility

Plus one small addition needed specifically for 2.6.x: this branch configures caches via `ehcache-api.xml` rather than the `cache-api.yaml` resource master/2.8.x use, so a `testCache` entry was added there to keep the accompanying unit tests passing.

## Validation

We independently reproduced and validated this against a real reference-application-distro Docker environment (not just unit tests):

1. Confirmed the failure using stock `appframework` + FHIR2 2.9.1 on an unmodified Platform 2.6.x-based core — reproduces the reported bug exactly.
2. Added a diagnostic `BeanFactoryPostProcessor` to confirm the actual `AutoProxyCreator`/`Advisor` pair responsible lives in `applicationContext-service.xml` (`DefaultAdvisorAutoProxyCreator` + `TransactionAttributeSourceAdvisor`), not in FHIR2 itself — ruling out a FHIR2-side fix.
3. Rebuilt core with these 3 commits cherry-picked onto `2.6.x`, deployed it alongside **completely stock, unpatched** `appframework` and `fhir2` modules, and confirmed the proxy-conversion failure is fully gone across multiple independent clean-container boots (including a fully-stopped-then-restarted container to rule out classloader caching artifacts).
4. Also confirmed on a **plain, unmodified 2.6.x** build (no cherry-picks) that an unrelated bean-ordering flakiness exists independently of this fix, in this specific test environment — so it's not something this PR introduces.

## Known follow-up

`OpenmrsCacheManagerFactoryBeanTest` has one flaky assertion around Spring `CacheManager`/EhCache bean resolution timing on this branch's older cache-config style, distinct from the core fix. Flagging transparently — happy to iterate based on maintainer feedback rather than delay this proposal.
