### PR TITLE
TRUNK-6801: Fix DoubleRange toString formatting and remove deprecated Double constructors

### DIFF
--- a/api/src/main/java/org/openmrs/util/DoubleRange.java
+++ b/api/src/main/java/org/openmrs/util/DoubleRange.java
@@ -39,8 +39,8 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	 * <strong>Should</strong> return infinite low and high if called with null parameters
 	 */
 	public DoubleRange(Double low, Double high) {
-		this.low = low == null ? new Double(Double.NEGATIVE_INFINITY) : low;
-		this.high = high == null ? new Double(Double.POSITIVE_INFINITY) : high;
+		this.low = low == null ? Double.NEGATIVE_INFINITY : low;
+		this.high = high == null ? Double.POSITIVE_INFINITY : high;
 	}
 
 	/**
@@ -62,7 +62,7 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	 * @param high The high to set.
 	 */
 	public void setHigh(Double high) {
-		this.high = high == null ? new Double(Double.POSITIVE_INFINITY) : high;
+		this.high = high == null ? Double.POSITIVE_INFINITY : high;
 	}
 
 	/**
@@ -84,7 +84,7 @@ public class DoubleRange implements Comparable<DoubleRange> {
 	 * @param low The low to set.
 	 */
 	public void setLow(Double low) {
-		this.low = low == null ? new Double(Double.NEGATIVE_INFINITY) : low;
+		this.low = low == null ? Double.NEGATIVE_INFINITY : low;
 	}
 
 	/**
@@ -164,8 +164,7 @@ public class DoubleRange implements Comparable<DoubleRange> {
 				ret.append("=");
 			}
 			ret.append(" ").append(Format.format(low));
-			if (high != null && high != Double.NEGATIVE_INFINITY) {
-				//BUG: should not append this if high is also infinite
+			if (high != null && high != Double.POSITIVE_INFINITY) {
 				ret.append(" and ");
 			}
 		}


### PR DESCRIPTION
### Summary of Changes
This PR addresses issue [TRUNK-6801](https://openmrs.atlassian.net/browse/TRUNK-6801).

1. **Fixed `DoubleRange.toString()` Formatting:** Updated the boundary check from `Double.NEGATIVE_INFINITY` to `Double.POSITIVE_INFINITY` for the upper bound (`high`), ensuring `" and "` is not appended incorrectly when `high` is infinite.
2. **Removed Deprecated Constructors:** Replaced deprecated `new Double(...)` constructor calls in `DoubleRange.java` with direct references to `Double.NEGATIVE_INFINITY` and `Double.POSITIVE_INFINITY`.

### Issue Link
https://openmrs.atlassian.net/browse/TRUNK-6801

### Testing
- Ran unit tests locally via Maven (`mvn test -pl api -Dtest=DoubleRangeTest`).
- All 28 tests in `DoubleRangeTest` passed successfully without errors.

[TRUNK-6801]: https://openmrs.atlassian.net/browse/TRUNK-6801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ