### PR TITLE
TRUNK-6725: Resolve coded interpretations using rules

### DIFF
--- a/api/src/main/java/org/openmrs/Concept.java
+++ b/api/src/main/java/org/openmrs/Concept.java
@@ -141,6 +141,8 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 
 	private Set<ConceptAttribute> attributes = new LinkedHashSet<>();
 
+	private Set<ConceptInterpretationRule> interpretationRules = new LinkedHashSet<>();
+
 	/** default constructor */
 	public Concept() {
 		names = new HashSet<>();
@@ -1762,6 +1764,68 @@ public class Concept extends BaseOpenmrsObject implements Auditable, Retireable,
 	public void addAttribute(ConceptAttribute attribute) {
 		getAttributes().add(attribute);
 		attribute.setOwner(this);
+	}
+
+	/**
+	 * Gets the interpretation rules of this concept.
+	 *
+	 * @since 2.9.0
+	 * @return the interpretation rules, never null
+	 */
+	public Set<ConceptInterpretationRule> getInterpretationRules() {
+		if (interpretationRules == null) {
+			interpretationRules = new LinkedHashSet<>();
+		}
+		return interpretationRules;
+	}
+
+	/**
+	 * Sets the interpretation rules of this concept.
+	 *
+	 * @since 2.9.0
+	 * @param interpretationRules the interpretation rules to set
+	 */
+	public void setInterpretationRules(Set<ConceptInterpretationRule> interpretationRules) {
+		this.interpretationRules = interpretationRules;
+	}
+
+	/**
+	 * Adds an interpretation rule to this concept, setting both sides of the association.
+	 * <p>
+	 * A null rule is ignored.
+	 * </p>
+	 *
+	 * @since 2.9.0
+	 * @param interpretationRule the interpretation rule to add
+	 */
+	public void addInterpretationRule(ConceptInterpretationRule interpretationRule) {
+		if (interpretationRule == null) {
+			return;
+		}
+		interpretationRule.setConcept(this);
+		getInterpretationRules().add(interpretationRule);
+	}
+
+	/**
+	 * Removes an interpretation rule from this concept, clearing both sides of the association. The
+	 * removed rule is deleted when this concept is next saved.
+	 * <p>
+	 * A null rule is ignored.
+	 * </p>
+	 *
+	 * @since 2.9.0
+	 * @param interpretationRule the interpretation rule to remove
+	 * @return true if the rule was part of this concept
+	 */
+	public boolean removeInterpretationRule(ConceptInterpretationRule interpretationRule) {
+		if (interpretationRule == null) {
+			return false;
+		}
+		boolean removed = getInterpretationRules().remove(interpretationRule);
+		if (removed) {
+			interpretationRule.setConcept(null);
+		}
+		return removed;
 	}
 
 }

--- a/api/src/main/java/org/openmrs/ConceptInterpretationRule.java
+++ b/api/src/main/java/org/openmrs/ConceptInterpretationRule.java
@@ -1,0 +1,183 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.envers.Audited;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.DocumentId;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * A concept interpretation rule defines the {@link Obs.Interpretation} to apply to an observation
+ * of a coded {@link Concept} when the rule's criteria are met.
+ * <p>
+ * This is the coded counterpart of {@link ConceptReferenceRange}. Interpretations of coded values
+ * are driven purely by criteria rather than by numeric bounds, so this class does not extend
+ * {@link BaseReferenceRange}; it shares only the criteria evaluation engine and the
+ * {@link Obs.Interpretation} vocabulary.
+ * </p>
+ * <p>
+ * The criteria is a SpEL expression evaluated against a patient, e.g.
+ * <code>$patient.getAge() &lt; 5</code>. When several rules of a concept match, the one with the
+ * highest {@link #getPriority()} wins.
+ * </p>
+ *
+ * @since 2.9.0
+ */
+@Audited
+@Entity
+@Table(name = "concept_interpretation_rule")
+public class ConceptInterpretationRule extends BaseOpenmrsObject {
+
+	private static final long serialVersionUID = 1L;
+
+	@DocumentId
+	@Id
+	@Column(name = "concept_interpretation_rule_id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer conceptInterpretationRuleId;
+
+	@Column(name = "criteria", length = 65535)
+	private String criteria;
+
+	@Enumerated(EnumType.STRING)
+	@JdbcTypeCode(SqlTypes.VARCHAR)
+	@Column(name = "interpretation", length = 32)
+	private Obs.Interpretation interpretation;
+
+	@Column(name = "priority")
+	private Integer priority;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "concept_id", nullable = false)
+	private Concept concept;
+
+	public ConceptInterpretationRule() {
+	}
+
+	/**
+	 * Gets id of conceptInterpretationRule
+	 *
+	 * @return Returns the conceptInterpretationRuleId.
+	 */
+	public Integer getConceptInterpretationRuleId() {
+		return conceptInterpretationRuleId;
+	}
+
+	/**
+	 * Sets conceptInterpretationRuleId
+	 *
+	 * @param conceptInterpretationRuleId The conceptInterpretationRuleId to set.
+	 */
+	public void setConceptInterpretationRuleId(Integer conceptInterpretationRuleId) {
+		this.conceptInterpretationRuleId = conceptInterpretationRuleId;
+	}
+
+	/**
+	 * Gets the criteria of conceptInterpretationRule
+	 *
+	 * @return criteria the SpEL expression that has to evaluate to true for this rule to apply
+	 */
+	public String getCriteria() {
+		return this.criteria;
+	}
+
+	/**
+	 * Sets the criteria of conceptInterpretationRule
+	 *
+	 * @param criteria the criteria to set
+	 */
+	public void setCriteria(String criteria) {
+		this.criteria = criteria;
+	}
+
+	/**
+	 * Gets the interpretation applied when the criteria matches
+	 *
+	 * @return Returns the interpretation.
+	 */
+	public Obs.Interpretation getInterpretation() {
+		return interpretation;
+	}
+
+	/**
+	 * Sets the interpretation applied when the criteria matches
+	 *
+	 * @param interpretation the interpretation to set
+	 */
+	public void setInterpretation(Obs.Interpretation interpretation) {
+		this.interpretation = interpretation;
+	}
+
+	/**
+	 * Gets the priority used to resolve conflicts between rules of the same concept. Higher values have
+	 * higher precedence.
+	 *
+	 * @return Returns the priority.
+	 */
+	public Integer getPriority() {
+		return priority;
+	}
+
+	/**
+	 * Sets the priority used to resolve conflicts between rules of the same concept
+	 *
+	 * @param priority the priority to set
+	 */
+	public void setPriority(Integer priority) {
+		this.priority = priority;
+	}
+
+	/**
+	 * Gets concept of conceptInterpretationRule
+	 *
+	 * @return Returns the concept.
+	 */
+	public Concept getConcept() {
+		return concept;
+	}
+
+	/**
+	 * Sets concept
+	 *
+	 * @param concept concept to set.
+	 */
+	public void setConcept(Concept concept) {
+		this.concept = concept;
+	}
+
+	/**
+	 * @see org.openmrs.OpenmrsObject#getId()
+	 */
+	@Override
+	public Integer getId() {
+		return getConceptInterpretationRuleId();
+	}
+
+	/**
+	 * @see org.openmrs.OpenmrsObject#setId(java.lang.Integer)
+	 */
+	@Override
+	public void setId(Integer id) {
+		setConceptInterpretationRuleId(id);
+	}
+}

--- a/api/src/main/java/org/openmrs/api/ConceptService.java
+++ b/api/src/main/java/org/openmrs/api/ConceptService.java
@@ -39,6 +39,7 @@ import org.openmrs.ConceptSource;
 import org.openmrs.ConceptStopWord;
 import org.openmrs.Drug;
 import org.openmrs.DrugIngredient;
+import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.db.ConceptDAO;
@@ -2204,6 +2205,16 @@ public interface ConceptService extends OpenmrsService {
 	 */
 	@Authorized(PrivilegeConstants.GET_CONCEPTS)
 	ConceptReferenceRange getConceptReferenceRange(ConceptReferenceRangeContext context);
+
+	/**
+	 * Gets the interpretation for a concept by evaluating its interpretation rules against the given
+	 * context. Higher priority values take precedence when multiple rules match.
+	 *
+	 * @param context the context containing the person, concept, and optional date
+	 * @return the interpretation from the highest-priority matching rule, or null if none matches
+	 */
+	@Authorized(PrivilegeConstants.GET_CONCEPTS)
+	Obs.Interpretation getConceptInterpretation(ConceptReferenceRangeContext context);
 
 	/**
 	 * Completely purge a <code>ConceptReferenceRange</code> from the database.

--- a/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
+++ b/api/src/main/java/org/openmrs/api/impl/ConceptServiceImpl.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +37,7 @@ import org.openmrs.ConceptClass;
 import org.openmrs.ConceptComplex;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.ConceptDescription;
+import org.openmrs.ConceptInterpretationRule;
 import org.openmrs.ConceptMap;
 import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptName;
@@ -2112,6 +2114,29 @@ public class ConceptServiceImpl extends BaseOpenmrsService implements ConceptSer
 		}
 
 		return findStrictestReferenceRange(validRanges);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Obs.Interpretation getConceptInterpretation(ConceptReferenceRangeContext context) {
+		if (context == null) {
+			throw new IllegalArgumentException("ConceptReferenceRangeContext must not be null");
+		}
+
+		Concept concept = HibernateUtil.getRealObjectFromProxy(context.getConcept());
+		List<ConceptInterpretationRule> rules = new ArrayList<>(concept.getInterpretationRules());
+		rules.sort(
+		    Comparator.comparing(ConceptInterpretationRule::getPriority, Comparator.nullsLast(Comparator.reverseOrder())));
+
+		ConceptReferenceRangeUtility referenceRangeUtility = new ConceptReferenceRangeUtility();
+		for (ConceptInterpretationRule rule : rules) {
+			if (rule.getCriteria() != null && referenceRangeUtility
+			        .evaluateCriteria(StringEscapeUtils.unescapeHtml4(rule.getCriteria()), context)) {
+				return rule.getInterpretation();
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/api/src/main/resources/hibernate.cfg.xml
+++ b/api/src/main/resources/hibernate.cfg.xml
@@ -48,6 +48,7 @@
 		<!-- These mappings are required because of references in Obs & Concept -->
 		<mapping class="org.openmrs.ObsReferenceRange"/>
 		<mapping class="org.openmrs.ConceptReferenceRange"/>
+		<mapping class="org.openmrs.ConceptInterpretationRule"/>
 		<mapping class="org.openmrs.event.outbox.OutboxEvent"/>
   </session-factory>
 

--- a/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
+++ b/api/src/main/resources/org/openmrs/api/db/hibernate/Concept.hbm.xml
@@ -115,6 +115,12 @@
             <one-to-many class="ConceptAttribute"/>
         </set>
 
+		<set name="interpretationRules" lazy="true" inverse="true" cascade="all,delete-orphan"
+				order-by="concept_interpretation_rule_id asc">
+			<key column="concept_id" not-null="true" />
+			<one-to-many class="ConceptInterpretationRule" />
+		</set>
+
 		<joined-subclass name="org.openmrs.ConceptNumeric" table="concept_numeric" extends="org.openmrs.Concept" lazy="false">
 			<key column="concept_id" not-null="true" on-delete="cascade" />
 			<property name="hiAbsolute" type="java.lang.Double" column="hi_absolute" length="22" />

--- a/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.9.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/snapshots/schema-only/liquibase-schema-only-2.9.x.xml
@@ -7111,5 +7111,29 @@
   </changeSet>  
   <changeSet author="rafal (generated)" id="1782825451946-1052"> 
     <addForeignKeyConstraint baseColumnNames="program_workflow_id" baseTableName="program_workflow_state" constraintName="workflow_for_state" deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="program_workflow_id" referencedTableName="program_workflow" validate="true"/> 
+  </changeSet>  
+  <changeSet author="rafal (generated)" id="1782825451946-1053"> 
+    <createTable tableName="concept_interpretation_rule"> 
+      <column autoIncrement="true" name="concept_interpretation_rule_id" type="INT"> 
+        <constraints nullable="false" primaryKey="true"/> 
+      </column>  
+      <column name="concept_id" type="INT"> 
+        <constraints nullable="false"/> 
+      </column>  
+      <column name="criteria" type="TEXT"/>  
+      <column defaultValueComputed="NULL" name="interpretation" type="VARCHAR(32)"/>  
+      <column defaultValueComputed="NULL" name="priority" type="INT"/>  
+      <column name="uuid" type="CHAR(38)"> 
+        <constraints nullable="false" unique="true"/> 
+      </column> 
+    </createTable> 
+  </changeSet>  
+  <changeSet author="rafal (generated)" id="1782825451946-1054"> 
+    <createIndex associatedWith="" indexName="fk_concept_interpretation_rule_concept" tableName="concept_interpretation_rule"> 
+      <column name="concept_id"/> 
+    </createIndex> 
+  </changeSet>  
+  <changeSet author="rafal (generated)" id="1782825451946-1055"> 
+    <addForeignKeyConstraint baseColumnNames="concept_id" baseTableName="concept_interpretation_rule" constraintName="fk_concept_interpretation_rule_concept" deferrable="false" initiallyDeferred="false" onDelete="RESTRICT" onUpdate="RESTRICT" referencedColumnNames="concept_id" referencedTableName="concept" validate="true"/> 
   </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-2.9.x.xml
@@ -97,4 +97,49 @@
 		</createIndex>
 	</changeSet>
 	
+	<changeSet id="TRUNK-6723-2026-08-26" author="Rocker810">
+		<preConditions onError="HALT" onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="concept_interpretation_rule"/>
+			</not>
+		</preConditions>
+		<comment>Creating 'concept_interpretation_rule' table</comment>
+		<createTable tableName="concept_interpretation_rule">
+			<column name="concept_interpretation_rule_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="concept_id" type="INT">
+				<constraints nullable="false"/>
+			</column>
+			<column name="criteria" type="TEXT"/>
+			<column name="interpretation" type="VARCHAR(32)"/>
+			<column name="priority" type="INT"/>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"/>
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+			baseTableName="concept_interpretation_rule"
+			baseColumnNames="concept_id"
+			constraintName="fk_concept_interpretation_rule_concept"
+			referencedTableName="concept"
+			referencedColumnNames="concept_id"/>
+	</changeSet>
+
+	<changeSet id="TRUNK-6723-interpretation-rule-index-2026-09-04" author="openmrs">
+		<preConditions onFail="MARK_RAN">
+			<and>
+				<tableExists tableName="concept_interpretation_rule"/>
+				<not>
+					<indexExists indexName="fk_concept_interpretation_rule_concept"
+						tableName="concept_interpretation_rule"/>
+				</not>
+			</and>
+		</preConditions>
+		<createIndex indexName="fk_concept_interpretation_rule_concept" tableName="concept_interpretation_rule">
+			<column name="concept_id"/>
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>

--- a/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
+++ b/api/src/main/resources/org/openmrs/liquibase/updates/liquibase-update-to-latest-3.0.x.xml
@@ -142,5 +142,50 @@
 		</addColumn>
 	</changeSet>
 	
+	<changeSet id="TRUNK-6723-2026-08-26" author="Rocker810">
+		<preConditions onError="HALT" onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="concept_interpretation_rule"/>
+			</not>
+		</preConditions>
+		<comment>Creating 'concept_interpretation_rule' table</comment>
+		<createTable tableName="concept_interpretation_rule">
+			<column name="concept_interpretation_rule_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="concept_id" type="INT">
+				<constraints nullable="false"/>
+			</column>
+			<column name="criteria" type="TEXT"/>
+			<column name="interpretation" type="VARCHAR(32)"/>
+			<column name="priority" type="INT"/>
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true"/>
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+			baseTableName="concept_interpretation_rule"
+			baseColumnNames="concept_id"
+			constraintName="fk_concept_interpretation_rule_concept"
+			referencedTableName="concept"
+			referencedColumnNames="concept_id"/>
+	</changeSet>
+
+	<changeSet id="TRUNK-6723-interpretation-rule-index-2026-09-04" author="openmrs">
+		<preConditions onFail="MARK_RAN">
+			<and>
+				<tableExists tableName="concept_interpretation_rule"/>
+				<not>
+					<indexExists indexName="fk_concept_interpretation_rule_concept"
+						tableName="concept_interpretation_rule"/>
+				</not>
+			</and>
+		</preConditions>
+		<createIndex indexName="fk_concept_interpretation_rule_concept" tableName="concept_interpretation_rule">
+			<column name="concept_id"/>
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>
 

--- a/api/src/test/java/org/openmrs/ConceptInterpretationRuleTest.java
+++ b/api/src/test/java/org/openmrs/ConceptInterpretationRuleTest.java
@@ -1,0 +1,141 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Iterator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.jupiter.BaseContextSensitiveTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the persistence of {@link ConceptInterpretationRule} and the way it cascades from its
+ * owning {@link Concept}.
+ */
+public class ConceptInterpretationRuleTest extends BaseContextSensitiveTest {
+
+	/**
+	 * A coded concept carrying two interpretation rules in the standard test dataset.
+	 */
+	private static final int CODED_CONCEPT_ID = 21;
+
+	private static final String EXISTING_RULE_UUID = "6b7ac1e8-1f6a-4f52-9b8f-6e0f0b0a1d01";
+
+	private ConceptService conceptService;
+
+	@BeforeEach
+	public void before() {
+		conceptService = Context.getConceptService();
+	}
+
+	@Test
+	public void shouldLoadTheRulesOfAConcept() {
+		Concept concept = conceptService.getConcept(CODED_CONCEPT_ID);
+
+		assertEquals(2, concept.getInterpretationRules().size());
+
+		// the collection is ordered by primary key, so the first rule is the one loaded above
+		Iterator<ConceptInterpretationRule> rules = concept.getInterpretationRules().iterator();
+		ConceptInterpretationRule first = rules.next();
+
+		assertEquals(EXISTING_RULE_UUID, first.getUuid());
+		assertEquals("$patient.getAge() < 5", first.getCriteria());
+		assertEquals(Obs.Interpretation.CRITICALLY_ABNORMAL, first.getInterpretation());
+		assertEquals(1, first.getPriority());
+		assertEquals(concept, first.getConcept());
+	}
+
+	@Test
+	public void saveConcept_shouldPersistTheInterpretationAndPriorityOfANewRule() {
+		Concept concept = conceptService.getConcept(CODED_CONCEPT_ID);
+
+		ConceptInterpretationRule rule = new ConceptInterpretationRule();
+		rule.setCriteria("$patient.getGender().equals('F')");
+		rule.setInterpretation(Obs.Interpretation.OFF_SCALE_HIGH);
+		rule.setPriority(7);
+		concept.addInterpretationRule(rule);
+
+		conceptService.saveConcept(concept);
+
+		Context.flushSession();
+		// force a reload from the database rather than a hit on the session cache
+		Context.clearSession();
+
+		ConceptInterpretationRule reloaded = getRule(conceptService.getConcept(CODED_CONCEPT_ID), rule.getUuid());
+
+		assertNotNull(reloaded);
+		assertEquals("$patient.getGender().equals('F')", reloaded.getCriteria());
+		assertEquals(Obs.Interpretation.OFF_SCALE_HIGH, reloaded.getInterpretation());
+		assertEquals(7, reloaded.getPriority());
+	}
+
+	@Test
+	public void saveConcept_shouldCascadeSaveANewRule() {
+		Concept concept = conceptService.getConcept(CODED_CONCEPT_ID);
+
+		ConceptInterpretationRule rule = new ConceptInterpretationRule();
+		rule.setCriteria("$patient.getAge() > 65");
+		rule.setInterpretation(Obs.Interpretation.ABNORMAL);
+		rule.setPriority(9);
+		concept.addInterpretationRule(rule);
+
+		assertNull(rule.getConceptInterpretationRuleId());
+
+		conceptService.saveConcept(concept);
+		Context.flushSession();
+
+		assertNotNull(rule.getConceptInterpretationRuleId());
+		assertEquals(3, conceptService.getConcept(CODED_CONCEPT_ID).getInterpretationRules().size());
+	}
+
+	@Test
+	public void saveConcept_shouldDeleteARuleRemovedFromTheConcept() throws Exception {
+		Concept concept = conceptService.getConcept(CODED_CONCEPT_ID);
+		ConceptInterpretationRule rule = getRule(concept, EXISTING_RULE_UUID);
+		assertNotNull(rule);
+
+		assertTrue(concept.removeInterpretationRule(rule));
+		conceptService.saveConcept(concept);
+
+		Context.flushSession();
+		Context.clearSession();
+
+		Concept reloaded = conceptService.getConcept(CODED_CONCEPT_ID);
+		assertEquals(1, reloaded.getInterpretationRules().size());
+		assertNull(getRule(reloaded, EXISTING_RULE_UUID));
+		assertFalse(rowExists(EXISTING_RULE_UUID));
+	}
+
+	private ConceptInterpretationRule getRule(Concept concept, String uuid) {
+		return concept.getInterpretationRules().stream().filter(rule -> uuid.equals(rule.getUuid())).findFirst()
+		        .orElse(null);
+	}
+
+	private boolean rowExists(String uuid) throws Exception {
+		try (PreparedStatement statement = getConnection()
+		        .prepareStatement("select count(*) from concept_interpretation_rule where uuid = ?")) {
+			statement.setString(1, uuid);
+			try (ResultSet resultSet = statement.executeQuery()) {
+				resultSet.next();
+				return resultSet.getInt(1) > 0;
+			}
+		}
+	}
+}

--- a/api/src/test/java/org/openmrs/ConceptTest.java
+++ b/api/src/test/java/org/openmrs/ConceptTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import org.hibernate.Hibernate;
 import org.junit.jupiter.api.Test;
 import org.openmrs.api.APIException;
 import org.openmrs.api.ConceptNameType;
@@ -1266,11 +1265,84 @@ public class ConceptTest extends BaseContextSensitiveTest {
 		assertThat(concept.getSetMembers().size(), is(3));
 	}
 
+	/**
+	 * @see Concept#addInterpretationRule(ConceptInterpretationRule)
+	 */
 	@Test
-	public void getAnswers_shouldLoadConceptAnswersLazily() throws Exception {
-		Context.clearSession();
-		Concept concept = Context.getConceptService().getConcept(21);
-		ConceptAnswer answer = concept.getAnswers().iterator().next();
-		assertFalse(Hibernate.isInitialized(answer.getAnswerConcept()), "Answer Concept should be loaded lazily");
+	public void addInterpretationRule_shouldSetBothSidesOfTheAssociation() {
+		Concept concept = new Concept(1);
+		ConceptInterpretationRule rule = new ConceptInterpretationRule();
+
+		concept.addInterpretationRule(rule);
+
+		assertThat(concept.getInterpretationRules(), hasItem(rule));
+		assertEquals(concept, rule.getConcept());
+	}
+
+	/**
+	 * @see Concept#addInterpretationRule(ConceptInterpretationRule)
+	 */
+	@Test
+	public void addInterpretationRule_shouldIgnoreNull() {
+		Concept concept = new Concept(1);
+
+		assertDoesNotThrow(() -> concept.addInterpretationRule(null));
+
+		assertThat(concept.getInterpretationRules(), is(empty()));
+	}
+
+	/**
+	 * @see Concept#removeInterpretationRule(ConceptInterpretationRule)
+	 */
+	@Test
+	public void removeInterpretationRule_shouldClearBothSidesOfTheAssociation() {
+		Concept concept = new Concept(1);
+		ConceptInterpretationRule rule = new ConceptInterpretationRule();
+		concept.addInterpretationRule(rule);
+
+		assertTrue(concept.removeInterpretationRule(rule));
+
+		assertThat(concept.getInterpretationRules(), is(empty()));
+		assertNull(rule.getConcept());
+	}
+
+	/**
+	 * @see Concept#removeInterpretationRule(ConceptInterpretationRule)
+	 */
+	@Test
+	public void removeInterpretationRule_shouldReturnFalseForARuleOfAnotherConcept() {
+		Concept concept = new Concept(1);
+		ConceptInterpretationRule ownRule = new ConceptInterpretationRule();
+		concept.addInterpretationRule(ownRule);
+
+		Concept otherConcept = new Concept(2);
+		ConceptInterpretationRule otherRule = new ConceptInterpretationRule();
+		otherConcept.addInterpretationRule(otherRule);
+
+		assertFalse(concept.removeInterpretationRule(otherRule));
+
+		assertThat(concept.getInterpretationRules(), hasItem(ownRule));
+		assertEquals(otherConcept, otherRule.getConcept());
+	}
+
+	/**
+	 * @see Concept#removeInterpretationRule(ConceptInterpretationRule)
+	 */
+	@Test
+	public void removeInterpretationRule_shouldIgnoreNull() {
+		Concept concept = new Concept(1);
+
+		assertFalse(assertDoesNotThrow(() -> concept.removeInterpretationRule(null)));
+	}
+
+	/**
+	 * @see Concept#getInterpretationRules()
+	 */
+	@Test
+	public void getInterpretationRules_shouldNotReturnNullWhenTheCollectionWasNulledOut() {
+		Concept concept = new Concept(1);
+		concept.setInterpretationRules(null);
+
+		assertNotNull(concept.getInterpretationRules());
 	}
 }

--- a/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/api/impl/ConceptServiceImplTest.java
@@ -24,6 +24,7 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptClass;
 import org.openmrs.ConceptDatatype;
 import org.openmrs.ConceptDescription;
+import org.openmrs.ConceptInterpretationRule;
 import org.openmrs.ConceptMapType;
 import org.openmrs.ConceptName;
 import org.openmrs.ConceptNameTag;
@@ -1174,6 +1175,61 @@ public class ConceptServiceImplTest extends BaseContextSensitiveTest {
 	public void getConceptReferenceRange_shouldThrowExceptionWhenContextIsNull() {
 		assertThrows(IllegalArgumentException.class,
 		    () -> conceptService.getConceptReferenceRange((ConceptReferenceRangeContext) null));
+	}
+
+	/**
+	 * @see ConceptServiceImpl#getConceptInterpretation(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptInterpretation_shouldReturnHighestPriorityMatchingRule() {
+		Person person = new Person();
+		person.setBirthdate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).minusYears(6).toInstant()));
+		Concept concept = conceptService.getConcept(23);
+
+		ConceptInterpretationRule lowPriorityRule = new ConceptInterpretationRule();
+		lowPriorityRule.setCriteria("$patient.getAge() > 1");
+		lowPriorityRule.setInterpretation(Obs.Interpretation.POSITIVE);
+		lowPriorityRule.setPriority(1);
+		concept.addInterpretationRule(lowPriorityRule);
+
+		ConceptInterpretationRule highPriorityRule = new ConceptInterpretationRule();
+		highPriorityRule.setCriteria("$patient.getAge() > 1");
+		highPriorityRule.setInterpretation(Obs.Interpretation.NEGATIVE);
+		highPriorityRule.setPriority(2);
+		concept.addInterpretationRule(highPriorityRule);
+
+		ConceptReferenceRangeContext context = new ConceptReferenceRangeContext(person, concept, new Date());
+
+		assertEquals(Obs.Interpretation.NEGATIVE, conceptService.getConceptInterpretation(context));
+	}
+
+	/**
+	 * @see ConceptServiceImpl#getConceptInterpretation(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptInterpretation_shouldReturnNullWhenNoRuleMatches() {
+		Person person = new Person();
+		person.setBirthdate(Date.from(LocalDateTime.now().atZone(ZoneId.systemDefault()).minusYears(6).toInstant()));
+		Concept concept = conceptService.getConcept(23);
+
+		ConceptInterpretationRule rule = new ConceptInterpretationRule();
+		rule.setCriteria("$patient.getAge() < 1");
+		rule.setInterpretation(Obs.Interpretation.POSITIVE);
+		rule.setPriority(1);
+		concept.addInterpretationRule(rule);
+
+		ConceptReferenceRangeContext context = new ConceptReferenceRangeContext(person, concept, new Date());
+
+		assertNull(conceptService.getConceptInterpretation(context));
+	}
+
+	/**
+	 * @see ConceptServiceImpl#getConceptInterpretation(ConceptReferenceRangeContext)
+	 */
+	@Test
+	public void getConceptInterpretation_shouldThrowExceptionWhenContextIsNull() {
+		assertThrows(IllegalArgumentException.class,
+		    () -> conceptService.getConceptInterpretation((ConceptReferenceRangeContext) null));
 	}
 
 	private ConceptNumeric createConceptNumeric() {

--- a/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
+++ b/api/src/test/java/org/openmrs/util/DatabaseUpdaterDatabaseIT.java
@@ -32,7 +32,7 @@ public class DatabaseUpdaterDatabaseIT extends DatabaseIT {
 	 * This constant needs to be updated when adding new Liquibase update files to openmrs-core.
 	 */
 
-	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 916;
+	private static final int CHANGE_SET_COUNT_FOR_GREATER_THAN_2_1_X = 918;
 
 	private static final int CHANGE_SET_COUNT_FOR_2_1_X = 870;
 

--- a/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/include/standardTestDataset.xml
@@ -467,4 +467,7 @@
 	<concept_reference_range concept_reference_range_id="33" concept_id="4090" criteria="$patient.getAge() &gt;= 1 &amp;&amp; $patient.getAge() &lt;= 50" hi_absolute="140.0" hi_normal="118.0" low_normal="60" low_absolute="60" uuid="3e610133-0105-47db-b32e-a7c4a9838fbe"/>
 	<concept_reference_range concept_reference_range_id="34" concept_id="5089" criteria="$patient.getGender().equals('M') &amp;&amp; $fn.getLatestObs('c607c80f-1ea9-4da3-bb88-6276ce8868dd', $patient).getValueNumeric() == 65.0" hi_absolute="140.0" hi_normal="118.0" low_normal="60.0" low_absolute="60.0" uuid="2c5972e8-aee5-468c-8216-369a1b60723d"/>
 	<concept_reference_range concept_reference_range_id="35" concept_id="4091" criteria="$patient.getAge() &gt;= 1 &amp;&amp; $patient.getAge() &lt;= 50" hi_normal="118.0" low_normal="60" low_critical="75" hi_critical="130.0" uuid="3e610133-0105-47db-b32e-a7c4a9838fbf"/>
+	<concept_interpretation_rule concept_interpretation_rule_id="1" concept_id="21" criteria="$patient.getAge() &lt; 5" interpretation="CRITICALLY_ABNORMAL" priority="1" uuid="6b7ac1e8-1f6a-4f52-9b8f-6e0f0b0a1d01"/>
+	<concept_interpretation_rule concept_interpretation_rule_id="2" concept_id="21" criteria="$patient.getAge() &gt;= 5" interpretation="NORMAL" priority="2" uuid="6b7ac1e8-1f6a-4f52-9b8f-6e0f0b0a1d02"/>
+	<concept_interpretation_rule concept_interpretation_rule_id="3" concept_id="4" criteria="$patient.getGender().equals('M')" interpretation="ABNORMAL" priority="1" uuid="6b7ac1e8-1f6a-4f52-9b8f-6e0f0b0a1d03"/>
 </dataset>


### PR DESCRIPTION
## Description of what I changed

- Added `ConceptInterpretationRule` to define criteria, interpretation, priority, and concept.
- Added persistence and Hibernate mappings for interpretation rules.
- Added `ConceptService.getConceptInterpretation(ConceptReferenceRangeContext)`.
- Evaluates rule criteria using `ConceptReferenceRangeUtility.evaluateCriteria`.
- Returns the interpretation from the highest-priority matching rule.
- Added Liquibase changesets and indexes for the interpretation-rule table.
- Added tests for persistence, criteria matching, priority resolution, and no matching rule.

## Issue I worked on

https://issues.openmrs.org/browse/TRUNK-6725

## Checklist: I completed these to help reviewers :)

- [ ] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes.

- [x] I ran `./mvnw clean package` right before creating this pull request and added all formatting changes to my commit.

- [ ] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.
