### PR TITLE
TRUNK-6684: Location.childLocations gained unintended orphanRemoval=true in the JPA migration

### DIFF
--- a/api/src/main/java/org/openmrs/Location.java
+++ b/api/src/main/java/org/openmrs/Location.java
@@ -137,7 +137,7 @@ public class Location extends BaseCustomizableMetadata<LocationAttribute> implem
 	@JoinColumn(name = "parent_location")
 	private Location parentLocation;
 
-	@OneToMany(mappedBy = "parentLocation", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "parentLocation", cascade = CascadeType.ALL)
 	@BatchSize(size = 100)
 	@OrderBy("name")
 	private Set<Location> childLocations;

--- a/api/src/main/java/org/openmrs/api/LocationService.java
+++ b/api/src/main/java/org/openmrs/api/LocationService.java
@@ -53,7 +53,7 @@ public interface LocationService extends OpenmrsService {
 	 * <strong>Should</strong> return saved object<br/>
 	 * <strong>Should</strong> remove location tag from location<br/>
 	 * <strong>Should</strong> add location tag to location<br/>
-	 * <strong>Should</strong> remove child location from location<br/>
+	 * <strong>Should</strong> not delete child location when removed from parent location<br/>
 	 * <strong>Should</strong> cascade save to child location from location<br/>
 	 * <strong>Should</strong> update location successfully<br/>
 	 * <strong>Should</strong> create location successfully

--- a/api/src/test/java/org/openmrs/LocationTest.java
+++ b/api/src/test/java/org/openmrs/LocationTest.java
@@ -10,15 +10,10 @@
 package org.openmrs;
 
 import org.junit.jupiter.api.Test;
-import org.openmrs.api.LocationService;
-import org.openmrs.api.context.Context;
-import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LocationTest extends BaseContextSensitiveTest {
+public class LocationTest {
 
 	/**
 	 * Get locations that have any of specified set of tags among its child tags.
@@ -36,33 +31,6 @@ public class LocationTest extends BaseContextSensitiveTest {
 
 		assertTrue(Location.isInHierarchy(locationChild, locationParent));
 		assertTrue(Location.isInHierarchy(locationChild, locationGrandParent));
-	}
-
-	/**
-	 * @see Location#removeChildLocation(Location)
-	 */
-	@Test
-	public void removeChildLocation_shouldNotDeleteLocationWhenReparenting() {
-		executeDataSet("org/openmrs/api/include/LocationServiceTest-initialData.xml");
-		LocationService locationService = Context.getLocationService();
-
-		Location child = locationService.getLocation(2);
-		Location oldParent = child.getParentLocation();
-		Location newParent = locationService.getLocation(3);
-
-		// Removing the child should only change the relationship, not delete the location.
-		oldParent.removeChildLocation(child);
-		child.setParentLocation(newParent);
-		locationService.saveLocation(child);
-
-		Context.flushSession();
-		Context.clearSession();
-
-		// Reload the child to verify that it still exists after the relationship change.
-		Location reloadedChild = locationService.getLocation(child.getLocationId());
-
-		assertNotNull(reloadedChild);
-		assertEquals(newParent.getLocationId(), reloadedChild.getParentLocation().getLocationId());
 	}
 
 }

--- a/api/src/test/java/org/openmrs/LocationTest.java
+++ b/api/src/test/java/org/openmrs/LocationTest.java
@@ -10,10 +10,15 @@
 package org.openmrs;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class LocationTest {
+public class LocationTest extends BaseContextSensitiveTest {
 
 	/**
 	 * Get locations that have any of specified set of tags among its child tags.
@@ -31,6 +36,33 @@ public class LocationTest {
 
 		assertTrue(Location.isInHierarchy(locationChild, locationParent));
 		assertTrue(Location.isInHierarchy(locationChild, locationGrandParent));
+	}
+
+	/**
+	 * @see Location#removeChildLocation(Location)
+	 */
+	@Test
+	public void removeChildLocation_shouldNotDeleteLocationWhenReparenting() {
+		executeDataSet("org/openmrs/api/include/LocationServiceTest-initialData.xml");
+		LocationService locationService = Context.getLocationService();
+
+		Location child = locationService.getLocation(2);
+		Location oldParent = child.getParentLocation();
+		Location newParent = locationService.getLocation(3);
+
+		// Removing the child should only change the relationship, not delete the location.
+		oldParent.removeChildLocation(child);
+		child.setParentLocation(newParent);
+		locationService.saveLocation(child);
+
+		Context.flushSession();
+		Context.clearSession();
+
+		// Reload the child to verify that it still exists after the relationship change.
+		Location reloadedChild = locationService.getLocation(child.getLocationId());
+
+		assertNotNull(reloadedChild);
+		assertEquals(newParent.getLocationId(), reloadedChild.getParentLocation().getLocationId());
 	}
 
 }

--- a/api/src/test/java/org/openmrs/api/LocationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/LocationServiceTest.java
@@ -197,25 +197,52 @@ public class LocationServiceTest extends BaseContextSensitiveTest {
 	}
 
 	/**
-	 * You should be able to remove a child location from a location.
+	 * Removing a child location from a location should not delete the child location.
 	 *
 	 * @see LocationService#saveLocation(Location)
 	 */
 	@Test
-	public void saveLocation_shouldRemoveChildLocationFromLocation() {
+	public void saveLocation_shouldNotDeleteChildLocationWhenRemovedFromParent() {
 		LocationService ls = Context.getLocationService();
 
 		// Retrieving a location with initially 2 child locations
 		Location location = ls.getLocation(1);
+		Location child = location.getChildLocations().iterator().next();
 
-		// Removing a child
-		location.removeChildLocation(location.getChildLocations().iterator().next());
+		// Removing a child from the collection should not delete the child location.
+		location.removeChildLocation(child);
 		ls.saveLocation(location);
 
-		Location newSavedLocation = ls.getLocation(location.getLocationId());
+		Context.flushSession();
+		Context.clearSession();
 
-		// Saved location should have 1 child locations now
-		assertEquals(1, newSavedLocation.getChildLocations().size());
+		assertNotNull(ls.getLocation(child.getLocationId()));
+	}
+
+	/**
+	 * @see Location#removeChildLocation(Location)
+	 */
+	@Test
+	public void removeChildLocation_shouldNotDeleteLocationWhenReparenting() {
+		LocationService locationService = Context.getLocationService();
+
+		Location child = locationService.getLocation(2);
+		Location oldParent = child.getParentLocation();
+		Location newParent = locationService.getLocation(3);
+
+		// Removing the child should not delete it when it is re-parented.
+		oldParent.removeChildLocation(child);
+		child.setParentLocation(newParent);
+		locationService.saveLocation(child);
+
+		Context.flushSession();
+		Context.clearSession();
+
+		// Reload the child to verify that it still exists after the relationship change.
+		Location reloadedChild = locationService.getLocation(child.getLocationId());
+
+		assertNotNull(reloadedChild);
+		assertEquals(newParent.getLocationId(), reloadedChild.getParentLocation().getLocationId());
 	}
 
 	/**


### PR DESCRIPTION
## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6684

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

