### PR TITLE
TRUNK-6787:Added hibernate disable auto commit property

### DIFF
--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -11,6 +11,8 @@ package org.openmrs.api.db.hibernate;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,8 +28,11 @@ import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.cfg.Environment;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.jspecify.annotations.NonNull;
@@ -225,6 +230,7 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 	public void integrate(Metadata metadata, BootstrapContext bootstrapContext, SessionFactoryImplementor sessionFactory) {
 		this.metadata = metadata;
 		generateEnversAuditTables(metadata, bootstrapContext.getServiceRegistry());
+		assertProviderDisablesAutocommitPremise(bootstrapContext.getServiceRegistry(), sessionFactory);
 	}
 
 	@Override
@@ -247,4 +253,31 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 			throw new APIException("An error occurred while initializing the Envers audit tables", e);
 		}
 	}
+
+	private void assertProviderDisablesAutocommitPremise(ServiceRegistry serviceRegistry,
+	        SessionFactoryImplementor sessionFactory) {
+		Map<String, Object> settings = sessionFactory.getProperties();
+		boolean declared = ConfigurationHelper.getBoolean(Environment.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, settings,
+		    false);
+		if (!declared) {
+			return;
+		}
+		ConnectionProvider provider = serviceRegistry.getService(ConnectionProvider.class);
+		try {
+			Connection conn = provider.getConnection();
+			try {
+				if (conn.getAutoCommit()) {
+					throw new HibernateException(
+					        "provider_disables_autocommit=true but the pool returned a connection with autoCommit=true; "
+					                + "configure the pool to disable autocommit at checkout or remove the property");
+				}
+			} finally {
+				provider.closeConnection(conn);
+			}
+		} catch (SQLException e) {
+			throw new HibernateException(
+			        "Failed to obtain a connection from the pool to check autoCommit state: " + e.getMessage(), e);
+		}
+	}
+
 }

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -28,11 +28,9 @@ import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
-import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
-import org.hibernate.internal.util.config.ConfigurationHelper;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
 import org.jspecify.annotations.NonNull;
@@ -256,10 +254,8 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 
 	private void assertProviderDisablesAutocommitPremise(ServiceRegistry serviceRegistry,
 	        SessionFactoryImplementor sessionFactory) {
-		Map<String, Object> settings = sessionFactory.getProperties();
-		boolean declared = ConfigurationHelper.getBoolean(JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, settings,
-		    false);
-		if (!declared) {
+
+		if (!sessionFactory.getSessionFactoryOptions().doesConnectionProviderDisableAutoCommit()) {
 			return;
 		}
 		ConnectionProvider provider = serviceRegistry.getService(ConnectionProvider.class);

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -28,7 +28,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
 import org.hibernate.boot.Metadata;
 import org.hibernate.boot.spi.BootstrapContext;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.integrator.spi.Integrator;
@@ -257,7 +257,7 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 	private void assertProviderDisablesAutocommitPremise(ServiceRegistry serviceRegistry,
 	        SessionFactoryImplementor sessionFactory) {
 		Map<String, Object> settings = sessionFactory.getProperties();
-		boolean declared = ConfigurationHelper.getBoolean(Environment.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, settings,
+		boolean declared = ConfigurationHelper.getBoolean(JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT, settings,
 		    false);
 		if (!declared) {
 			return;

--- a/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
+++ b/api/src/main/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBean.java
@@ -265,7 +265,9 @@ public class HibernateSessionFactoryBean extends LocalSessionFactoryBean impleme
 				if (conn.getAutoCommit()) {
 					throw new HibernateException(
 					        "provider_disables_autocommit=true but the pool returned a connection with autoCommit=true; "
-					                + "configure the pool to disable autocommit at checkout or remove the property");
+					                + "remove connection.autocommit=true from openmrs-runtime.properties, or set "
+					                + "connection.provider_disables_autocommit=false there if this pool really must hand out "
+					                + "auto-commit-enabled connections");
 				}
 			} finally {
 				provider.closeConnection(conn);

--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -5,6 +5,8 @@ hibernate.connection.username=test
 hibernate.connection.password=test
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
 hibernate.connection.url=jdbc:mysql://localhost:3306/openmrs?autoReconnect=true
+# safe because hibernate-c3p0 disables auto-commit at every connection checkout;
+# HibernateSessionFactoryBean refuses to start if that stops being true, see TRUNK-6787.
 hibernate.connection.provider_disables_autocommit=true
 
 # Hibernate specific connection/debug properties

--- a/api/src/main/resources/hibernate.default.properties
+++ b/api/src/main/resources/hibernate.default.properties
@@ -5,6 +5,7 @@ hibernate.connection.username=test
 hibernate.connection.password=test
 hibernate.connection.driver_class=com.mysql.jdbc.Driver
 hibernate.connection.url=jdbc:mysql://localhost:3306/openmrs?autoReconnect=true
+hibernate.connection.provider_disables_autocommit=true
 
 # Hibernate specific connection/debug properties
 hibernate.show_sql=false

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
-import org.hibernate.cfg.Environment;
+import org.hibernate.cfg.JdbcSettings;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
 	public void shouldHaveProviderDisablesAutocommitConfigured() {
 		Map<String, Object> settings = sessionFactory.getProperties();
 
-		assertEquals("true", String.valueOf(settings.get(Environment.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT)),
+		assertEquals("true", String.valueOf(settings.get(JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT)),
 		    "hibernate.connection.provider_disables_autocommit must be true so Hibernate skips the redundant setAutoCommit()");
 	}
 

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -66,6 +66,12 @@ public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
 
 	@Test
 	public void shouldHaveProviderDisablesAutocommitConfigured() {
+		// as above, a machine-local openmrs-runtime.properties may legitimately turn this off
+		assumeTrue(
+		    Stream.of("hibernate.connection.provider_disables_autocommit", "connection.provider_disables_autocommit")
+		            .noneMatch(runtimeProperties::containsKey),
+		    "skipped because local runtime properties override provider_disables_autocommit");
+
 		Map<String, Object> settings = sessionFactory.getProperties();
 
 		assertEquals("true", String.valueOf(settings.get(JdbcSettings.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT)),

--- a/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/ConnectionPoolConfigTest.java
@@ -9,10 +9,12 @@
  */
 package org.openmrs.api.db.hibernate;
 
+import java.util.Map;
 import java.util.stream.Stream;
 import javax.sql.DataSource;
 
 import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Environment;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.junit.jupiter.api.Test;
@@ -61,4 +63,13 @@ public class ConnectionPoolConfigTest extends BaseContextSensitiveTest {
 		assertEquals(30000, pool.getCheckoutTimeout());
 		assertEquals(50, pool.getMaxPoolSize());
 	}
+
+	@Test
+	public void shouldHaveProviderDisablesAutocommitConfigured() {
+		Map<String, Object> settings = sessionFactory.getProperties();
+
+		assertEquals("true", String.valueOf(settings.get(Environment.CONNECTION_PROVIDER_DISABLES_AUTOCOMMIT)),
+		    "hibernate.connection.provider_disables_autocommit must be true so Hibernate skips the redundant setAutoCommit()");
+	}
+
 }

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
@@ -1,0 +1,78 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.api.db.hibernate;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.hibernate.HibernateException;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.boot.spi.SessionFactoryOptions;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class HibernateSessionFactoryBeanTest {
+
+	private void integrate(boolean settingOn, boolean poolAutoCommit, ConnectionProvider provider) throws SQLException {
+		SessionFactoryOptions options = mock(SessionFactoryOptions.class);
+		when(options.doesConnectionProviderDisableAutoCommit()).thenReturn(settingOn);
+		SessionFactoryImplementor sessionFactory = mock(SessionFactoryImplementor.class);
+		when(sessionFactory.getSessionFactoryOptions()).thenReturn(options);
+
+		Connection connection = mock(Connection.class);
+		when(connection.getAutoCommit()).thenReturn(poolAutoCommit);
+		when(provider.getConnection()).thenReturn(connection);
+
+		StandardServiceRegistry registry = mock(StandardServiceRegistry.class);
+		when(registry.getService(ConnectionProvider.class)).thenReturn(provider);
+		BootstrapContext bootstrapContext = mock(BootstrapContext.class);
+		when(bootstrapContext.getServiceRegistry()).thenReturn(registry);
+
+		new HibernateSessionFactoryBean().integrate(mock(Metadata.class), bootstrapContext, sessionFactory);
+	}
+
+	@Test
+	public void shouldRefuseToStartWhenThePoolHandsOutAutoCommitEnabledConnections() throws SQLException {
+		ConnectionProvider provider = mock(ConnectionProvider.class);
+
+		assertThrows(HibernateException.class, () -> integrate(true, true, provider));
+
+		verify(provider).closeConnection(any());
+	}
+
+	@Test
+	public void shouldStartWhenThePoolHandsOutAutoCommitDisabledConnections() throws SQLException {
+		ConnectionProvider provider = mock(ConnectionProvider.class);
+
+		assertDoesNotThrow(() -> integrate(true, false, provider));
+
+		verify(provider).closeConnection(any());
+	}
+
+	@Test
+	public void shouldNotTouchThePoolWhenTheSettingIsOff() throws SQLException {
+		ConnectionProvider provider = mock(ConnectionProvider.class);
+
+		assertDoesNotThrow(() -> integrate(false, true, provider));
+
+		verify(provider, never()).getConnection();
+	}
+}

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
@@ -50,7 +50,7 @@ class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	 void shouldRefuseToStartWhenThePoolHandsOutAutoCommitEnabledConnections() throws SQLException {
+	void shouldRefuseToStartWhenThePoolHandsOutAutoCommitEnabledConnections() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertThrows(HibernateException.class, () -> integrate(true, true, provider));
@@ -59,7 +59,7 @@ class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	 void shouldStartWhenThePoolHandsOutAutoCommitDisabledConnections() throws SQLException {
+	void shouldStartWhenThePoolHandsOutAutoCommitDisabledConnections() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertDoesNotThrow(() -> integrate(true, false, provider));
@@ -68,7 +68,7 @@ class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	 void shouldNotTouchThePoolWhenTheSettingIsOff() throws SQLException {
+	void shouldNotTouchThePoolWhenTheSettingIsOff() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertDoesNotThrow(() -> integrate(false, true, provider));

--- a/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
+++ b/api/src/test/java/org/openmrs/api/db/hibernate/HibernateSessionFactoryBeanTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class HibernateSessionFactoryBeanTest {
+class HibernateSessionFactoryBeanTest {
 
 	private void integrate(boolean settingOn, boolean poolAutoCommit, ConnectionProvider provider) throws SQLException {
 		SessionFactoryOptions options = mock(SessionFactoryOptions.class);
@@ -50,7 +50,7 @@ public class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	public void shouldRefuseToStartWhenThePoolHandsOutAutoCommitEnabledConnections() throws SQLException {
+	 void shouldRefuseToStartWhenThePoolHandsOutAutoCommitEnabledConnections() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertThrows(HibernateException.class, () -> integrate(true, true, provider));
@@ -59,7 +59,7 @@ public class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	public void shouldStartWhenThePoolHandsOutAutoCommitDisabledConnections() throws SQLException {
+	 void shouldStartWhenThePoolHandsOutAutoCommitDisabledConnections() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertDoesNotThrow(() -> integrate(true, false, provider));
@@ -68,7 +68,7 @@ public class HibernateSessionFactoryBeanTest {
 	}
 
 	@Test
-	public void shouldNotTouchThePoolWhenTheSettingIsOff() throws SQLException {
+	 void shouldNotTouchThePoolWhenTheSettingIsOff() throws SQLException {
 		ConnectionProvider provider = mock(ConnectionProvider.class);
 
 		assertDoesNotThrow(() -> integrate(false, true, provider));


### PR DESCRIPTION

## Description of what I changed
Added `hibernate.connection.provider_disables_autocommit=true` , to remove the redundant `SET autocommit=0` DB command, which helps to reduce network round-trips from 4 to 3 and reduce the overall latency too .

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/TRUNK-6787

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `./mvnw clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`

