### PR TITLE
TRUNK-6790: Fix week-to-millisecond conversion

### DIFF
--- a/api/src/main/java/org/openmrs/logic/Duration.java
+++ b/api/src/main/java/org/openmrs/logic/Duration.java
@@ -97,7 +97,7 @@ public class Duration implements Operand {
 			case DAYS:
 				return d * 86400000;
 			case WEEKS:
-				return d * 10080000;
+				return d * 604800000L;
 			case MONTHS:
 				return d * 2628000000L;
 			case YEARS:

--- a/api/src/test/java/org/openmrs/logic/DurationTest.java
+++ b/api/src/test/java/org/openmrs/logic/DurationTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
 package org.openmrs.logic;
 
 import org.junit.jupiter.api.Test;

--- a/api/src/test/java/org/openmrs/logic/DurationTest.java
+++ b/api/src/test/java/org/openmrs/logic/DurationTest.java
@@ -1,0 +1,57 @@
+package org.openmrs.logic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DurationTest {
+
+	@Test
+	public void getDurationInMillis_shouldConvertSecondsCorrectly() {
+		Duration duration = Duration.seconds(30.0);
+
+		assertEquals(30000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertMinutesCorrectly() {
+		Duration duration = Duration.minutes(5.0);
+
+		assertEquals(300000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertHoursCorrectly() {
+		Duration duration = Duration.hours(2.0);
+
+		assertEquals(7200000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertDaysCorrectly() {
+		Duration duration = Duration.days(3.0);
+
+		assertEquals(259200000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertMonthsCorrectly() {
+		Duration duration = Duration.months(1.0);
+
+		assertEquals(2628000000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertYearsCorrectly() {
+		Duration duration = Duration.years(1.0);
+
+		assertEquals(31536000000L, duration.getDurationInMillis());
+	}
+
+	@Test
+	public void getDurationInMillis_shouldConvertOneWeekCorrectly() {
+		Duration duration = Duration.weeks(1.0);
+
+		assertEquals(604800000L, duration.getDurationInMillis());
+	}
+}


### PR DESCRIPTION
## Changes

* Fixed incorrect week-to-millisecond conversion.
* Added tests for all duration units.
* Added regression coverage for the week conversion bug.

## Issue I worked on
See : https://openmrs.atlassian.net/browse/TRUNK-6790

## Testing

mvn -pl api -Dtest=org.openmrs.logic.DurationTest test

All tests pass.

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(These are minor code quality fixes that do not require new tests.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**
