### PR TITLE
TRUNK-6779: Fix flaky OpenmrsConfigurationFactoryTest when running as root

### DIFF
--- a/api/src/test/java/org/openmrs/logging/OpenmrsConfigurationFactoryTest.java
+++ b/api/src/test/java/org/openmrs/logging/OpenmrsConfigurationFactoryTest.java
@@ -174,8 +174,9 @@ class OpenmrsConfigurationFactoryTest {
 	void getConfigurationFiles_shouldIgnoreUnreadableFiles() throws IOException {
 		Path unreadable = configurationDir().resolve("log4j2.xml");
 		write(unreadable, "<Configuration/>");
-		Assumptions.assumeTrue(unreadable.toFile().setReadable(false),
-		    "Cannot make file unreadable on this platform; skipping test");
+		unreadable.toFile().setReadable(false);
+		Assumptions.assumeFalse(unreadable.toFile().canRead(),
+		    "Cannot make file unreadable to this process (e.g., running as root); skipping test");
 
 		try {
 			OpenmrsConfigurationFactory factory = new OpenmrsConfigurationFactory();


### PR DESCRIPTION
## Summary
- CI (Docker) runs Maven as root, which bypasses Unix file-permission bits, so `getConfigurationFiles_shouldIgnoreUnreadableFiles` was failing consistently on CI even though it passed locally.
- The test's assumption only checked that `File.setReadable(false)` returned `true`, not that the file was actually unreadable afterward — root processes can still read a file after its read bit is cleared.
- The assumption now checks `canRead()` directly, so the test skips (rather than fails) in environments where permission bits don't restrict access, such as a root-run container.

## Test plan
- [x] Reproduced the CI failure locally by running `mvn test` inside the `openmrs/openmrs-core:2.9.x-dev` Docker image (which runs as root) against this source.
- [x] Confirmed the fix: full `mvn test` in that same Docker image now results in `BUILD SUCCESS`.
- [x] Confirmed no regression: `OpenmrsConfigurationFactoryTest` still runs all 15 tests with 0 failures when run locally as a non-root user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)