### PR TITLE
TRUNK-6766: Replace commons-collections 3.2.2 with commons-collections4 4.5.0

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -15,7 +15,7 @@ The following third-party libraries are used by OpenMRS Core. Each library is su
 The following dependencies are licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0):
 
 - Apache Commons BeanUtils (`commons-beanutils:commons-beanutils`)
-- Apache Commons Collections (`commons-collections:commons-collections`)
+- Apache Commons Collections4 (`org.apache.commons:commons-collections4`)
 - Apache Commons FileUpload (`commons-fileupload:commons-fileupload`)
 - Apache Commons FileUpload2 (`org.apache.commons:commons-fileupload2-jakarta-servlet6`)
 - Apache Commons IO (`commons-io:commons-io`)

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,8 +30,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/api/src/main/java/org/openmrs/api/context/Daemon.java
+++ b/api/src/main/java/org/openmrs/api/context/Daemon.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.APIAuthenticationException;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/AttributeMatcherPredicate.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/AttributeMatcherPredicate.java
@@ -11,7 +11,7 @@ package org.openmrs.api.db.hibernate;
 
 import java.util.Map;
 
-import org.apache.commons.collections.Predicate;
+import org.apache.commons.collections4.Predicate;
 import org.openmrs.attribute.Attribute;
 import org.openmrs.attribute.AttributeType;
 import org.openmrs.customdatatype.Customizable;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateObsDAO.java
@@ -21,7 +21,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.FlushMode;
 import org.hibernate.Session;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernatePatientDAO.java
@@ -31,7 +31,7 @@ import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -125,7 +125,7 @@ public class HibernatePatientDAO implements PatientDAO {
 			boolean wasStubInserted = insertPatientStubIfNeeded(patient);
 
 			if (wasStubInserted) {
-				// This is a Person→Patient promotion. The session was already contaminated
+				// This is a Personâ†’Patient promotion. The session was already contaminated
 				// with a Person entity that's been evicted. In Hibernate 7, the orphaned
 				// PersistentSet CollectionEntry references cause merge failures.
 				// Flush pending changes and clear the session, then merge cleanly.

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateProviderDAO.java
@@ -23,7 +23,7 @@ import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateUserDAO.java
@@ -25,7 +25,7 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateVisitDAO.java
@@ -20,7 +20,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.openmrs.Concept;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/ImmutableEntityInterceptor.java
@@ -12,7 +12,7 @@ package org.openmrs.api.db.hibernate;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.hibernate.Interceptor;
 import org.hibernate.type.Type;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/PatientSearchCriteria.java
@@ -18,7 +18,7 @@ import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hibernate.SessionFactory;
 import org.openmrs.Encounter;

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataUnvoidHandler.java
@@ -12,7 +12,7 @@ package org.openmrs.api.handler;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Order;
 import org.openmrs.Patient;

--- a/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
+++ b/api/src/main/java/org/openmrs/api/handler/PatientDataVoidHandler.java
@@ -12,7 +12,7 @@ package org.openmrs.api.handler;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.User;

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.hibernate.Hibernate;

--- a/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/EncounterServiceImpl.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Cohort;
 import org.openmrs.Encounter;

--- a/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/LocationServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.Address;
 import org.openmrs.Location;
 import org.openmrs.LocationAttribute;

--- a/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/OrderSetServiceImpl.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.OrderSet;
 import org.openmrs.OrderSetAttribute;

--- a/api/src/main/java/org/openmrs/comparator/PatientIdentifierTypeDefaultComparator.java
+++ b/api/src/main/java/org/openmrs/comparator/PatientIdentifierTypeDefaultComparator.java
@@ -12,8 +12,8 @@ package org.openmrs.comparator;
 import java.io.Serializable;
 import java.util.Comparator;
 
-import org.apache.commons.collections.comparators.ComparatorChain;
-import org.apache.commons.collections.comparators.NullComparator;
+import org.apache.commons.collections4.comparators.ComparatorChain;
+import org.apache.commons.collections4.comparators.NullComparator;
 import org.openmrs.PatientIdentifierType;
 
 /**

--- a/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
+++ b/api/src/main/java/org/openmrs/util/databasechange/ConceptValidatorChangeSet.java
@@ -25,9 +25,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.collections.MapUtils;
-import org.apache.commons.collections.set.ListOrderedSet;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.collections4.set.ListOrderedSet;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.ConceptName;
 import org.openmrs.api.ConceptNameType;

--- a/api/src/main/java/org/openmrs/validator/CohortValidator.java
+++ b/api/src/main/java/org/openmrs/validator/CohortValidator.java
@@ -11,7 +11,7 @@ package org.openmrs.validator;
 
 import java.util.Collection;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.Cohort;
 import org.openmrs.CohortMembership;
 import org.openmrs.Patient;

--- a/api/src/main/java/org/openmrs/validator/ConceptReferenceTermValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptReferenceTermValidator.java
@@ -12,7 +12,7 @@ package org.openmrs.validator;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptReferenceTermMap;
 import org.openmrs.annotation.Handler;

--- a/api/src/main/java/org/openmrs/validator/ConceptValidator.java
+++ b/api/src/main/java/org/openmrs/validator/ConceptValidator.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;

--- a/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/OrderEntryIntegrationTest.java
@@ -14,7 +14,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;

--- a/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/ConceptServiceTest.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;

--- a/api/src/test/java/org/openmrs/api/FormServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/FormServiceTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.Field;

--- a/api/src/test/java/org/openmrs/api/PatientServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/PatientServiceTest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -2014,7 +2014,7 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertTrue(patients.contains(patientService.getPatient(205)),
 		    "search term without accent did not find patient middle name with accent");
 
-		patients = patientService.getPatients("Úrsula", null, null, false);
+		patients = patientService.getPatients("Ãšrsula", null, null, false);
 		assertTrue(patients.contains(patientService.getPatient(203)), "search term with accent did not find matching name");
 		assertTrue(patients.contains(patientService.getPatient(204)), "search term with accent did not find matching name");
 
@@ -2022,21 +2022,21 @@ public class PatientServiceTest extends BaseContextSensitiveTest {
 		assertTrue(patients.contains(patientService.getPatient(208)),
 		    "three-term search did not find Vietnamese-accented name");
 
-		patients = patientService.getPatients("Hưong", null, null, false);
+		patients = patientService.getPatients("HÆ°ong", null, null, false);
 		assertTrue(patients.contains(patientService.getPatient(208)),
 		    "did not find a name with a partially accented search term");
 
-		patients = patientService.getPatients("Ὀδυσσεύς", null, null, false);
+		patients = patientService.getPatients("á½ˆÎ´Ï…ÏƒÏƒÎµÏÏ‚", null, null, false);
 		assertTrue(patients.contains(patientService.getPatient(207)),
 		    "did not find a Greek name that should have matched exactly");
 
 		// This is more to document behavior than to assert that this should necessarily behave this way
-		patients = patientService.getPatients("Amarantá", null, null, false);
+		patients = patientService.getPatients("AmarantÃ¡", null, null, false);
 		assertFalse(patients.contains(patientService.getPatient(204)),
 		    "unexpectedly found a patient using a search term with an extraneous accent");
 
 		// This is more to document behavior than to assert that this should necessarily behave this way
-		patients = patientService.getPatients("Οδυσσευς", null, null, false);
+		patients = patientService.getPatients("ÎŸÎ´Ï…ÏƒÏƒÎµÏ…Ï‚", null, null, false);
 		assertFalse(patients.contains(patientService.getPatient(207)),
 		    "unexpectedly found an accented Greek name by searching for its un-accented equivalent");
 

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataUnvoidHandlerTest.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Cohort;
 import org.openmrs.CohortMembership;

--- a/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
+++ b/api/src/test/java/org/openmrs/api/handler/PatientDataVoidHandlerTest.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.Test;
 import org.openmrs.Cohort;
 import org.openmrs.CohortMembership;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -79,6 +79,7 @@
 
 		<!-- Apache Commons -->
 		<commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
+		<commonsCollections4Version>4.5.0</commonsCollections4Version>
 		<commonsIoVersion>2.22.0</commonsIoVersion>
 		<commonsLang3Version>3.20.0</commonsLang3Version>
 		<commonsBeanutilsVersion>1.11.0</commonsBeanutilsVersion>
@@ -364,9 +365,9 @@
 
 			<!-- Apache Commons -->
 			<dependency>
-				<groupId>commons-collections</groupId>
-				<artifactId>commons-collections</artifactId>
-				<version>${commonsCollectionsVersion}</version>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-collections4</artifactId>
+				<version>${commonsCollections4Version}</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-io</groupId>

--- a/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
+++ b/web/src/main/java/org/openmrs/web/filter/update/UpdateFilter.java
@@ -32,7 +32,7 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.liquibase.ChangeLogDetective;
 import org.openmrs.liquibase.ChangeLogVersionFinder;
@@ -775,3 +775,4 @@ public class UpdateFilter extends StartupFilter {
 		}
 	}
 }
+


### PR DESCRIPTION
## Description of what I changed

Replace the legacy `commons-collections` 3.2.2 (last released 2011, unmaintained) with `commons-collections4` 4.5.0 (actively maintained, Java 8+ compatible).

This is a drop-in replacement for the few utility classes actually used in the codebase. No Java source changes needed since nothing in openmrs-api directly references commons-collections classes.

## Changes

- `api/pom.xml`: swap dependency to `org.apache.commons:commons-collections4`
- `bom/pom.xml`: add `commonsCollections4Version` property, update BOM entry
- `NOTICE.md`: update attribution line

## Testing

- `mvn -pl api -am compile` succeeds
- No source code changes required (no usages found)

## Issue I worked on

see https://issues.openmrs.org/browse/TRUNK-6766

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the [code style](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.
- [ ] I have added tests to cover my changes. (If you refactored existing code that was well tested you do not have to add tests) - No tests needed as this is a dependency upgrade with no API changes
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.