### PR TITLE
TRUNK-6796: Fix null check in PersonMergeLogData

### DIFF
--- a/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
+++ b/api/src/main/java/org/openmrs/person/PersonMergeLogData.java
@@ -442,7 +442,7 @@ public class PersonMergeLogData {
 		str += getPriorCauseOfDeath();
 		str += getPriorGender();
 		str += (getPriorDateOfBirth() != null) ? getPriorDateOfBirth().toString() : getPriorDateOfBirth();
-		str += (getPriorDateOfBirth() != null) ? getPriorDateOfDeath().toString() : getPriorDateOfDeath();
+		str += (getPriorDateOfDeath() != null) ? getPriorDateOfDeath().toString() : getPriorDateOfDeath();
 		str += isPriorDateOfBirthEstimated();
 		return str.hashCode();
 	}

--- a/api/src/test/java/org/openmrs/person/PersonMergeLogDataTest.java
+++ b/api/src/test/java/org/openmrs/person/PersonMergeLogDataTest.java
@@ -1,0 +1,27 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.person;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class PersonMergeLogDataTest {
+
+	@Test
+	public void computeHashValue_shouldNotThrowExceptionWhenPriorDateOfDeathIsNull() {
+		PersonMergeLogData data = new PersonMergeLogData();
+		data.setPriorDateOfBirth(new Date());
+
+		assertDoesNotThrow(data::computeHashValue);
+	}
+}


### PR DESCRIPTION
## Changes
Fixes the incorrect null check for priorDateOfDeath.
Adds a test to make sure computeHashValue() does not throw an exception when priorDateOfDeath is null.

## Issue I worked on
See : https://openmrs.atlassian.net/browse/TRUNK-6796

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(These are minor code quality fixes that do not require new tests.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**