### PR TITLE
Run a module's liquibase when its version is a SNAPSHOT, even if unchanged (#6528)

### DIFF
--- a/api/src/main/java/org/openmrs/api/AdministrationService.java
+++ b/api/src/main/java/org/openmrs/api/AdministrationService.java
@@ -463,6 +463,10 @@ public interface AdministrationService extends OpenmrsService {
 
 	/**
 	 * Checks whether a module setup needs to be run due to a version change.
+	 * <p>
+	 * A module whose version is a <code>-SNAPSHOT</code> always needs setup, because a snapshot version
+	 * is republished unchanged for every rebuild and so cannot distinguish an unchanged module from one
+	 * that has gained liquibase changesets since it was installed.
 	 *
 	 * @since 2.9.0
 	 * @param moduleId the identifier of the module to check

--- a/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/AdministrationServiceImpl.java
@@ -1035,10 +1035,29 @@ public class AdministrationServiceImpl extends BaseOpenmrsService implements Adm
 		String current = module.getVersion();
 		if (!Objects.equals(stored, current)) {
 			return true;
-		} else {
-			log.info("{} module did not change, skipping setup", moduleId);
-			return false;
 		}
+
+		if (isSnapshotVersion(current)) {
+			log.info("{} module version {} is a snapshot, so it does not identify the build; running setup", moduleId,
+			    current);
+			return true;
+		}
+
+		log.info("{} module did not change, skipping setup", moduleId);
+		return false;
+	}
+
+	/**
+	 * A snapshot version is by definition not a stable identifier for a build: the same version string
+	 * is republished for every rebuild. Comparing it against the stored version therefore cannot tell
+	 * an unchanged module from one that has gained changesets since it was installed, and answering
+	 * "unchanged" means the new changesets are never run and nothing reports it.
+	 *
+	 * @param version the module version to inspect, may be null
+	 * @return true if the version is a Maven snapshot
+	 */
+	private boolean isSnapshotVersion(String version) {
+		return version != null && version.trim().toUpperCase(Locale.ROOT).endsWith("-SNAPSHOT");
 	}
 
 	/**

--- a/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
+++ b/api/src/test/java/org/openmrs/api/AdministrationServiceTest.java
@@ -36,6 +36,7 @@ import org.openmrs.messagesource.MutableMessageSource;
 import org.openmrs.messagesource.impl.MutableResourceBundleMessageSource;
 import org.openmrs.module.Module;
 import org.openmrs.module.ModuleActivator;
+import org.openmrs.module.ModuleFactory;
 import org.openmrs.test.jupiter.BaseContextSensitiveTest;
 import org.openmrs.util.HttpClient;
 import org.openmrs.util.LocaleUtility;
@@ -1295,5 +1296,82 @@ public class AdministrationServiceTest extends BaseContextSensitiveTest {
 
 		// verify hook methods must be called
 		verify(activator).setupOnVersionChange(previousCoreVersion, previousModuleVersion);
+	}
+
+	/**
+	 * A released module whose stored version equals its current one really is unchanged, so the startup
+	 * optimisation of TRUNK-6418 correctly skips its setup.
+	 */
+	@Test
+	public void isModuleSetupOnVersionChangeNeeded_shouldNotNeedSetupWhenAReleasedVersionIsUnchanged() {
+		adminService.setGlobalProperty("core.version", OpenmrsConstants.OPENMRS_VERSION_SHORT);
+		Module module = loadTestModule("releasedmodule", "1.2.3");
+		adminService.setGlobalProperty("module.releasedmodule.version", "1.2.3");
+
+		try {
+			assertFalse(adminService.isModuleSetupOnVersionChangeNeeded(module.getModuleId()));
+		} finally {
+			ModuleFactory.getLoadedModulesMap().remove(module.getModuleId());
+		}
+	}
+
+	/**
+	 * A snapshot version is republished unchanged for every rebuild, so an equal version string is no
+	 * evidence the module is unchanged. Skipping setup there means a changeset added after the module
+	 * was installed never runs, and nothing reports it.
+	 */
+	@Test
+	public void isModuleSetupOnVersionChangeNeeded_shouldNeedSetupWhenTheVersionIsASnapshotEvenIfUnchanged() {
+		adminService.setGlobalProperty("core.version", OpenmrsConstants.OPENMRS_VERSION_SHORT);
+		Module module = loadTestModule("snapshotmodule", "1.0.0-SNAPSHOT");
+		adminService.setGlobalProperty("module.snapshotmodule.version", "1.0.0-SNAPSHOT");
+
+		try {
+			assertTrue(adminService.isModuleSetupOnVersionChangeNeeded(module.getModuleId()));
+		} finally {
+			ModuleFactory.getLoadedModulesMap().remove(module.getModuleId());
+		}
+	}
+
+	/**
+	 * The qualifier is a Maven convention rather than a validated field, so the check must not depend
+	 * on how it happens to be cased.
+	 */
+	@Test
+	public void isModuleSetupOnVersionChangeNeeded_shouldRecogniseASnapshotQualifierInAnyCase() {
+		adminService.setGlobalProperty("core.version", OpenmrsConstants.OPENMRS_VERSION_SHORT);
+		Module module = loadTestModule("lowercasesnapshotmodule", "1.0.0-snapshot");
+		adminService.setGlobalProperty("module.lowercasesnapshotmodule.version", "1.0.0-snapshot");
+
+		try {
+			assertTrue(adminService.isModuleSetupOnVersionChangeNeeded(module.getModuleId()));
+		} finally {
+			ModuleFactory.getLoadedModulesMap().remove(module.getModuleId());
+		}
+	}
+
+	/**
+	 * A version that merely contains the word elsewhere is not a snapshot, so it must not defeat the
+	 * optimisation.
+	 */
+	@Test
+	public void isModuleSetupOnVersionChangeNeeded_shouldNotTreatAVersionMerelyMentioningSnapshotAsOne() {
+		adminService.setGlobalProperty("core.version", OpenmrsConstants.OPENMRS_VERSION_SHORT);
+		Module module = loadTestModule("snapshotnamedmodule", "1.0.0-SNAPSHOTS.1");
+		adminService.setGlobalProperty("module.snapshotnamedmodule.version", "1.0.0-SNAPSHOTS.1");
+
+		try {
+			assertFalse(adminService.isModuleSetupOnVersionChangeNeeded(module.getModuleId()));
+		} finally {
+			ModuleFactory.getLoadedModulesMap().remove(module.getModuleId());
+		}
+	}
+
+	private Module loadTestModule(String moduleId, String version) {
+		Module module = new Module("Test Module " + moduleId);
+		module.setModuleId(moduleId);
+		module.setVersion(version);
+		ModuleFactory.getLoadedModulesMap().put(moduleId, module);
+		return module;
 	}
 }


### PR DESCRIPTION
Fixes #6528.

## The problem

TRUNK-6418 runs a module's setup — and so its `liquibase.xml`, since `runModuleSetupOnVersionChange` is the only caller of `ModuleFactory.runLiquibaseForModule` — only when the module's version string differs from the stored `module.<moduleId>.version` property.

For a release that is a sound proxy for *"this artifact is unchanged"*. For a snapshot it is not: `-SNAPSHOT` means the version is republished unchanged for every rebuild, so an equal version string is no evidence the module has not gained changesets since it was installed. Every module developer runs `-SNAPSHOT`, and so does every CI SNAPSHOT deploy.

And the skip is silent. The module starts, is added to the started-modules map, `<module>.started` is set `true`, and the changeset never runs. The failure surfaces later as `Unknown column ... in 'INSERT INTO'` in code with no visible relationship to a startup optimisation. #6528 records a module where this cost every audit-log write for a day across three servers before anyone noticed — 10,224 rows and then nothing, while the module kept answering requests normally.

## The change

Treat a snapshot version as always changed:

```java
 if (!Objects.equals(stored, current)) {
     return true;
 }
+
+if (isSnapshotVersion(current)) {
+    log.info("{} module version {} is a snapshot, so it does not identify the build; running setup",
+        moduleId, current);
+    return true;
+}
+
 log.info("{} module did not change, skipping setup", moduleId);
 return false;
```

Releases keep the optimisation in full; the one configuration where the version string cannot answer the question stops being asked it. Liquibase is idempotent, so on an unchanged snapshot the added cost is a changelog check, which is the pre-TRUNK-6418 behaviour for that case only.

The check is **case-insensitive**, because the qualifier is a Maven convention rather than a validated field, and **anchored to the end**, so a version that merely mentions the word (`1.0.0-SNAPSHOTS.1`) is unaffected.

## Deliberately not changed

The core-version side of the comparison has the same shape, but `OPENMRS_VERSION_SHORT` drops the qualifier, so a core snapshot rebuild is a different problem needing a different fix. Left alone to keep this reviewable.

The other options floated on #6528 — comparing an artifact checksum instead of the version, or warning when a skipped module has unrun changesets — are both larger and neither is needed to close the reported failure. Happy to follow up with the WARN if reviewers want a safety net for the same-version *release* `.omod` case, which this PR does not cover.

## Tests

Four in `AdministrationServiceTest`, covering both directions, because a fix that simply always returned `true` would also make the snapshot cases pass:

| Test | Against `master` | With this PR |
|---|---|---|
| `...shouldNeedSetupWhenTheVersionIsASnapshotEvenIfUnchanged` | **fails** — expected `true`, was `false` | passes |
| `...shouldRecogniseASnapshotQualifierInAnyCase` | **fails** — expected `true`, was `false` | passes |
| `...shouldNotNeedSetupWhenAReleasedVersionIsUnchanged` | passes | passes |
| `...shouldNotTreatAVersionMerelyMentioningSnapshotAsOne` | passes | passes |

The two that pass either way are the point of the pair: they pin that the optimisation is not lost for the versions it is valid for.

Verified by reverting only `AdministrationServiceImpl` and re-running: `Tests run: 4, Failures: 2`.

Ran green: `AdministrationServiceTest`, `ModuleFactoryTest`, `ModuleUtilTest` — 170 tests, 0 failures, 4 skipped. `mvn -pl api spotless:check` clean.

## Verified end to end

The reported instance was recovered by forcing the comparison to differ (`DELETE FROM global_property WHERE property = 'module.chartsearchai.version'`, then restart), which is what this PR makes unnecessary. On restart the pending changeset ran and the feature it belonged to started working again:

```
chartsearchai-002   2026-07-19 01:14:00   EXECUTED
chartsearchai-009   2026-08-31 23:11:29   EXECUTED   <- had never run
```
