### PR TITLE
TRUNK-6794: Refactor duplicate layout template lookup logic

### DIFF
--- a/api/src/main/java/org/openmrs/layout/LayoutSupport.java
+++ b/api/src/main/java/org/openmrs/layout/LayoutSupport.java
@@ -11,6 +11,7 @@ package org.openmrs.layout;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,47 +79,23 @@ public abstract class LayoutSupport<T extends LayoutTemplate> {
 	}
 
 	public T getLayoutTemplateByCodeName(String templateName) {
-		if (this.layoutTemplates != null && templateName != null) {
-			T ret = null;
-
-			for (T at : this.layoutTemplates) {
-				if (at != null && templateName.equalsIgnoreCase(at.getCodeName())) {
-					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
-				}
-			}
-
-			return ret;
-		} else {
-			log.debug("No Layout Templates defined");
-			return null;
-		}
+		return findLayoutTemplate(templateName, LayoutTemplate::getCodeName);
 	}
 
 	public T getLayoutTemplateByCountry(String templateName) {
-		if (this.layoutTemplates != null && templateName != null) {
-			T ret = null;
-
-			for (T at : this.layoutTemplates) {
-				if (at != null && templateName.equalsIgnoreCase(at.getCountry())) {
-					ret = at;
-					log.debug("Found Layout Template named " + at.getDisplayName());
-				}
-			}
-
-			return ret;
-		} else {
-			log.debug("No Layout Templates defined");
-			return null;
-		}
+		return findLayoutTemplate(templateName, LayoutTemplate::getCountry);
 	}
 
 	public T getLayoutTemplateByDisplayName(String templateName) {
+		return findLayoutTemplate(templateName, LayoutTemplate::getDisplayName);
+	}
+
+	private T findLayoutTemplate(String templateName, Function<T, String> valueExtractor) {
 		if (this.layoutTemplates != null && templateName != null) {
 			T ret = null;
 
 			for (T at : this.layoutTemplates) {
-				if (at != null && templateName.equalsIgnoreCase(at.getDisplayName())) {
+				if (at != null && templateName.equalsIgnoreCase(valueExtractor.apply(at))) {
 					ret = at;
 					log.debug("Found Layout Template named " + at.getDisplayName());
 				}

--- a/api/src/test/java/org/openmrs/layout/LayoutSupportTest.java
+++ b/api/src/test/java/org/openmrs/layout/LayoutSupportTest.java
@@ -1,0 +1,78 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.layout;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LayoutSupportTest {
+
+	@Test
+	public void getLayoutTemplateByCodeName_shouldReturnMatchingTemplate() {
+		LayoutTemplate template = new TestLayoutTemplate();
+		template.setCodeName("test-code");
+
+		TestLayoutSupport support = new TestLayoutSupport();
+		support.setLayoutTemplates(Collections.singletonList(template));
+
+		assertEquals(template, support.getLayoutTemplateByCodeName("test-code"));
+	}
+
+	@Test
+	public void getLayoutTemplateByCountry_shouldReturnMatchingTemplate() {
+		LayoutTemplate template = new TestLayoutTemplate();
+		template.setCountry("India");
+
+		TestLayoutSupport support = new TestLayoutSupport();
+		support.setLayoutTemplates(Collections.singletonList(template));
+
+		assertEquals(template, support.getLayoutTemplateByCountry("India"));
+	}
+
+	@Test
+	public void getLayoutTemplateByDisplayName_shouldReturnMatchingTemplate() {
+		LayoutTemplate template = new TestLayoutTemplate();
+		template.setDisplayName("Test Template");
+
+		TestLayoutSupport support = new TestLayoutSupport();
+		support.setLayoutTemplates(Collections.singletonList(template));
+
+		assertEquals(template, support.getLayoutTemplateByDisplayName("Test Template"));
+	}
+
+	private static class TestLayoutTemplate extends LayoutTemplate {
+
+		@Override
+		public String getLayoutToken() {
+			return "";
+		}
+
+		@Override
+		public String getNonLayoutToken() {
+			return "";
+		}
+
+		@Override
+		public LayoutSupport<?> getLayoutSupportInstance() {
+			return null;
+		}
+	}
+
+	private static class TestLayoutSupport extends LayoutSupport<LayoutTemplate> {
+
+		@Override
+		public String getDefaultLayoutFormat() {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
## Changes
Extracted common lookup logic into a private helper method.
Added tests for lookup by code name, country, and display name.

## Issue I worked on
https://openmrs.atlassian.net/browse/TRUNK-6794

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(These are minor code quality fixes that do not require new tests.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**
