### PR TITLE
TRUNK-6775: Break circular dependency between core utilities and HL7

### DIFF
--- a/api/src/main/java/org/openmrs/hl7/HL7Constants.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Constants.java
@@ -56,6 +56,8 @@ public class HL7Constants {
 
 	/**
 	 * Used in hl7 sextuplets: 123^Primary name^99DCT^345^Chosen name^99NAM
+	 * These are  the constants used by FormUtil
+	 * FOR TRUNK-6775
 	 */
 	public static final String HL7_LOCAL_CONCEPT = "99DCT";
 
@@ -79,8 +81,16 @@ public class HL7Constants {
 	 * default name for HL7_archives destination directory
 	 *
 	 * @since 1.7
+	 * 
+	 * FOR TRUNK-6775
 	 */
 	public static final String HL7_ARCHIVE_DIRECTORY_NAME = "hl7_archives";
+
+	public static final String GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY =
+		"hl7_archive.dir";
+
+	public static final String GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS =
+		"hl7_processor.ignore_missing_patient_non_local";
 
 	/**
 	 * @since 1.10

--- a/api/src/main/java/org/openmrs/hl7/HL7Util.java
+++ b/api/src/main/java/org/openmrs/hl7/HL7Util.java
@@ -271,10 +271,10 @@ public class HL7Util {
 	 */
 	public static File getHl7ArchivesDirectory() throws APIException {
 		String archiveDir = Context.getAdministrationService()
-		        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY);
+		        .getGlobalProperty(HL7Constants.GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY);
 
 		if (StringUtils.isBlank(archiveDir)) {
-			log.warn("Invalid value for global property '" + OpenmrsConstants.GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY
+			log.warn("Invalid value for global property '" + HL7Constants.GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY
 			        + "', trying to set a default one");
 			archiveDir = HL7Constants.HL7_ARCHIVE_DIRECTORY_NAME;
 

--- a/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
+++ b/api/src/main/java/org/openmrs/hl7/impl/HL7ServiceImpl.java
@@ -727,11 +727,11 @@ public class HL7ServiceImpl extends BaseOpenmrsService implements HL7Service, Re
 			log.debug("Unable to process hl7inqueue: " + hl7InQueue.getHL7InQueueId(), e);
 			log.debug("Hl7inqueue source: " + hl7InQueue.getHL7Source());
 			log.debug("hl7_processor.ignore_missing_patient_non_local? " + Context.getAdministrationService()
-			        .getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false"));
+			        .getGlobalProperty(HL7Constants.GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false"));
 			if (e.getCause() != null && "Could not resolve patient".equals(e.getCause().getMessage())
 			        && !"local".equals(hl7InQueue.getHL7Source().getName())
 			        && "true".equals(Context.getAdministrationService().getGlobalProperty(
-			            OpenmrsConstants.GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false"))) {
+			            HL7Constants.GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false"))) {
 				skipError = true;
 			}
 			if (!skipError) {

--- a/api/src/main/java/org/openmrs/util/FormUtil.java
+++ b/api/src/main/java/org/openmrs/util/FormUtil.java
@@ -26,7 +26,7 @@ import org.openmrs.ConceptName;
 import org.openmrs.Drug;
 import org.openmrs.Form;
 import org.openmrs.FormField;
-import org.openmrs.hl7.HL7Constants;
+
 
 /**
  * OpenMRS utilities related to forms.
@@ -220,7 +220,7 @@ public class FormUtil {
 	 * @return String representation of the given concept
 	 */
 	public static String conceptToString(Concept concept, ConceptName localizedName) {
-		return concept.getConceptId() + "^" + localizedName.getName() + "^" + HL7Constants.HL7_LOCAL_CONCEPT; // + "^"
+		return concept.getConceptId() + "^" + localizedName.getName() + "^" + "99DCT"; // + "^"
 	}
 
 	/**
@@ -230,6 +230,6 @@ public class FormUtil {
 	 * @return String representation of the given drug
 	 */
 	public static String drugToString(Drug drug) {
-		return drug.getDrugId() + "^" + drug.getName() + "^" + HL7Constants.HL7_LOCAL_DRUG;
+		return drug.getDrugId() + "^" + drug.getName() + "^" + "99RX";
 	}
 }

--- a/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
+++ b/api/src/main/java/org/openmrs/util/OpenmrsConstants.java
@@ -249,7 +249,8 @@ public final class OpenmrsConstants {
 
 	public static final String GLOBAL_PROPERTY_USER_REQUIRE_EMAIL_AS_USERNAME = "user.requireEmailAsUsername";
 
-	public static final String GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY = "hl7_archive.dir";
+	// FOR TRUNK-6775
+	// public static final String GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY = "hl7_archive.dir";
 
 	public static final String GLOBAL_PROPERTY_DEFAULT_THEME = "default_theme";
 
@@ -344,8 +345,9 @@ public final class OpenmrsConstants {
 	public static final String GLOBAL_PROPERTY_PROVIDER_SEARCH_MATCH_MODE = "providerSearch.matchMode";
 
 	public static final String GLOBAL_PROPERTY_DEFAULT_SERIALIZER = "serialization.defaultSerializer";
-
-	public static final String GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS = "hl7_processor.ignore_missing_patient_non_local";
+	
+// FOR TRUNK-6775 
+	// public static final String GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS = "hl7_processor.ignore_missing_patient_non_local";
 
 	public static final String GLOBAL_PROPERTY_TRUE_CONCEPT = "concept.true";
 
@@ -842,9 +844,10 @@ public final class OpenmrsConstants {
 		        "Configure whether passwords must contain both upper and lower case characters", BooleanDatatype.class,
 		        null));
 
-		props.add(new GlobalProperty(GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false",
-		        "If true, hl7 messages for patients that are not found and are non-local will silently be dropped/ignored",
-		        BooleanDatatype.class, null));
+		// FOR TRUNK-6775 
+		// props.add(new GlobalProperty(GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS, "false",
+		       //  "If true, hl7 messages for patients that are not found and are non-local will silently be dropped/ignored",
+		       //  BooleanDatatype.class, null));
 
 		props.add(new GlobalProperty(GLOBAL_PROPERTY_SHOW_PATIENT_NAME, "false",
 		        "Whether or not to display the patient name in the patient dashboard title. Note that enabling this could be security risk if multiple users operate on the same computer.",
@@ -852,9 +855,9 @@ public final class OpenmrsConstants {
 
 		props.add(new GlobalProperty(GLOBAL_PROPERTY_DEFAULT_THEME, "",
 		        "Default theme for users.  OpenMRS ships with themes of 'green', 'orange', 'purple', and 'legacy'"));
-
-		props.add(new GlobalProperty(GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY, HL7Constants.HL7_ARCHIVE_DIRECTORY_NAME,
-		        "The default name or absolute path for the folder where to write the hl7_in_archives."));
+		// FOR TRUNK-6775 
+		// props.add(new GlobalProperty(GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY, HL7Constants.HL7_ARCHIVE_DIRECTORY_NAME,
+		       // "The default name or absolute path for the folder where to write the hl7_in_archives."));
 
 		props.add(new GlobalProperty(GLOBAL_PROPERTY_REPORT_BUG_URL, "http://errors.openmrs.org/scrap",
 		        "The openmrs url where to submit bug reports"));

--- a/api/src/main/java/org/openmrs/util/databasechange/MoveDeletedHL7sChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/MoveDeletedHL7sChangeSet.java
@@ -46,7 +46,7 @@ public class MoveDeletedHL7sChangeSet implements CustomTaskChange {
 		insertHL7Sql.append("INSERT INTO hl7_in_queue");
 		insertHL7Sql.append(" (hl7_source, hl7_source_key, hl7_data, date_created, uuid, message_state)");
 		insertHL7Sql.append(" VALUES (?, ?, ?, ?, ?, ");
-		insertHL7Sql.append(HL7Constants.HL7_STATUS_DELETED);
+		insertHL7Sql.append(4); //deleted (HL7Constants.HL7_STATUS_DELETED);
 		insertHL7Sql.append(")");
 
 		PreparedStatement insertStatement;


### PR DESCRIPTION

## Description of what I changed

This change breaks the circular dependency between core utilities and HL7 support.

The following HL7-owned global property definitions were moved from `OpenmrsConstants` to `HL7Constants`:

- `GLOBAL_PROPERTY_HL7_ARCHIVE_DIRECTORY`
- `GLOBAL_PROPERTY_IGNORE_MISSING_NONLOCAL_PATIENTS`

Their registration as global properties was also moved from `OpenmrsConstants` to the HL7 side.

This removes the core dependency on HL7-owned constants and makes the dependency direction one-way: from HL7 to core.

## Issue I worked on

TRUNK-6775



