### PR TITLE
Fix #6336: mergePatients runs the merge tail twice (duplicate savePatient and PersonMergeLog)

### DIFF
--- a/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/PatientServiceImpl.java
@@ -822,6 +822,11 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 	}
 
 	private void mergeDateOfDeath(Patient preferred, Patient notPreferred, PersonMergeLogData mergedData) {
+		mergedData.setPriorDateOfDeathEstimated(preferred.getDeathdateEstimated());
+		if (preferred.getDeathdateEstimated() == null) {
+			preferred.setDeathdateEstimated(notPreferred.getDeathdateEstimated());
+		}
+
 		mergedData.setPriorDateOfDeath(preferred.getDeathDate());
 		if (preferred.getDeathDate() == null) {
 			preferred.setDeathDate(notPreferred.getDeathDate());
@@ -923,69 +928,6 @@ public class PatientServiceImpl extends BaseOpenmrsService implements PatientSer
 				log.debug("Merging address " + newAddress.getPersonAddressId() + " to " + preferred.getPatientId());
 			}
 		}
-
-		// copy person attributes
-		for (PersonAttribute attr : notPreferred.getAttributes()) {
-			if (!attr.getVoided()) {
-				PersonAttribute tmpAttr = attr.copy();
-				tmpAttr.setPerson(null);
-				tmpAttr.setUuid(UuidUtil.newUuidString());
-				preferred.addAttribute(tmpAttr);
-				mergedData.addCreatedAttribute(tmpAttr.getUuid());
-			}
-		}
-
-		// move all other patient info
-		mergedData.setPriorGender(preferred.getGender());
-		if (!"M".equals(preferred.getGender()) && !"F".equals(preferred.getGender())) {
-			preferred.setGender(notPreferred.getGender());
-		}
-
-		mergedData.setPriorDateOfBirth(preferred.getBirthdate());
-		mergedData.setPriorDateOfBirthEstimated(preferred.getBirthdateEstimated());
-		if (preferred.getBirthdate() == null
-		        || (preferred.getBirthdateEstimated() && !notPreferred.getBirthdateEstimated())) {
-			preferred.setBirthdate(notPreferred.getBirthdate());
-			preferred.setBirthdateEstimated(notPreferred.getBirthdateEstimated());
-		}
-		mergedData.setPriorDateOfDeathEstimated(preferred.getDeathdateEstimated());
-		if (preferred.getDeathdateEstimated() == null) {
-			preferred.setDeathdateEstimated(notPreferred.getDeathdateEstimated());
-		}
-
-		mergedData.setPriorDateOfDeath(preferred.getDeathDate());
-		if (preferred.getDeathDate() == null) {
-			preferred.setDeathDate(notPreferred.getDeathDate());
-		}
-
-		if (preferred.getCauseOfDeath() != null) {
-			mergedData.setPriorCauseOfDeath(preferred.getCauseOfDeath().getUuid());
-		}
-		if (preferred.getCauseOfDeath() == null) {
-			preferred.setCauseOfDeath(notPreferred.getCauseOfDeath());
-		}
-
-		// void the non preferred patient
-		Context.getPatientService().voidPatient(notPreferred, "Merged with patient #" + preferred.getPatientId());
-
-		// void the person associated with not preferred patient
-		Context.getPersonService().voidPerson(notPreferred,
-		    "The patient corresponding to this person has been voided and Merged with patient #" + preferred.getPatientId());
-
-		// associate the Users associated with the not preferred person, to the preferred person.
-		changeUserAssociations(preferred, notPreferred, mergedData);
-
-		// Save the newly update preferred patient
-		// This must be called _after_ voiding the nonPreferred patient so that
-		//  a "Duplicate Identifier" error doesn't pop up.
-		preferred = savePatient(preferred);
-
-		//save the person merge log
-		PersonMergeLog personMergeLog = new PersonMergeLog();
-		personMergeLog.setWinner(preferred);
-		personMergeLog.setLoser(notPreferred);
-		personMergeLog.setPersonMergeLogData(mergedData);
-		Context.getPersonService().savePersonMergeLog(personMergeLog);
 	}
 
 	/**


### PR DESCRIPTION


### What's going on here

Found the cause of #6336 — mergePatients was running the "merge tail" step (saving the preferred patient, writing the PersonMergeLog, voiding the non-preferred patient/person) twice for every merge.

The reason: mergeAddresses(...) had a copy of the entire merge tail pasted in right after it merges the addresses. No idea why it ended up there, but it meant the tail logic ran once from mergeAddresses and then again from mergePatients like normal. Two savePatient calls, two PersonMergeLog entries, for one merge.

### What I did about it:

Ripped out that duplicate block from mergeAddresses. Now it just merges addresses like it's supposed to, nothing else tacked on.
While pulling that block out, I noticed it was doing some audit logging for deathdateEstimated that mergeDateOfDeath (the method that should actually own this) doesn't do on its own. Didn't want to just throw that away, so I moved it over to mergeDateOfDeath where it belongs.

After this, the merge tail only fires once, from mergePatients, which is how it was supposed to work in the first place.

### Issue

Fixes #6336 — https://github.com/openmrs/openmrs-core/issues/6336

