### PR TITLE
TRUNK-6788: Add missing test coverage for FilterUtil and GZIPFilter

### DIFF
--- a/web/src/test/java/org/openmrs/web/filter/GZIPFilterTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/GZIPFilterTest.java
@@ -9,12 +9,9 @@
  */
 package org.openmrs.web.filter;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
 import jakarta.servlet.FilterChain;
@@ -29,6 +26,7 @@ import org.mockito.Mockito;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.GlobalPropertiesTestHelper;
+import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -62,8 +60,9 @@ public class GZIPFilterTest extends BaseWebContextSensitiveTest {
 	 * it, so the value does not leak into whatever test runs next in this JVM.
 	 */
 	@AfterEach
-	public void purgeAcceptedPathsProperty() {
+	public void purgeGlobalProperties() {
 		globalProperties.purgeGlobalProperty(ACCEPT_PATHS);
+		globalProperties.purgeGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_GZIP_ENABLED);
 	}
 
 	/**
@@ -145,6 +144,34 @@ public class GZIPFilterTest extends BaseWebContextSensitiveTest {
 		req.setContent(bytes.toByteArray());
 
 		return req;
+	}
+
+	@Test
+	public void doFilterInternal_shouldCompressResponseWhenGZIPIsSupportedAndEnabled() throws Exception {
+		globalProperties.setGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_GZIP_ENABLED, "true");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Accept-Encoding", "gzip");
+
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		FilterChain filterChain = (req, res) -> {
+			res.getOutputStream().write("message string".getBytes(StandardCharsets.UTF_8));
+		};
+
+		GZIPFilter gzipFilter = new GZIPFilter();
+
+		gzipFilter.doFilterInternal(request, response, filterChain);
+
+		assertThat(response.getHeader("Content-Encoding"), is("gzip"));
+
+		byte[] compressedResponse = response.getContentAsByteArray();
+
+		try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedResponse));
+		        InputStreamReader reader = new InputStreamReader(gzipInputStream, StandardCharsets.UTF_8);
+		        BufferedReader bufferedReader = new BufferedReader(reader)) {
+
+			assertThat(bufferedReader.readLine(), is("message string"));
+		}
 	}
 
 }

--- a/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
+++ b/web/src/test/java/org/openmrs/web/filter/update/util/FilterUtilTest.java
@@ -10,11 +10,13 @@
 package org.openmrs.web.filter.update.util;
 
 import org.junit.jupiter.api.Test;
+import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.filter.util.FilterUtil;
 import org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -74,6 +76,26 @@ public class FilterUtilTest extends BaseWebContextSensitiveTest {
 		// and returns null. On the earlier string-concatenated query this payload resolved a single
 		// row and returned "7", so this asserts the value is now treated as data, not query text.
 		assertNull(FilterUtil.getGlobalPropertyValue("nonexistent' OR property = 'concept.true"));
+	}
+
+	@Test
+	public void storeLocale_shouldReturnFalseForNullLocale() {
+		assertFalse(FilterUtil.storeLocale(null));
+	}
+
+	@Test
+	public void storeLocale_shouldReturnFalseForBlankLocale() {
+		assertFalse(FilterUtil.storeLocale(""));
+	}
+
+	@Test
+	public void restoreLocale_shouldReturnDefaultLocaleForNullUsername() {
+		assertEquals(OpenmrsConstants.GLOBAL_PROPERTY_DEFAULT_LOCALE_DEFAULT_VALUE, FilterUtil.restoreLocale(null));
+	}
+
+	@Test
+	public void restoreLocale_shouldReturnDefaultLocaleForBlankUsername() {
+		assertEquals(OpenmrsConstants.GLOBAL_PROPERTY_DEFAULT_LOCALE_DEFAULT_VALUE, FilterUtil.restoreLocale(""));
 	}
 
 }


### PR DESCRIPTION
## Description

This PR adds missing test coverage for `FilterUtil` and `GZIPFilter`.

### Changes

* Added tests for null and blank inputs in `FilterUtil`.
* Added a test for GZIP response compression in `GZIPFilter`.
* Added cleanup for the GZIP global property after tests.

No application behavior has been changed.

## Issue I worked on
https://openmrs.atlassian.net/browse/TRUNK-6788

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(These are minor code quality fixes that do not require new tests.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**
