### PR TITLE
TRUNK-6761: Mark eligible fields as final and fix JavaDoc typos

### DIFF
--- a/api/src/main/java/liquibase/ext/sqlgenerator/core/ModifyColumnStatement.java
+++ b/api/src/main/java/liquibase/ext/sqlgenerator/core/ModifyColumnStatement.java
@@ -19,11 +19,11 @@ import liquibase.statement.AbstractSqlStatement;
  */
 public class ModifyColumnStatement extends AbstractSqlStatement {
 
-	private String schemaName;
+	private final String schemaName;
 
-	private String tableName;
+	private final String tableName;
 
-	private ColumnConfig[] columns;
+	private final ColumnConfig[] columns;
 
 	public ModifyColumnStatement(String schemaName, String tableName, ColumnConfig... columns) {
 		this.schemaName = schemaName;

--- a/api/src/main/java/org/openmrs/annotation/AddOnStartup.java
+++ b/api/src/main/java/org/openmrs/annotation/AddOnStartup.java
@@ -18,11 +18,11 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation used to describe constants in the PrivilegeConstants or RoleConstants class.
- * Constant`s description or/and it`s belonging to core constants can be marked with this
+ * Constant's description or/and it's belonging to core constants can be marked with this
  * annotation. If you want constant to be put into a database at app startup, just mark it: <pre>
  *      &#64;AddOnStartup(description = "Constant description")
  *      public static final String MANAGE_SMTH = "Manage smth";
- * </pre> Or if you want to add only a constant`s description, mark it as "not core": <pre>
+ * </pre> Or if you want to add only a constant's description, mark it as "not core": <pre>
  *      &#64;AddOnStartup(description = "Constant description", core = false)
  *      public static final String CONSTANT_SMTH = "Manage smth";
  * </pre>

--- a/api/src/main/java/org/openmrs/annotation/AllowEmptyStrings.java
+++ b/api/src/main/java/org/openmrs/annotation/AllowEmptyStrings.java
@@ -24,7 +24,7 @@ import org.openmrs.api.handler.OpenmrsObjectSaveHandler;
  * public void setName(String name);
  * </pre> Note: This should be annotated on the setter methods.<br>
  * <br>
- * If this annotation is not present the the property will be set to null by the
+ * If this annotation is not present the property will be set to null by the
  * {@link OpenmrsObjectSaveHandler} if the value is an empty string.
  *
  * @since 1.9

--- a/api/src/main/java/org/openmrs/annotation/OpenmrsProfileIncludeFilter.java
+++ b/api/src/main/java/org/openmrs/annotation/OpenmrsProfileIncludeFilter.java
@@ -21,7 +21,7 @@ import org.springframework.core.type.filter.TypeFilter;
  */
 public class OpenmrsProfileIncludeFilter implements TypeFilter {
 
-	private OpenmrsProfileExcludeFilter openmrsProfileExcludeFilter = new OpenmrsProfileExcludeFilter();
+	private final OpenmrsProfileExcludeFilter openmrsProfileExcludeFilter = new OpenmrsProfileExcludeFilter();
 
 	/**
 	 * <p>


### PR DESCRIPTION
## Description of what I changed

This pull request improves code quality by:

- Marking eligible fields as `final` where they are initialized once and never reassigned.
- Fixing minor JavaDoc typos and grammar issues.

These changes are purely refactoring and documentation improvements. No functional behavior has been changed.

## Issue I worked on

See: https://openmrs.atlassian.net/browse/TRUNK-6761

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(This is a refactoring of existing well-tested code, so no new tests were required.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**

