### PR TITLE
TRUNK-6769: Allow null default in getGlobalPropertyValue and fix WebUtil.formatDate

### DIFF
--- a/api/src/main/java/org/openmrs/api/AdministrationService.java
+++ b/api/src/main/java/org/openmrs/api/AdministrationService.java
@@ -348,10 +348,14 @@ public interface AdministrationService extends OpenmrsService {
 	 * <p>
 	 * <strong>Should</strong> get property value in the proper type specified<br/>
 	 * <strong>Should</strong> return default value if property name does not exist
+	 * <p>
+	 * The value is converted to the type of the default value by invoking its {@code String}
+	 * constructor. When {@code defaultValue} is null there is no type to convert to, so no conversion
+	 * is performed and null is returned.
 	 *
 	 * @param <T>
 	 * @param propertyName
-	 * @return property value in the type of the default value
+	 * @return property value in the type of the default value, or null when the default value is null
 	 * @since 1.7
 	 */
 	@Authorized(PrivilegeConstants.GET_GLOBAL_PROPERTIES)

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -734,7 +734,7 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 	@SuppressWarnings("unchecked")
 	public <T> T getGlobalPropertyValue(String propertyName, T defaultValue) throws APIException {
 		if (defaultValue == null) {
-			throw new IllegalArgumentException("The defaultValue argument cannot be null");
+			return null;
 		}
 
 		String propVal = Context.getAdministrationService().getGlobalProperty(propertyName);

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceUnitTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceUnitTest.java
@@ -20,7 +20,7 @@ import org.openmrs.api.impl.AdministrationServiceImpl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -66,9 +66,9 @@ public class AdministrationServiceUnitTest {
 	}
 
 	@Test
-	public void getGlobalPropertyValue_shouldFailIfDefaultValueIsNull() {
+	public void getGlobalPropertyValue_shouldReturnNullIfDefaultValueIsNull() {
 
-		assertThrows(IllegalArgumentException.class, () -> adminService.getGlobalPropertyValue("valid.double", null));
+		assertNull(adminService.getGlobalPropertyValue("valid.double", null));
 	}
 
 	@Test

--- a/web/src/main/java/org/openmrs/web/WebUtil.java
+++ b/web/src/main/java/org/openmrs/web/WebUtil.java
@@ -385,7 +385,7 @@ public class WebUtil implements GlobalPropertyListener {
 
 		if (type == FORMAT_TYPE.TIMESTAMP) {
 			String dateTimeFormat = Context.getAdministrationService()
-			        .getGlobalPropertyValue(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT, null);
+			        .getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT);
 			if (StringUtils.isEmpty(dateTimeFormat)) {
 				dateFormat = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG, locale);
 			} else {
@@ -393,7 +393,7 @@ public class WebUtil implements GlobalPropertyListener {
 			}
 		} else if (type == FORMAT_TYPE.TIME) {
 			String timeFormat = Context.getAdministrationService()
-			        .getGlobalPropertyValue(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT, null);
+			        .getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT);
 			if (StringUtils.isEmpty(timeFormat)) {
 				dateFormat = DateFormat.getTimeInstance(DateFormat.MEDIUM, locale);
 			} else {
@@ -401,7 +401,7 @@ public class WebUtil implements GlobalPropertyListener {
 			}
 		} else if (type == FORMAT_TYPE.DATE) {
 			String formatValue = Context.getAdministrationService()
-			        .getGlobalPropertyValue(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT, "");
+			        .getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT);
 			if (StringUtils.isEmpty(formatValue)) {
 				dateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, locale);
 			} else {

--- a/web/src/test/java/org/openmrs/web/WebUtilTest.java
+++ b/web/src/test/java/org/openmrs/web/WebUtilTest.java
@@ -11,13 +11,24 @@ package org.openmrs.web;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.openmrs.BaseOpenmrsObject;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.util.Format.FORMAT_TYPE;
+import org.openmrs.util.OpenmrsConstants;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests methods on the {@link WebUtil} class.
@@ -142,6 +153,86 @@ public class WebUtilTest {
 	@Test
 	public void sanitizeLocales_shouldNotFailWithEmptyString() {
 		assertNull(null, WebUtil.sanitizeLocales(""));
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldHonourConfiguredDateFormat() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT)).thenReturn("yyyy-MM-dd");
+			assertTrue(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.DATE).matches("\\d{4}-\\d{2}-\\d{2}"));
+		}
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldHonourConfiguredTimeFormat() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT)).thenReturn("HH:mm");
+			assertTrue(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.TIME).matches("\\d{2}:\\d{2}"));
+		}
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldHonourConfiguredTimestampFormat() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT))
+			        .thenReturn("yyyy-MM-dd HH:mm");
+			assertTrue(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.TIMESTAMP)
+			        .matches("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}"));
+		}
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldFormatDateWhenNoFormatPropertyIsSet() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT)).thenReturn(null);
+			assertFalse(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.DATE).isEmpty());
+		}
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldFormatTimeWhenNoFormatPropertyIsSet() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT)).thenReturn(null);
+			assertFalse(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.TIME).isEmpty());
+		}
+	}
+
+	/**
+	 * @see WebUtil#formatDate(Date, Locale, FORMAT_TYPE)
+	 */
+	@Test
+	public void formatDate_shouldFormatTimestampWhenNoFormatPropertyIsSet() {
+		try (MockedStatic<Context> mocked = mockStatic(Context.class)) {
+			AdministrationService adminService = mock(AdministrationService.class);
+			when(Context.getAdministrationService()).thenReturn(adminService);
+			when(adminService.getGlobalProperty(OpenmrsConstants.GP_SEARCH_DATE_DISPLAY_FORMAT)).thenReturn(null);
+			assertFalse(WebUtil.formatDate(new Date(0), Locale.US, FORMAT_TYPE.TIMESTAMP).isEmpty());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description of what I changed
Fix two bugs where a null default value broke global property reads:

- **`AdministrationService.getGlobalPropertyValue(String, T)`** threw `IllegalArgumentException` when the default value was null. `WebUtil.formatDate(Date, Locale, FORMAT_TYPE)` passes null as the default in both the `TIMESTAMP` and `TIME` branches, so both threw unconditionally and only the `DATE` branch (which passes `""`) worked. A null default now returns null instead of throwing, since there is no target type to convert to. Javadoc on `AdministrationService` updated to state this.
- **`WebUtil.formatDate`** now uses the untyped `getGlobalProperty(...)` accessor in all three branches (they read a plain `String` global property), instead of the converting `getGlobalPropertyValue(...)`.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6769

## Tests
- Updated `AdministrationServiceUnitTest#getGlobalPropertyValue_shouldReturnNullIfDefaultValueIsNull` (previously asserted the throw).
- Added six `WebUtilTest` cases: all three `FORMAT_TYPE` branches honour a configured `GP_SEARCH_DATE_DISPLAY_FORMAT`, and all three return formatted output when the property is unset.

Verification: `mvn -pl api,web -am test -Dtest=AdministrationServiceUnitTest,WebUtilTest` - BUILD SUCCESS, 25/25 tests pass (5 + 20).

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  Updated + added tests as described above.
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.