### PR TITLE
TRUNK-6784: LoggingAdvice should have a fast exit path

### DIFF
--- a/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
+++ b/api/src/main/java/org/openmrs/aop/LoggingAdvice.java
@@ -10,13 +10,13 @@
 package org.openmrs.aop;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.openmrs.User;
 import org.openmrs.annotation.Logging;
+import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
@@ -56,108 +56,121 @@ public class LoggingAdvice implements MethodInterceptor {
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
 
+		// This advice wraps every method of every service, so the overwhelmingly common case is that
+		// neither level is enabled and there is nothing to do. Bail out before touching the method
+		// name, the clock or a try/finally frame, none of which can affect the outcome here.
+		final boolean traceEnabled = log.isTraceEnabled();
+		final boolean debugEnabled = log.isDebugEnabled();
+		if (!traceEnabled && !debugEnabled) {
+			return invocation.proceed();
+		}
+
 		Method method = invocation.getMethod();
 		String name = method.getName();
 
 		// decide what type of logging we're doing with the current method and the loglevel
 		boolean isSetterTypeOfMethod = OpenmrsUtil.stringStartsWith(name, SETTER_METHOD_PREFIXES);
-		boolean logGetter = !isSetterTypeOfMethod && log.isTraceEnabled();
-		boolean logSetter = isSetterTypeOfMethod && log.isDebugEnabled();
+		boolean logGetter = !isSetterTypeOfMethod && traceEnabled;
+		boolean logSetter = isSetterTypeOfMethod && debugEnabled;
 
-		// used for the execution time calculations
-		long startTime = System.currentTimeMillis();
-
-		// check if this method has the logging annotation on it
-		Logging loggingAnnotation = null;
-		if (logGetter || logSetter) {
-			loggingAnnotation = AnnotationUtils.findAnnotation(method, Logging.class);
-			if (loggingAnnotation != null && loggingAnnotation.ignore()) {
-				logGetter = false;
-				logSetter = false;
-			}
+		// e.g. a getter when only DEBUG is enabled: the enabled level does not cover this method
+		if (!logGetter && !logSetter) {
+			return invocation.proceed();
 		}
 
-		if (logGetter || logSetter) {
-			StringBuilder output = new StringBuilder();
-			output.append("In method ").append(method.getDeclaringClass().getSimpleName()).append(".").append(name);
+		// check if this method has the logging annotation on it
+		Logging loggingAnnotation = AnnotationUtils.findAnnotation(method, Logging.class);
+		if (loggingAnnotation != null && loggingAnnotation.ignore()) {
+			return invocation.proceed();
+		}
 
-			// print the argument values unless we're ignoring all
-			if (loggingAnnotation == null || !loggingAnnotation.ignoreAllArgumentValues()) {
+		// used for the execution time calculations; nanoTime is monotonic, so unlike wall-clock time it
+		// cannot report a negative or inflated duration when the system clock is adjusted mid-call
+		long startTime = System.nanoTime();
 
-				int x;
-				Class<?>[] types = method.getParameterTypes();
-				Object[] values = invocation.getArguments();
+		StringBuilder output = new StringBuilder();
+		output.append("In method ").append(method.getDeclaringClass().getSimpleName()).append(".").append(name);
 
-				// change the annotation array of indexes to a list of indexes to ignore
-				List<Integer> argsToIgnore = new ArrayList<>();
-				if (loggingAnnotation != null && loggingAnnotation.ignoredArgumentIndexes().length > 0) {
-					for (int argIndexToIgnore : loggingAnnotation.ignoredArgumentIndexes()) {
-						argsToIgnore.add(argIndexToIgnore);
+		// print the argument values unless we're ignoring all
+		if (loggingAnnotation == null || !loggingAnnotation.ignoreAllArgumentValues()) {
+
+			Class<?>[] types = method.getParameterTypes();
+			Object[] values = invocation.getArguments();
+
+			// flag the indexes named by the annotation so the loop below can test them directly; indexes
+			// outside the parameter list are ignored rather than treated as an error
+			boolean[] argsToIgnore = null;
+			if (loggingAnnotation != null && loggingAnnotation.ignoredArgumentIndexes().length > 0) {
+				argsToIgnore = new boolean[types.length];
+				for (int argIndexToIgnore : loggingAnnotation.ignoredArgumentIndexes()) {
+					if (argIndexToIgnore >= 0 && argIndexToIgnore < types.length) {
+						argsToIgnore[argIndexToIgnore] = true;
 					}
 				}
+			}
 
-				// loop over and print out each argument value
-				output.append(". Arguments: ");
-				for (x = 0; x < types.length; x++) {
-					output.append(types[x].getSimpleName()).append("=");
+			// loop over and print out each argument value
+			output.append(". Arguments: ");
+			for (int x = 0; x < types.length; x++) {
+				output.append(types[x].getSimpleName()).append("=");
 
-					// if there is an annotation to skip this, print out a bogus string.
-					if (argsToIgnore.contains(x)) {
-						output.append("<Arg value ignored>");
-					} else {
-						output.append(values[x]);
-					}
-
-					output.append(", ");
+				// if there is an annotation to skip this, print out a bogus string.
+				if (argsToIgnore != null && argsToIgnore[x]) {
+					output.append("<Arg value ignored>");
+				} else {
+					output.append(values[x]);
 				}
 
+				output.append(", ");
 			}
 
-			// print the string as either trace or debug
-			if (logGetter) {
-				log.trace(output.toString());
-			} else if (logSetter) {
-				log.debug(output.toString());
-			}
+		}
+
+		// print the string as either trace or debug
+		if (logGetter) {
+			log.trace(output.toString());
+		} else {
+			log.debug(output.toString());
 		}
 
 		try {
 			// do the actual method we're wrapped around
 			return invocation.proceed();
 		} catch (Exception e) {
-			if (logGetter || logSetter) {
-				String username;
-				User user = Context.getAuthenticatedUser();
-				if (user == null) {
-					username = "Guest (Not logged in)";
-				} else {
-					username = user.getUsername();
-					if (username == null || username.length() == 0) {
-						username = user.getSystemId();
-					}
-				}
-				log.debug(
-				    String.format("An error occurred while executing this method.%nCurrent user: %s%nError message: %s",
-				        username, e.getMessage()),
-				    e);
+			String username;
+			User user = null;
+			try {
+				user = Context.getAuthenticatedUser();
+			} catch (APIException ignored) {
+				// no user context established
 			}
+
+			if (user == null) {
+				username = "Guest (Not logged in)";
+			} else {
+				username = user.getUsername();
+				if (username == null || username.length() == 0) {
+					username = user.getSystemId();
+				}
+			}
+			log.debug("An error occurred while executing this method.\nCurrent user: {}\nError message: {}", username,
+			    e.getMessage(), e);
 			throw e;
 		} finally {
-			if (logGetter || logSetter) {
-				StringBuilder output = new StringBuilder();
-				output.append("Exiting method ").append(name);
+			StringBuilder exitOutput = new StringBuilder();
+			exitOutput.append("Exiting method ").append(name);
 
-				// only append execution time info if we're in debug mode
-				if (log.isDebugEnabled()) {
-					output.append(". execution time: ").append(System.currentTimeMillis() - startTime).append(" ms");
-				}
+			// only append execution time info if we're in debug mode
+			if (debugEnabled) {
+				exitOutput.append(". execution time: ").append(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime))
+				        .append(" ms");
+			}
 
-				// print the string as either trace or debug
-				if (logGetter) {
-					log.trace(output.toString());
-				} else if (logSetter) {
-					log.debug(output.toString());
-				}
+			// output the string as either trace or debug
+			if (logGetter) {
+				log.trace(exitOutput.toString());
+			} else {
+				log.debug(exitOutput.toString());
 			}
 		}
 

--- a/api/src/test/java/org/openmrs/aop/LoggingAdviceTest.java
+++ b/api/src/test/java/org/openmrs/aop/LoggingAdviceTest.java
@@ -1,0 +1,274 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.aop;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.openmrs.annotation.Logging;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.logging.MemoryAppender;
+import org.openmrs.util.OpenmrsConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests {@link LoggingAdvice}. The advice logs to the fixed logger name
+ * {@link OpenmrsConstants#LOG_CLASS_DEFAULT}, so these tests attach a {@link MemoryAppender} to
+ * that logger and drive its level to exercise each branch.
+ */
+class LoggingAdviceTest {
+
+	/**
+	 * Methods the advice is exercised against. The advice classifies by method name prefix, so the
+	 * names here matter: "get" is a getter (TRACE) and "save" is a setter (DEBUG).
+	 */
+	public interface Sample {
+
+		String getThing(Integer id);
+
+		String saveThing(String thing, String password);
+
+		@Logging(ignore = true)
+		String saveIgnoredThing(String thing);
+
+		@Logging(ignoredArgumentIndexes = { 1 })
+		String saveThingWithSecret(String thing, String password);
+
+		@Logging(ignoredArgumentIndexes = { 1, 7 })
+		String saveThingWithOutOfRangeIgnoredIndex(String thing, String password);
+
+		@Logging(ignoreAllArgumentValues = true)
+		String saveSecretThing(String thing);
+	}
+
+	private MemoryAppender memoryAppender;
+
+	private Logger logger;
+
+	private Level originalLevel;
+
+	private boolean originalAdditive;
+
+	private LoggingAdvice advice;
+
+	@BeforeEach
+	void setup(TestInfo testInfo) {
+		// MemoryAppender keys its backing buffer on the appender name in a static map, so each test needs
+		// its own name or it sees the log lines every other test produced
+		memoryAppender = MemoryAppender.newBuilder().setName("LoggingAdviceTest-" + testInfo.getDisplayName())
+		        .setLayout(PatternLayout.newBuilder().withPattern("%m").build()).build();
+		memoryAppender.start();
+
+		logger = (Logger) LogManager.getLogger(OpenmrsConstants.LOG_CLASS_DEFAULT);
+		originalLevel = logger.getLevel();
+		originalAdditive = logger.isAdditive();
+		// NB This needs to come before the setLevel() call
+		logger.setAdditive(false);
+		logger.setLevel(Level.WARN);
+		logger.addAppender(memoryAppender);
+
+		advice = new LoggingAdvice();
+	}
+
+	@AfterEach
+	void tearDown() {
+		logger.removeAppender(memoryAppender);
+		logger.setLevel(originalLevel);
+		logger.setAdditive(originalAdditive);
+		((Logger) LogManager.getRootLogger()).getContext().updateLoggers();
+		memoryAppender.stop();
+
+		Context.clearUserContext();
+
+		memoryAppender = null;
+		logger = null;
+		advice = null;
+	}
+
+	private MethodInvocation invocationFor(String methodName, Class<?>[] parameterTypes, Object... arguments)
+	        throws Throwable {
+		Method method = Sample.class.getMethod(methodName, parameterTypes);
+		MethodInvocation invocation = mock(MethodInvocation.class);
+		when(invocation.getMethod()).thenReturn(method);
+		when(invocation.getArguments()).thenReturn(arguments);
+		when(invocation.proceed()).thenReturn("result");
+		return invocation;
+	}
+
+	@Test
+	void shouldNotLogAnythingWhenLoggerIsDisabled() throws Throwable {
+		MethodInvocation invocation = invocationFor("saveThing", new Class<?>[] { String.class, String.class }, "thing",
+		    "secret");
+
+		assertThat(advice.invoke(invocation), org.hamcrest.Matchers.equalTo("result"));
+
+		verify(invocation, times(1)).proceed();
+		assertThat(memoryAppender.getLogLines(), empty());
+	}
+
+	@Test
+	void shouldStillProceedWhenLoggerIsDisabled() throws Throwable {
+		MethodInvocation invocation = invocationFor("getThing", new Class<?>[] { Integer.class }, 1);
+
+		advice.invoke(invocation);
+
+		verify(invocation, times(1)).proceed();
+	}
+
+	@Test
+	void shouldPropagateExceptionsWhenLoggerIsDisabled() throws Throwable {
+		MethodInvocation invocation = invocationFor("getThing", new Class<?>[] { Integer.class }, 1);
+		IllegalStateException thrown = new IllegalStateException("boom");
+		when(invocation.proceed()).thenThrow(thrown);
+
+		assertThat(assertThrows(IllegalStateException.class, () -> advice.invoke(invocation)),
+		    org.hamcrest.Matchers.sameInstance(thrown));
+		assertThat(memoryAppender.getLogLines(), empty());
+	}
+
+	@Test
+	void shouldLogSettersWhenDebugIsEnabled() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveThing", new Class<?>[] { String.class, String.class }, "thing",
+		    "secret");
+
+		advice.invoke(invocation);
+
+		List<String> logLines = memoryAppender.getLogLines();
+		assertThat(logLines, hasItem(containsString("In method Sample.saveThing. Arguments: String=thing, String=secret,")));
+		assertThat(logLines, hasItem(containsString("Exiting method saveThing. execution time:")));
+	}
+
+	@Test
+	void shouldNotLogGettersWhenOnlyDebugIsEnabled() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("getThing", new Class<?>[] { Integer.class }, 1);
+
+		advice.invoke(invocation);
+
+		verify(invocation, times(1)).proceed();
+		assertThat(memoryAppender.getLogLines(), empty());
+	}
+
+	@Test
+	void shouldLogGettersWhenTraceIsEnabled() throws Throwable {
+		logger.setLevel(Level.TRACE);
+		MethodInvocation invocation = invocationFor("getThing", new Class<?>[] { Integer.class }, 1);
+
+		advice.invoke(invocation);
+
+		List<String> logLines = memoryAppender.getLogLines();
+		assertThat(logLines, hasItem(containsString("In method Sample.getThing. Arguments: Integer=1,")));
+		// TRACE implies DEBUG here, so the execution time is included
+		assertThat(logLines, hasItem(containsString("Exiting method getThing. execution time:")));
+	}
+
+	@Test
+	void shouldNotLogMethodsAnnotatedAsIgnored() throws Throwable {
+		logger.setLevel(Level.TRACE);
+		MethodInvocation invocation = invocationFor("saveIgnoredThing", new Class<?>[] { String.class }, "thing");
+
+		advice.invoke(invocation);
+
+		verify(invocation, times(1)).proceed();
+		assertThat(memoryAppender.getLogLines(), empty());
+	}
+
+	@Test
+	void shouldMaskArgumentsAtTheAnnotatedIndexes() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveThingWithSecret", new Class<?>[] { String.class, String.class },
+		    "thing", "secret");
+
+		advice.invoke(invocation);
+
+		List<String> logLines = memoryAppender.getLogLines();
+		assertThat(logLines, hasItem(
+		    containsString("In method Sample.saveThingWithSecret. Arguments: String=thing, String=<Arg value ignored>,")));
+		assertThat(logLines, not(hasItem(containsString("secret"))));
+	}
+
+	@Test
+	void shouldIgnoreAnnotatedIndexesOutsideTheParameterList() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveThingWithOutOfRangeIgnoredIndex",
+		    new Class<?>[] { String.class, String.class }, "thing", "secret");
+
+		advice.invoke(invocation);
+
+		assertThat(memoryAppender.getLogLines(), hasItem(containsString(
+		    "In method Sample.saveThingWithOutOfRangeIgnoredIndex. Arguments: String=thing, String=<Arg value ignored>,")));
+	}
+
+	@Test
+	void shouldOmitAllArgumentsWhenAnnotatedToDoSo() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveSecretThing", new Class<?>[] { String.class }, "thing");
+
+		advice.invoke(invocation);
+
+		List<String> logLines = memoryAppender.getLogLines();
+		assertThat(logLines, hasItem(containsString("In method Sample.saveSecretThing")));
+		assertThat(logLines, not(hasItem(containsString("Arguments:"))));
+	}
+
+	@Test
+	void shouldLogTheErrorAndTheExitWhenTheWrappedMethodThrows() throws Throwable {
+		UserContext userContext = mock(UserContext.class);
+		when(userContext.getAuthenticatedUser()).thenReturn(null);
+		Context.setUserContext(userContext);
+
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveThing", new Class<?>[] { String.class, String.class }, "thing",
+		    "secret");
+		IllegalStateException thrown = new IllegalStateException("boom");
+		when(invocation.proceed()).thenThrow(thrown);
+
+		assertThat(assertThrows(IllegalStateException.class, () -> advice.invoke(invocation)),
+		    org.hamcrest.Matchers.sameInstance(thrown));
+
+		List<String> logLines = memoryAppender.getLogLines();
+		assertThat(logLines, hasItem(containsString("An error occurred while executing this method.")));
+		assertThat(logLines, hasItem(containsString("Guest (Not logged in)")));
+		assertThat(logLines, hasItem(containsString("Exiting method saveThing")));
+	}
+
+	@Test
+	void shouldLogEntryBeforeAndExitAfterTheWrappedMethod() throws Throwable {
+		logger.setLevel(Level.DEBUG);
+		MethodInvocation invocation = invocationFor("saveSecretThing", new Class<?>[] { String.class }, "thing");
+
+		advice.invoke(invocation);
+
+		assertThat(memoryAppender.getLogLines(),
+		    contains(containsString("In method Sample.saveSecretThing"), containsString("Exiting method saveSecretThing")));
+	}
+}


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111: Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->

`LoggingAdvice` is wrapped-around every service method call and provides useful logging information when the loggers are setup to display it. Most of the time, this logging is disabled; however, because `LoggingAdvice` lacks a fast exit pathway when it won't log any messages, it winds up adding some unnecessary method overhead. While the overhead here is quite small on a per-call basis, because it's invoked on every service method, the overhead can become a significant portion of a single threads CPU usage when the underlying wrapped calls are fast.

This adds some reasonable fast exit points to the `LoggingAdvice` which should trigger in the normal case where `DEBUG` and `TRACE` level logging are not enabled. Also adds some tests for `LoggingAdvice` itself. These tests pass both with and without these changes.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6784

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

