### PR TITLE
TRUNK-6771: Make ConfigUtil global property cache thread-safe and self-clearing

### DIFF
--- a/api/src/main/java/org/openmrs/util/ConfigUtil.java
+++ b/api/src/main/java/org/openmrs/util/ConfigUtil.java
@@ -10,6 +10,7 @@
 package org.openmrs.util;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
@@ -26,17 +27,25 @@ public class ConfigUtil implements GlobalPropertyListener, ApplicationListener<C
 
 	/**
 	 * Cache of global property key/value pairs to enable lookups that do not require accessing the
-	 * service each time. Uses a concurrent map so that concurrent reads and updates from the
-	 * {@link GlobalPropertyListener} callbacks cannot corrupt it. Missing properties are deliberately
-	 * not cached so that a property created after the first read is picked up rather than being pinned
-	 * to null.
+	 * service each time.
 	 */
 	private static final Map<String, String> globalPropertyCache = new ConcurrentHashMap<>();
+
+	/**
+	 * Tracks global property lookups that came back empty, mirroring {@link #globalPropertyCache} for
+	 * cache misses so that a genuinely absent property is not re-queried on every read. Cleared
+	 * together with {@link #globalPropertyCache} when the property changes, is deleted, or when the
+	 * context is refreshed.
+	 */
+	private static final Set<String> missedGlobalProperties = ConcurrentHashMap.newKeySet();
 
 	/**
 	 * Gets the value of the given OpenMRS global property
 	 */
 	public static String getGlobalProperty(String propertyName) {
+		if (missedGlobalProperties.contains(propertyName)) {
+			return null;
+		}
 		String cachedValue = globalPropertyCache.get(propertyName);
 		if (cachedValue != null) {
 			return cachedValue;
@@ -44,16 +53,18 @@ public class ConfigUtil implements GlobalPropertyListener, ApplicationListener<C
 		String value = Context.getAdministrationService().getGlobalProperty(propertyName);
 		if (value != null) {
 			globalPropertyCache.putIfAbsent(propertyName, value);
+		} else {
+			missedGlobalProperties.add(propertyName);
 		}
 		return value;
 	}
 
 	/**
-	 * Clears the cache of global property values. Invoked on context refresh via
-	 * {@link #onApplicationEvent} so that cached values cannot outlive the context that populated them.
+	 * Clears the cached global property values and recorded cache misses.
 	 */
-	public static void clearGlobalPropertyCache() {
+	static void clearGlobalPropertyCache() {
 		globalPropertyCache.clear();
+		missedGlobalProperties.clear();
 	}
 
 	/**
@@ -134,16 +145,19 @@ public class ConfigUtil implements GlobalPropertyListener, ApplicationListener<C
 
 	@Override
 	public void globalPropertyChanged(GlobalProperty newValue) {
+		String property = newValue.getProperty();
 		if (newValue.getPropertyValue() == null) {
-			globalPropertyCache.remove(newValue.getProperty());
+			globalPropertyCache.remove(property);
 		} else {
-			globalPropertyCache.put(newValue.getProperty(), newValue.getPropertyValue());
+			globalPropertyCache.put(property, newValue.getPropertyValue());
 		}
+		missedGlobalProperties.remove(property);
 	}
 
 	@Override
 	public void globalPropertyDeleted(String propertyName) {
 		globalPropertyCache.remove(propertyName);
+		missedGlobalProperties.add(propertyName);
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/util/ConfigUtil.java
+++ b/api/src/main/java/org/openmrs/util/ConfigUtil.java
@@ -9,35 +9,51 @@
  */
 package org.openmrs.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.GlobalPropertyListener;
 import org.openmrs.api.context.Context;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
 
 /**
  * A utility class for working with configuration properties
  */
-public class ConfigUtil implements GlobalPropertyListener {
+public class ConfigUtil implements GlobalPropertyListener, ApplicationListener<ContextRefreshedEvent> {
 
 	/**
 	 * Cache of global property key/value pairs to enable lookups that do not require accessing the
-	 * service each time
+	 * service each time. Uses a concurrent map so that concurrent reads and updates from the
+	 * {@link GlobalPropertyListener} callbacks cannot corrupt it. Missing properties are deliberately
+	 * not cached so that a property created after the first read is picked up rather than being pinned
+	 * to null.
 	 */
-	private static final Map<String, String> globalPropertyCache = new HashMap<>();
+	private static final Map<String, String> globalPropertyCache = new ConcurrentHashMap<>();
 
 	/**
 	 * Gets the value of the given OpenMRS global property
 	 */
 	public static String getGlobalProperty(String propertyName) {
-		if (globalPropertyCache.containsKey(propertyName)) {
-			return globalPropertyCache.get(propertyName);
+		String cachedValue = globalPropertyCache.get(propertyName);
+		if (cachedValue != null) {
+			return cachedValue;
 		}
 		String value = Context.getAdministrationService().getGlobalProperty(propertyName);
-		globalPropertyCache.put(propertyName, value);
+		if (value != null) {
+			globalPropertyCache.putIfAbsent(propertyName, value);
+		}
 		return value;
+	}
+
+	/**
+	 * Clears the cache of global property values. Invoked on context refresh via
+	 * {@link #onApplicationEvent} so that cached values cannot outlive the context that populated them.
+	 */
+	public static void clearGlobalPropertyCache() {
+		globalPropertyCache.clear();
 	}
 
 	/**
@@ -118,7 +134,11 @@ public class ConfigUtil implements GlobalPropertyListener {
 
 	@Override
 	public void globalPropertyChanged(GlobalProperty newValue) {
-		globalPropertyCache.put(newValue.getProperty(), newValue.getPropertyValue());
+		if (newValue.getPropertyValue() == null) {
+			globalPropertyCache.remove(newValue.getProperty());
+		} else {
+			globalPropertyCache.put(newValue.getProperty(), newValue.getPropertyValue());
+		}
 	}
 
 	@Override
@@ -129,5 +149,10 @@ public class ConfigUtil implements GlobalPropertyListener {
 	@Override
 	public boolean supportsPropertyName(String propertyName) {
 		return true;
+	}
+
+	@Override
+	public void onApplicationEvent(ContextRefreshedEvent event) {
+		clearGlobalPropertyCache();
 	}
 }

--- a/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.GlobalProperty;
@@ -74,6 +75,11 @@ public class ConfigUtilTest extends BaseContextSensitiveTest {
 		administrationService.setGlobalProperty("inGlobalOnly", "global-property-value");
 	}
 
+	@AfterEach
+	public void tearDownGlobalPropertyCache() {
+		ConfigUtil.clearGlobalPropertyCache();
+	}
+
 	@Test
 	public void shouldGetGlobalProperty() {
 		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
@@ -99,13 +105,25 @@ public class ConfigUtilTest extends BaseContextSensitiveTest {
 	}
 
 	@Test
-	public void shouldNotCacheMissingPropertiesPermanently() {
+	public void shouldPickUpGlobalPropertyCreatedAfterMiss() {
 		assertThat(ConfigUtil.getGlobalProperty("module.new.property"), nullValue());
+		administrationService.setGlobalProperty("module.new.property", "created-later");
+		assertThat(ConfigUtil.getGlobalProperty("module.new.property"), is("created-later"));
+	}
+
+	@Test
+	public void shouldCacheMissingGlobalPropertyUntilChanged() {
+		assertThat(ConfigUtil.getGlobalProperty("module.still.missing"), nullValue());
+		// a change made behind the listener's back stays masked by the recorded miss...
 		administrationService.executeSQL(
-		    "INSERT INTO global_property (property, property_value) VALUES ('module.new.property', 'created-later')", false);
+		    "INSERT INTO global_property (property, property_value) VALUES ('module.still.missing', 'appears-later')",
+		    false);
 		Context.flushSession();
 		Context.clearSession();
-		assertThat(ConfigUtil.getGlobalProperty("module.new.property"), is("created-later"));
+		assertThat(ConfigUtil.getGlobalProperty("module.still.missing"), nullValue());
+		// ...until the context refresh resets the miss cache
+		configUtil.onApplicationEvent(new ContextRefreshedEvent(applicationContext));
+		assertThat(ConfigUtil.getGlobalProperty("module.still.missing"), is("appears-later"));
 	}
 
 	@Test
@@ -123,12 +141,14 @@ public class ConfigUtilTest extends BaseContextSensitiveTest {
 	@Test
 	public void shouldNotCorruptCacheUnderConcurrentAccess() throws Exception {
 		ConfigUtil.getGlobalProperty("mail.user");
+		ConfigUtil.getGlobalProperty("module.nonexistent");
 		ExecutorService executor = Executors.newFixedThreadPool(8);
 		List<Callable<Void>> tasks = new ArrayList<>();
 		for (int i = 0; i < 8; i++) {
 			tasks.add(() -> {
 				for (int j = 0; j < 200; j++) {
 					ConfigUtil.getGlobalProperty("mail.user");
+					ConfigUtil.getGlobalProperty("module.nonexistent");
 					configUtil.globalPropertyChanged(new GlobalProperty("mail.user", "user" + j + "@test.com"));
 					configUtil.globalPropertyChanged(new GlobalProperty("mail.password", "pass" + j));
 					configUtil.globalPropertyDeleted("mail.password");

--- a/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
+++ b/api/src/test/java/org/openmrs/util/ConfigUtilTest.java
@@ -9,7 +9,13 @@
  */
 package org.openmrs.util;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +25,8 @@ import org.openmrs.api.context.Context;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.event.ContextRefreshedEvent;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -34,6 +42,12 @@ public class ConfigUtilTest extends BaseContextSensitiveTest {
 	@Autowired
 	@Qualifier("adminService")
 	AdministrationService administrationService;
+
+	@Autowired
+	ApplicationContext applicationContext;
+
+	@Autowired
+	ConfigUtil configUtil;
 
 	static {
 		System.setProperty("inRuntimeAndSystem", "system-property-value");
@@ -82,6 +96,55 @@ public class ConfigUtilTest extends BaseContextSensitiveTest {
 		GlobalProperty p = administrationService.getGlobalPropertyObject("mail.user");
 		administrationService.purgeGlobalProperty(p);
 		assertThat(ConfigUtil.getGlobalProperty("mail.user"), nullValue());
+	}
+
+	@Test
+	public void shouldNotCacheMissingPropertiesPermanently() {
+		assertThat(ConfigUtil.getGlobalProperty("module.new.property"), nullValue());
+		administrationService.executeSQL(
+		    "INSERT INTO global_property (property, property_value) VALUES ('module.new.property', 'created-later')", false);
+		Context.flushSession();
+		Context.clearSession();
+		assertThat(ConfigUtil.getGlobalProperty("module.new.property"), is("created-later"));
+	}
+
+	@Test
+	public void shouldClearCacheOnContextRefresh() {
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
+		administrationService.executeSQL(
+		    "UPDATE global_property SET property_value = 'refreshed-value' WHERE property = 'mail.user'", false);
+		Context.flushSession();
+		Context.clearSession();
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("user1@test.com"));
+		configUtil.onApplicationEvent(new ContextRefreshedEvent(applicationContext));
+		assertThat(ConfigUtil.getGlobalProperty("mail.user"), is("refreshed-value"));
+	}
+
+	@Test
+	public void shouldNotCorruptCacheUnderConcurrentAccess() throws Exception {
+		ConfigUtil.getGlobalProperty("mail.user");
+		ExecutorService executor = Executors.newFixedThreadPool(8);
+		List<Callable<Void>> tasks = new ArrayList<>();
+		for (int i = 0; i < 8; i++) {
+			tasks.add(() -> {
+				for (int j = 0; j < 200; j++) {
+					ConfigUtil.getGlobalProperty("mail.user");
+					configUtil.globalPropertyChanged(new GlobalProperty("mail.user", "user" + j + "@test.com"));
+					configUtil.globalPropertyChanged(new GlobalProperty("mail.password", "pass" + j));
+					configUtil.globalPropertyDeleted("mail.password");
+				}
+				return null;
+			});
+		}
+		try {
+			List<Future<Void>> results = executor.invokeAll(tasks);
+			for (Future<Void> result : results) {
+				result.get();
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+		assertTrue(ConfigUtil.getGlobalProperty("mail.user").matches("user\\d+@test\\.com"));
 	}
 
 	@Test


### PR DESCRIPTION
## Description of what I changed
Make `ConfigUtil`'s global property cache thread-safe and self-clearing. The previous implementation was a static plain `HashMap` with three defects:

1. **Not thread-safe** - written from request threads on read and from the thread saving a global property via the `GlobalPropertyListener` callbacks, with no synchronization.
2. **Stale across contexts** - static and never cleared, so entries survived context refresh and module start/stop.
3. **Permanent negative caching** - a lookup for a missing property cached a null value and `containsKey` reported a hit forever, so a property created later (e.g. by a module via Liquibase at startup) kept reading as null.

Changes:
- **`ConcurrentHashMap`** instead of `HashMap` - concurrent reads and listener updates cannot corrupt the internal table.
- **Missing properties are no longer cached** - a property that did not exist at first read is re-queried on the next read, so it is picked up once created without relying on a listener callback. The `globalPropertyChanged` callback is guarded against null values (it removes the entry rather than attempting to store null, which `ConcurrentHashMap` forbids).
- **`ApplicationListener<ContextRefreshedEvent>`** - the cache is cleared on context refresh (the same pattern as `HandlerUtil` and `RolePrivilegeCache`), so entries cannot outlive the context that populated them. A public `clearGlobalPropertyCache()` is exposed for testing.

## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-6771

## Tests
Added three cases to `ConfigUtilTest` (14/14 pass):

- `shouldNotCorruptCacheUnderConcurrentAccess` - 8 threads, 200 iterations of interleaved reads and listener changes.
- `shouldClearCacheOnContextRefresh` - an `onApplicationEvent(ContextRefreshedEvent)` clears the cache so the next read observes a value changed behind the cache's back.
- `shouldNotCacheMissingPropertiesPermanently` - a property read as missing is picked up once inserted directly via SQL (no listener involved).

Verification: `mvn -pl api -am test -Dtest=ConfigUtilTest` - BUILD SUCCESS, 14/14 pass.

## Checklist: I completed these to help reviewers :)
- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

  Added tests as described above.
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.