### PR TITLE
TRUNK-6797: Fix CachedMessageSource merge overwrite behavior

### DIFF
--- a/api/src/main/java/org/openmrs/messagesource/impl/CachedMessageSource.java
+++ b/api/src/main/java/org/openmrs/messagesource/impl/CachedMessageSource.java
@@ -79,7 +79,9 @@ public class CachedMessageSource extends AbstractMessageSource implements Mutabl
 	@Override
 	public void merge(MutableMessageSource fromSource, boolean overwrite) {
 		for (PresentationMessage message : fromSource.getPresentations()) {
-			addPresentation(message);
+			if (overwrite || getPresentation(message.getCode(), message.getLocale()) == null) {
+				addPresentation(message);
+			}
 		}
 	}
 

--- a/api/src/test/java/org/openmrs/messagesource/impl/CachedMessageSourceTest.java
+++ b/api/src/test/java/org/openmrs/messagesource/impl/CachedMessageSourceTest.java
@@ -59,4 +59,24 @@ public class CachedMessageSourceTest {
 		assertEquals(valueAsString, valueAsPM.getMessage());
 	}
 
+	/**
+	 * The merge operation should not overwrite an existing message when overwrite is false.
+	 */
+	@Test
+	public void merge_shouldNotOverwriteExistingMessageWhenOverwriteIsFalse() {
+		CachedMessageSource cachedMessages = new CachedMessageSource();
+
+		PresentationMessage existingMessage = new PresentationMessage("test.code", Locale.ENGLISH, "Old message",
+		        "Old message");
+		PresentationMessage newMessage = new PresentationMessage("test.code", Locale.ENGLISH, "New message", "New message");
+
+		cachedMessages.addPresentation(existingMessage);
+
+		CachedMessageSource source = new CachedMessageSource();
+		source.addPresentation(newMessage);
+
+		cachedMessages.merge(source, false);
+
+		assertEquals("Old message", cachedMessages.getPresentation("test.code", Locale.ENGLISH).getMessage());
+	}
 }


### PR DESCRIPTION
## Changes

Fixed CachedMessageSource#merge to respect the overwrite parameter.

Added a test to verify that existing messages are not overwritten when overwrite is false.

## Issue I worked on

https://openmrs.atlassian.net/browse/TRUNK-6797

## Checklist: I completed these to help reviewers :)

- [x] My IDE is configured to follow the **code style** of this project.
- [x] I have added tests to cover my changes. *(These are minor code quality fixes that do not require new tests.)*
- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] **All new and existing tests passed.**
- [x] My pull request is **based on the latest changes of the master branch.**