### PR TITLE
TRUNK-6756: Remove deprecated Daemon thread-execution overloads

### DIFF
--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -201,60 +201,6 @@ public final class Daemon {
 	 * scheduled task) and you want to start up a new parallel Daemon thread. You may only call this
 	 * method from a Daemon thread.
 	 *
-	 * @param runnable what to run in a new thread
-	 * @return the newly spawned {@link Thread}
-	 * @deprecated As of 2.7.0, consider using {@link #runNewDaemonTask(Runnable)} instead
-	 */
-	@Deprecated
-	public static Thread runInNewDaemonThread(final Runnable runnable) {
-		// make sure we're already in a daemon thread
-		if (!isDaemonThread()) {
-			throw new APIAuthenticationException("Only daemon threads can spawn new daemon threads");
-		}
-
-		// the previous implementation ensured that Thread.start() was called before this function returned
-		// since we cannot guarantee that the executor will run the thread when `execute()` is called, we need another
-		// mechanism to ensure the submitted Runnable was actually started.
-		final CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		// we should consider making DaemonThread public, so the caller can access returnedObject and exceptionThrown
-		DaemonThread thread = new DaemonThread() {
-
-			@Override
-			public void run() {
-				isDaemonThread.set(true);
-				try {
-					Context.openSession();
-					countDownLatch.countDown();
-					//Suppressing sonar issue "squid:S1217"
-					//We intentionally do not start a new thread yet, rather wrap the run call in a session.
-					runnable.run();
-				} finally {
-					try {
-						Context.closeSession();
-					} finally {
-						isDaemonThread.remove();
-						daemonThreadUser.remove();
-					}
-				}
-			}
-		};
-
-		OpenmrsThreadPoolHolder.threadExecutor.execute(thread);
-
-		// do not return until the thread is actually started to emulate the previous behaviour
-		try {
-			countDownLatch.await();
-		} catch (InterruptedException ignored) {}
-
-		return thread;
-	}
-
-	/**
-	 * Call this method if you are inside a Daemon thread (for example in a Module activator or a
-	 * scheduled task) and you want to start up a new parallel Daemon thread. You may only call this
-	 * method from a Daemon thread.
-	 *
 	 * @param callable what to run in a new thread
 	 * @return a future that completes when the task is done;
 	 * @since 2.7.0
@@ -359,48 +305,6 @@ public final class Daemon {
 				        service.getClass().getSimpleName(), e);
 			}
 		}
-	}
-
-	/**
-	 * Executes the given runnable in a new thread that is authenticated as the daemon user.
-	 *
-	 * @param runnable an object implementing the {@link Runnable} interface.
-	 * @param token the token required to run code as the daemon user
-	 * @return the newly spawned {@link Thread}
-	 * @since 1.9.2
-	 * @deprecated Since 2.7.0 use {@link #runInDaemonThreadWithoutResult(Runnable, DaemonToken)}
-	 *             instead
-	 */
-	@Deprecated
-	@SuppressWarnings({ "squid:S1217", "unused" })
-	public static Thread runInDaemonThread(final Runnable runnable, DaemonToken token) {
-		if (!ModuleFactory.isTokenValid(token)) {
-			throw new ContextAuthenticationException("Invalid token " + token);
-		}
-
-		DaemonThread thread = new DaemonThread() {
-
-			@Override
-			public void run() {
-				isDaemonThread.set(true);
-				try {
-					Context.openSession();
-					//Suppressing sonar issue "squid:S1217"
-					//We intentionally do not start a new thread yet, rather wrap the run call in a session.
-					runnable.run();
-				} finally {
-					try {
-						Context.closeSession();
-					} finally {
-						isDaemonThread.remove();
-						daemonThreadUser.remove();
-					}
-				}
-			}
-		};
-
-		OpenmrsThreadPoolHolder.threadExecutor.execute(thread);
-		return thread;
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/context/DaemonTest.java
+++ b/api/src/test/java/org/openmrs/api/context/DaemonTest.java
@@ -15,7 +15,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -37,7 +36,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 /**
  * Tests the methods on the {@link Daemon} class
@@ -104,21 +102,6 @@ public class DaemonTest extends BaseContextSensitiveTest {
 		    new Object[] { u.getDisplayString() }, Locale.ENGLISH)));
 	}
 
-	/**
-	 * @see Daemon#runInNewDaemonThread(Runnable)
-	 */
-	@Test
-	public void runInNewDaemonThread_shouldThrowErrorIfCalledFromANonDaemonThread() {
-		try {
-			Daemon.runInNewDaemonThread(() -> {
-				// do nothing
-			});
-			fail("Should not hit this line, since the previous needed to throw an exception");
-		} catch (APIAuthenticationException ex) {
-			assertThat(ex.getMessage(), is("Only daemon threads can spawn new daemon threads"));
-		}
-	}
-
 	@Test
 	public void runInNewDaemonThreadCallable_shouldThrowErrorIfCalledFromANonDaemonThread() {
 		try {
@@ -172,23 +155,6 @@ public class DaemonTest extends BaseContextSensitiveTest {
 		@Override
 		public void execute() throws InterruptedException, ExecutionException {
 			this.wasRun = true;
-		}
-	}
-
-	/**
-	 * A task that starts another Daemon thread that marks *this* thread when it gets run.
-	 */
-	private static class TaskThatStartsAnotherThread extends PrivateTask {
-
-		@Override
-		public void execute() throws InterruptedException {
-			Thread another = Daemon.runInNewDaemonThread(() -> {
-				this.wasRun = true;
-			});
-
-			// another.join(10000); doesn't actually work as runInNewDaemonThread doesn't use the Thread object rather it
-			// only executes the run method. The only way to determine it completed is to wait for wasRun to return true.
-			await().atMost(10, TimeUnit.SECONDS).untilTrue(new AtomicBoolean(wasRun));
 		}
 	}
 


### PR DESCRIPTION
TRUNK-6756: Remove deprecated Daemon thread-execution overloads

## Description of what I changed

Removed the deprecated Daemon thread-execution overloads and the tests that specifically covered those removed overloads.

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6756

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)

- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.