### PR TITLE
TRUNK-6701: Avoid unnecessary session attribute updates

### DIFF
--- a/web/src/main/java/org/openmrs/web/WebConstants.java
+++ b/web/src/main/java/org/openmrs/web/WebConstants.java
@@ -19,6 +19,8 @@ public class WebConstants {
 
 	public static final String OPENMRS_CONTEXT_HTTPSESSION_ATTR = "__openmrs_context";
 
+	public static final String INIT_REQ_UNIQUE_ID = "__INIT_REQ_UNIQUE_ID__";
+
 	public static final String OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR = "__openmrs_user_context";
 
 	public static final String OPENMRS_CLIENT_IP_HTTPSESSION_ATTR = "__openmrs_client_ip";

--- a/web/src/main/java/org/openmrs/web/WebConstants.java
+++ b/web/src/main/java/org/openmrs/web/WebConstants.java
@@ -19,8 +19,6 @@ public class WebConstants {
 
 	public static final String OPENMRS_CONTEXT_HTTPSESSION_ATTR = "__openmrs_context";
 
-	public static final String INIT_REQ_UNIQUE_ID = "__INIT_REQ_UNIQUE_ID__";
-
 	public static final String OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR = "__openmrs_user_context";
 
 	public static final String OPENMRS_CLIENT_IP_HTTPSESSION_ATTR = "__openmrs_client_ip";

--- a/web/src/main/java/org/openmrs/web/WebConstants.java
+++ b/web/src/main/java/org/openmrs/web/WebConstants.java
@@ -17,8 +17,6 @@ public class WebConstants {
 	private WebConstants() {
 	}
 
-	public static final String INIT_REQ_UNIQUE_ID = "__INIT_REQ_UNIQUE_ID__";
-
 	public static final String OPENMRS_CONTEXT_HTTPSESSION_ATTR = "__openmrs_context";
 
 	public static final String OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR = "__openmrs_user_context";

--- a/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
@@ -59,6 +59,8 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 	        throws ServletException, IOException {
 
 		HttpSession httpSession = httpRequest.getSession();
+		// used by htmlInclude tag
+		httpRequest.setAttribute(WebConstants.INIT_REQ_UNIQUE_ID, String.valueOf(System.currentTimeMillis()));
 
 		log.debug("requestURI {}", httpRequest.getRequestURI());
 		log.debug("requestURL {}", httpRequest.getRequestURL());

--- a/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
@@ -10,6 +10,7 @@
 package org.openmrs.web.filter;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -59,9 +60,6 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 
 		HttpSession httpSession = httpRequest.getSession();
 
-		// used by htmlInclude tag
-		httpRequest.setAttribute(WebConstants.INIT_REQ_UNIQUE_ID, String.valueOf(System.currentTimeMillis()));
-
 		log.debug("requestURI {}", httpRequest.getRequestURI());
 		log.debug("requestURL {}", httpRequest.getRequestURL());
 		log.debug("request path info {}", httpRequest.getPathInfo());
@@ -71,8 +69,8 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 		// 		 prevent stack traces being shown to non-authenticated users
 		UserContext userContext = (UserContext) httpSession.getAttribute(WebConstants.OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR);
 
-		// default the session username attribute to anonymous
-		httpSession.setAttribute("username", "-anonymous user-");
+		// determine the username that should be stored in the session
+		String sessionUsername = "-anonymous user-";
 
 		// if there isn't a userContext on the session yet, create one
 		// and set it onto the session
@@ -82,16 +80,21 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 
 			log.debug("Just set user context {} as attribute on session", userContext);
 		} else {
-			// set username as attribute on session so parent servlet container
-			// can identify sessions easier
+			// determine the username for authenticated users
 			User user = userContext.getAuthenticatedUser();
 			if (user != null) {
-				httpSession.setAttribute("username", user.getUsername());
+				sessionUsername = user.getUsername();
 			}
 		}
 
-		// set the locale on the session (for the servlet container as well)
-		httpSession.setAttribute("locale", userContext.getLocale());
+		// only update the session if the username has changed
+		if (!Objects.equals(httpSession.getAttribute("username"), sessionUsername)) {
+			httpSession.setAttribute("username", sessionUsername);
+		}
+		// update the session locale only when it has changed
+		if (!Objects.equals(httpSession.getAttribute("locale"), userContext.getLocale())) {
+			httpSession.setAttribute("locale", userContext.getLocale());
+		}
 
 		//TODO We do not cache the csrfguard javascript file because it contains the
 		//csrf token that is dynamically embedded in forms. For this to work,

--- a/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/OpenmrsFilter.java
@@ -10,6 +10,7 @@
 package org.openmrs.web.filter;
 
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Objects;
 
 import jakarta.servlet.FilterChain;
@@ -59,8 +60,6 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 	        throws ServletException, IOException {
 
 		HttpSession httpSession = httpRequest.getSession();
-		// used by htmlInclude tag
-		httpRequest.setAttribute(WebConstants.INIT_REQ_UNIQUE_ID, String.valueOf(System.currentTimeMillis()));
 
 		log.debug("requestURI {}", httpRequest.getRequestURI());
 		log.debug("requestURL {}", httpRequest.getRequestURL());
@@ -93,11 +92,11 @@ public class OpenmrsFilter extends OncePerRequestFilter {
 		if (!Objects.equals(httpSession.getAttribute("username"), sessionUsername)) {
 			httpSession.setAttribute("username", sessionUsername);
 		}
+		Locale locale = userContext.getLocale();
 		// update the session locale only when it has changed
-		if (!Objects.equals(httpSession.getAttribute("locale"), userContext.getLocale())) {
-			httpSession.setAttribute("locale", userContext.getLocale());
+		if (!Objects.equals(httpSession.getAttribute("locale"), locale)) {
+			httpSession.setAttribute("locale", locale);
 		}
-
 		//TODO We do not cache the csrfguard javascript file because it contains the
 		//csrf token that is dynamically embedded in forms. For this to work,
 		//the OpenmrsFilter should be before the CSRFGuard filter in web.xml

--- a/web/src/test/java/org/openmrs/web/filter/OpenmrsFilterTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/OpenmrsFilterTest.java
@@ -108,4 +108,24 @@ class OpenmrsFilterTest {
 
 		verify(session, never()).setAttribute("username", "admin");
 	}
+
+	@Test
+	void shouldUpdateLocaleWhenLocaleChanges() throws Exception {
+		UserContext userContext = mock(UserContext.class);
+
+		when(userContext.getLocale()).thenReturn(Locale.ENGLISH);
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(WebConstants.OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR, userContext);
+		session.setAttribute("locale", Locale.FRENCH);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		new OpenmrsFilter().doFilter(request, response, new MockFilterChain());
+
+		assertEquals(Locale.ENGLISH, session.getAttribute("locale"));
+	}
 }

--- a/web/src/test/java/org/openmrs/web/filter/OpenmrsFilterTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/OpenmrsFilterTest.java
@@ -1,0 +1,111 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.filter;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.User;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.web.WebConstants;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OpenmrsFilterTest {
+
+	@Test
+	void shouldNotRewriteUnchangedSessionAttributesForAnonymousUser() throws Exception {
+		// arrange
+		UserContext userContext = new UserContext(Context.getAuthenticationScheme());
+		Locale locale = userContext.getLocale();
+
+		MockHttpSession originalSession = new MockHttpSession();
+		originalSession.setAttribute(WebConstants.OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR, userContext);
+		originalSession.setAttribute("username", "-anonymous user-");
+		originalSession.setAttribute("locale", locale);
+
+		MockHttpSession session = spy(originalSession);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+
+		OpenmrsFilter filter = new OpenmrsFilter();
+
+		// act
+		filter.doFilterInternal(request, response, chain);
+
+		// assert
+		verify(session, never()).setAttribute("username", "-anonymous user-");
+		verify(session, never()).setAttribute("locale", locale);
+	}
+
+	@Test
+	void shouldUpdateUsernameWhenAuthenticatedUserChanges() throws Exception {
+		UserContext userContext = mock(UserContext.class);
+		User user = new User();
+		user.setUsername("admin");
+
+		when(userContext.getAuthenticatedUser()).thenReturn(user);
+		when(userContext.getLocale()).thenReturn(Locale.ENGLISH);
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(WebConstants.OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR, userContext);
+		session.setAttribute("username", "-anonymous user-");
+		session.setAttribute("locale", Locale.ENGLISH);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		new OpenmrsFilter().doFilter(request, response, new MockFilterChain());
+
+		assertEquals("admin", session.getAttribute("username"));
+	}
+
+	@Test
+	void shouldNotUpdateUsernameWhenUsernameHasNotChanged() throws Exception {
+		UserContext userContext = mock(UserContext.class);
+		User user = new User();
+		user.setUsername("admin");
+
+		when(userContext.getAuthenticatedUser()).thenReturn(user);
+		when(userContext.getLocale()).thenReturn(Locale.ENGLISH);
+
+		MockHttpSession originalSession = new MockHttpSession();
+		originalSession.setAttribute(WebConstants.OPENMRS_USER_CONTEXT_HTTPSESSION_ATTR, userContext);
+		originalSession.setAttribute("username", "admin");
+		originalSession.setAttribute("locale", Locale.ENGLISH);
+
+		MockHttpSession session = spy(originalSession);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setSession(session);
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		new OpenmrsFilter().doFilter(request, response, new MockFilterChain());
+
+		verify(session, never()).setAttribute("username", "admin");
+	}
+}


### PR DESCRIPTION
## Description of what I changed

Avoid unnecessary HTTP session attribute updates in `OpenmrsFilter`.

The filter now checks the current session values before updating OpenMRS session attributes, preventing redundant `setAttribute` calls when the values have not changed.

I also added `OpenmrsFilterTest` to cover the updated behavior and verify that session attributes are only updated when necessary.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6701

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes.

- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.