### PR TITLE
TRUNK-6763: Remove dead commons-fileupload dependency

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -17,6 +17,7 @@ The following dependencies are licensed under the [Apache License, Version 2.0](
 - Apache Commons BeanUtils (`commons-beanutils:commons-beanutils`)
 - Apache Commons Collections (`commons-collections:commons-collections`)
 - Apache Commons IO (`commons-io:commons-io`)
+- Apache Commons FileUpload2 (`org.apache.commons:commons-fileupload2-jakarta-servlet6`)
 - Apache Commons Lang (`org.apache.commons:commons-lang3`)
 - Apache Commons Validator (`commons-validator:commons-validator`)
 - Apache Log4j (`org.apache.logging.log4j:log4j-core`, `log4j-slf4j-impl`, `log4j-1.2-api`)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -16,8 +16,6 @@ The following dependencies are licensed under the [Apache License, Version 2.0](
 
 - Apache Commons BeanUtils (`commons-beanutils:commons-beanutils`)
 - Apache Commons Collections (`commons-collections:commons-collections`)
-- Apache Commons FileUpload (`commons-fileupload:commons-fileupload`)
-- Apache Commons FileUpload2 (`org.apache.commons:commons-fileupload2-jakarta-servlet6`)
 - Apache Commons IO (`commons-io:commons-io`)
 - Apache Commons Lang (`org.apache.commons:commons-lang3`)
 - Apache Commons Validator (`commons-validator:commons-validator`)

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -80,6 +80,7 @@
 		<commonsIoVersion>2.22.0</commonsIoVersion>
 		<commonsLang3Version>3.20.0</commonsLang3Version>
 		<commonsBeanutilsVersion>1.11.0</commonsBeanutilsVersion>
+		<commonsFileupload2JakartaVersion>2.0.0-M5</commonsFileupload2JakartaVersion>
 		<commonsValidatorVersion>1.11.0</commonsValidatorVersion>
 
 		<!-- Velocity -->
@@ -376,6 +377,11 @@
 						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+				<version>${commonsFileupload2JakartaVersion}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-validator</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -80,8 +80,6 @@
 		<commonsIoVersion>2.22.0</commonsIoVersion>
 		<commonsLang3Version>3.20.0</commonsLang3Version>
 		<commonsBeanutilsVersion>1.11.0</commonsBeanutilsVersion>
-		<commonsFileuploadVersion>1.6.0</commonsFileuploadVersion>
-		<commonsFileupload2JakartaVersion>2.0.0-M5</commonsFileupload2JakartaVersion>
 		<commonsValidatorVersion>1.11.0</commonsValidatorVersion>
 
 		<!-- Velocity -->
@@ -378,16 +376,6 @@
 						<artifactId>commons-logging</artifactId>
 					</exclusion>
 				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>${commonsFileuploadVersion}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
-				<version>${commonsFileupload2JakartaVersion}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-validator</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -70,6 +70,10 @@
          <artifactId>commons-io</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.apache.commons</groupId>
+         <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.springframework</groupId>
          <artifactId>spring-web</artifactId>
       </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -70,14 +70,6 @@
          <artifactId>commons-io</artifactId>
       </dependency>
       <dependency>
-         <groupId>commons-fileupload</groupId>
-         <artifactId>commons-fileupload</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.commons</groupId>
-         <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.springframework</groupId>
          <artifactId>spring-web</artifactId>
       </dependency>


### PR DESCRIPTION
## Description of what I changed
Remove the dead `commons-fileupload:commons-fileupload` 1.6.0 dependency from `web/pom.xml` (and its BOM entry / NOTICE line).

`commons-fileupload` 1.6.0 is built against `javax.servlet` and cannot function in Jakarta EE 10, so keeping it ships a jar nothing in the platform can load. Multipart handling goes through `StandardServletMultipartResolver` (see `WebConfig.java:85`), and Spring 6.x removed `CommonsMultipartResolver`, which was the only consumer commons-fileupload existed to support. A full `mvnw clean package` + reactor `dependency:tree` scan confirmed 0 references from `api`, `web`, `webapp`, or the test suite.

`org.apache.commons:commons-fileupload2-jakarta-servlet6` is **kept** in this PR: legacyui's `XSSFilter` calls `JakartaServletFileUpload.isMultipartContent(...)` at runtime and relies on the platform WAR shipping the class (the omod declares it `provided`), so removing it would take the legacy UI down. That dependency remains in `web/pom.xml`, the BOM, and `NOTICE.md`.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6763

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  Tests pass with the dependency removed (`mvnw clean package`).
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.